### PR TITLE
Give every planning-chat IPC channel the long deadline by prefix.

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -9,11 +9,13 @@ import {
   IpcBus,
   DEFAULT_REQUEST_DEADLINE_MS,
   MALFORMED_FRAME_RATE_LIMIT_MS,
+  channelHasLongRequestDeadline,
   resolveDefaultSocketPath,
   isServeRecoveryEligible,
   shouldForwardRelayedErrorResponse,
   type MalformedFrameEvent,
 } from '../ipc-bus.js';
+import { IpcChannels } from '@invoker/contracts/ipc-channels';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -537,6 +539,42 @@ describe('IpcBus', () => {
     const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
 
     expect(winner).toBe(stillPending);
+  });
+
+  it('REGRESSION: a slow invoker:planning-chat-create delegated over headless.gui-mutation gets the long deadline without being listed in LONG_REQUEST_DEADLINE_CHANNELS', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('headless.gui-mutation', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(client);
+    await client.ready();
+    await sleep(20);
+
+    const pending = client.request('headless.gui-mutation', {
+      channel: 'invoker:planning-chat-create',
+      args: [{}],
+    });
+
+    const stillPending = Symbol('still-pending');
+    const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
+
+    expect(winner).toBe(stillPending);
+  });
+
+  it('gives every invoker:planning-chat-* IpcChannels key the long deadline', () => {
+    const planningChannels = Object.keys(IpcChannels).filter((channel) =>
+      channel.startsWith('invoker:planning-chat-'),
+    );
+    expect(planningChannels.length).toBeGreaterThan(0);
+    for (const channel of planningChannels) {
+      expect(channelHasLongRequestDeadline(channel), channel).toBe(true);
+    }
+    expect(channelHasLongRequestDeadline('invoker:get-status')).toBe(false);
   });
 
   it('REGRESSION: a slow invoker:start-ready delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection headless.exec gets', async () => {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -277,6 +277,15 @@ const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
 ]);
 export const LONG_REQUEST_DEADLINE_MS = 2 * 60 * 60 * 1000;
 export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
+const PLANNING_CHAT_CHANNEL_PREFIX = 'invoker:planning-chat-';
+
+/** True when a request on this channel (or a gui-mutation inner channel) gets
+ *  the long deadline. Planning-chat channels inherit it so a new clone/send
+ *  sibling cannot ship on the 30s default just because nobody appended a name. */
+export function channelHasLongRequestDeadline(channel: string): boolean {
+  return LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
+    || channel.startsWith(PLANNING_CHAT_CHANNEL_PREFIX);
+}
 
 export interface IpcBusOptions {
   allowServe?: boolean;
@@ -766,8 +775,8 @@ export class IpcBus implements MessageBus {
       // operation name inside the message body, so a long-running operation
       // delegated through one must be recognized there too.
       const innerChannel = (message as { channel?: unknown } | null)?.channel;
-      const isLongRunning = LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
-        || (typeof innerChannel === 'string' && LONG_REQUEST_DEADLINE_CHANNELS.has(innerChannel));
+      const isLongRunning = channelHasLongRequestDeadline(channel)
+        || (typeof innerChannel === 'string' && channelHasLongRequestDeadline(innerChannel));
       const effectiveDeadlineMs = isLongRunning
         ? Math.max(this.requestDeadlineMs, LONG_REQUEST_DEADLINE_MS)
         : this.requestDeadlineMs;


### PR DESCRIPTION
## Summary

`LONG_REQUEST_DEADLINE_CHANNELS` required naming each
`invoker:planning-chat-*` channel individually, so a new sibling channel
shipped on the 30s default until someone remembered to add it there too.

This replaces per-channel naming with a prefix check
(`channelHasLongRequestDeadline`), so every current and future
`invoker:planning-chat-*` channel gets the long deadline automatically.

## Review Claim

Matching every `invoker:planning-chat-*` channel by prefix instead of by
individually named entries closes the class of bug this stack's prior two
slices fixed one channel at a time.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`channelHasLongRequestDeadline` only widens the timeout ceiling for channels
under the `invoker:planning-chat-` prefix; it does not change the
long-deadline set for any channel outside that prefix (verified by the new
test asserting `invoker:get-status` stays on the default), does not change
who owns the socket or the wire protocol, and does not change responder-side
behavior for any channel.

## Slice Rationale

This stacks directly on `#10226` (`invoker:planning-chat-rebind-repo`),
which fixed the same bug for one channel by name. Generalizing to a prefix
match is a distinct, reviewable claim from that one-line fix, so it ships as
its own slice on top rather than being folded into it.

## Non-goals

Does not add real cancellation propagation for abandoned requests. Does not
change the deadline for any channel outside the `invoker:planning-chat-`
prefix. Does not change planning-chat behavior itself, only its IPC
deadline.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/transport test` (includes the regression test
      proving a slow `invoker:planning-chat-create` delegated over
      `headless.gui-mutation` gets the long deadline without being listed in
      `LONG_REQUEST_DEADLINE_CHANNELS`, plus a test that every
      `invoker:planning-chat-*` key in `IpcChannels` gets the long deadline
      while `invoker:get-status` does not)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>