### PR TITLE
[admin-bypass-repair-bot-thread-pr-9963-7f5d78e](2) pr_worker_safe_push: settle quietly when branch is gone because PR merged/closed

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3355,6 +3355,7 @@ export function App() {
     activePlanningSession,
     commitPlanningRepo,
     invoker,
+    selectedPlanningConfirmationMode,
     selectedPlanningPresetKey,
     updatePlanningSessionById,
   ]);

--- a/scripts/pr_worker_safe_push.py
+++ b/scripts/pr_worker_safe_push.py
@@ -20,6 +20,10 @@ class SafePushError(RuntimeError):
         self.exit_code = exit_code
 
 
+class BranchMissingError(SafePushError):
+    """The expected branch has no remote ref at all (as opposed to one that moved)."""
+
+
 def run_git(args: Sequence[str], *, cwd: Path | str | None = None) -> str:
     completed = subprocess.run(
         ["git", *args],
@@ -75,6 +79,33 @@ def local_head(*, cwd: Path | str | None = None) -> str:
     return head
 
 
+def repo_slug(remote: str, *, cwd: Path | str | None = None) -> str | None:
+    completed = subprocess.run(
+        ["git", "remote", "get-url", remote],
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        return None
+    match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/]+?)(?:\.git)?/?$", completed.stdout.strip())
+    return match.group("slug") if match else None
+
+
+def pr_state(pr_number: int, *, repo: str, cwd: Path | str | None = None) -> str | None:
+    completed = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "state", "-q", ".state"],
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
 def safe_push(
     *,
     branch: str,
@@ -96,9 +127,14 @@ def safe_push(
             )
         lease = f"refs/heads/{branch_name}:"
     else:
+        if live is None:
+            raise BranchMissingError(
+                f"stale-head: refs/heads/{branch_name} is missing; expected {expected}",
+                exit_code=20,
+            )
         if live != expected:
             raise SafePushError(
-                f"stale-head: refs/heads/{branch_name} is {live or 'missing'}; expected {expected}",
+                f"stale-head: refs/heads/{branch_name} is {live}; expected {expected}",
                 exit_code=20,
             )
         lease = f"refs/heads/{branch_name}:{expected}"
@@ -181,6 +217,59 @@ def require_all(label: str, values: Mapping[str, object | None]) -> None:
         raise SafePushError(f"{label} requires {', '.join(missing)}", exit_code=2)
 
 
+def _record_ledgers(args: argparse.Namespace) -> None:
+    if args.record_tsv_ledger:
+        require_all("TSV ledger recording", {
+            "--tsv-kind": args.tsv_kind,
+            "--tsv-key": args.tsv_key,
+            "--tsv-marker": args.tsv_marker,
+        })
+        append_tsv_ledger(
+            Path(args.record_tsv_ledger).expanduser(),
+            kind=args.tsv_kind,
+            key=args.tsv_key,
+            marker=args.tsv_marker,
+        )
+    if args.record_json_ledger:
+        require_all("JSONL ledger recording", {
+            "--json-kind": args.json_kind,
+            "--json-pr": args.json_pr,
+            "--json-head-sha": args.json_head_sha,
+            "--json-key": args.json_key,
+        })
+        meta = None
+        if args.json_meta:
+            decoded = json.loads(args.json_meta)
+            if not isinstance(decoded, dict):
+                raise SafePushError("--json-meta must decode to a JSON object", exit_code=2)
+            meta = decoded
+        append_json_ledger(
+            Path(args.record_json_ledger).expanduser(),
+            kind=args.json_kind,
+            pr_number=args.json_pr,
+            head_sha=args.json_head_sha,
+            key=args.json_key,
+            meta=meta,
+        )
+
+
+# A branch can go missing between the caller capturing --expected-head and this
+# script running because the PR it belongs to merged (GitHub deletes the head
+# branch on merge) or was closed out-of-band -- not just because of a genuine
+# race with another writer. In that case there is nothing left to push and no
+# unsafe write to guard against, so settle quietly instead of failing the same
+# way a real stale-head race would (mirrors mergify_admin_requeue_repair_normalize.py's
+# handling of a PR merged/closed mid-repair).
+def _settled_via_pr_merge_or_close(args: argparse.Namespace) -> str | None:
+    if args.json_pr is None:
+        return None
+    repo = repo_slug(args.remote, cwd=Path(args.cwd))
+    if repo is None:
+        return None
+    state = pr_state(args.json_pr, repo=repo, cwd=Path(args.cwd))
+    return state if state in ("MERGED", "CLOSED") else None
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
@@ -191,40 +280,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             remote=args.remote,
             cwd=Path(args.cwd),
         )
-        if args.record_tsv_ledger:
-            require_all("TSV ledger recording", {
-                "--tsv-kind": args.tsv_kind,
-                "--tsv-key": args.tsv_key,
-                "--tsv-marker": args.tsv_marker,
-            })
-            append_tsv_ledger(
-                Path(args.record_tsv_ledger).expanduser(),
-                kind=args.tsv_kind,
-                key=args.tsv_key,
-                marker=args.tsv_marker,
-            )
-        if args.record_json_ledger:
-            require_all("JSONL ledger recording", {
-                "--json-kind": args.json_kind,
-                "--json-pr": args.json_pr,
-                "--json-head-sha": args.json_head_sha,
-                "--json-key": args.json_key,
-            })
-            meta = None
-            if args.json_meta:
-                decoded = json.loads(args.json_meta)
-                if not isinstance(decoded, dict):
-                    raise SafePushError("--json-meta must decode to a JSON object", exit_code=2)
-                meta = decoded
-            append_json_ledger(
-                Path(args.record_json_ledger).expanduser(),
-                kind=args.json_kind,
-                pr_number=args.json_pr,
-                head_sha=args.json_head_sha,
-                key=args.json_key,
-                meta=meta,
-            )
+        _record_ledgers(args)
         print(f"pr-worker-safe-push: pushed refs/heads/{normalize_branch(args.branch)} to {pushed}")
+        return 0
+    except BranchMissingError as exc:
+        state = _settled_via_pr_merge_or_close(args)
+        if state is None:
+            print(f"pr-worker-safe-push: {exc}", file=sys.stderr)
+            return exc.exit_code or 1
+        _record_ledgers(args)
+        print(
+            f"pr-worker-safe-push: noop: PR #{args.json_pr} is already {state.lower()}; "
+            f"refs/heads/{normalize_branch(args.branch)} no longer exists, nothing to push",
+            file=sys.stderr,
+        )
         return 0
     except SafePushError as exc:
         print(f"pr-worker-safe-push: {exc}", file=sys.stderr)

--- a/scripts/test_pr_worker_safe_push.py
+++ b/scripts/test_pr_worker_safe_push.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -12,6 +13,7 @@ from scripts import pr_worker_safe_push as safe_push
 
 
 REAL_GIT = shutil.which("git") or "git"
+REAL_GH = shutil.which("gh") or "gh"
 
 
 def git(cwd: Path, *args: str, env: dict[str, str] | None = None) -> str:
@@ -151,6 +153,89 @@ class SafePushTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("git push", result.stderr)
+        self.assertFalse(ledger.exists())
+
+    def _fake_github_remote_and_gh(self, *, pr_number: int, state: str) -> dict[str, str]:
+        # Fakes just enough of `git remote get-url` (so repo_slug() sees a
+        # github.com URL) and `gh pr view` (so pr_state() sees a merged/closed
+        # PR) while every other git subcommand still hits the real local
+        # bare-repo remote used by the rest of the test.
+        wrapper_dir = self.root / "bin"
+        wrapper_dir.mkdir(exist_ok=True)
+        git_wrapper = wrapper_dir / "git"
+        git_wrapper.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ "${{1:-}}" = "remote" ] && [ "${{2:-}}" = "get-url" ]; then
+                  echo 'git@github.com:acme/widgets.git'
+                  exit 0
+                fi
+                exec {REAL_GIT!r} "$@"
+                """
+            ),
+            encoding="utf-8",
+        )
+        git_wrapper.chmod(0o755)
+        gh_wrapper = wrapper_dir / "gh"
+        gh_wrapper.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ "${{1:-}}" = "pr" ] && [ "${{2:-}}" = "view" ] && [ "${{3:-}}" = "{pr_number}" ]; then
+                  echo '{state}'
+                  exit 0
+                fi
+                exec {REAL_GH!r} "$@"
+                """
+            ),
+            encoding="utf-8",
+        )
+        gh_wrapper.chmod(0o755)
+        return {"PATH": f"{wrapper_dir}:{os.environ['PATH']}"}
+
+    def test_missing_branch_settles_as_noop_when_pr_already_merged(self) -> None:
+        env = self._fake_github_remote_and_gh(pr_number=456, state="MERGED")
+        ledger = self.root / "ledger.jsonl"
+
+        result = self.invoke_helper(
+            "--branch", "gone",
+            "--expected-head", self.expected,
+            "--record-json-ledger", str(ledger),
+            "--json-kind", "repair-bot-thread-settled",
+            "--json-pr", "456",
+            "--json-head-sha", self.expected,
+            "--json-key", "thread-1",
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("noop", result.stderr)
+        self.assertIn("merged", result.stderr)
+        self.assertIsNone(safe_push.remote_branch_sha("gone", remote="origin", cwd=self.repo))
+        recorded = json.loads(ledger.read_text(encoding="utf-8").strip())
+        self.assertEqual(recorded["kind"], "repair-bot-thread-settled")
+        self.assertEqual(recorded["pr"], 456)
+
+    def test_missing_branch_stays_stale_when_pr_still_open(self) -> None:
+        env = self._fake_github_remote_and_gh(pr_number=456, state="OPEN")
+        ledger = self.root / "ledger.jsonl"
+
+        result = self.invoke_helper(
+            "--branch", "gone",
+            "--expected-head", self.expected,
+            "--record-json-ledger", str(ledger),
+            "--json-kind", "repair-bot-thread-settled",
+            "--json-pr", "456",
+            "--json-head-sha", self.expected,
+            "--json-key", "thread-1",
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("stale-head", result.stderr)
         self.assertFalse(ledger.exists())
 
     def test_new_prerequisite_branch_succeeds_only_when_remote_branch_is_absent(self) -> None:


### PR DESCRIPTION
## Summary

`pr_worker_safe_push.py` guards a compare-and-swap push with an
`--expected-head` check, and treats any mismatch (including a missing
branch) as a stale-head race.

A branch can also go missing because the PR it belongs to already merged
(the head branch stops existing once GitHub merges it) or was closed
out-of-band.

That is not a race. There is nothing left to push.

This slice detects that settled case via `gh pr view` and exits cleanly as
a recorded noop instead of failing like a genuine stale-head race.

## Review Claim

Approve making `pr_worker_safe_push.py` check the PR's merge/close state
before treating a missing expected branch as a stale-head failure, and
settle as a noop when the PR already merged or closed.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new `BranchMissingError` path only fires when the expected branch is
already absent, a case that previously always failed. The check is
read-only (`git remote get-url`, `gh pr view`) and gated on the PR already
being `MERGED` or `CLOSED`; any other state re-raises the original
stale-head failure unchanged, so existing race detection is preserved.

## Slice Rationale

Depends on the confirmation-mode dependency fix only because both commits
came off the same working branch; the two changes touch unrelated files
(`packages/ui` vs `scripts/`) and are split into separate PRs so each
carries one review claim.

## Non-goals

Does not change the stale-head detection behavior for a branch whose PR is
still open. Does not change ledger recording formats or add new ledger
fields.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd scripts && python3 -m pytest test_pr_worker_safe_push.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b7a3e9fcd`
- Post-revert steps: None
- Data migration? No

</details>
