### PR TITLE
[admin-bypass-repair-bot-thread-pr-9963-7f5d78e](1) Fix stale confirmationMode dependency in handlePlanningModeChange

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3355,6 +3355,7 @@ export function App() {
     activePlanningSession,
     commitPlanningRepo,
     invoker,
+    selectedPlanningConfirmationMode,
     selectedPlanningPresetKey,
     updatePlanningSessionById,
   ]);


### PR DESCRIPTION
## Summary

Add `selectedPlanningConfirmationMode` to `handlePlanningModeChange`'s dependency array so the callback always closes over the current value.

## Review Claim

`handlePlanningModeChange` reads `selectedPlanningConfirmationMode` when creating a planning chat session, so it must re-create whenever that value changes.

## Review Lane

- behavior

## Review Unit

- activation-surface

## Safety Invariant

Only the `useCallback` dependency array changes; `handlePlanningModeChange`'s body and every other callback in `App.tsx`, including the unrelated `dag-surface-background-click-noop` guard on `handleDagSurfaceClick`, are untouched.

## Slice Rationale

One behavior slice: the missing dependency fix only, flagged by CodeRabbit.

## Non-goals

- No other `useCallback`/`useEffect` dependency arrays are changed in this slice.
- `dag-surface-background-click-noop` is not touched by this diff.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 30748ad85f760034d313ae5a0fab21b87e1b3e5d`
- Post-revert steps: None
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Planning terminal mode changes now consistently use the current confirmation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->