### PR TITLE
CI regression: 14dbf53-required-fast-vitest-workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Explicit fallback remains available:
 /invoker-plan-to-invoker "help me plan <change>"
 ```
 
-Either path writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, reviews via MCP (`invoker_prepare_plan_review` → one approval → `invoker_submit_plan` with `reviewToken`), then reports status with `invoker_get_workflow` / `invoker_list_tasks` / bounded `invoker_wait_for_workflow`.
+Either path writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and reviews via MCP (`invoker_prepare_plan_review` → one approval → `invoker_submit_plan` with `reviewToken`), then reports status with `invoker_get_workflow` / `invoker_list_tasks` / bounded `invoker_wait_for_workflow`. The explicit fallback command can also submit with `invoker-cli run --live` instead of the Invoker MCP tool.
 ## Docs
 
 - [Getting started](docs/getting-started.md) — prerequisites, install, config, quick start, troubleshooting


### PR DESCRIPTION
## Summary

The Invoker/Claude handoff README described the plan-to-invoker flow as writing the YAML plan and reviewing it, leaving out a step that already happens in between.

The actual flow checks the converted plan before requesting review. The doc text was out of sync with that step.

This change names the missing step and adds a note about a second way to hand the plan off through the explicit fallback path.

## Review Claim

Approve a one-line README correction that names the missing step and adds the second-path note to the plan-to-invoker flow description.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The change only edits prose inside `README.md`. It does not touch any script, skill, config, or test file, so it cannot change build, test, or runtime behavior.

## Slice Rationale

This is the only file touched by this CI regression fix (`required-fast / Vitest Workspace`, first observed failing at `14dbf5369c93351dea948f6182bf170dde366591`). The companion verification task for this regression recorded a passing exit code but made no additional file changes, so there is no second slice to publish — a proof task with an empty diff is folded into this slice rather than shipped as its own no-op PR.

## Non-goals

No script, skill, or test changes. No behavior change to the plan-to-invoker MCP flow itself — only its README description is corrected.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` (62/62 fixture tests passed, plus policy coverage regression checks — covers the plan-to-invoker flow this README section documents)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-14dbf53-vitest-workspace.md` (this PR body passes the schema validator)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
