### PR TITLE
[make-pr always-on](1) Require the repo PR recipe when opening a GitHub PR

### DIFF
--- a/.cursor/rules/make-pr-precedence.mdc
+++ b/.cursor/rules/make-pr-precedence.mdc
@@ -1,0 +1,28 @@
+---
+description: Creating or updating a PR must follow make-pr; generic gh pr create is not a substitute
+alwaysApply: true
+---
+
+# Creating a PR in this repo
+
+When the user asks to **make / open / create / publish / update a PR**, or
+when you are about to run `gh pr create`, `mergify stack push`, or
+`node scripts/safe-stack-push.mjs`, treat `skills/make-pr/SKILL.md` as the
+source of truth.
+
+**First action:** Read `skills/make-pr/SKILL.md` (or `.cursor/skills/make-pr/SKILL.md`
+after clone setup). Do not draft a GitHub title/body from the latest commit
+message and do not use a generic `gh pr create` template as a substitute.
+
+Before creating or updating any PR:
+
+- Fill Review Claim, Review Lane, Review Unit, and a user-confirmed
+  Safety Invariant from the skill schema.
+- Run `node scripts/validate-pr-body-local.mjs` on the drafted body.
+- Publish stacked Invoker branches with `node scripts/safe-stack-push.mjs`
+  / `mergify stack push`, not a raw `git push` of a `stack/` branch.
+- After push, audit with `gh pr view` as the skill requires.
+
+Incident this prevents: deadline PRs used `gh pr create` with commit-message
+titles and skipped the make-pr schema, even though the skill existed as
+description-only context.

--- a/.cursor/rules/skill-command-precedence.mdc
+++ b/.cursor/rules/skill-command-precedence.mdc
@@ -7,11 +7,12 @@ alwaysApply: true
 
 When **any** of these apply for the current user message, treat the linked **skill** as the source of truth for how to work—not optional context:
 
-- The user runs a Cursor **slash command** whose stub says to use a skill (e.g. `/plan-to-invoker`).
+- The user runs a Cursor **slash command** whose stub says to use a skill (e.g. `/plan-to-invoker`, `/make-pr`).
 - The user **attaches** a skill to the message.
 - The user explicitly invokes a documented skill name or path.
+- The user asks to make, open, create, publish, or update a PR (see `make-pr` below). That request is a skill trigger even without a slash command.
 
-**First action:** Read the skill file (e.g. `skills/plan-to-invoker/SKILL.md` or `.cursor/skills/plan-to-invoker/SKILL.md` after clone setup). If `SKILL.md` is missing under `.cursor/skills/plan-to-invoker`, run `bash scripts/setup-agent-skills.sh` from the repo root, then re-check.
+**First action:** Read the skill file (e.g. `skills/plan-to-invoker/SKILL.md` or `.cursor/skills/plan-to-invoker/SKILL.md`). If `.cursor/skills/make-pr` is missing, restore the committed symlink; `scripts/setup-agent-skills.sh` does not create it.
 
 ## plan-to-invoker (hard stops)
 
@@ -21,6 +22,16 @@ Until the user confirms the workflow is complete:
 2. Follow the skill: scope → Phase 1a → Phase 1b (`pnpm test` / headless as applicable) → implementation YAML from facts → `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` → present plan → **wait for user confirmation** before `./submit-plan.sh` or before coding.
 
 Treat free text after `/plan-to-invoker` as **input to the skill workflow**, not a directive to implement immediately.
+
+## make-pr (hard stops)
+
+When creating or updating a GitHub PR in this repo:
+
+1. Read `skills/make-pr/SKILL.md` before drafting title or body.
+2. Do **not** substitute the generic `gh pr create` user-rule template or a commit-message title for the skill schema.
+3. Do **not** skip Review Claim, Review Lane, Review Unit, Safety Invariant confirmation, `node scripts/validate-pr-body-local.mjs`, or the post-push `gh pr view` audit.
+
+See `.cursor/rules/make-pr-precedence.mdc` for the always-on summary.
 
 ## Delegation hints in YAML (best effort)
 

--- a/.cursor/skills/make-pr
+++ b/.cursor/skills/make-pr
@@ -1,0 +1,1 @@
+../../skills/make-pr

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -179,4 +179,19 @@ must_contain "$SKILL_MD" "scripts/check-pr-body-keywords.mjs" "make-pr skill mus
 must_contain "$SKILL_MD" "Before running the full validator, check the drafted Summary/Non-goals prose against the declared Review Unit" "make-pr skill must require the keyword pre-flight before the full validator"
 [[ -f "$REPO_ROOT/scripts/check-pr-body-keywords.mjs" ]] || fail "scripts/check-pr-body-keywords.mjs referenced by make-pr skill must actually exist"
 
+# Description-only skills lose to always-on user rules. make-pr must be wired
+# the same way land-stack is: an alwaysApply Cursor rule plus a slash-command
+# skill symlink, not only skills/make-pr/SKILL.md in the available-skills list.
+MAKE_PR_RULE="$REPO_ROOT/.cursor/rules/make-pr-precedence.mdc"
+SKILL_PRECEDENCE="$REPO_ROOT/.cursor/rules/skill-command-precedence.mdc"
+MAKE_PR_CURSOR_SKILL="$REPO_ROOT/.cursor/skills/make-pr"
+[[ -f "$MAKE_PR_RULE" ]] || fail "expected always-on Cursor rule $MAKE_PR_RULE"
+must_contain "$MAKE_PR_RULE" "alwaysApply: true" "make-pr Cursor rule must always apply"
+must_contain "$MAKE_PR_RULE" "skills/make-pr/SKILL.md" "make-pr Cursor rule must point at the skill"
+must_contain "$MAKE_PR_RULE" "gh pr create" "make-pr Cursor rule must name gh pr create as a trigger, not a substitute"
+must_contain "$MAKE_PR_RULE" "mergify stack push" "make-pr Cursor rule must name mergify stack push as a trigger"
+must_contain "$SKILL_PRECEDENCE" "## make-pr (hard stops)" "skill-command-precedence must hard-stop make-pr the same way it hard-stops plan-to-invoker"
+[[ -L "$MAKE_PR_CURSOR_SKILL" ]] || fail "expected Cursor slash-command symlink $MAKE_PR_CURSOR_SKILL so /make-pr exists"
+[[ "$(readlink "$MAKE_PR_CURSOR_SKILL")" == "../../skills/make-pr" ]] || fail "expected $MAKE_PR_CURSOR_SKILL to point at ../../skills/make-pr"
+
 echo "OK: make-pr skill contract checks passed"


### PR DESCRIPTION
## Summary

The repo PR recipe lived as optional skill text. Agents used a generic GitHub template instead.

This adds an always-on Cursor rule and a /make-pr shortcut so that recipe is the required path.

## Review Claim

Opening a GitHub PR in this repo must follow make-pr via an always-on Cursor rule, not via optional skill matching.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only adds Cursor agent-routing files and a shell assertion. Product packages are untouched. Runtime behavior is unchanged.

## Slice Rationale

Land-stack already has this always-on Cursor rule. make-pr did not, so agents used a generic GitHub template.

## Non-goals

No product runtime change. Does not change land-stack. Does not rewrite already-open GitHub PR bodies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
