### PR TITLE
[harness-self-delegation-routing](1) Add self-triggered delegation routing criteria to plan-to-invoker skill

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -69,6 +69,15 @@ Use this mode when invoked by the installed command or MCP prompt.
 - Later PR publication is a separate explicit action. When the user separately asks about creating, updating, publishing, or splitting pull requests or PR stacks after workflow handoff, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
 - If the request involves multiple review slices, first read and follow `skills/review-compression/SKILL.md` (or `skill://review-compression/SKILL.md` when available) before writing workflow YAML.
 
+### Self-triggered delegation routing (agents and subagents)
+
+Use `confirmationMode` to distinguish who decided the hand-off should happen:
+
+- **Self-triggered delegation: confirmationMode: auto_submit** — the agent or subagent itself decided, mid-task and without a direct human instruction, that a chunk of work should be handed off to Invoker. No human message asked for this specific hand-off; it's the agent's own routing choice. In this case, skip the Slack review-card wait and call `invoker_submit_plan` once `invoker_prepare_plan_review` reports `confirmationMode: auto_submit`.
+- **Human-triggered delegation: confirmationMode: require** — a human's message is the direct request to hand off or send work to Invoker. Today's `require` + human-approval flow is unchanged: show the ordered steps and `confirmationText`, and wait for explicit approval before calling `invoker_submit_plan`.
+
+In both paths, the delegating agent chooses `poolId` best-effort per `references/schema.md` (an existing field) — omit it for the local default when unsure. `skill-doctor.sh` still runs against the generated plan in both paths; self-triggered delegation changes who approves the submission, not the validation gate.
+
 ## Intended flow (do not skip steps)
 
 **Current auto-fix schema:** Never emit `autoFix` or `autoFixRetries` at the plan, workflow, or task level. Those YAML fields are obsolete. Auto-fix retries are configured only with `autoFixRetries` in `~/.invoker/config.json`. A draft containing either YAML field must be corrected and re-run through `skill-doctor.sh`; do not present or submit it.


### PR DESCRIPTION
## Summary

Adds a new subsection to the plan-to-invoker skill's existing "Harness handoff mode" section.

The subsection gives explicit criteria for when a Claude agent or subagent may hand mid-task work to Invoker on its own, versus when a human message is the direct trigger.

The underlying mechanism, `confirmationMode: auto_submit`, already exists and is wired end-to-end. This slice only adds the decision text for when an agent should choose it over `require`.

Self-triggered work does not wait for a Slack review card. Human-triggered work keeps today's `require` and human-approval flow unchanged. `skill-doctor.sh` still runs against the generated plan either way.

## Review Claim

Approve the new subsection that adds `confirmationMode: auto_submit` (self-triggered) vs `confirmationMode: require` (human-triggered) criteria to the plan-to-invoker skill's existing Harness handoff mode section.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Default behavior for human-initiated submissions is unchanged: `confirmationMode` stays `require` unless a hand-off decision is self-triggered by an agent or subagent's own mid-task judgment call, not a direct human instruction. `skill-doctor.sh` still runs on every auto-submitted plan; this slice adds no bypass of that gate.

## Slice Rationale

This is the one substantive policy-text change (the new subsection in the skill file). The one-line CLAUDE.md pointer that references it ships as a separate, stacked slice, because these files fall under different review units in this repo's PR-body validator.

## Non-goals

No new skill directory. No change to `plan-parser.ts` schema, MCP tool parameters, or `confirmationMode`'s existing wiring. No validation-bypass flag. No change to the existing human-approval flow for human-triggered hand-offs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `grep -q '### Self-triggered delegation routing (agents and subagents)' skills/plan-to-invoker/SKILL.md`
- [x] `grep -q 'Self-triggered delegation: confirmationMode: auto_submit' skills/plan-to-invoker/SKILL.md`
- [x] `grep -q 'Human-triggered delegation: confirmationMode: require' skills/plan-to-invoker/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
