### PR TITLE
[Planning draft ownership](1) Prove restart repair-budget loss

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -439,4 +439,38 @@ tasks:
       expect(conv2.history.length).toBe(4);
     });
   });
+
+  describe('approved-draft repair budget restart repro', () => {
+    it.fails('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
+      const threadTs = 'ts-restart-doctor-budget';
+      const first = new PlanConversation({
+        threadTs,
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await first.sendMessage('Draft the plan');
+
+      const rejectingDoctor = vi.fn().mockResolvedValue({
+        ok: false,
+        diagnostics: ['validate-plan: still invalid'],
+      });
+      const recovered = new PlanConversation({
+        threadTs,
+        conversationRepo: repo,
+        draftDoctor: rejectingDoctor,
+        firstDraftPlanDoctorRepairLimit: 3,
+      });
+      await recovered.init();
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate One'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Two'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Three'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Four'));
+
+      const reply = await recovered.sendMessage('Replace the plan');
+
+      expect(rejectingDoctor).toHaveBeenCalledTimes(3);
+      expect(reply).toContain('(2 repair turns attempted)');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A pending regression test demonstrates that restart loses the shorter doctor budget for replacements.

## Review Claim

The test directly proves the replacement-budget state is not restored.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes no production behavior; the expected-failure test keeps the base branch green.

## Slice Rationale

The regression evidence lands before the persistence change that makes it pass.

## Non-goals

No runtime behavior, storage, or host integration changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation-persistence.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c1d3d37f7e`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for restoring a previously approved draft and applying a replacement-plan repair limit.
  * Documented an expected failure where the configured repair budget is not preserved after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->