### PR TITLE
CI regression: cd07355-required-fast-mergify-admin-requeue

### DIFF
--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -104,6 +104,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-pr-body-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-human-split.sh
@@ -212,6 +212,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -204,6 +204,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -205,6 +205,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -173,6 +173,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-queue-only-check.sh
+++ b/scripts/repro/repro-babysit-queue-only-check.sh
@@ -151,6 +151,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-queue-only-empty-log.sh
+++ b/scripts/repro/repro-babysit-queue-only-empty-log.sh
@@ -127,6 +127,9 @@ run_worker() {
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
+++ b/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
@@ -50,6 +50,9 @@ WORK_ROOT="$WORK_PARENT/7727"
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null

--- a/scripts/repro/repro-normalize-blocked-dirty-pycache.sh
+++ b/scripts/repro/repro-normalize-blocked-dirty-pycache.sh
@@ -18,9 +18,22 @@ git -C "$WORK" -c user.name=repro -c user.email=repro@example.invalid commit -q 
 START_HEAD="$(git -C "$WORK" rev-parse HEAD)"
 STATE_FILE="$TMP/ledger.jsonl"
 
+# The clean-noop path calls _record_repair_noop_or_invalid_for_pr_body, which
+# looks up the PR over `gh`. Use the same fake-gh fixture its sibling repros
+# use (e.g. repro-babysit-pr-body-valid-noop.sh) instead of the real `gh`
+# CLI, so this repro stays hermetic and doesn't depend on network access, an
+# installed `gh` binary, or a real PR #7560 existing in Neko-Catpital-Labs/Invoker.
+FAKE_GH_STATE_DIR="$TMP/state"
+mkdir -p "$FAKE_GH_STATE_DIR"
+cat > "$FAKE_GH_STATE_DIR/state.json" <<'EOF'
+{"prs": [{"number": 7560, "state": "MERGED"}]}
+EOF
+
 run_normalize() {
   (
     cd "$WORK"
+    PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH" \
+    FAKE_GH_STATE_DIR="$FAKE_GH_STATE_DIR" \
     env -u PYTHONDONTWRITEBYTECODE -u PYTHONPYCACHEPREFIX python3 \
       scripts/mergify_admin_requeue_repair_normalize.py \
       --repo Neko-Catpital-Labs/Invoker \


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch push commit `cd07355fe0` (run 31917892808), and stayed red through `927825d16f` (run 32555740907).

Several disposable-repo repro scripts under `scripts/repro/`, picked up by name pattern and run by `scripts/test-suites/required/12-mergify-admin-requeue.sh`, left git's background auto-gc enabled in their seed clone.

Auto-gc could race the script's `EXIT` trap (`rm -rf` on the temp workdir), corrupting or failing teardown non-deterministically.

A separate repro, `repro-normalize-blocked-dirty-pycache.sh`, shells out to the real `gh` binary to look up a PR.

That made the repro depend on network access and a real PR existing, instead of running hermetically.

This slice disables `git config gc.auto 0` in the seed clone of every affected repro, and points the pycache repro at the existing fake-gh fixture its siblings already use.

## Review Claim

Approve hardening the hermeticity of the `required-fast / Mergify Admin Requeue` repro suite: disable git auto-gc racing the `EXIT` trap's teardown in 8 `repro-babysit-*.sh` scripts, and swap a real `gh` network call for the existing fake-gh fixture in `repro-normalize-blocked-dirty-pycache.sh`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Every changed line lives inside a disposable, hermetic repro script under `scripts/repro/` that only touches its own temp-directory git clone. No production code path, worker behavior, or non-repro test changes.

## Slice Rationale

One proof slice: the root cause (non-hermetic repro teardown/dependencies) and its fix across every repro instance this CI job's suite picks up and runs, so the fix is provably complete for this job rather than patching one instance and leaving siblings flaky.

## Non-goals

No refactor, no unrelated cleanup, no product code changes, no new repro scripts, no snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 29fc79b9f`
- Post-revert steps: None
- Data migration? No

</details>
