### PR TITLE
[Planning draft ownership](4) Bind Slack review identity

### DIFF
--- a/packages/data-store/src/__tests__/planning-draft-repository.test.ts
+++ b/packages/data-store/src/__tests__/planning-draft-repository.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { PlanningDraftRepository } from '../planning-draft-repository.js';
+
+describe('PlanningDraftRepository', () => {
+  let adapter: SQLiteAdapter;
+  let repo: PlanningDraftRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new PlanningDraftRepository(adapter);
+  });
+
+  afterEach(() => adapter.close());
+
+  it('creates immutable versions with at most one current draft', () => {
+    const first = repo.createCurrent('conversation-1', 'name: First');
+    const second = repo.createCurrent('conversation-1', 'name: Second');
+
+    expect(first.version).toBe(1);
+    expect(second.version).toBe(2);
+    expect(repo.getCurrent('conversation-1')).toEqual(second);
+    expect(repo.get(first.id)?.status).toBe('superseded');
+    expect(repo.get(second.id)?.status).toBe('current');
+  });
+
+  it('stores a hash of the exact normalized plan text', () => {
+    const draft = repo.createCurrent('conversation-1', '  name: Exact  \n');
+
+    expect(draft.planText).toBe('name: Exact');
+    expect(draft.contentHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('marks only the current immutable version submitted', () => {
+    const draft = repo.createCurrent('conversation-1', 'name: Submit');
+    repo.markSubmitted(draft.id);
+
+    expect(repo.get(draft.id)?.status).toBe('submitted');
+    expect(repo.getCurrent('conversation-1')).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/__tests__/slack-plan-draft-repository.test.ts
+++ b/packages/data-store/src/__tests__/slack-plan-draft-repository.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SlackPlanDraftRepository } from '../slack-plan-draft-repository.js';
+import { PlanningDraftRepository } from '../planning-draft-repository.js';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 
 describe('SlackPlanDraftRepository', () => {
@@ -54,5 +55,64 @@ describe('SlackPlanDraftRepository', () => {
       status: 'submitting',
       executionKey: `${draft.draftId}:${draft.version}`,
     });
+  });
+
+  it('links review rows to the exact immutable doctor-approved draft', () => {
+    const planningDrafts = new PlanningDraftRepository(adapter);
+    const planText = 'name: test\ntasks:\n  - id: task\n    description: Test';
+    const approved = planningDrafts.createCurrent('T1', planText);
+
+    const draft = repository.create({
+      channelId: 'C1',
+      threadTs: 'T1',
+      planningDraftId: approved.id,
+      planText,
+      summaryJson: '{}',
+      repoUrl: 'https://github.com/acme/repo.git',
+      harnessPreset: 'codex',
+      workingDir: '/tmp/repo',
+      requestedBy: 'U1',
+    });
+
+    expect(repository.resolvePlanText(draft)).toBe(planText);
+    expect(repository.get(draft.draftId, draft.version)?.planningDraftId).toBe(approved.id);
+  });
+
+  it('rejects review text that differs from its immutable draft', () => {
+    const planningDrafts = new PlanningDraftRepository(adapter);
+    const approved = planningDrafts.createCurrent('T1', 'name: approved');
+
+    expect(() => repository.create({
+      channelId: 'C1',
+      threadTs: 'T1',
+      planningDraftId: approved.id,
+      planText: 'name: changed',
+      summaryJson: '{}',
+      repoUrl: 'https://github.com/acme/repo.git',
+      harnessPreset: 'codex',
+      workingDir: '/tmp/repo',
+      requestedBy: 'U1',
+    })).toThrow(/exact current doctor-approved/);
+  });
+
+  it('rejecting an older review does not supersede a newer current draft', () => {
+    const planningDrafts = new PlanningDraftRepository(adapter);
+    const first = planningDrafts.createCurrent('T1', 'name: first');
+    const review = repository.create({
+      channelId: 'C1',
+      threadTs: 'T1',
+      planningDraftId: first.id,
+      planText: first.planText,
+      summaryJson: '{}',
+      repoUrl: 'https://github.com/acme/repo.git',
+      harnessPreset: 'codex',
+      workingDir: '/tmp/repo',
+      requestedBy: 'U1',
+    });
+    const second = planningDrafts.createCurrent('T1', 'name: second');
+
+    repository.decide(review, 'rejected', 'U1');
+
+    expect(planningDrafts.getCurrent('T1')?.id).toBe(second.id);
   });
 });

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -466,6 +466,8 @@ describe('SQLiteAdapter', () => {
         'confirmation_mode',
         'draft_plan_summary_json',
         'draft_plan_text',
+        'planning_draft_id',
+        'planning_draft_hash',
         'submitted_workflow_id',
         'submitted_plan_name',
         'terminal_mode',

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -33,6 +33,20 @@ export interface ConversationMessage {
   createdAt: string;
 }
 
+export type PlanningDraftStatus = 'current' | 'superseded' | 'submitted';
+
+export interface PlanningDraft {
+  id: string;
+  conversationId: string;
+  version: number;
+  planText: string;
+  contentHash: string;
+  status: PlanningDraftStatus;
+  createdAt: string;
+  supersededAt?: string;
+  submittedAt?: string;
+}
+
 export interface SlackLaunchContext {
   threadTs: string;
   repoUrl: string;
@@ -56,6 +70,7 @@ export type SlackPlanDraftStatus =
 export interface SlackPlanDraft {
   draftId: string;
   version: number;
+  planningDraftId?: string;
   channelId: string;
   threadTs: string;
   messageTs?: string;
@@ -329,6 +344,8 @@ export interface InAppPlanningSessionRecord {
   messages: InAppPlanningChatLine[];
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
+  planningDraftId?: string;
+  planningDraftHash?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   terminalMode?: PlanningTerminalMode;
@@ -358,6 +375,8 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'messages'
   | 'draftPlanSummary'
   | 'draftPlanText'
+  | 'planningDraftId'
+  | 'planningDraftHash'
   | 'submittedWorkflowId'
   | 'submittedPlanName'
   | 'terminalMode'
@@ -444,6 +463,14 @@ export interface PersistenceAdapter {
   appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void;
   countMessages(threadTs: string): number;
   loadMessages(threadTs: string): ConversationMessage[];
+
+  // Immutable doctor-approved planning drafts
+  createCurrentPlanningDraft(input: Omit<PlanningDraft, 'version' | 'status' | 'supersededAt' | 'submittedAt'>): PlanningDraft;
+  loadCurrentPlanningDraft(conversationId: string): PlanningDraft | undefined;
+  loadPlanningDraft(id: string): PlanningDraft | undefined;
+  supersedePlanningDraft(id: string, supersededAt: string): void;
+  supersedeCurrentPlanningDraft(conversationId: string, supersededAt: string): void;
+  markPlanningDraftSubmitted(id: string, submittedAt: string): void;
 
   // Slack plan submission session state
   saveSlackLaunchContext(context: SlackLaunchContext): void;

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -8,6 +8,7 @@
 
 import type { PlanDefinition } from '@invoker/workflow-core';
 import type { PersistenceAdapter, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
+import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 // ── Public Types ─────────────────────────────────────────────
 
@@ -47,10 +48,12 @@ const defaultLogger: Logger = {
 export class ConversationRepository {
   private adapter: PersistenceAdapter;
   private log: Logger;
+  readonly planningDrafts: PlanningDraftRepository;
 
   constructor(adapter: PersistenceAdapter, logger?: Logger) {
     this.adapter = adapter;
     this.log = logger ?? defaultLogger;
+    this.planningDrafts = new PlanningDraftRepository(adapter);
   }
 
   /**

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -3,6 +3,7 @@ export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
+export * from './planning-draft-repository.js';
 export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';

--- a/packages/data-store/src/planning-draft-repository.ts
+++ b/packages/data-store/src/planning-draft-repository.ts
@@ -1,0 +1,43 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { PersistenceAdapter, PlanningDraft } from './adapter.js';
+
+export class PlanningDraftRepository {
+  constructor(private readonly adapter: PersistenceAdapter) {}
+
+  createCurrent(conversationId: string, planText: string): PlanningDraft {
+    const normalized = planText.trim();
+    if (!normalized) {
+      throw new Error('Cannot persist an empty planning draft.');
+    }
+    return this.adapter.createCurrentPlanningDraft({
+      id: randomUUID(),
+      conversationId,
+      planText: normalized,
+      contentHash: createHash('sha256').update(normalized).digest('hex'),
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  getCurrent(conversationId: string): PlanningDraft | undefined {
+    return this.adapter.loadCurrentPlanningDraft(conversationId);
+  }
+
+  get(id: string): PlanningDraft | undefined {
+    return this.adapter.loadPlanningDraft(id);
+  }
+
+  supersedeCurrent(conversationId: string): void {
+    this.adapter.supersedeCurrentPlanningDraft(conversationId, new Date().toISOString());
+  }
+
+  supersede(id: string): void {
+    this.adapter.supersedePlanningDraft(id, new Date().toISOString());
+  }
+
+  markSubmitted(id: string): void {
+    this.adapter.markPlanningDraftSubmitted(id, new Date().toISOString());
+    if (this.adapter.loadPlanningDraft(id)?.status !== 'submitted') {
+      throw new Error(`Planning draft ${id} is not the current draft and cannot be submitted.`);
+    }
+  }
+}

--- a/packages/data-store/src/slack-plan-draft-repository.ts
+++ b/packages/data-store/src/slack-plan-draft-repository.ts
@@ -1,9 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto';
 import type { PersistenceAdapter, SlackPlanDraft } from './adapter.js';
+import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 export interface CreateSlackPlanDraft {
   channelId: string;
   threadTs: string;
+  planningDraftId?: string;
   planText: string;
   summaryJson: string;
   repoUrl: string;
@@ -14,16 +16,32 @@ export interface CreateSlackPlanDraft {
 }
 
 export class SlackPlanDraftRepository {
-  constructor(private readonly adapter: PersistenceAdapter) {}
+  private readonly planningDrafts: PlanningDraftRepository;
+
+  constructor(private readonly adapter: PersistenceAdapter) {
+    this.planningDrafts = new PlanningDraftRepository(adapter);
+  }
 
   create(input: CreateSlackPlanDraft): SlackPlanDraft {
     const now = new Date().toISOString();
+    if (input.planningDraftId) {
+      const approved = this.planningDrafts.get(input.planningDraftId);
+      const inputHash = createHash('sha256').update(input.planText).digest('hex');
+      if (!approved
+        || approved.conversationId !== input.threadTs
+        || approved.status !== 'current'
+        || approved.contentHash !== inputHash
+        || approved.planText !== input.planText) {
+        throw new Error('Slack review must reference the exact current doctor-approved planning draft.');
+      }
+    }
     const previous = this.adapter.loadReadySlackPlanDraft(input.channelId, input.threadTs);
     const version = (previous?.version ?? 0) + 1;
     this.adapter.supersedeReadySlackPlanDrafts(input.channelId, input.threadTs, now);
     const draft: SlackPlanDraft = {
       draftId: randomUUID(),
       version,
+      planningDraftId: input.planningDraftId,
       channelId: input.channelId,
       threadTs: input.threadTs,
       planText: input.planText,
@@ -77,6 +95,27 @@ export class SlackPlanDraftRepository {
       status: 'submitted',
       workflowIdsJson: JSON.stringify(workflowIds),
     });
+    if (draft.planningDraftId) {
+      this.planningDrafts.markSubmitted(draft.planningDraftId);
+    }
+  }
+
+  resolvePlanText(draft: SlackPlanDraft): string {
+    if (!draft.planningDraftId) {
+      const legacyHash = createHash('sha256').update(draft.planText).digest('hex');
+      if (legacyHash !== draft.contentHash) {
+        throw new Error('This legacy plan review failed its integrity check.');
+      }
+      return draft.planText;
+    }
+    const approved = this.planningDrafts.get(draft.planningDraftId);
+    if (!approved
+      || approved.conversationId !== draft.threadTs
+      || approved.planText !== draft.planText
+      || approved.contentHash !== draft.contentHash) {
+      throw new Error('This plan review no longer matches its immutable approved draft.');
+    }
+    return approved.planText;
   }
 
   markFailed(draft: SlackPlanDraft, userId: string): void {
@@ -97,5 +136,8 @@ export class SlackPlanDraftRepository {
       decidedAt: new Date().toISOString(),
       decidedBy: userId,
     });
+    if (status === 'rejected' && draft.planningDraftId) {
+      this.planningDrafts.supersede(draft.planningDraftId);
+    }
   }
 }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -54,6 +54,7 @@ import type {
   ActivityLogEntry,
   Conversation,
   ConversationMessage,
+  PlanningDraft,
   SlackLaunchContext,
   SlackPlanDraft,
   SlackPendingConfirmation,
@@ -635,6 +636,8 @@ type InAppPlanningSessionRow = {
   worktree_branch?: unknown;
   draft_plan_summary_json?: unknown;
   draft_plan_text?: unknown;
+  planning_draft_id?: unknown;
+  planning_draft_hash?: unknown;
   submitted_workflow_id?: unknown;
   submitted_plan_name?: unknown;
   terminal_mode?: unknown;
@@ -1398,6 +1401,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
           worktree_branch,
           draft_plan_summary_json,
           draft_plan_text,
+          planning_draft_id,
+          planning_draft_hash,
           submitted_workflow_id,
           submitted_plan_name,
           terminal_mode,
@@ -1412,7 +1417,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           active_turn_error,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
@@ -1425,6 +1430,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
           worktree_branch = excluded.worktree_branch,
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           draft_plan_text = excluded.draft_plan_text,
+          planning_draft_id = excluded.planning_draft_id,
+          planning_draft_hash = excluded.planning_draft_hash,
           submitted_workflow_id = excluded.submitted_workflow_id,
           submitted_plan_name = excluded.submitted_plan_name,
           terminal_mode = excluded.terminal_mode,
@@ -1452,6 +1459,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.worktreeBranch ?? null,
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.draftPlanText ?? null,
+          record.planningDraftId ?? null,
+          record.planningDraftHash ?? null,
           record.submittedWorkflowId ?? null,
           record.submittedPlanName ?? null,
           record.terminalMode ?? 'chat',
@@ -1533,6 +1542,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'draftPlanText')) {
         setClauses.push('draft_plan_text = ?');
         values.push(patch.draftPlanText ?? null);
+      }
+      if (Object.hasOwn(patch, 'planningDraftId')) {
+        setClauses.push('planning_draft_id = ?');
+        values.push(patch.planningDraftId ?? null);
+      }
+      if (Object.hasOwn(patch, 'planningDraftHash')) {
+        setClauses.push('planning_draft_hash = ?');
+        values.push(patch.planningDraftHash ?? null);
       }
       if (Object.hasOwn(patch, 'submittedWorkflowId')) {
         setClauses.push('submitted_workflow_id = ?');
@@ -2335,6 +2352,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM slack_launch_contexts WHERE thread_ts = ?', [threadTs]);
       this.db.run('DELETE FROM slack_pending_confirmations WHERE thread_ts = ?', [threadTs]);
       this.db.run('DELETE FROM conversation_messages WHERE thread_ts = ?', [threadTs]);
+      this.db.run('DELETE FROM planning_drafts WHERE conversation_id = ?', [threadTs]);
       this.db.run('DELETE FROM conversations WHERE thread_ts = ?', [threadTs]);
     });
   }
@@ -2390,12 +2408,106 @@ export class SQLiteAdapter implements PersistenceAdapter {
           SELECT thread_ts FROM conversations WHERE updated_at < ?
         )
       `, [cutoffIso]);
+      this.db.run(`
+        DELETE FROM planning_drafts WHERE conversation_id IN (
+          SELECT thread_ts FROM conversations WHERE updated_at < ?
+        )
+      `, [cutoffIso]);
       this.db.run(
         'DELETE FROM conversations WHERE updated_at < ?',
         [cutoffIso],
       );
       return this.db.getRowsModified();
     });
+  }
+
+  private mapPlanningDraftRow(row: Record<string, unknown>): PlanningDraft {
+    return {
+      id: row.id as string,
+      conversationId: row.conversation_id as string,
+      version: Number(row.version),
+      planText: row.plan_text as string,
+      contentHash: row.content_hash as string,
+      status: row.status as PlanningDraft['status'],
+      createdAt: row.created_at as string,
+      ...(typeof row.superseded_at === 'string' ? { supersededAt: row.superseded_at } : {}),
+      ...(typeof row.submitted_at === 'string' ? { submittedAt: row.submitted_at } : {}),
+    };
+  }
+
+  createCurrentPlanningDraft(
+    input: Omit<PlanningDraft, 'version' | 'status' | 'supersededAt' | 'submittedAt'>,
+  ): PlanningDraft {
+    return this.runTransaction(() => {
+      const previous = this.queryOne(
+        `SELECT COALESCE(MAX(version), 0) AS version
+         FROM planning_drafts
+         WHERE conversation_id = ?`,
+        [input.conversationId],
+      );
+      const version = Number(previous?.version ?? 0) + 1;
+      this.execRun(
+        `UPDATE planning_drafts
+         SET status = 'superseded', superseded_at = ?
+         WHERE conversation_id = ? AND status = 'current'`,
+        [input.createdAt, input.conversationId],
+      );
+      this.execRun(
+        `INSERT INTO planning_drafts (
+           id, conversation_id, version, plan_text, content_hash, status, created_at
+         ) VALUES (?, ?, ?, ?, ?, 'current', ?)`,
+        [
+          input.id,
+          input.conversationId,
+          version,
+          input.planText,
+          input.contentHash,
+          input.createdAt,
+        ],
+      );
+      return { ...input, version, status: 'current' };
+    });
+  }
+
+  loadCurrentPlanningDraft(conversationId: string): PlanningDraft | undefined {
+    const row = this.queryOne(
+      `SELECT * FROM planning_drafts
+       WHERE conversation_id = ? AND status = 'current'`,
+      [conversationId],
+    );
+    return row ? this.mapPlanningDraftRow(row) : undefined;
+  }
+
+  loadPlanningDraft(id: string): PlanningDraft | undefined {
+    const row = this.queryOne('SELECT * FROM planning_drafts WHERE id = ?', [id]);
+    return row ? this.mapPlanningDraftRow(row) : undefined;
+  }
+
+  supersedePlanningDraft(id: string, supersededAt: string): void {
+    this.execRun(
+      `UPDATE planning_drafts
+       SET status = 'superseded', superseded_at = ?
+       WHERE id = ? AND status = 'current'`,
+      [supersededAt, id],
+    );
+  }
+
+  supersedeCurrentPlanningDraft(conversationId: string, supersededAt: string): void {
+    this.execRun(
+      `UPDATE planning_drafts
+       SET status = 'superseded', superseded_at = ?
+       WHERE conversation_id = ? AND status = 'current'`,
+      [supersededAt, conversationId],
+    );
+  }
+
+  markPlanningDraftSubmitted(id: string, submittedAt: string): void {
+    this.execRun(
+      `UPDATE planning_drafts
+       SET status = 'submitted', submitted_at = ?
+       WHERE id = ? AND status = 'current'`,
+      [submittedAt, id],
+    );
   }
 
   // ── Conversation Messages ──────────────────────────────
@@ -2480,12 +2592,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   saveSlackPlanDraft(draft: SlackPlanDraft): void {
     this.execRun(`
       INSERT OR REPLACE INTO slack_plan_drafts
-        (draft_id, version, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
+        (draft_id, version, planning_draft_id, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
          status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       draft.draftId,
       draft.version,
+      draft.planningDraftId ?? null,
       draft.channelId,
       draft.threadTs,
       draft.messageTs ?? null,
@@ -2594,6 +2707,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return {
       draftId: row.draft_id as string,
       version: Number(row.version),
+      planningDraftId: typeof row.planning_draft_id === 'string' ? row.planning_draft_id : undefined,
       channelId: row.channel_id as string,
       threadTs: row.thread_ts as string,
       messageTs: typeof row.message_ts === 'string' ? row.message_ts : undefined,
@@ -3351,6 +3465,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         messages,
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.draft_plan_text === 'string' ? { draftPlanText: row.draft_plan_text } : {}),
+        ...(typeof row.planning_draft_id === 'string' ? { planningDraftId: row.planning_draft_id } : {}),
+        ...(typeof row.planning_draft_hash === 'string' ? { planningDraftHash: row.planning_draft_hash } : {}),
         ...(typeof row.submitted_workflow_id === 'string' ? { submittedWorkflowId: row.submitted_workflow_id } : {}),
         ...(typeof row.submitted_plan_name === 'string' ? { submittedPlanName: row.submitted_plan_name } : {}),
         terminalMode,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -172,6 +172,26 @@ export const SCHEMA_DDL = `
         updated_at TEXT DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS planning_drafts (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        version INTEGER NOT NULL CHECK (version > 0),
+        plan_text TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('current', 'superseded', 'submitted')),
+        created_at TEXT NOT NULL,
+        superseded_at TEXT,
+        submitted_at TEXT,
+        UNIQUE(conversation_id, version)
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_planning_drafts_current
+        ON planning_drafts(conversation_id)
+        WHERE status = 'current';
+
+      CREATE INDEX IF NOT EXISTS idx_planning_drafts_conversation_version
+        ON planning_drafts(conversation_id, version DESC);
+
       CREATE TABLE IF NOT EXISTS conversation_messages (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         thread_ts TEXT NOT NULL,
@@ -199,6 +219,7 @@ export const SCHEMA_DDL = `
       CREATE TABLE IF NOT EXISTS slack_plan_drafts (
         draft_id TEXT NOT NULL,
         version INTEGER NOT NULL,
+        planning_draft_id TEXT,
         channel_id TEXT NOT NULL,
         thread_ts TEXT NOT NULL,
         message_ts TEXT,
@@ -245,6 +266,8 @@ export const SCHEMA_DDL = `
         confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
         draft_plan_text TEXT,
+        planning_draft_id TEXT,
+        planning_draft_hash TEXT,
         submitted_workflow_id TEXT,
         submitted_plan_name TEXT,
         terminal_mode TEXT NOT NULL DEFAULT 'chat' CHECK (terminal_mode IN ('chat', 'tmux')),
@@ -647,6 +670,9 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_id TEXT',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_status TEXT CHECK (active_turn_status IS NULL OR active_turn_status IN ('running', 'failed'))",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_error TEXT',
+  'ALTER TABLE slack_plan_drafts ADD COLUMN planning_draft_id TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_id TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_hash TEXT',
 ];
 
 /**

--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -439,4 +439,38 @@ tasks:
       expect(conv2.history.length).toBe(4);
     });
   });
+
+  describe('approved-draft repair budget restart repro', () => {
+    it.fails('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
+      const threadTs = 'ts-restart-doctor-budget';
+      const first = new PlanConversation({
+        threadTs,
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await first.sendMessage('Draft the plan');
+
+      const rejectingDoctor = vi.fn().mockResolvedValue({
+        ok: false,
+        diagnostics: ['validate-plan: still invalid'],
+      });
+      const recovered = new PlanConversation({
+        threadTs,
+        conversationRepo: repo,
+        draftDoctor: rejectingDoctor,
+        firstDraftPlanDoctorRepairLimit: 3,
+      });
+      await recovered.init();
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate One'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Two'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Three'));
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Candidate Four'));
+
+      const reply = await recovered.sendMessage('Replace the plan');
+
+      expect(rejectingDoctor).toHaveBeenCalledTimes(3);
+      expect(reply).toContain('(2 repair turns attempted)');
+    });
+  });
 });

--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -441,7 +441,7 @@ tasks:
   });
 
   describe('approved-draft repair budget restart repro', () => {
-    it.fails('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
+    it('keeps the replacement budget after restoring a prior doctor-approved draft', async () => {
       const threadTs = 'ts-restart-doctor-budget';
       const first = new PlanConversation({
         threadTs,
@@ -471,6 +471,107 @@ tasks:
 
       expect(rejectingDoctor).toHaveBeenCalledTimes(3);
       expect(reply).toContain('(2 repair turns attempted)');
+    });
+  });
+
+  describe('immutable doctor-approved drafts', () => {
+    it('restores the exact doctor-approved draft without recovering YAML from chat', async () => {
+      const doctor = vi.fn().mockResolvedValue({ ok: true, diagnostics: [] });
+      const first = new PlanConversation({
+        threadTs: 'ts-approved-restart',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await first.sendMessage('Draft the plan');
+      const stored = first.approvedPlanningDraft;
+
+      const recovered = new PlanConversation({
+        threadTs: 'ts-approved-restart',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+      });
+      await recovered.init();
+
+      expect(recovered.approvedPlanningDraft?.id).toBe(stored?.id);
+      expect(recovered.getDraftedPlan()).toBe(stored?.planText);
+    });
+
+    it('does not classify unvalidated YAML recovered from chat as doctor-approved', async () => {
+      repo.saveConversation('ts-unvalidated-chat-yaml', [
+        { role: 'assistant', content: VALID_YAML_PLAN },
+      ]);
+      const recovered = new PlanConversation({
+        threadTs: 'ts-unvalidated-chat-yaml',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+
+      await recovered.init();
+
+      expect(recovered.approvedPlanningDraft).toBeNull();
+      expect(recovered.getDraftedPlan()).toBeNull();
+    });
+
+    it('keeps the current approved draft when a replacement is rejected', async () => {
+      const doctor = vi.fn()
+        .mockResolvedValueOnce({ ok: true, diagnostics: [] })
+        .mockResolvedValueOnce({ ok: false, diagnostics: ['still invalid'] });
+      const conversation = new PlanConversation({
+        threadTs: 'ts-rejected-replacement',
+        conversationRepo: repo,
+        draftDoctor: doctor,
+        planDoctorRepairLimit: 0,
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await conversation.sendMessage('Draft the plan');
+      const approved = conversation.approvedPlanningDraft;
+
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Rejected Plan'));
+      const reply = await conversation.sendMessage('Replace it');
+
+      expect(reply).toContain('Draft not shown: the plan doctor rejected it.');
+      expect(conversation.approvedPlanningDraft?.id).toBe(approved?.id);
+      expect(conversation.getDraftedPlan()).toBe(approved?.planText);
+    });
+
+    it('fails closed when an approved draft cannot be persisted', async () => {
+      const conversation = new PlanConversation({
+        threadTs: 'ts-draft-write-failure',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      vi.spyOn(repo.planningDrafts, 'createCurrent').mockImplementation(() => {
+        throw new Error('database unavailable');
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+
+      const reply = await conversation.sendMessage('Draft the plan');
+
+      expect(reply).toContain('approved plan could not be persisted');
+      expect(conversation.lastTurnDraftPlanText).toBeNull();
+      expect(conversation.approvedPlanningDraft).toBeNull();
+    });
+
+    it('preserves the current approved draft when replacement persistence fails', async () => {
+      const conversation = new PlanConversation({
+        threadTs: 'ts-replacement-write-failure',
+        conversationRepo: repo,
+        draftDoctor: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+      });
+      mockCursorResponse(VALID_YAML_PLAN);
+      await conversation.sendMessage('Draft the plan');
+      const approved = conversation.approvedPlanningDraft;
+      vi.spyOn(repo.planningDrafts, 'createCurrent').mockImplementation(() => {
+        throw new Error('database unavailable');
+      });
+      mockCursorResponse(VALID_YAML_PLAN.replace('Test Plan', 'Lost Replacement'));
+
+      const reply = await conversation.sendMessage('Replace it');
+
+      expect(reply).toContain('approved plan could not be persisted');
+      expect(conversation.approvedPlanningDraft?.id).toBe(approved?.id);
+      expect(conversation.getDraftedPlan()).toBe(approved?.planText);
     });
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -14,7 +14,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import type { ConversationRepository } from '@invoker/data-store';
+import type { ConversationRepository, PlanningDraft } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import {
@@ -526,6 +526,7 @@ export class PlanConversation {
   private _lastTurnDraftFromSidecarFile = false;
   private _lastTurnPlanIntentSignal: PlanIntentSignal | null = null;
   private lastKnownGoodPlanText: string | null = null;
+  private _approvedPlanningDraft: PlanningDraft | null = null;
   private harnessSessionDriver?: HarnessSessionDriver;
   private _harnessSessionId?: string;
   private onHarnessSessionId?: (sessionId: string) => void;
@@ -606,6 +607,8 @@ export class PlanConversation {
       })).filter((m) => m.content.length > 0);
       this._planSubmitted = saved.planSubmitted;
       this.mode = saved.mode ?? this.mode;
+      this._approvedPlanningDraft = this.conversationRepo.planningDrafts.getCurrent(this.threadTs) ?? null;
+      this.lastKnownGoodPlanText = this._approvedPlanningDraft?.planText ?? null;
 
       this.log('plan-conversation', 'info', `Restored conversation ${this.threadTs}: ${saved.messages.length} messages`);
     } catch (err) {
@@ -681,6 +684,25 @@ export class PlanConversation {
       message = gated.message;
       finalFormatted = gated.formatted;
     }
+    if (nextDraft && this.draftDoctor && this.conversationRepo && this.threadTs) {
+      try {
+        this._approvedPlanningDraft = this.conversationRepo.planningDrafts.createCurrent(
+          this.threadTs,
+          nextDraft,
+        );
+        nextDraft = this._approvedPlanningDraft.planText;
+      } catch (error) {
+        this.log(
+          'plan-conversation',
+          'error',
+          `Failed to persist approved planning draft ${this.threadTs}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        nextDraft = null;
+        message = 'Draft not shown: the approved plan could not be persisted.\n\nNothing was submitted.';
+      }
+    }
     this._lastTurnDraftPlanText = nextDraft;
     this._lastTurnDraftFromSidecarFile = sidecarDraftSelected && Boolean(nextDraft);
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
@@ -717,7 +739,7 @@ export class PlanConversation {
     turn: number,
   ): Promise<{ planText: string | null; message: string; formatted: ReturnType<typeof formatCodexPlannerStdout> }> {
     const startedAt = Date.now();
-    const isFirstDraft = !this.lastKnownGoodPlanText;
+    const isFirstDraft = !(this._approvedPlanningDraft || this.lastKnownGoodPlanText);
     const repairLimit = this.resolvePlanDoctorRepairLimit(isFirstDraft);
     let planText = initialPlanText;
     let message = initialMessage;
@@ -836,6 +858,31 @@ export class PlanConversation {
     return this._lastTurnDraftPlanText;
   }
 
+  get approvedPlanningDraft(): PlanningDraft | null {
+    return this._approvedPlanningDraft;
+  }
+
+  get draftDoctorEnabled(): boolean {
+    return Boolean(this.draftDoctor);
+  }
+
+  markApprovedPlanningDraftSubmitted(): void {
+    if (!this._approvedPlanningDraft || !this.conversationRepo) return;
+    this.conversationRepo.planningDrafts.markSubmitted(this._approvedPlanningDraft.id);
+    this._approvedPlanningDraft = this.conversationRepo.planningDrafts.get(
+      this._approvedPlanningDraft.id,
+    ) ?? this._approvedPlanningDraft;
+  }
+
+  discardApprovedPlanningDraft(): void {
+    if (this._approvedPlanningDraft && this.conversationRepo) {
+      this.conversationRepo.planningDrafts.supersede(this._approvedPlanningDraft.id);
+    }
+    this._approvedPlanningDraft = null;
+    this._lastTurnDraftPlanText = null;
+    this.lastKnownGoodPlanText = null;
+  }
+
   /**
    * Whether this turn's draft came from the dedicated plan-draft sidecar file
    * (a deliberate planner act), rather than YAML embedded in the chat reply.
@@ -872,7 +919,11 @@ export class PlanConversation {
   getDraftedPlan(): string | null {
     // Only sendMessage may promote a candidate after its configured doctor
     // passes. Re-reading the sidecar here would bypass that review gate.
-    if (this.draftDoctor) return this._lastTurnDraftPlanText ?? this.lastKnownGoodPlanText;
+    if (this.draftDoctor) {
+      return this._lastTurnDraftPlanText
+        ?? this._approvedPlanningDraft?.planText
+        ?? this.lastKnownGoodPlanText;
+    }
     const fileDraft = this.readPlanDraftFile();
     if (fileDraft && summarizePlanText(fileDraft)) return fileDraft;
     return this._lastTurnDraftPlanText ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
@@ -967,6 +1018,7 @@ export class PlanConversation {
     this._lastTurnDraftFromSidecarFile = false;
     this._lastTurnPlanIntentSignal = null;
     this.lastKnownGoodPlanText = null;
+    this._approvedPlanningDraft = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);
     }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -46,7 +46,7 @@ import type { LobbyControl } from './lobby-control.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
-import type { ConversationRepository, SlackPlanDraft, SlackSessionRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
+import type { ConversationRepository, PlanningDraft, SlackPlanDraft, SlackSessionRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
 import { SlackPlanDraftRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout, materializeLocalAgentPrompt } from '@invoker/execution-engine';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
@@ -537,6 +537,8 @@ interface ConversationLike {
   getDraftedPlan(): string | null;
   readonly history: readonly { role: 'user' | 'assistant'; content: string }[];
   readonly lastTurnDraftPlanText: string | null;
+  readonly approvedPlanningDraft: PlanningDraft | null;
+  readonly draftDoctorEnabled: boolean;
   readonly lastTurnPlanIntentSignal: PlanIntentSignal | null;
   readonly conversationMode: ConversationMode;
   readonly planSubmitted: boolean;
@@ -1359,11 +1361,18 @@ export class SlackSurface implements Surface {
       });
       return { staged: false, reason: 'no_context' };
     }
-    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(draftReview.planText, context.repoUrl);
+    const approvedDraft = conversation.approvedPlanningDraft;
+    const reviewPlanText = approvedDraft?.planText ?? draftReview.planText;
+    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(reviewPlanText, context.repoUrl);
+    if (conversation.draftDoctorEnabled
+      && (!approvedDraft || approvedDraft.planText !== normalizedPlanText)) {
+      throw new Error('The review text does not exactly match the immutable doctor-approved draft.');
+    }
     const normalizedSummary = summarizePlanText(normalizedPlanText) ?? draftReview.summary;
     const draft = this.slackPlanDraftRepo.create({
       channelId: channel,
       threadTs,
+      planningDraftId: approvedDraft?.id,
       planText: normalizedPlanText,
       summaryJson: JSON.stringify(normalizedSummary),
       repoUrl: context.repoUrl,
@@ -1584,20 +1593,27 @@ export class SlackSurface implements Surface {
     if (draft.status !== 'ready') {
       throw new Error(`This plan review is ${draft.status}.`);
     }
-    if (!draft.messageTs || !draft.slackFileId
-      || createHash('sha256').update(draft.planText).digest('hex') !== draft.contentHash) {
+    if (!draft.messageTs || !draft.slackFileId) {
       throw new Error('This plan review failed its integrity check and cannot be approved.');
     }
+    const approvedPlanText = this.slackPlanDraftRepo?.resolvePlanText(draft);
+    if (!approvedPlanText) {
+      throw new Error('This plan review has no resolvable immutable draft.');
+    }
+    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(approvedPlanText, draft.repoUrl);
+    if (draft.planningDraftId && normalizedPlanText !== approvedPlanText) {
+      throw new Error('This plan review would change during submission and cannot be approved.');
+    }
+    const planTextForSubmit = draft.planningDraftId ? approvedPlanText : normalizedPlanText;
     const executionKey = this.slackPlanDraftRepo?.claim(draft);
     if (!executionKey) {
       throw new Error('This plan is already being submitted.');
     }
     await this.replacePlanDraftMessage(draft, 'Starting plan execution…', []);
     try {
-      const planText = this.normalizeDraftedPlanRepoUrl(draft.planText, draft.repoUrl);
       const result = await this.onCommand?.({
         type: 'start_plan',
-        planText,
+        planText: planTextForSubmit,
         repoUrl: draft.repoUrl,
         harnessPreset: draft.harnessPreset,
         requestedBy: draft.requestedBy,

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -15,7 +15,7 @@
 
 import { PlanConversation } from './plan-conversation.js';
 import type { ConversationMode, PlanIntentSignal, PlanningCommandBuilder } from './plan-conversation.js';
-import type { ConversationRepository } from '@invoker/data-store';
+import type { ConversationRepository, PlanningDraft } from '@invoker/data-store';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
 
@@ -116,6 +116,14 @@ export class SessionHandle {
 
   get lastTurnDraftPlanText(): string | null {
     return this.conversation.lastTurnDraftPlanText;
+  }
+
+  get approvedPlanningDraft(): PlanningDraft | null {
+    return this.conversation.approvedPlanningDraft;
+  }
+
+  get draftDoctorEnabled(): boolean {
+    return this.conversation.draftDoctorEnabled;
   }
 
   get lastTurnPlanIntentSignal(): PlanIntentSignal | null {


### PR DESCRIPTION
## Summary

Slack review rows bind to the exact immutable draft identity produced by the doctor gate.

Legacy review rows continue using their existing content-hash integrity check.

## Review Claim

Approve exposing immutable draft identity through Slack review and approval handling.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Slack executes the exact approved bytes, while older review rows remain usable through their existing hash contract.

## Slice Rationale

Slack activation is isolated from the independent in-app consumer.

## Non-goals

No in-app planning behavior or storage-schema changes.

## Architecture

### Before

```mermaid
graph TD
    A["Slack review row: copied YAML"] --> B["Approval"]
```

### After

```mermaid
graph TD
    A["Immutable planning draft"] --> B["Slack review row: draft ID and hash"]
    B --> C["Approval uses exact bytes"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b3f49f00a9`
- Post-revert steps: None
- Data migration? No

</details>
