### PR TITLE
[Separate catstack Invoker](1) Review-bound MCP handoff and status tools

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -424,11 +424,11 @@ tasks:
     });
   });
 
-  it('tells MCP handoff users to call invoker_prepare_plan_review before approval', () => {
+  it('requires exclusive planPath or sessionId in the MCP handoff prompt', () => {
     const prompt = handoffPrompt('ship this change');
 
-    expect(prompt).toContain('Call `invoker_prepare_plan_review` on that exact YAML file');
-    expect(prompt).toContain('show the returned ordered steps and confirmation text to the user');
+    expect(prompt.includes('Call `invoker_prepare_plan_review` with exactly one of `planPath` or `sessionId`')).toBe(true);
+    expect(prompt.includes('show the returned ordered steps and confirmation text to the user')).toBe(true);
   });
 
   it('documents the auto-submit branch in the MCP handoff prompt', () => {

--- a/packages/cli/src/__tests__/mcp-review-and-status.test.ts
+++ b/packages/cli/src/__tests__/mcp-review-and-status.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertPlanUnchanged,
+  createReviewTokenStore,
+  hashPlanContent,
+} from '../mcp-review-binding.js';
+import {
+  summarizeTaskStatuses,
+  waitForWorkflowTasks,
+  workflowTasksSettled,
+} from '../mcp-workflow-status.js';
+
+describe('mcp-review-binding', () => {
+  it('issues tokens bound to plan content hashes', () => {
+    const store = createReviewTokenStore();
+    const binding = store.issue({
+      planText: 'name: Demo\n',
+      source: { kind: 'planPath', planPath: '/tmp/plan.yaml' },
+    });
+    expect(binding.token).toMatch(/^rev_/);
+    expect(binding.contentHash).toBe(hashPlanContent('name: Demo\n'));
+    expect(store.get(binding.token)?.source).toEqual({ kind: 'planPath', planPath: '/tmp/plan.yaml' });
+    expect(store.consume(binding.token)?.token).toBe(binding.token);
+    expect(store.get(binding.token)).toBeUndefined();
+  });
+
+  it('rejects changed plan content', () => {
+    const hash = hashPlanContent('original');
+    expect(() => assertPlanUnchanged(hash, 'changed')).toThrow(/changed after review/);
+  });
+});
+
+describe('mcp-workflow-status', () => {
+  it('treats approval and blocked states as settled', () => {
+    expect(workflowTasksSettled([
+      { id: 'a', status: 'completed' },
+      { id: 'b', status: 'awaiting_approval' },
+    ])).toBe(true);
+    expect(workflowTasksSettled([{ id: 'a', status: 'running' }])).toBe(false);
+    expect(summarizeTaskStatuses([
+      { id: 'a', status: 'completed' },
+      { id: 'b', status: 'failed' },
+      { id: 'c', status: 'awaiting_approval' },
+    ])).toMatchObject({
+      total: 3,
+      completed: 1,
+      failed: 1,
+      awaitingApproval: 1,
+    });
+  });
+
+  it('returns settled=true once tasks stop being active', async () => {
+    let calls = 0;
+    const result = await waitForWorkflowTasks({
+      workflowId: 'wf-1',
+      maxWaitMs: 1000,
+      pollIntervalMs: 1,
+      sleep: async () => undefined,
+      loadTasks: async () => {
+        calls += 1;
+        if (calls === 1) return [{ id: 'a', status: 'running' }];
+        return [{ id: 'a', status: 'completed' }];
+      },
+    });
+    expect(result).toMatchObject({
+      settled: true,
+      timedOut: false,
+      status: { completed: 1, running: 0 },
+    });
+  });
+});

--- a/packages/cli/src/__tests__/mcp-server-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-server-session.test.ts
@@ -5,6 +5,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { LocalBus, type MessageBus } from '@invoker/transport';
 
 import { createMcpServer, type McpServerOptions } from '../mcp-server.js';
+import { createReviewTokenStore } from '../mcp-review-binding.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const fixturePlan = resolve(repoRoot, 'plans/fixtures/hello-world.yaml');
@@ -29,6 +30,15 @@ async function connectMcpClient(options: McpServerOptions) {
 function refusingCreateMessageBus(): () => Promise<MessageBus> {
   return () => {
     throw new Error('createMessageBus should not be called without an effective session id');
+  };
+}
+
+/** LocalBus.disconnect() clears handlers, so multi-call flows need a fresh bus each time. */
+function liveOwnerBusFactory(setup: (bus: LocalBus) => void): () => Promise<MessageBus> {
+  return async () => {
+    const bus = new LocalBus();
+    setup(bus);
+    return bus;
   };
 }
 
@@ -58,18 +68,17 @@ describe('mcp-server session-scoped tools', () => {
       expect(result.isError).toBeFalsy();
       const content = result.content as Array<{ type: string; text: string }>;
       const parsed = JSON.parse(content[0]!.text);
-      expect(parsed).toMatchObject({
-        planText: expect.any(String),
-        summary: { name: 'Hello World CLI', taskCount: 1 },
-        confirmationMode: 'require',
-        confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
-      });
+      expect(parsed.planText).toEqual(expect.any(String));
+      expect(parsed.summary).toEqual(expect.objectContaining({ name: 'Hello World CLI', taskCount: 1 }));
+      expect(parsed.confirmationMode).toEqual('require');
+      expect(parsed.confirmationText).toEqual('Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.');
+      expect(parsed.reviewToken).toEqual(expect.stringMatching(/^rev_/));
     } finally {
       await close();
     }
   });
 
-  it('leaves the file-path invoker_submit_plan behavior unchanged with no sessionId and no env var', async () => {
+  it('rejects file-path submit without a reviewToken', async () => {
     delete process.env.INVOKER_PLANNING_SESSION_ID;
     const runner = {
       run: vi.fn(async () => ({ exitCode: 0, stdout: '{"workflow":{"id":"wf-file-path"}}\n', stderr: '' })),
@@ -84,10 +93,57 @@ describe('mcp-server session-scoped tools', () => {
         arguments: { planPath: fixturePlan },
       });
 
+      expect(String((result.content as Array<{text:string}>)[0]?.text ?? '')).toMatch(/reviewToken/i);
+      expect(runner.run.mock.calls).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('submits a file-path plan only with a matching reviewToken', async () => {
+    delete process.env.INVOKER_PLANNING_SESSION_ID;
+    const runner = {
+      run: vi.fn(async () => ({ exitCode: 0, stdout: '{"workflow":{"id":"wf-file-path"}}\n', stderr: '' })),
+    };
+    const { client, close } = await connectMcpClient({
+      runner,
+      createMessageBus: refusingCreateMessageBus(),
+    });
+    try {
+      const review = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: fixturePlan },
+      });
+      const reviewToken = JSON.parse((review.content as Array<{ text: string }>)[0]!.text).reviewToken as string;
+
+      const result = await client.callTool({
+        name: 'invoker_submit_plan',
+        arguments: { planPath: fixturePlan, reviewToken },
+      });
+
       expect(result.isError).toBeFalsy();
       expect(runner.run).toHaveBeenCalledTimes(1);
       const content = result.content as Array<{ type: string; text: string }>;
-      expect(content[0]!.text).toContain('wf-file-path');
+      const payload = JSON.parse(content[0]!.text) as { ok: boolean; workflowId: string };
+      expect(payload.ok).toEqual(true);
+      expect(payload.workflowId).toEqual('wf-file-path');
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects providing both planPath and sessionId', async () => {
+    const { client, close } = await connectMcpClient({
+      createMessageBus: refusingCreateMessageBus(),
+    });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: fixturePlan, sessionId: 'sess-both' },
+      });
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text.includes('exactly one')).toEqual(true);
     } finally {
       await close();
     }
@@ -103,7 +159,7 @@ describe('mcp-server session-scoped tools', () => {
     try {
       const result = await client.callTool({
         name: 'invoker_prepare_plan_review',
-        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-no-owner' },
+        arguments: { sessionId: 'sess-no-owner' },
       });
 
       expect(result.isError).toBe(true);
@@ -133,18 +189,17 @@ describe('mcp-server session-scoped tools', () => {
     try {
       const result = await client.callTool({
         name: 'invoker_prepare_plan_review',
-        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-with-draft' },
+        arguments: { sessionId: 'sess-with-draft' },
       });
 
       expect(result.isError).toBeFalsy();
       const content = result.content as Array<{ type: string; text: string }>;
       const parsed = JSON.parse(content[0]!.text);
-      expect(parsed).toEqual({
-        planText: 'name: Session Plan\nonFinish: none\ntasks: []\n',
-        summary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
-        confirmationMode: 'require',
-        confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
-      });
+      expect(parsed.planText).toEqual('name: Session Plan\nonFinish: none\ntasks: []\n');
+      expect(parsed.summary).toEqual({ name: 'Session Plan', taskCount: 0, taskGroups: [] });
+      expect(parsed.confirmationMode).toEqual('require');
+      expect(parsed.confirmationText).toEqual('Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.');
+      expect(parsed.reviewToken).toEqual(expect.stringMatching(/^rev_/));
     } finally {
       await close();
     }
@@ -158,7 +213,7 @@ describe('mcp-server session-scoped tools', () => {
     try {
       const result = await client.callTool({
         name: 'invoker_prepare_plan_review',
-        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-missing' },
+        arguments: { sessionId: 'sess-missing' },
       });
 
       expect(result.isError).toBe(true);
@@ -170,8 +225,7 @@ describe('mcp-server session-scoped tools', () => {
   });
 
   it('dispatches invoker_submit_plan through headless.gui-mutation and maps an ok response', async () => {
-    const bus = new LocalBus();
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    const planText = 'name: Session Plan\nonFinish: none\ntasks: []\n';
     const guiMutation = vi.fn(async (req: unknown) => {
       expect(req).toEqual({
         channel: 'invoker:planning-chat-submit',
@@ -179,32 +233,107 @@ describe('mcp-server session-scoped tools', () => {
       });
       return { ok: true, planName: 'Session Plan', workflowId: 'wf-session-1' };
     });
-    bus.onRequest('headless.gui-mutation', guiMutation);
-    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', async () => ({
+          session: {
+            draftPlanText: planText,
+            draftPlanSummary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
+            confirmationMode: 'require',
+            status: 'draft_ready',
+          },
+        }));
+        bus.onRequest('headless.gui-mutation', guiMutation);
+      }),
+    });
     try {
+      const review = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { sessionId: 'sess-submit-ok' },
+      });
+      const reviewToken = JSON.parse((review.content as Array<{ text: string }>)[0]!.text).reviewToken as string;
+
       const result = await client.callTool({
         name: 'invoker_submit_plan',
-        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-submit-ok' },
+        arguments: { sessionId: 'sess-submit-ok', reviewToken },
       });
 
       expect(result.isError).toBeFalsy();
       expect(guiMutation).toHaveBeenCalledTimes(1);
       const content = result.content as Array<{ type: string; text: string }>;
-      expect(content[0]!.text).toBe('Submitted Invoker plan. Workflow id: wf-session-1.');
+      const submitPayload = JSON.parse(content[0]!.text) as { ok: boolean; workflowId: string };
+      expect(submitPayload.ok).toEqual(true);
+      expect(submitPayload.workflowId).toEqual('wf-session-1');
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects submit when session draft changed after review', async () => {
+    let draft = 'name: Session Plan\nonFinish: none\ntasks: []\n';
+    const guiMutation = vi.fn(async () => ({ ok: true, planName: 'Session Plan', workflowId: 'wf-session-1' }));
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', async () => ({
+          session: {
+            draftPlanText: draft,
+            draftPlanSummary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
+            confirmationMode: 'require',
+            status: 'draft_ready',
+          },
+        }));
+        bus.onRequest('headless.gui-mutation', guiMutation);
+      }),
+    });
+    try {
+      const review = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { sessionId: 'sess-stale' },
+      });
+      const reviewToken = JSON.parse((review.content as Array<{ text: string }>)[0]!.text).reviewToken as string;
+      draft = 'name: Changed Plan\nonFinish: none\ntasks: []\n';
+
+      const result = await client.callTool({
+        name: 'invoker_submit_plan',
+        arguments: { sessionId: 'sess-stale', reviewToken },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(guiMutation).not.toHaveBeenCalled();
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toContain('changed after review');
     } finally {
       await close();
     }
   });
 
   it('maps a failed headless.gui-mutation response to an MCP error result', async () => {
-    const bus = new LocalBus();
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.gui-mutation', async () => ({ ok: false, error: 'This planning session was already submitted.' }));
-    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    const planText = 'name: Session Plan\nonFinish: none\ntasks: []\n';
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', async () => ({
+          session: {
+            draftPlanText: planText,
+            draftPlanSummary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
+            confirmationMode: 'require',
+            status: 'draft_ready',
+          },
+        }));
+        bus.onRequest('headless.gui-mutation', async () => ({ ok: false, error: 'This planning session was already submitted.' }));
+      }),
+    });
     try {
+      const review = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { sessionId: 'sess-submit-fail' },
+      });
+      const reviewToken = JSON.parse((review.content as Array<{ text: string }>)[0]!.text).reviewToken as string;
       const result = await client.callTool({
         name: 'invoker_submit_plan',
-        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-submit-fail' },
+        arguments: { sessionId: 'sess-submit-fail', reviewToken },
       });
 
       expect(result.isError).toBe(true);
@@ -215,10 +344,8 @@ describe('mcp-server session-scoped tools', () => {
     }
   });
 
-  it('honors INVOKER_PLANNING_SESSION_ID as a fallback when no explicit sessionId argument is given', async () => {
+  it('honors INVOKER_PLANNING_SESSION_ID as a fallback when no planPath or sessionId is given', async () => {
     process.env.INVOKER_PLANNING_SESSION_ID = 'sess-from-env';
-    const bus = new LocalBus();
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     const query = vi.fn(async (req: unknown) => {
       expect(req).toEqual({ kind: 'planning-chat-session', sessionId: 'sess-from-env' });
       return {
@@ -230,12 +357,16 @@ describe('mcp-server session-scoped tools', () => {
         },
       };
     });
-    bus.onRequest('headless.query', query);
-    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', query);
+      }),
+    });
     try {
       const result = await client.callTool({
         name: 'invoker_prepare_plan_review',
-        arguments: { planPath: '/nonexistent/plan.yaml' },
+        arguments: {},
       });
 
       expect(result.isError).toBeFalsy();
@@ -244,6 +375,84 @@ describe('mcp-server session-scoped tools', () => {
       const parsed = JSON.parse(content[0]!.text);
       expect(parsed.confirmationMode).toBe('auto_submit');
       expect(parsed.confirmationText).toBe('Auto-submit is enabled. Submit this exact YAML now.');
+      expect(parsed.reviewToken).toMatch(/^rev_/);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns workflow and task snapshots from live owner queries', async () => {
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', async (req: unknown) => {
+          const request = req as { kind: string; args: string[] };
+          expect(request.kind).toBe('cli-query');
+          if (request.args.includes('workflows')) {
+            return { output: JSON.stringify([{ id: 'wf-1', name: 'Demo', status: 'running' }]) };
+          }
+          return {
+            output: JSON.stringify([
+              { id: 'wf-1/task-a', status: 'completed', description: 'A' },
+              { id: 'wf-1/task-b', status: 'running', description: 'B' },
+            ]),
+          };
+        });
+      }),
+    });
+    try {
+      const workflow = await client.callTool({
+        name: 'invoker_get_workflow',
+        arguments: { workflowId: 'wf-1' },
+      });
+      const tasks = await client.callTool({
+        name: 'invoker_list_tasks',
+        arguments: { workflowId: 'wf-1' },
+      });
+      expect(workflow.isError).toBeFalsy();
+      expect(tasks.isError).toBeFalsy();
+      expect(JSON.parse((workflow.content as Array<{ text: string }>)[0]!.text)).toMatchObject({
+        ok: true,
+        workflow: { id: 'wf-1', name: 'Demo' },
+      });
+      expect(JSON.parse((tasks.content as Array<{ text: string }>)[0]!.text)).toMatchObject({
+        ok: true,
+        workflowId: 'wf-1',
+        tasks: [
+          { id: 'wf-1/task-a', status: 'completed' },
+          { id: 'wf-1/task-b', status: 'running' },
+        ],
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it('bounded wait times out while tasks remain unsettled', async () => {
+    const sleep = vi.fn(async () => undefined);
+    const { client, close } = await connectMcpClient({
+      createMessageBus: liveOwnerBusFactory((bus) => {
+        bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+        bus.onRequest('headless.query', async () => ({
+          output: JSON.stringify([{ id: 'wf-1/task-a', status: 'running', description: 'A' }]),
+        }));
+      }),
+      sleep,
+      reviewTokens: createReviewTokenStore(),
+    });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_wait_for_workflow',
+        arguments: { workflowId: 'wf-1', maxWaitMs: 5, pollIntervalMs: 1 },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as Array<{ text: string }>)[0]!.text);
+      expect(parsed).toMatchObject({
+        ok: true,
+        settled: false,
+        timedOut: true,
+        status: { running: 1 },
+      });
     } finally {
       await close();
     }

--- a/packages/cli/src/mcp-review-binding.ts
+++ b/packages/cli/src/mcp-review-binding.ts
@@ -1,0 +1,71 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+export interface ReviewBinding {
+  token: string;
+  contentHash: string;
+  source: { kind: 'planPath'; planPath: string } | { kind: 'sessionId'; sessionId: string };
+  createdAtMs: number;
+}
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+export function hashPlanContent(planText: string): string {
+  return createHash('sha256').update(planText).digest('hex');
+}
+
+export function createReviewTokenStore(ttlMs = DEFAULT_TTL_MS) {
+  const bindings = new Map<string, ReviewBinding>();
+
+  function prune(now = Date.now()): void {
+    for (const [token, binding] of bindings) {
+      if (now - binding.createdAtMs > ttlMs) {
+        bindings.delete(token);
+      }
+    }
+  }
+
+  return {
+    issue(input: {
+      planText: string;
+      source: ReviewBinding['source'];
+    }): ReviewBinding {
+      prune();
+      const binding: ReviewBinding = {
+        token: `rev_${randomUUID().replace(/-/g, '')}`,
+        contentHash: hashPlanContent(input.planText),
+        source: input.source,
+        createdAtMs: Date.now(),
+      };
+      bindings.set(binding.token, binding);
+      return binding;
+    },
+
+    get(token: string): ReviewBinding | undefined {
+      prune();
+      return bindings.get(token);
+    },
+
+    consume(token: string): ReviewBinding | undefined {
+      prune();
+      const binding = bindings.get(token);
+      if (!binding) return undefined;
+      bindings.delete(token);
+      return binding;
+    },
+
+    clear(): void {
+      bindings.clear();
+    },
+  };
+}
+
+export type ReviewTokenStore = ReturnType<typeof createReviewTokenStore>;
+
+export function assertPlanUnchanged(expectedHash: string, planText: string): void {
+  const actual = hashPlanContent(planText);
+  if (actual !== expectedHash) {
+    throw new Error(
+      'Plan content changed after review. Call invoker_prepare_plan_review again and get a fresh approval.',
+    );
+  }
+}

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -13,6 +13,17 @@ import type { PlanSummary } from '../../planning-core/src/plan-summary.js';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { z } from 'zod';
 import { createDefaultMessageBus, discoverLiveOwner } from './live-owner-bus.js';
+import {
+  assertPlanUnchanged,
+  createReviewTokenStore,
+  type ReviewTokenStore,
+} from './mcp-review-binding.js';
+import {
+  normalizeTaskSnapshots,
+  normalizeWorkflowSnapshot,
+  waitForWorkflowTasks,
+  type WorkflowTaskSnapshot,
+} from './mcp-workflow-status.js';
 
 export type McpSubmitMode = 'live' | 'auto' | 'standalone';
 
@@ -24,6 +35,9 @@ export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR s
 
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 const NO_LIVE_OWNER_ERROR = 'No live Invoker app is running to answer this planning session.';
+const EXCLUSIVE_SOURCE_ERROR = 'Provide exactly one of planPath or sessionId.';
+const MISSING_REVIEW_TOKEN_ERROR = 'reviewToken is required. Call invoker_prepare_plan_review first and pass the returned reviewToken.';
+const UNKNOWN_REVIEW_TOKEN_ERROR = 'Unknown or expired reviewToken. Call invoker_prepare_plan_review again.';
 
 interface PlanningChatSessionSnapshot {
   draftPlanText?: string;
@@ -33,15 +47,43 @@ interface PlanningChatSessionSnapshot {
 }
 
 type McpToolErrorResult = { content: [{ type: 'text'; text: string }]; isError: true };
+type McpToolTextResult = { content: [{ type: 'text'; text: string }]; isError?: false };
 
 function mcpError(text: string): McpToolErrorResult {
   return { content: [{ type: 'text', text }], isError: true };
+}
+
+function mcpJson(value: unknown): McpToolTextResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
 }
 
 function resolveEffectiveSessionId(sessionId: string | undefined): string | undefined {
   if (sessionId) return sessionId;
   const envSessionId = process.env.INVOKER_PLANNING_SESSION_ID;
   return envSessionId && envSessionId.length > 0 ? envSessionId : undefined;
+}
+
+function resolveExclusiveSource(input: {
+  planPath?: string;
+  sessionId?: string;
+}): { kind: 'planPath'; planPath: string } | { kind: 'sessionId'; sessionId: string } | McpToolErrorResult {
+  const explicitSessionId = input.sessionId && input.sessionId.length > 0 ? input.sessionId : undefined;
+  const planPath = input.planPath && input.planPath.length > 0 ? input.planPath : undefined;
+  if (explicitSessionId && planPath) {
+    return mcpError(EXCLUSIVE_SOURCE_ERROR);
+  }
+  if (explicitSessionId) {
+    return { kind: 'sessionId', sessionId: explicitSessionId };
+  }
+  if (planPath) {
+    // Env session only applies when the caller did not pass planPath.
+    return { kind: 'planPath', planPath };
+  }
+  const envSessionId = resolveEffectiveSessionId(undefined);
+  if (envSessionId) {
+    return { kind: 'sessionId', sessionId: envSessionId };
+  }
+  return mcpError(EXCLUSIVE_SOURCE_ERROR);
 }
 
 export async function preparePlanReviewForSession(
@@ -74,6 +116,15 @@ export async function preparePlanReviewForSession(
   } finally {
     bus.disconnect();
   }
+}
+
+export async function loadSessionPlanText(
+  sessionId: string,
+  createBus: () => Promise<MessageBus> = createDefaultMessageBus,
+): Promise<{ ok: true; planText: string } | McpToolErrorResult> {
+  const draft = await preparePlanReviewForSession(sessionId, createBus);
+  if ('isError' in draft) return draft;
+  return { ok: true, planText: draft.planText };
 }
 
 export async function submitPlanForSession(
@@ -227,12 +278,47 @@ function formatSubmitFailure(result: SubmitFailure): string {
     .join('\n');
 }
 
+async function queryLiveOwnerJson(
+  createBus: () => Promise<MessageBus>,
+  args: string[],
+): Promise<unknown> {
+  const bus = await createBus();
+  try {
+    const owner = await discoverLiveOwner(bus);
+    if (!owner) {
+      throw new Error(NO_LIVE_OWNER_ERROR);
+    }
+    const raw = await bus.request<{ kind: string; args: string[] }, { output?: unknown }>(
+      'headless.query',
+      { kind: 'cli-query', args },
+    );
+    if (!raw || typeof raw !== 'object' || typeof raw.output !== 'string') {
+      throw new Error('Live owner returned invalid headless.query response: missing output string');
+    }
+    return JSON.parse(raw.output);
+  } finally {
+    bus.disconnect();
+  }
+}
+
+async function loadWorkflowTasks(
+  workflowId: string,
+  createBus: () => Promise<MessageBus>,
+  status?: string,
+): Promise<WorkflowTaskSnapshot[]> {
+  const args = ['query', 'tasks', '--workflow', workflowId, '--output', 'json'];
+  if (status) {
+    args.push('--status', status);
+  }
+  return normalizeTaskSnapshots(await queryLiveOwnerJson(createBus, args));
+}
+
 export function handoffPrompt(request: string): string {
   const handoffInstructions = buildPlanningHandoffInstructions({
     planFilePath: 'plans/invoker-handoff.yaml',
-    reviewInstruction: 'Call `invoker_prepare_plan_review` on that exact YAML file, then show the returned ordered steps and confirmation text to the user.',
+    reviewInstruction: 'Call `invoker_prepare_plan_review` with exactly one of `planPath` or `sessionId`, then show the returned ordered steps and confirmation text to the user. Keep the returned `reviewToken`.',
     shortReplyInstruction: 'Then keep the chat reply focused on the review summary and approval state. Never paste the YAML into chat.',
-    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Use mode `live` so the workflow appears in the running Invoker app.',
+    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Always pass the same source (`planPath` or `sessionId`) plus the `reviewToken`. Use mode `live` so the workflow appears in the running Invoker app. After submit, use `invoker_get_workflow`, `invoker_list_tasks`, or bounded `invoker_wait_for_workflow` to report status.',
   });
   return [
     `User request: ${request}`,
@@ -251,12 +337,16 @@ export interface McpServerOptions {
   runner?: McpCliRunner;
   cliPath?: string;
   createMessageBus?: () => Promise<MessageBus>;
+  reviewTokens?: ReviewTokenStore;
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export function createMcpServer(options: McpServerOptions = {}): McpServer {
   const runner = options.runner ?? createProcessRunner(options.cliPath);
   const createBus = options.createMessageBus ?? createDefaultMessageBus;
-  const server = new McpServer({ name: 'invoker', version: '0.0.5' });
+  const reviewTokens = options.reviewTokens ?? createReviewTokenStore();
+  const sleep = options.sleep;
+  const server = new McpServer({ name: 'invoker', version: '0.0.6' });
 
   server.registerTool(
     'invoker_validate_plan',
@@ -285,89 +375,192 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
   server.registerTool(
     'invoker_prepare_plan_review',
     {
-      description: 'Prepare the canonical ordered-step review for an existing Invoker YAML plan.',
+      description: 'Prepare the canonical ordered-step review for an existing Invoker YAML plan or planning session. Provide exactly one of planPath or sessionId.',
       inputSchema: {
-        planPath: z.string(),
+        planPath: z.string().optional(),
         confirmationMode: z.enum(['require', 'auto_submit']).optional(),
         sessionId: z.string().optional(),
       },
     },
     async ({ planPath, confirmationMode, sessionId }) => {
-      const effectiveSessionId = resolveEffectiveSessionId(sessionId);
-      if (effectiveSessionId) {
-        const sessionResult = await preparePlanReviewForSession(effectiveSessionId, createBus);
+      const source = resolveExclusiveSource({ planPath, sessionId });
+      if ('isError' in source) return source;
+
+      if (source.kind === 'sessionId') {
+        const sessionResult = await preparePlanReviewForSession(source.sessionId, createBus);
         if ('isError' in sessionResult) {
           return sessionResult;
         }
+        const binding = reviewTokens.issue({
+          planText: sessionResult.planText,
+          source,
+        });
+        return mcpJson({
+          ...sessionResult,
+          reviewToken: binding.token,
+        });
+      }
+
+      let rawPlanText: string;
+      try {
+        rawPlanText = await readFile(resolve(source.planPath), 'utf8');
+      } catch (err) {
         return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(sessionResult, null, 2),
-            },
-          ],
+          content: [{ type: 'text', text: `Could not prepare Invoker plan review: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
         };
       }
-      const result = await preparePlanReviewForMcp(planPath, confirmationMode ?? 'require');
+      const result = await preparePlanReviewForMcp(source.planPath, confirmationMode ?? 'require');
       if ('ok' in result && result.ok === false) {
         return {
           content: [{ type: 'text', text: `Could not prepare Invoker plan review: ${result.error}` }],
           isError: true,
         };
       }
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const draft = result as PlanningReviewDraft;
+      const binding = reviewTokens.issue({
+        // Bind to on-disk bytes so submit's re-read matches.
+        planText: rawPlanText,
+        source: { kind: 'planPath', planPath: resolve(source.planPath) },
+      });
+      return mcpJson({
+        ...draft,
+        reviewToken: binding.token,
+      });
     },
   );
 
   server.registerTool(
     'invoker_submit_plan',
     {
-      description: 'Submit an existing Invoker YAML plan through invoker-cli run.',
+      description: 'Submit a previously reviewed Invoker plan. Provide the same planPath or sessionId used for review, plus the reviewToken.',
       inputSchema: {
-        planPath: z.string(),
+        planPath: z.string().optional(),
         mode: z.enum(['live', 'auto', 'standalone']).optional(),
         sessionId: z.string().optional(),
+        reviewToken: z.string(),
       },
     },
-    async ({ planPath, mode, sessionId }) => {
-      const effectiveSessionId = resolveEffectiveSessionId(sessionId);
-      if (effectiveSessionId) {
-        const sessionResult = await submitPlanForSession(effectiveSessionId, createBus);
+    async ({ planPath, mode, sessionId, reviewToken }) => {
+      if (!reviewToken) {
+        return mcpError(MISSING_REVIEW_TOKEN_ERROR);
+      }
+      const source = resolveExclusiveSource({ planPath, sessionId });
+      if ('isError' in source) return source;
+
+      const binding = reviewTokens.get(reviewToken);
+      if (!binding) {
+        return mcpError(UNKNOWN_REVIEW_TOKEN_ERROR);
+      }
+      if (binding.source.kind !== source.kind
+        || (source.kind === 'planPath' && binding.source.kind === 'planPath' && resolve(binding.source.planPath) !== resolve(source.planPath))
+        || (source.kind === 'sessionId' && binding.source.kind === 'sessionId' && binding.source.sessionId !== source.sessionId)) {
+        return mcpError('reviewToken does not match the provided planPath/sessionId. Re-run invoker_prepare_plan_review.');
+      }
+
+      if (source.kind === 'sessionId') {
+        const current = await loadSessionPlanText(source.sessionId, createBus);
+        if ('isError' in current) return current;
+        try {
+          assertPlanUnchanged(binding.contentHash, current.planText);
+        } catch (err) {
+          return mcpError(err instanceof Error ? err.message : String(err));
+        }
+        reviewTokens.consume(reviewToken);
+        const sessionResult = await submitPlanForSession(source.sessionId, createBus);
         if ('isError' in sessionResult) {
           return sessionResult;
         }
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Submitted Invoker plan. Workflow id: ${sessionResult.workflowId}.`,
-            },
-          ],
-        };
+        return mcpJson({
+          ok: true,
+          workflowId: sessionResult.workflowId,
+          message: `Submitted Invoker plan. Workflow id: ${sessionResult.workflowId}.`,
+        });
       }
-      const result = await submitPlanForMcp(planPath, mode ?? 'live', runner);
+
+      let planText: string;
+      try {
+        planText = await readFile(resolve(source.planPath), 'utf8');
+        assertPlanUnchanged(binding.contentHash, planText);
+      } catch (err) {
+        return mcpError(err instanceof Error ? err.message : String(err));
+      }
+      reviewTokens.consume(reviewToken);
+      const result = await submitPlanForMcp(source.planPath, mode ?? 'live', runner);
       if (!result.ok) {
         return {
           content: [{ type: 'text', text: formatSubmitFailure(result) }],
           isError: true,
         };
       }
-      const workflowText = ` Workflow id: ${result.workflowId}.`;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Submitted Invoker plan.${workflowText}\nstdout:\n${result.stdout}`,
-          },
-        ],
-      };
+      return mcpJson({
+        ok: true,
+        workflowId: result.workflowId,
+        message: `Submitted Invoker plan. Workflow id: ${result.workflowId}.`,
+        stdout: result.stdout,
+      });
+    },
+  );
+
+  server.registerTool(
+    'invoker_get_workflow',
+    {
+      description: 'Read one workflow snapshot from the live Invoker owner.',
+      inputSchema: { workflowId: z.string() },
+    },
+    async ({ workflowId }) => {
+      try {
+        const raw = await queryLiveOwnerJson(createBus, ['query', 'workflows', '--output', 'json']);
+        const workflow = normalizeWorkflowSnapshot(raw, workflowId);
+        return mcpJson({ ok: true, workflow });
+      } catch (err) {
+        return mcpError(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.registerTool(
+    'invoker_list_tasks',
+    {
+      description: 'List tasks for a workflow from the live Invoker owner.',
+      inputSchema: {
+        workflowId: z.string(),
+        status: z.string().optional(),
+      },
+    },
+    async ({ workflowId, status }) => {
+      try {
+        const tasks = await loadWorkflowTasks(workflowId, createBus, status);
+        return mcpJson({ ok: true, workflowId, tasks });
+      } catch (err) {
+        return mcpError(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.registerTool(
+    'invoker_wait_for_workflow',
+    {
+      description: 'Poll a workflow until tasks settle or maxWaitMs elapses. Default maxWaitMs is 30000.',
+      inputSchema: {
+        workflowId: z.string(),
+        maxWaitMs: z.number().int().positive().optional(),
+        pollIntervalMs: z.number().int().positive().optional(),
+      },
+    },
+    async ({ workflowId, maxWaitMs, pollIntervalMs }) => {
+      try {
+        const result = await waitForWorkflowTasks({
+          workflowId,
+          maxWaitMs,
+          pollIntervalMs,
+          sleep,
+          loadTasks: () => loadWorkflowTasks(workflowId, createBus),
+        });
+        return mcpJson({ ok: true, ...result });
+      } catch (err) {
+        return mcpError(err instanceof Error ? err.message : String(err));
+      }
     },
   );
 

--- a/packages/cli/src/mcp-workflow-status.ts
+++ b/packages/cli/src/mcp-workflow-status.ts
@@ -1,0 +1,144 @@
+export type WorkflowTaskSnapshot = {
+  id: string;
+  status: string;
+  description?: string;
+  reviewUrl?: string;
+};
+
+export type WorkflowStatusSummary = {
+  total: number;
+  completed: number;
+  failed: number;
+  closed: number;
+  running: number;
+  pending: number;
+  awaitingApproval: number;
+  blocked: number;
+};
+
+export type WorkflowWaitResult = {
+  workflowId: string;
+  settled: boolean;
+  timedOut: boolean;
+  status: WorkflowStatusSummary;
+  reviewUrl?: string;
+  tasks: WorkflowTaskSnapshot[];
+};
+
+const ACTIVE = new Set(['running', 'fixing_with_ai', 'queued']);
+
+export function summarizeTaskStatuses(tasks: WorkflowTaskSnapshot[]): WorkflowStatusSummary {
+  return {
+    total: tasks.length,
+    completed: tasks.filter((task) => task.status === 'completed').length,
+    failed: tasks.filter((task) => task.status === 'failed').length,
+    closed: tasks.filter((task) => task.status === 'closed').length,
+    running: tasks.filter((task) => task.status === 'running' || task.status === 'fixing_with_ai').length,
+    pending: tasks.filter((task) => task.status === 'pending').length,
+    awaitingApproval: tasks.filter((task) => task.status === 'awaiting_approval' || task.status === 'review_ready').length,
+    blocked: tasks.filter((task) => task.status === 'blocked' || task.status === 'needs_input' || task.status === 'stale').length,
+  };
+}
+
+export function workflowTasksSettled(tasks: WorkflowTaskSnapshot[]): boolean {
+  if (tasks.length === 0) return false;
+  const settled = new Set([
+    'completed',
+    'failed',
+    'closed',
+    'needs_input',
+    'awaiting_approval',
+    'review_ready',
+    'blocked',
+    'stale',
+  ]);
+  if (tasks.every((task) => settled.has(task.status))) {
+    return true;
+  }
+  const noneActive = !tasks.some((task) => ACTIVE.has(task.status));
+  const hasHumanGate = tasks.some((task) => settled.has(task.status) && task.status !== 'completed');
+  return noneActive && hasHumanGate;
+}
+
+export function pickReviewUrl(tasks: WorkflowTaskSnapshot[]): string | undefined {
+  return tasks.find((task) => typeof task.reviewUrl === 'string' && task.reviewUrl.length > 0)?.reviewUrl;
+}
+
+export function normalizeTaskSnapshots(raw: unknown): WorkflowTaskSnapshot[] {
+  if (!Array.isArray(raw)) {
+    throw new Error('Expected a JSON array of tasks');
+  }
+  return raw.map((item) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error('Expected each task to be an object');
+    }
+    const row = item as Record<string, unknown>;
+    const id = typeof row.id === 'string' ? row.id : '';
+    const status = typeof row.status === 'string' ? row.status : '';
+    if (!id || !status) {
+      throw new Error('Each task must include id and status');
+    }
+    const description = typeof row.description === 'string' ? row.description : undefined;
+    const execution = row.execution && typeof row.execution === 'object'
+      ? row.execution as Record<string, unknown>
+      : undefined;
+    const reviewUrl = typeof execution?.reviewUrl === 'string' ? execution.reviewUrl : undefined;
+    return { id, status, description, reviewUrl };
+  });
+}
+
+export function normalizeWorkflowSnapshot(raw: unknown, workflowId: string): Record<string, unknown> {
+  if (Array.isArray(raw)) {
+    const match = raw.find((item) => item && typeof item === 'object' && (item as { id?: unknown }).id === workflowId);
+    if (!match || typeof match !== 'object') {
+      throw new Error(`Workflow "${workflowId}" was not found`);
+    }
+    return match as Record<string, unknown>;
+  }
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Workflow "${workflowId}" was not found`);
+  }
+  const row = raw as Record<string, unknown>;
+  if (row.id !== workflowId) {
+    throw new Error(`Workflow "${workflowId}" was not found`);
+  }
+  return row;
+}
+
+export async function waitForWorkflowTasks(options: {
+  workflowId: string;
+  loadTasks: () => Promise<WorkflowTaskSnapshot[]>;
+  maxWaitMs?: number;
+  pollIntervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<WorkflowWaitResult> {
+  const maxWaitMs = options.maxWaitMs ?? 30_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 1_000;
+  const sleep = options.sleep ?? ((ms: number) => new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  }));
+  const startedAt = Date.now();
+  let tasks = await options.loadTasks();
+  let settled = workflowTasksSettled(tasks);
+  let timedOut = false;
+
+  while (!settled) {
+    if (Date.now() - startedAt >= maxWaitMs) {
+      timedOut = true;
+      break;
+    }
+    await sleep(pollIntervalMs);
+    tasks = await options.loadTasks();
+    settled = workflowTasksSettled(tasks);
+  }
+
+  return {
+    workflowId: options.workflowId,
+    settled,
+    timedOut,
+    status: summarizeTaskStatuses(tasks),
+    reviewUrl: pickReviewUrl(tasks),
+    tasks,
+  };
+}

--- a/packages/planning-core/src/planning-review.ts
+++ b/packages/planning-core/src/planning-review.ts
@@ -8,6 +8,8 @@ export interface PlanningReviewDraft {
   summary: PlanSummary;
   confirmationMode: PlanningConfirmationMode;
   confirmationText: string;
+  /** Opaque token binding this review to exact plan content. Required by invoker_submit_plan. */
+  reviewToken?: string;
 }
 
 export interface PreparePlanningReviewInput {


### PR DESCRIPTION
## Summary

Chat agents can prepare an Invoker plan and only continue after a matching review token.

New MCP tools also expose workflow status and a bounded wait for settled tasks.

## Review Claim

Approve review-token gated MCP handoff plus workflow status and wait tools.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Handoff still requires a matching reviewToken from prepare; without it the CLI run path is not invoked.

## Slice Rationale

Ship the MCP activation surface before agent skills and onboarding prose that teach it.

## Non-goals

Does not add chat-submit skill text, onboarding prose, or live owner-serve proofs.

## Architecture

### Before

```mermaid
graph TD
    A["MCP handoff"] --> B["CLI run"]
```

### After

```mermaid
graph TD
    A["prepare review"] --> B["reviewToken"]
    B --> C["token-gated handoff"]
    C --> D["status and wait tools"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/cli exec vitest run src/__tests__/mcp-review-and-status.test.ts src/__tests__/mcp-server-session.test.ts`
- [ ] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts -t "handoff"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
