### PR TITLE
Harden Invoker test reliability (4): Stabilize E2E waits with condition-based polling

### DIFF
--- a/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { stringify as yamlStringify } from 'yaml';
-import { E2E_REPO_URL, injectTaskStates } from './fixtures/electron-app.js';
+import { E2E_REPO_URL, injectTaskStates, waitForTasksResult } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
@@ -96,10 +96,7 @@ async function closeApp(app: ElectronApplication): Promise<void> {
 
 async function loadPlan(page: Page): Promise<void> {
   await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(TERMINAL_RESTART_PLAN));
-  await page.waitForFunction(() => window.invoker.getTasks().then((result) => {
-    const tasks = Array.isArray(result) ? result : result.tasks;
-    return tasks.some((task: { id: string }) => task.id.endsWith('/terminal-task'));
-  }), null, { timeout: 10000 });
+  await waitForTasksResult(page, ({ tasks }) => tasks.some((task) => task.id.endsWith('/terminal-task')));
   await page.getByTestId('sidebar-planning').click();
   await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10000 });
   await page.getByRole('button', { name: 'Refresh' }).click();

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -359,6 +359,31 @@ export async function selectFirstWorkflow(page: Page): Promise<void> {
   await selectWorkflowNode(page);
 }
 
+type TasksBridgeResult = {
+  tasks: Array<{ id: string }>;
+  workflows: Array<{ id: string }>;
+};
+
+/**
+ * Poll `window.invoker.getTasks()` from Node until `predicate` is satisfied.
+ * `page.waitForFunction` cannot express this: an in-page predicate that calls
+ * `.then(...)` on a bridge promise returns that (always-truthy) Promise object
+ * to Playwright's polling loop, which resolves on the first tick instead of
+ * waiting for the awaited result (see PR #9267 / #9416).
+ */
+export async function waitForTasksResult(
+  page: Page,
+  predicate: (result: TasksBridgeResult) => boolean,
+  timeoutMs = 10000,
+): Promise<void> {
+  await expect.poll(async () => {
+    const raw = await page.evaluate(() => window.invoker.getTasks());
+    const tasks = Array.isArray(raw) ? raw : raw.tasks;
+    const workflows = Array.isArray(raw) ? [] : raw.workflows ?? [];
+    return predicate({ tasks, workflows });
+  }, { timeout: timeoutMs }).toBe(true);
+}
+
 /** Load a plan into the running app via the IPC bridge and wait for its mini-DAG to render. */
 export async function loadPlan(page: Page, plan: { tasks: readonly { id: string }[] }): Promise<string> {
   const planYaml = yamlStringify(plan);
@@ -376,14 +401,9 @@ export async function loadPlan(page: Page, plan: { tasks: readonly { id: string 
   if (!workflowId) {
     throw new Error('Loaded plan did not create a workflow');
   }
-  await page.waitForFunction(
-    (expectedTaskCount) => window.invoker.getTasks().then((result) => {
-      const tasks = Array.isArray(result) ? result : result.tasks;
-      const workflows = Array.isArray(result) ? [] : result.workflows ?? [];
-      return tasks.length >= expectedTaskCount && workflows.length > 0;
-    }),
-    plan.tasks.length,
-    { timeout: 10000 },
+  await waitForTasksResult(
+    page,
+    ({ tasks, workflows }) => tasks.length >= plan.tasks.length && workflows.length > 0,
   );
   await page.getByTestId('sidebar-planning').click();
   await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 10000 });


### PR DESCRIPTION
## Summary

Some Playwright specs used local, ad hoc wait logic that raced against the app instead of checking a real condition.

This change switches those specs onto the shared Electron fixture's condition-based polling helper, checking the same observable state as before.

## Review Claim

Shared condition-based polling replaces local race-prone waits in the targeted E2E paths, with each wait checking the same end state as before.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Only test synchronization changes; every migrated wait still asserts the same observable DOM, IPC, animation, or task-state condition it checked before.

## Slice Rationale

Synchronization stabilizes before the Linux screenshot work lands, so the screenshot proof runs against specs that are no longer flaky.

## Non-goals

- No product IPC changes.
- No CI policy edits.
- No blanket removal of intentional timing probes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
