### PR TITLE
Stop dumping full plan YAML as raw Slack chat text

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PlanConversation, buildPlanSystemPrompt, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation } from '../slack/plan-conversation.js';
+import { PlanConversation, buildPlanSystemPrompt, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation, redactEmbeddedPlanFence } from '../slack/plan-conversation.js';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -598,7 +598,11 @@ describe('PlanConversation', () => {
 
     const reply = await conversational.sendMessage('yes');
 
-    expect(reply).toBe(VALID_YAML_PLAN);
+    // The raw ```yaml fence is redacted from the reply text (it would
+    // otherwise get posted verbatim to Slack); the draft itself is still
+    // fully captured via lastTurnDraftPlanText for the review-card flow.
+    expect(reply).toBe(redactEmbeddedPlanFence(VALID_YAML_PLAN));
+    expect(conversational.lastTurnDraftPlanText).toContain('Test Plan');
     expect(conversational.planSubmitted).toBe(false);
     expect(conversational.submittedPlanText).toBeNull();
     expect(mockSpawn).toHaveBeenCalledTimes(1);

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -596,12 +596,8 @@ describe('PlanConversation', () => {
     });
     mockCursorResponse(VALID_YAML_PLAN);
 
-    const reply = await conversational.sendMessage('yes');
+    await conversational.sendMessage('yes');
 
-    // The raw ```yaml fence is redacted from the reply text (it would
-    // otherwise get posted verbatim to Slack); the draft itself is still
-    // fully captured via lastTurnDraftPlanText for the review-card flow.
-    expect(reply).toBe(redactEmbeddedPlanFence(VALID_YAML_PLAN));
     expect(conversational.lastTurnDraftPlanText).toContain('Test Plan');
     expect(conversational.planSubmitted).toBe(false);
     expect(conversational.submittedPlanText).toBeNull();
@@ -613,6 +609,23 @@ describe('PlanConversation', () => {
     expect(prompt).toContain('skills/plan-to-invoker/SKILL.md');
     expect(prompt).not.toContain('name: "Plan Name"');
     expect(prompt).not.toContain('tasks:\n  - id: task-1');
+  });
+
+  it('redacts the raw yaml fence from the conversational reply once a draft is captured', async () => {
+    const conversational = new PlanConversation({ conversationalPlanning: true, planningSurface: 'in_app' });
+    (conversational as any).messages.push({
+      role: 'assistant',
+      content: 'I understand the scope. Would you like me to draft the YAML plan?',
+    });
+    mockCursorResponse(VALID_YAML_PLAN);
+
+    const reply = await conversational.sendMessage('yes');
+
+    // The review-card flow reads the draft from lastTurnDraftPlanText
+    // directly, so the raw ```yaml fence would be pure duplication if left
+    // in the chat reply that Slack posts verbatim.
+    expect(reply).toBe(redactEmbeddedPlanFence(VALID_YAML_PLAN));
+    expect(conversational.lastTurnDraftPlanText).toContain('Test Plan');
   });
 
   it('submittedPlanText is null before confirmation', async () => {

--- a/packages/surfaces/src/__tests__/slack-plan-dump-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-dump-repro.e2e.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PlanConversation } from '../slack/plan-conversation.js';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { ConversationRepository } from '@invoker/data-store';
+import * as child_process from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+// ── Mock child_process.spawn ────────────────────────────────
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function createMockProcess(stdout: string, exitCode = 0): any {
+  const proc = new EventEmitter() as any;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  proc.stdout = stdoutEmitter;
+  proc.stderr = stderrEmitter;
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    stdoutEmitter.emit('data', Buffer.from(stdout));
+    proc.emit('close', exitCode);
+  }, 0);
+
+  return proc;
+}
+
+function mockCursorResponse(text: string) {
+  mockSpawn.mockReturnValueOnce(createMockProcess(text));
+}
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// Shaped like a real Invoker chat-submit reply: prose, a fenced plan with
+// many tasks (so the fence is long), then closing prose — the exact shape
+// that appeared as a multi-message raw dump in Slack (see the "Invoker
+// [11:57 AM]" transcript pasted into the CI-fix session on 2026-08-22).
+const LONG_DRAFTED_PLAN = `Here's the plan staged for your review — this is a docs-only change:
+
+\`\`\`yaml
+name: "harness-self-delegation-routing"
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: "git@github.com:Neko-Catpital-Labs/Invoker.git"
+tasks:
+  - id: "add-self-triggered-delegation-routing"
+    description: "Add routing text to skills/plan-to-invoker/SKILL.md and CLAUDE.md."
+    prompt: "Add the routing criteria as described."
+    dependencies: []
+  - id: "verify-skill-md-self-delegation-text"
+    description: "Proves the new heading and its two literal lines exist."
+    command: "grep -F \\"### Self-triggered delegation routing\\" skills/plan-to-invoker/SKILL.md"
+    dependencies: ["add-self-triggered-delegation-routing"]
+  - id: "verify-claude-md-self-delegation-pointer"
+    description: "Proves the new CLAUDE.md pointer exists."
+    command: "grep -F \\"Self-triggered delegation routing\\" CLAUDE.md"
+    dependencies: ["add-self-triggered-delegation-routing"]
+  - id: "verify-plan-to-invoker-skill-regression"
+    description: "Confirms the existing regression script still passes."
+    command: "bash scripts/test-plan-to-invoker-skill.sh"
+    dependencies: ["add-self-triggered-delegation-routing"]
+\`\`\`
+
+Approve to stage it for Invoker. Note: this lands the routing criteria as
+docs/policy only — no application code changes.`;
+
+describe('Slack plan-dump repro: drafted plan text must not be sent verbatim to Slack', () => {
+  let adapter: SQLiteAdapter;
+  let repo: ConversationRepository;
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new ConversationRepository(adapter, silentLogger);
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  it('a turn that drafts a plan does not return the raw ```yaml fence for Slack to post verbatim', async () => {
+    const conv = new PlanConversation({ threadTs: 'ts-plan-dump', conversationRepo: repo, mode: 'plan' });
+    mockCursorResponse(LONG_DRAFTED_PLAN);
+
+    // This is exactly what handleConversationMessage in slack-surface.ts
+    // sends to Slack (chunked via splitForSlack, posted as one or more
+    // plain-text messages) -- it must not still contain the raw fenced plan.
+    const reply = await conv.sendMessage('Generate a plan');
+
+    expect(reply).not.toContain('```yaml');
+    expect(reply).not.toContain('verify-plan-to-invoker-skill-regression');
+
+    // The draft itself must still be fully captured for the real review
+    // flow (file-attached card), which reads conversation.lastTurnDraftPlanText
+    // directly and does not re-parse the (now redacted) reply text.
+    expect(conv.lastTurnDraftPlanText).toContain('harness-self-delegation-routing');
+    expect(conv.lastTurnDraftPlanText).toContain('verify-plan-to-invoker-skill-regression');
+  });
+
+  it('a turn with no drafted plan is left completely untouched', async () => {
+    const conv = new PlanConversation({ threadTs: 'ts-no-plan', conversationRepo: repo, mode: 'plan' });
+    mockCursorResponse('What repo should this target?');
+
+    const reply = await conv.sendMessage('I want to add a REST API');
+
+    expect(reply).toBe('What repo should this target?');
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -718,7 +718,7 @@ export class PlanConversation {
     const tSave = Date.now();
 
     this.log('plan-conversation', 'info', `[PERF] sendMessage: init=${tInit - t0}ms, buildPrompt=${tPrompt - tInit}ms, cursor=${tCursor - tPrompt}ms, saveState=${tSave - tCursor}ms, total=${tSave - t0}ms`);
-    return message;
+    return nextDraft ? redactEmbeddedPlanFence(message) : message;
   }
 
   private resolvePlanDoctorRepairLimit(isFirstDraft: boolean): number {
@@ -1366,4 +1366,28 @@ export function extractYamlPlan(text: string): string | null {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
+}
+
+const PLAN_DRAFT_PLACEHOLDER = '_(Plan drafted — see the review card for the full plan.)_';
+
+/**
+ * Once a turn's plan draft is captured (lastTurnDraftPlanText), the raw
+ * ```yaml fence in the reply text is redundant: the review-card flow reads
+ * the draft from lastTurnDraftPlanText directly (see
+ * preparePlanningReview's extractDraftPlanText in slack-surface.ts), not by
+ * re-parsing this text. Leaving the fence in means Slack posts the entire
+ * plan as chunked chat text in addition to the review card.
+ */
+export function redactEmbeddedPlanFence(text: string): string {
+  const fenceStart = text.lastIndexOf('```yaml\n');
+  if (fenceStart === -1) return text;
+  const contentStart = fenceStart + '```yaml\n'.length;
+  const rest = text.slice(contentStart);
+  const closeMatch = rest.match(/^```\s*$/m);
+  const fenceEnd = closeMatch && closeMatch.index !== undefined
+    ? contentStart + closeMatch.index + closeMatch[0].length
+    : text.length;
+  const before = text.slice(0, fenceStart).trimEnd();
+  const after = text.slice(fenceEnd).trimStart();
+  return [before, PLAN_DRAFT_PLACEHOLDER, after].filter(Boolean).join('\n\n');
 }


### PR DESCRIPTION
## Summary

Slack chat replies that draft an Invoker plan carried the whole fenced
`yaml` plan text, which the Slack layer posted as raw chunked chat
messages — the exact "text dumping" behavior seen in a real thread.

The dedicated review-card flow (file-attached plan + Approve/Cancel)
already reads the plan straight from `lastTurnDraftPlanText`, not by
re-scanning the reply text, so the raw fence in the reply was pure
duplication with no reader.

## Review Claim

Approve redacting the fenced plan YAML out of a Slack planning reply
once a draft is captured, replacing it with a short placeholder, while
the review-card flow keeps working unchanged.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The redaction only touches the value `sendMessage` returns to callers
(what gets posted to Slack). `this.messages` still stores the original,
un-redacted text, so the model keeps full context of its own prior plan
on later turns. `lastTurnDraftPlanText` (and therefore the review-card
flow) is set independently and is never touched by the redaction.

## Slice Rationale

One slice: the redaction helper, its one call site, and the repro/test
updates that prove it — a single self-contained behavior change with
no other file needing to move in lockstep.

## Non-goals

No change to how a draft is detected, validated, or staged for review.
No change to the file-attached review-card flow itself. No change to
Slack message chunking (`splitForSlack`) for non-plan replies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (54/54 test files, 588/588
      tests) — includes the new
      `src/__tests__/slack-plan-dump-repro.e2e.test.ts`; run against
      the pre-fix code first, it failed with the reply still
      containing the raw `` ```yaml `` fence, then passed once the
      redaction landed
- [x] `pnpm run check:types` (clean)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-slack-plan-yaml-dump.md` (this PR body passes the schema validator)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the old behavior where
  the full plan YAML is posted verbatim as chat text in addition to the
  review card.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack plan responses no longer expose complete YAML plan contents in conversational replies.
  * Redacted plan sections are replaced with a clear placeholder while drafts remain available for continued processing.
  * Non-plan responses continue to display unchanged.

* **Tests**
  * Added regression coverage for plan redaction, draft retention, and standard Slack responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->