### PR TITLE
Give planning repo rebind the same long IPC deadline as send.

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -514,6 +514,31 @@ describe('IpcBus', () => {
     expect(winner).toBe(stillPending);
   });
 
+  it('REGRESSION: a slow invoker:planning-chat-rebind-repo delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection planning-chat-send gets', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('headless.gui-mutation', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(client);
+    await client.ready();
+    await sleep(20);
+
+    const pending = client.request('headless.gui-mutation', {
+      channel: 'invoker:planning-chat-rebind-repo',
+      args: [{ sessionId: 'session-1', repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/' }],
+    });
+
+    const stillPending = Symbol('still-pending');
+    const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
+
+    expect(winner).toBe(stillPending);
+  });
+
   it('REGRESSION: a slow invoker:start-ready delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection headless.exec gets', async () => {
     const sock = tempSocketPath();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -270,6 +270,7 @@ const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
   'invoker:plan-from-goal',
   'invoker:planning-chat-send',
   'invoker:planning-chat-submit',
+  'invoker:planning-chat-rebind-repo',
   'invoker:start-ready',
   // start-ready --recreate-all and other bulk mutations run inline on the owner.
   'headless.exec',


### PR DESCRIPTION
## Summary

`invoker:planning-chat-rebind-repo` clones a fresh repo URL before rebinding
the planning session, but used the default 30s IPC deadline. A slow clone
made the caller give up before the responder replied.

This adds the channel to the same long-deadline set that
`invoker:planning-chat-send` already uses, so a slow clone no longer aborts
a request that is still in flight.

## Review Claim

Adding `invoker:planning-chat-rebind-repo` to `LONG_REQUEST_DEADLINE_CHANNELS`
gives it the same 2-hour caller deadline as the sibling planning channels,
matching a proven fix pattern.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only widens one channel's timeout ceiling; it does not change
who owns the socket, the wire protocol, or any other channel's deadline.
The responder-side behavior for `invoker:planning-chat-rebind-repo` is
unchanged.

## Slice Rationale

This is a single one-line fix plus its regression test, scoped to the one
channel that was missing long-deadline protection. It ships as its own
slice because it stacks on top of unrelated prior CI-hardening commits
already on this branch history.

## Non-goals

Does not add real cancellation propagation for abandoned requests. Does not
change the deadline for any other channel. Does not change clone behavior
itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/transport test` (includes the new regression
      test proving the old 30s default deadline killed a slow
      `invoker:planning-chat-rebind-repo` request, and that the fix keeps it
      pending past 300ms)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>