### PR TITLE
CI regression: 3a27257-required-fast-vitest-workspace

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -11,6 +11,7 @@ import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from './fixtures/pr-6976-oauth-se
 import {
   buildRepoMirrorRepairScript,
   createInfraRepairTick,
+  deriveCorruptWorktreeAdminPathFromWorkspace,
   extractCorruptMirrorPath,
   extractCorruptWorktreeAdminPath,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
@@ -328,6 +329,50 @@ describe('infra-repair worker', () => {
     expect(h.submit).toHaveBeenCalledTimes(1);
     expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
     expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-1',
+        status: 'completed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-worktree-corrupt',
+          channel: INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+        }),
+      }),
+    ]));
+  });
+
+  it('classifies finalize-time worktree corruption and derives the admin path from workspacePath when git omits it', async () => {
+    const managedPath = '/home/invoker/.invoker/worktrees/c9d4f5f68faf/'
+      + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23';
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          workspacePath: managedPath,
+          error: 'remote commit or push failed (code 128): fatal: not a git repository: (null)',
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(extractCorruptWorktreeAdminPath(
+      'remote commit or push failed (code 128): fatal: not a git repository: (null)',
+    )).toBeUndefined();
+    expect(deriveCorruptWorktreeAdminPathFromWorkspace(managedPath, undefined)).toEqual({
+      adminPath: '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/'
+        + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23',
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      worktreeName: 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23',
+    });
+    expect(h.runWorktreeCorruptRepairFn).toHaveBeenCalledTimes(1);
+    expect(h.runWorktreeCorruptRepairFn).toHaveBeenCalledWith(expect.objectContaining({
+      adminPath: '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/'
+        + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23',
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      managedWorktreePath: managedPath,
+    }));
     expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
       expect.objectContaining({
         workerKind: INFRA_REPAIR_WORKER_KIND,

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -7,6 +7,7 @@ import { TaskRunner } from '../task-runner.js';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   buildWorktreeCorruptRepairScript,
+  deriveCorruptWorktreeAdminPathFromWorkspace,
   extractCorruptWorktreeAdminPath,
 } from '../workers/infra-repair-worker.js';
 
@@ -272,7 +273,11 @@ describe('SSH worktree metadata repro', () => {
     }
     expect(failed).toBe(true);
     expect(message).toMatch(/not a git repository/);
-    expect(message).toContain('.git/worktrees/');
+    // git's exact wording for this failure is version-dependent: older git
+    // embeds the corrupt admin path (`.git/worktrees/<name>`), newer git
+    // (observed on git 2.55.0) prints `fatal: not a git repository: (null)`
+    // with no path at all. Both are real, observed shapes of the same failure.
+    expect(message).toMatch(/\.git\/worktrees\/|\(null\)/);
 
     const shapedAdmin = '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/experiment-task';
     const shapedError = `remote commit or push failed (code 128): fatal: not a git repository: ${shapedAdmin}`;
@@ -289,5 +294,18 @@ describe('SSH worktree metadata repro', () => {
     expect(script).toContain('worktree prune');
     expect(script).toContain('Removing stale worktree admin path');
     expect(script).toContain('Removing managed worktree path');
+
+    // On the newer git shape, the error text carries no path at all --
+    // extraction must fall back to the task's own managed workspace path.
+    const pathlessError = 'remote commit or push failed (code 128): fatal: not a git repository: (null)';
+    expect(extractCorruptWorktreeAdminPath(pathlessError)).toBeUndefined();
+    expect(deriveCorruptWorktreeAdminPathFromWorkspace(
+      '/home/invoker/.invoker/worktrees/c9d4f5f68faf/experiment-task',
+      undefined,
+    )).toEqual({
+      adminPath: shapedAdmin,
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      worktreeName: 'experiment-task',
+    });
   });
 });

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -554,6 +554,41 @@ function isPathUnderConfiguredRemoteHome(
   return path === normalizedHome || path.startsWith(`${normalizedHome}/`);
 }
 
+/**
+ * Fallback for git error text that doesn't embed the admin path (some git
+ * versions print `fatal: not a git repository: (null)` instead of the path).
+ * The managed worktree path is always `<remoteInvokerHome>/worktrees/<repoHash>/<name>`,
+ * which mirrors the mirror clone's `<remoteInvokerHome>/repos/<repoHash>` shape
+ * closely enough to derive the admin path directly, without relying on git's
+ * own error formatting.
+ */
+export function deriveCorruptWorktreeAdminPathFromWorkspace(
+  managedWorktreePath: string | undefined,
+  remoteInvokerHome: string | undefined,
+): CorruptWorktreeAdminPaths | undefined {
+  if (typeof managedWorktreePath !== 'string') return undefined;
+  if (!isPathUnderConfiguredRemoteHome(managedWorktreePath, remoteInvokerHome)) return undefined;
+
+  const marker = '/worktrees/';
+  const markerIdx = managedWorktreePath.lastIndexOf(marker);
+  if (markerIdx < 0) return undefined;
+
+  const rest = managedWorktreePath.slice(markerIdx + marker.length);
+  const segments = rest.split('/').filter(Boolean);
+  if (segments.length !== 2) return undefined;
+  const [hash, worktreeName] = segments;
+  if (!hash || hash.includes('..') || !worktreeName || worktreeName.includes('..')) return undefined;
+
+  const remoteClone = `${managedWorktreePath.slice(0, markerIdx)}/repos/${hash}`;
+  if (!isSafeMirrorPath(remoteClone)) return undefined;
+
+  return {
+    adminPath: `${remoteClone}/.git/worktrees/${worktreeName}`,
+    remoteClone,
+    worktreeName,
+  };
+}
+
 export function buildWorktreeCorruptRepairScript(options: {
   remoteClone: string;
   adminPath: string;
@@ -818,7 +853,20 @@ async function handleWorktreeCorruptRecovery(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
 ): Promise<void> {
-  const parsed = extractCorruptWorktreeAdminPath(candidate.task.execution.error);
+  const errorText = candidate.task.execution.error;
+  // Only fall back to the task's own workspacePath when the error truly
+  // carries no admin path at all (e.g. git 2.55+'s pathless
+  // `fatal: not a git repository: (null)`). When a path IS present but
+  // fails validation, that is a distinct signal worth refusing on rather
+  // than silently reinterpreting via workspacePath.
+  const hasEmbeddedAdminPath = typeof errorText === 'string' && errorText.includes('/.git/worktrees/');
+  const parsed = extractCorruptWorktreeAdminPath(errorText)
+    ?? (hasEmbeddedAdminPath
+      ? undefined
+      : deriveCorruptWorktreeAdminPathFromWorkspace(
+        candidate.task.execution.workspacePath,
+        candidate.target.remoteInvokerHome,
+      ));
   if (!parsed) {
     recordTaskDecision(options, candidate, candidate.reason, 'failed', 'Could not determine the corrupt worktree admin path from the task error', {
       targetId: candidate.targetId,

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -44,6 +44,18 @@ describe('FailureClassifier.classifyError', () => {
     )).toBe('ssh-worktree-corrupt');
   });
 
+  it('classifies finalize-time worktree corruption when git omits the admin path', () => {
+    expect(FailureClassifier.classifyError(
+      'remote commit or push failed (code 128): fatal: not a git repository: (null)',
+    )).toBe('ssh-worktree-corrupt');
+  });
+
+  it('does not classify a bare "not a git repository" outside the finalize commit/push path', () => {
+    expect(FailureClassifier.classifyError(
+      'fatal: not a git repository: (null)',
+    )).toBeUndefined();
+  });
+
   it('classifies the OAuth-session-expired signature', () => {
     expect(FailureClassifier.classifyError(PR_6976_OAUTH_SESSION_EXPIRED_ERROR))
       .toBe('ssh-oauth-session-expired');

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -53,7 +53,10 @@ export class FailureClassifier {
     }
     if (
       errorText.includes('fatal: not a git repository')
-      && errorText.includes('/.git/worktrees/')
+      && (
+        errorText.includes('/.git/worktrees/')
+        || errorText.includes('remote commit or push failed (code')
+      )
     ) {
       return 'ssh-worktree-corrupt';
     }


### PR DESCRIPTION
## Summary

`required-fast / Vitest Workspace` failed because a hermetic repro assumed
git's corrupted-worktree error always embeds the admin path. Newer git
(observed as 2.55.0 on the CI runner) prints `fatal: not a git repository:
(null)` instead, with no path.

That same assumption lived in production, not just the test. The failure
classifier and admin-path extractor behind Invoker's worktree-corrupt
auto-repair both require that embedded path. A remote SSH pool host on a
newer git could hit the same gap and silently stop auto-repairing.

## Review Claim

Approve hardening the worktree-corrupt classification and repair-path
extraction to work when git's error text carries no path, plus a matching
fix to the hermetic repro test that only checked the older, path-bearing
shape.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new fallback (`deriveCorruptWorktreeAdminPathFromWorkspace`) only
activates when the error text has *no* `/.git/worktrees/` marker at all. If
a path is present but fails validation, the existing refusal behavior is
unchanged (covered by the existing "refuses finalize-time worktree repair
when the admin path cannot be validated" test, which still passes). The
derived path is independently re-validated by the same `/repos/<hash>` and
`remoteInvokerHome` safety checks used everywhere else in this file before
any remote `rm -rf` can run.

## Slice Rationale

One slice: the test that surfaced the gap, the classifier rule, and the
extraction fallback are one coherent fix for one failure class
(`required-fast / Vitest Workspace`, first observed failing at
`3a27257f669775129ef2b1e75256a7aa03ceabb3`). Landing the classifier
change without the extractor change would leave the classifier newly
matching errors the extractor still cannot resolve a path for.

## Non-goals

No change to the actual worktree-corrupt repair script or its `rm -rf`
targeting logic — only how the corrupt admin path is recognized and
derived. No change to remote SSH pool git provisioning.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test` (131/131 test files,
      1703 passed / 1 skipped) — includes the two updated repro files
      (`ssh-worktree-metadata-repro.test.ts`, `infra-repair-worker.test.ts`)
      and the new "derives the admin path from workspacePath when git omits
      it" and "refuses ... when the admin path cannot be validated" cases
- [x] `pnpm --filter @invoker/workflow-graph test` (119/119 tests) —
      includes the new pathless-classification and negative-scope cases
- [x] `pnpm run check:types` (clean)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-3a27257-vitest-workspace.md` (this PR body passes the schema validator)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the narrower, path-only
  classification/extraction behavior; the hermetic test would need its
  original path-only assertion restored too if git's runner version keeps
  printing the pathless `(null)` message, or `required-fast / Vitest
  Workspace` will start failing again.

</details>
