### PR TITLE
Fix stale confirmationMode dependency in handlePlanningModeChange

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3355,6 +3355,7 @@ export function App() {
     activePlanningSession,
     commitPlanningRepo,
     invoker,
+    selectedPlanningConfirmationMode,
     selectedPlanningPresetKey,
     updatePlanningSessionById,
   ]);


### PR DESCRIPTION
CodeRabbit flagged that the useCallback deps array for
handlePlanningModeChange omitted selectedPlanningConfirmationMode even
though the callback reads it when creating a planning chat session,
risking a stale confirmationMode being sent to planningChatCreate.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>