### PR TITLE
[Planning draft ownership](3) Persist approved drafts before review

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -441,7 +441,7 @@ tasks:
   });
 
   describe('approved-draft repair budget restart repro', () => {
-    it.fails('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
+    it('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
       const threadTs = 'ts-restart-doctor-budget';
       const first = new PlanConversation({
         threadTs,
@@ -471,6 +471,107 @@ tasks:
 
       expect(rejectingDoctor).toHaveBeenCalledTimes(3);
       expect(reply).toContain('(2 repair turns attempted)');
+    });
+  });
+
+  describe('immutable doctor-approved drafts', () => {
+    it('restores the exact doctor-approved draft without recovering YAML from chat', async () => {
+      const doctor = vi.fn().mockResolvedValue({ ok: true, diagnostics: [] });
+      const first = new PlanConversation({
+        threadTs: 'ts-approved-restart',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await first.sendMessage('Draft the plan');
+      const stored = first.approvedPlanningDraft;
+
+      const recovered = new PlanConversation({
+        threadTs: 'ts-approved-restart',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+      });
+      await recovered.init();
+
+      expect(recovered.approvedPlanningDraft?.id).toBe(stored?.id);
+      expect(recovered.getDraftedPlan()).toBe(stored?.planText);
+    });
+
+    it('does not classify unvalidated YAML recovered from chat as doctor-approved', async () => {
+      repo.saveConversation('ts-unvalidated-chat-yaml', [
+        { role: 'assistant', content: VALID_YAML_PLAN },
+      ]);
+      const recovered = new PlanConversation({
+        threadTs: 'ts-unvalidated-chat-yaml',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+
+      await recovered.init();
+
+      expect(recovered.approvedPlanningDraft).toBeNull();
+      expect(recovered.getDraftedPlan()).toBeNull();
+    });
+
+    it('keeps the current approved draft when a replacement is rejected', async () => {
+      const doctor = vi.fn()
+        .mockResolvedValueOnce({ ok: true, diagnostics: [] })
+        .mockResolvedValueOnce({ ok: false, diagnostics: ['still invalid'] });
+      const conversation = new PlanConversation({
+        threadTs: 'ts-rejected-replacement',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+        planDoctorRepairLimit: 0,
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await conversation.sendMessage('Draft the plan');
+      const approved = conversation.approvedPlanningDraft;
+
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Rejected Plan'));
+      const reply = await conversation.sendMessage('Replace it');
+
+      expect(reply).toContain('Draft not shown: the plan doctor rejected it.');
+      expect(conversation.approvedPlanningDraft?.id).toBe(approved?.id);
+      expect(conversation.getDraftedPlan()).toBe(approved?.planText);
+    });
+
+    it('fails closed when an approved draft cannot be persisted', async () => {
+      const conversation = new PlanConversation({
+        threadTs: 'ts-draft-write-failure',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      vi.spyOn(repo.planningDrafts, 'createCurrent').mockImplementation(() => {
+        throw new Error('database unavailable');
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+
+      const reply = await conversation.sendMessage('Draft the plan');
+
+      expect(reply).toContain('approved plan could not be persisted');
+      expect(conversation.lastTurnDraftPlanText).toBeNull();
+      expect(conversation.approvedPlanningDraft).toBeNull();
+    });
+
+    it('preserves the current approved draft when replacement persistence fails', async () => {
+      const conversation = new PlanConversation({
+        threadTs: 'ts-replacement-write-failure',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await conversation.sendMessage('Draft the plan');
+      const approved = conversation.approvedPlanningDraft;
+      vi.spyOn(repo.planningDrafts, 'createCurrent').mockImplementation(() => {
+        throw new Error('database unavailable');
+      });
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Lost Replacement'));
+
+      const reply = await conversation.sendMessage('Replace it');
+
+      expect(reply).toContain('approved plan could not be persisted');
+      expect(conversation.approvedPlanningDraft?.id).toBe(approved?.id);
+      expect(conversation.getDraftedPlan()).toBe(approved?.planText);
     });
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -14,7 +14,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import type { ConversationRepository } from '@invoker/data-store';
+import type { ConversationRepository, PlanningDraft } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import {
@@ -526,6 +526,7 @@ export class PlanConversation {
   private _lastTurnDraftFromSidecarFile = false;
   private _lastTurnPlanIntentSignal: PlanIntentSignal | null = null;
   private lastKnownGoodPlanText: string | null = null;
+  private _approvedPlanningDraft: PlanningDraft | null = null;
   private harnessSessionDriver?: HarnessSessionDriver;
   private _harnessSessionId?: string;
   private onHarnessSessionId?: (sessionId: string) => void;
@@ -606,6 +607,8 @@ export class PlanConversation {
       })).filter((m) => m.content.length > 0);
       this._planSubmitted = saved.planSubmitted;
       this.mode = saved.mode ?? this.mode;
+      this._approvedPlanningDraft = this.conversationRepo.planningDrafts.getCurrent(this.threadTs) ?? null;
+      this.lastKnownGoodPlanText = this._approvedPlanningDraft?.planText ?? null;
 
       this.log('plan-conversation', 'info', `Restored conversation ${this.threadTs}: ${saved.messages.length} messages`);
     } catch (err) {
@@ -681,6 +684,25 @@ export class PlanConversation {
       message = gated.message;
       finalFormatted = gated.formatted;
     }
+    if (nextDraft && this.draftDoctor && this.conversationRepo && this.threadTs) {
+      try {
+        this._approvedPlanningDraft = this.conversationRepo.planningDrafts.createCurrent(
+          this.threadTs,
+          nextDraft,
+        );
+        nextDraft = this._approvedPlanningDraft.planText;
+      } catch (error) {
+        this.log(
+          'plan-conversation',
+          'error',
+          `Failed to persist approved planning draft ${this.threadTs}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        nextDraft = null;
+        message = 'Draft not shown: the approved plan could not be persisted.\n\nNothing was submitted.';
+      }
+    }
     this._lastTurnDraftPlanText = nextDraft;
     this._lastTurnDraftFromSidecarFile = sidecarDraftSelected && Boolean(nextDraft);
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
@@ -717,7 +739,7 @@ export class PlanConversation {
     turn: number,
   ): Promise<{ planText: string | null; message: string; formatted: ReturnType<typeof formatCodexPlannerStdout> }> {
     const startedAt = Date.now();
-    const isFirstDraft = !this.lastKnownGoodPlanText;
+    const isFirstDraft = !(this._approvedPlanningDraft || this.lastKnownGoodPlanText);
     const repairLimit = this.resolvePlanDoctorRepairLimit(isFirstDraft);
     let planText = initialPlanText;
     let message = initialMessage;
@@ -836,6 +858,31 @@ export class PlanConversation {
     return this._lastTurnDraftPlanText;
   }
 
+  get approvedPlanningDraft(): PlanningDraft | null {
+    return this._approvedPlanningDraft;
+  }
+
+  get draftDoctorEnabled(): boolean {
+    return Boolean(this.draftDoctor);
+  }
+
+  markApprovedPlanningDraftSubmitted(): void {
+    if (!this._approvedPlanningDraft || !this.conversationRepo) return;
+    this.conversationRepo.planningDrafts.markSubmitted(this._approvedPlanningDraft.id);
+    this._approvedPlanningDraft = this.conversationRepo.planningDrafts.get(
+      this._approvedPlanningDraft.id,
+    ) ?? this._approvedPlanningDraft;
+  }
+
+  discardApprovedPlanningDraft(): void {
+    if (this._approvedPlanningDraft && this.conversationRepo) {
+      this.conversationRepo.planningDrafts.supersede(this._approvedPlanningDraft.id);
+    }
+    this._approvedPlanningDraft = null;
+    this._lastTurnDraftPlanText = null;
+    this.lastKnownGoodPlanText = null;
+  }
+
   /**
    * Whether this turn's draft came from the dedicated plan-draft sidecar file
    * (a deliberate planner act), rather than YAML embedded in the chat reply.
@@ -872,7 +919,11 @@ export class PlanConversation {
   getDraftedPlan(): string | null {
     // Only sendMessage may promote a candidate after its configured doctor
     // passes. Re-reading the sidecar here would bypass that review gate.
-    if (this.draftDoctor) return this._lastTurnDraftPlanText ?? this.lastKnownGoodPlanText;
+    if (this.draftDoctor) {
+      return this._lastTurnDraftPlanText
+        ?? this._approvedPlanningDraft?.planText
+        ?? this.lastKnownGoodPlanText;
+    }
     const fileDraft = this.readPlanDraftFile();
     if (fileDraft && summarizePlanText(fileDraft)) return fileDraft;
     return this._lastTurnDraftPlanText ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
@@ -967,6 +1018,7 @@ export class PlanConversation {
     this._lastTurnDraftFromSidecarFile = false;
     this._lastTurnPlanIntentSignal = null;
     this.lastKnownGoodPlanText = null;
+    this._approvedPlanningDraft = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);
     }


### PR DESCRIPTION
## Summary

PlanConversation stores each doctor-approved draft before exposing it for review.

Restart restores only that approved draft, preserving replacement budgets and excluding YAML recovered from chat.

## Review Claim

Approve the doctor gate's persisted-current-draft policy and fail-closed behavior.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Only doctor-approved YAML becomes current; rejected or unwritable replacements never displace the prior approved draft.

## Slice Rationale

Shared approval semantics land once before Slack and in-app consume them.

## Non-goals

No host-specific review binding or legacy-row removal.

## Architecture

### Before

```mermaid
graph TD
    A["Doctor passes"] --> B["In-memory last-known text"]
```

### After

```mermaid
graph TD
    A["Doctor passes"] --> B["Persist immutable current draft"]
    B --> C["Expose review text"]
    B --> D["Restore replacement budget"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation-persistence.test.ts src/__tests__/plan-draft-file-activation.test.ts`
- [x] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6d573b690e`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approved planning drafts are now saved and restored across conversation restarts.
  * Added controls to submit or discard an approved draft.
  * Resetting a plan now clears its approved draft.

* **Bug Fixes**
  * Prevented unvalidated drafts from appearing as approved.
  * Preserved the current approved draft when replacement drafts are rejected.
  * Drafts are hidden and cannot be submitted if saving fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->