### PR TITLE
[admin-bypass-repair-bot-thread-pr-10217-79dff05](1) Keep first-draft plan doctor repair until pass

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1199,6 +1199,7 @@ tasks:
     if (!sent.ok) throw new Error(sent.error);
     expect(sent.draftPlanAvailable).toBe(false);
     expect(sent.reply).toContain('Draft not shown: the plan doctor rejected it.');
+    expect(sent.reply).toContain('Nothing was submitted.');
     const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
 
     await expect(submitPlanningChatDraft({

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -26,7 +26,11 @@ function fakePlannerChild(stdout: string, beforeClose?: () => void): any {
   proc.stderr = new EventEmitter();
   proc.kill = vi.fn();
   setTimeout(() => {
-    beforeClose?.();
+    try {
+      beforeClose?.();
+    } catch (err) {
+      proc.stderr.emit('data', Buffer.from(String(err)));
+    }
     if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
     proc.emit('close', 0);
   }, 0);
@@ -194,6 +198,92 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
+  it('first LGTM keeps repairing an incident-shaped candidate until skill-doctor passes', async () => {
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-incident-first-lgtm',
+      plannerRetryLimit: 0,
+      planningSurface: 'slack',
+      conversationalPlanning: true,
+      draftingPreauthorized: true,
+      // Use default first-draft budget (10); do not inject planDoctorRepairLimit: 2.
+      planDoctorScriptPath: join(testDir, '../../../../skills/plan-to-invoker/scripts/skill-doctor.sh'),
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    const incidentPlan = readFileSync(join(testDir, 'planning-review-doctor-reject-incident.yaml'), 'utf8');
+    const validPlan = readFileSync(
+      join(testDir, '../../../../skills/plan-to-invoker/fixtures/positive/08-bash-wrapped-pipefail.yaml'),
+      'utf8',
+    ).trim();
+
+    mockSpawn
+      .mockReturnValueOnce(fakePlannerChild('Drafted the first plan.', () => writeFileSync(path, incidentPlan, 'utf8')))
+      .mockImplementationOnce(() => {
+        // Write before the child resolves so a reset/race cannot strand the repair spawn.
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, validPlan, 'utf8');
+        return fakePlannerChild('Drafted the corrected plan.');
+      });
+
+    const reply = await conversation.sendMessage('LGTM');
+
+    expect(reply).toBe('Drafted the corrected plan.');
+    expect(reply).not.toContain('Nothing was submitted.');
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(conversation.lastTurnDraftPlanText).toBe(validPlan);
+    expect(conversation.getDraftedPlan()).toBe(validPlan);
+  }, 60_000);
+
+  it('harness append receives a hosted repair prompt after the first doctor reject', async () => {
+    const append = vi.fn((sessionId: string, prompt: string) => ({
+      command: 'agent',
+      args: ['--resume', sessionId, prompt],
+      sessionId,
+    }));
+    const start = vi.fn((prompt: string) => ({
+      command: 'agent',
+      args: [prompt],
+      sessionId: 'sess-1',
+    }));
+    const doctor = vi.fn()
+      .mockResolvedValueOnce({ ok: false, diagnostics: ['validate-plan: missing description'] })
+      .mockResolvedValueOnce({ ok: true, diagnostics: [] });
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-harness-repair',
+      plannerRetryLimit: 0,
+      planningSurface: 'slack',
+      conversationalPlanning: true,
+      draftingPreauthorized: true,
+      draftDoctor: doctor,
+      harnessSessionId: 'sess-1',
+      harnessSessionDriver: {
+        harness: 'cursor',
+        supportsSessionContinuity: true,
+        start,
+        append,
+      },
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    const incidentPlan = readFileSync(join(testDir, 'planning-review-doctor-reject-incident.yaml'), 'utf8');
+
+    mockSpawn
+      .mockReturnValueOnce(fakePlannerChild('Drafted the first plan.', () => writeFileSync(path, incidentPlan, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Drafted the corrected plan.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')));
+
+    await conversation.sendMessage('LGTM');
+
+    const repairPrompt = append.mock.calls
+      .map((call) => String(call[1] ?? ''))
+      .find((prompt) => prompt.includes('Doctor diagnostics:'));
+    expect(repairPrompt).toBeDefined();
+    expect(repairPrompt).toContain('Current planning host: Invoker Slack planner.');
+    expect(repairPrompt).toContain('validate-plan: missing description');
+    expect(doctor).toHaveBeenCalledTimes(2);
+  });
+
   it('exposes the exact candidate when the full doctor passes', async () => {
     const conversation = new PlanConversation({
       workingDir,
@@ -250,7 +340,41 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
-  it('fails closed after the bounded repair budget is exhausted', async () => {
+  it('does not stage a failing replacement over a prior good draft', async () => {
+    const doctor = vi.fn()
+      .mockResolvedValueOnce({ ok: true, diagnostics: [] })
+      .mockResolvedValue({ ok: false, diagnostics: ['validate-plan: still invalid'] });
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-replace-preserve',
+      plannerRetryLimit: 0,
+      planDoctorRepairLimit: 2,
+      draftDoctor: doctor,
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the good plan.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')));
+    await conversation.sendMessage('Draft the approved plan');
+    expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+
+    const badOne = VALID_PLAN_YAML.replace('Draft Activation', 'Bad One');
+    const badTwo = VALID_PLAN_YAML.replace('Draft Activation', 'Bad Two');
+    const badThree = VALID_PLAN_YAML.replace('Draft Activation', 'Bad Three');
+    mockSpawn
+      .mockReturnValueOnce(fakePlannerChild('Candidate one.', () => writeFileSync(path, badOne, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate two.', () => writeFileSync(path, badTwo, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate three.', () => writeFileSync(path, badThree, 'utf8')));
+
+    const reply = await conversation.sendMessage('Revise the plan');
+
+    expect(reply).toContain('Draft not shown: the plan doctor rejected it.');
+    expect(reply).toContain('Nothing was submitted.');
+    expect(conversation.lastTurnDraftPlanText).toBeNull();
+    expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+  });
+
+  it('fails closed after the first-draft repair cap without staging an invalid draft', async () => {
     const doctor = vi.fn().mockResolvedValue({ ok: false, diagnostics: ['validate-plan: still invalid'] });
     const conversation = new PlanConversation({
       workingDir,
@@ -262,10 +386,13 @@ describe('plan draft file - activation side', () => {
     const path = conversation.planDraftFilePath();
     if (!path) throw new Error('expected a plan draft path');
 
+    const c1 = VALID_PLAN_YAML.replace('Draft Activation', 'Candidate One');
+    const c2 = VALID_PLAN_YAML.replace('Draft Activation', 'Candidate Two');
+    const c3 = VALID_PLAN_YAML.replace('Draft Activation', 'Candidate Three');
     mockSpawn
-      .mockReturnValueOnce(fakePlannerChild('Candidate one.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')))
-      .mockReturnValueOnce(fakePlannerChild('Candidate two.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')))
-      .mockReturnValueOnce(fakePlannerChild('Candidate three.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')));
+      .mockReturnValueOnce(fakePlannerChild('Candidate one.', () => writeFileSync(path, c1, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate two.', () => writeFileSync(path, c2, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate three.', () => writeFileSync(path, c3, 'utf8')));
 
     const reply = await conversation.sendMessage('Draft the approved plan');
 
@@ -276,6 +403,32 @@ describe('plan draft file - activation side', () => {
     expect(existsSync(path)).toBe(false);
     expect(conversation.lastTurnDraftPlanText).toBeNull();
     expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('keeps one default doctor budget across every production PlanConversation host', () => {
+    // Slack + in-app planning terminal share PlanConversation defaults; no host may silently pin limit 0.
+    const repoRoot = join(testDir, '../../../..');
+    const productionHosts = [
+      'packages/surfaces/src/slack/slack-surface.ts',
+      'packages/surfaces/src/slack/thread-session-manager.ts',
+      'packages/app/src/in-app-planner.ts',
+      'packages/app/src/main.ts',
+      'packages/app/src/ipc/gui-mutation-handlers.ts',
+      'packages/slack-manager/src/index.ts',
+    ];
+    const pinnedZero = /\bplanDoctorRepairLimit\s*:\s*0\b/;
+    const mentionsDoctorPath = /planDoctorScriptPath/;
+    for (const rel of productionHosts) {
+      const source = readFileSync(join(repoRoot, rel), 'utf8');
+      expect(source, `${rel} must not pin planDoctorRepairLimit: 0`).not.toMatch(pinnedZero);
+      if (rel.includes('slack-manager') || rel.includes('main.ts') || rel.includes('gui-mutation') || rel.includes('in-app-planner')) {
+        expect(source, `${rel} wires planDoctorScriptPath`).toMatch(mentionsDoctorPath);
+      }
+    }
+    // Shared defaults live in one place.
+    const conversationSource = readFileSync(join(repoRoot, 'packages/surfaces/src/slack/plan-conversation.ts'), 'utf8');
+    expect(conversationSource).toContain('DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT = 2');
+    expect(conversationSource).toContain('DEFAULT_FIRST_DRAFT_PLAN_DOCTOR_REPAIR_LIMIT = 10');
   });
 });
 

--- a/packages/surfaces/src/__tests__/planning-review-doctor-reject-incident.yaml
+++ b/packages/surfaces/src/__tests__/planning-review-doctor-reject-incident.yaml
@@ -1,0 +1,33 @@
+name: "Workflow origin attribution"
+onFinish: pull_request
+mergeMode: manual
+repoUrl: "https://github.com/Neko-Catpital-Labs/Invoker.git"
+
+tasks:
+  - id: implement-origin-schema-and-types
+    description: "Add nullable origin column and shared enum"
+    prompt: |
+      Add a nullable origin column via sqlite-schema migration and define the enum.
+      Verify with: pnpm test
+    dependencies: []
+  - id: implement-origin-call-sites
+    description: "Pass origin enum at each submission call site"
+    prompt: |
+      Wire the right enum value at each submission point into loadPlan.
+      Verify with: pnpm test
+    dependencies:
+      - implement-origin-schema-and-types
+  - id: implement-origin-query-surfacing
+    description: "Expose origin on query workflows"
+    prompt: |
+      Wire origin through the row mapper and serializeWorkflow.
+      Verify with: pnpm test
+    dependencies:
+      - implement-origin-schema-and-types
+  - id: implement-origin-pr-body-stamping
+    description: "Stamp Origin line into PR bodies"
+    prompt: |
+      Add an Origin line to buildCanonicalPrBody for workflows with origin set.
+      Verify with: pnpm test
+    dependencies:
+      - implement-origin-schema-and-types

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -74,7 +74,10 @@ const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
 
 export const DEFAULT_PLANNER_RETRY_LIMIT = 2;
 export const DEFAULT_PLANNER_RETRY_BASE_DELAY_MS = 500;
+/** Replace-draft budget (#8533): leave a prior good draft intact after this many repairs. */
 export const DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT = 2;
+/** First-LGTM budget: keep doctor→repair until pass (or this cap / planning timeout). */
+export const DEFAULT_FIRST_DRAFT_PLAN_DOCTOR_REPAIR_LIMIT = 10;
 
 // Shared with slack-surface.ts so both planner spawn paths surface the same
 // actionable error when the CLI exits 0 but writes nothing to stdout. The
@@ -176,8 +179,13 @@ export interface PlanConversationConfig {
   planDoctorScriptPath?: string;
   /** Test/host injection for the full draft doctor. Takes precedence over planDoctorScriptPath. */
   draftDoctor?: PlanningDraftDoctor;
-  /** Maximum planner repair turns after doctor rejection. Default: 2 (3 candidates total). */
+  /** Maximum planner repair turns after doctor rejection when replacing a prior good draft. Default: 2. */
   planDoctorRepairLimit?: number;
+  /**
+   * Maximum planner repair turns for a first draft (no prior good YAML).
+   * Default: 10. Explicit `planDoctorRepairLimit` overrides both budgets when set.
+   */
+  firstDraftPlanDoctorRepairLimit?: number;
 }
 
 // ── Confirmation Detection ──────────────────────────────────
@@ -502,6 +510,8 @@ export class PlanConversation {
   private plannerRetryBaseDelayMs: number;
   private draftDoctor?: PlanningDraftDoctor;
   private planDoctorRepairLimit: number;
+  private firstDraftPlanDoctorRepairLimit: number;
+  private planDoctorRepairLimitConfigured: boolean;
   // Serializes turns on this conversation. Without this, two concurrent
   // sendMessage calls (e.g. two Slack events for the same thread arriving
   // close together) can interleave their per-turn side-channel files
@@ -546,7 +556,12 @@ export class PlanConversation {
     this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
     this.draftDoctor = config.draftDoctor
       ?? (config.planDoctorScriptPath ? createPlanningDraftDoctor(config.planDoctorScriptPath) : undefined);
+    this.planDoctorRepairLimitConfigured = config.planDoctorRepairLimit !== undefined;
     this.planDoctorRepairLimit = Math.max(0, config.planDoctorRepairLimit ?? DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT);
+    this.firstDraftPlanDoctorRepairLimit = Math.max(
+      0,
+      config.firstDraftPlanDoctorRepairLimit ?? DEFAULT_FIRST_DRAFT_PLAN_DOCTOR_REPAIR_LIMIT,
+    );
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -684,18 +699,35 @@ export class PlanConversation {
     return message;
   }
 
+  private resolvePlanDoctorRepairLimit(isFirstDraft: boolean): number {
+    if (this.planDoctorRepairLimitConfigured) return this.planDoctorRepairLimit;
+    return isFirstDraft ? this.firstDraftPlanDoctorRepairLimit : this.planDoctorRepairLimit;
+  }
+
+  /** Wrap repair/user turns for hosted Slack/in-app sessions the same way. */
+  private formatPlannerTurn(prompt: string): string {
+    if (!this.planningSurface) return prompt;
+    return formatPlanningHostedTurn(this.planningSurface, prompt);
+  }
+
   private async gateDraftForReview(
     initialPlanText: string,
     initialMessage: string,
     initialFormatted: ReturnType<typeof formatCodexPlannerStdout>,
     turn: number,
   ): Promise<{ planText: string | null; message: string; formatted: ReturnType<typeof formatCodexPlannerStdout> }> {
+    const startedAt = Date.now();
+    const isFirstDraft = !this.lastKnownGoodPlanText;
+    const repairLimit = this.resolvePlanDoctorRepairLimit(isFirstDraft);
     let planText = initialPlanText;
     let message = initialMessage;
     let formatted = initialFormatted;
     let lastResult: PlanningDraftDoctorResult = { ok: false, diagnostics: ['skill-doctor did not run'] };
+    let candidateNumber = 0;
+    let repairsAttempted = 0;
 
-    for (let candidateNumber = 1; candidateNumber <= this.planDoctorRepairLimit + 1; candidateNumber += 1) {
+    while (true) {
+      candidateNumber += 1;
       try {
         lastResult = await this.draftDoctor!(planText);
       } catch (error) {
@@ -713,12 +745,17 @@ export class PlanConversation {
       this.log(
         'plan-conversation',
         'warn',
-        `[PLAN_DOCTOR] Candidate ${candidateNumber} rejected (turn=${turn}, infrastructure=${lastResult.infrastructureError === true}): ${lastResult.diagnostics.join(' | ')}`,
+        `[PLAN_DOCTOR] Candidate ${candidateNumber} rejected (turn=${turn}, infrastructure=${lastResult.infrastructureError === true}, firstDraft=${isFirstDraft}): ${lastResult.diagnostics.join(' | ')}`,
       );
       this.resetPlanDraftFile();
-      if (lastResult.infrastructureError || candidateNumber > this.planDoctorRepairLimit) break;
 
-      const repairPrompt = this.buildDoctorRepairPrompt(planText, lastResult.diagnostics, candidateNumber);
+      const timedOut = Date.now() - startedAt >= this.timeoutMs;
+      if (lastResult.infrastructureError || repairsAttempted >= repairLimit || timedOut) break;
+
+      repairsAttempted += 1;
+      const repairPrompt = this.formatPlannerTurn(
+        this.buildDoctorRepairPrompt(planText, lastResult.diagnostics, candidateNumber),
+      );
       const repairResponse = await this.spawnPlanner(repairPrompt, turn);
       formatted = formatCodexPlannerStdout(repairResponse);
       message = formatted.message;
@@ -729,13 +766,21 @@ export class PlanConversation {
         lastResult = { ok: false, diagnostics: ['Planner repair turn did not produce a complete YAML candidate.'] };
         break;
       }
+      // An echoed copy of the rejected fence is not progress — require a real rewrite.
+      if (repairedDraft.trim() === planText.trim()) {
+        lastResult = {
+          ok: false,
+          diagnostics: ['Planner repair turn echoed the rejected candidate without changes.'],
+        };
+        break;
+      }
       planText = repairedDraft;
     }
 
     this.resetPlanDraftFile();
     const heading = lastResult.infrastructureError
       ? 'Draft not shown: plan validation is unavailable.'
-      : 'Draft not shown: the plan doctor rejected it.';
+      : `Draft not shown: the plan doctor rejected it. (${repairsAttempted} repair turn${repairsAttempted === 1 ? '' : 's'} attempted)`;
     const diagnostics = lastResult.diagnostics.slice(0, 8).map((line) => `- ${line}`).join('\n');
     return {
       planText: null,


### PR DESCRIPTION
## Summary

The Slack and in-app plan doctor no longer gives up on a first draft after two failed repairs.

When there is no prior good YAML yet, `PlanConversation` now keeps looping doctor-then-repair until the draft passes.

It also stops early if a repair turn stalls, the planning timeout hits, or a hard cap of 10 repairs is reached.

A repair turn that echoes back the exact rejected candidate now counts as a failed attempt instead of silently looping on a stale draft.

If a prior good draft already exists, a later failing candidate still never replaces it. That existing protection is unchanged.

## Review Claim

Approve widening the first-draft plan-doctor repair budget from 2 to 10 (with echo-detection and a planning-timeout backstop), while leaving the existing 2-repair budget and prior-good-draft protection for replacement drafts unchanged.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

A failing doctor result never stages or submits a draft. Infrastructure doctor errors stop the repair loop immediately. A prior good draft is never replaced by a failing candidate. A first draft (no prior good YAML yet) may keep repairing until it passes, a repair turn echoes the same candidate without change, the planning timeout elapses, or the 10-attempt cap is reached.

## Slice Rationale

One behavior change in the shared `PlanConversation` gate, landed with its matching test coverage (first-LGTM repair loop, echo-detection, prior-good-draft preservation, and a cross-host default-consistency check) in the same slice so Slack and the in-app planning terminal stay on one default. The new `planning-review-doctor-reject-incident.yaml` fixture's `Verify:` lines keep the fixture importable under the "every plan step must be testable" guideline without changing its intentionally incident-shaped content.

## Non-goals

- MCP validate/prepare-review repair loop
- Changing skill-doctor's own rejection rules
- Auto-submitting a passing draft
- Origin-tagging from Slack
- Docs/skill guidance updates for this change (separate slice)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-draft-file-activation.test.ts`
- [x] `cd packages/app && pnpm test -- src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 440dee0a` (or the equivalent commit once merged)
- Post-revert steps: None. Hosts fall back to the shared `DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT = 2` budget for every draft, with no echo-detection or timeout backstop.
- Data migration? No

</details>
