### PR TITLE
[Claude Planning Agent](1) Register a ClaudePlanningAgent so Slack's "claude" preset resolves

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -121,11 +121,12 @@ describe('registerBuiltinAgents', () => {
   });
 
 
-  it('registers cursor, omp, and codex planning agents', () => {
+  it('registers cursor, omp, codex, and claude planning agents', () => {
     const registry = registerBuiltinAgents();
     expect(registry.getPlanningOrThrow('cursor').name).toBe('cursor');
     expect(registry.getPlanningOrThrow('omp').name).toBe('omp');
     expect(registry.getPlanningOrThrow('codex').name).toBe('codex');
+    expect(registry.getPlanningOrThrow('claude').name).toBe('claude');
   });
 
   it('threads the planning model into the cursor command', () => {

--- a/packages/execution-engine/src/__tests__/claude-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-planning-agent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { ClaudePlanningAgent } from '../agents/claude-planning-agent.js';
+
+describe('ClaudePlanningAgent', () => {
+  it('builds a print-mode command with permissions skipped', () => {
+    const agent = new ClaudePlanningAgent({ command: 'claude-test' });
+    expect(agent.buildPlanningCommand('p')).toEqual({
+      command: 'claude-test',
+      args: ['--dangerously-skip-permissions', '-p', 'p'],
+    });
+  });
+
+  it('defaults the command to claude', () => {
+    expect(new ClaudePlanningAgent().buildPlanningCommand('p').command).toBe('claude');
+  });
+
+  it('inserts --model before -p when a model is given', () => {
+    const agent = new ClaudePlanningAgent({ command: 'claude-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'opus' }).args).toEqual([
+      '--dangerously-skip-permissions', '--model', 'opus', '-p', 'p',
+    ]);
+  });
+});

--- a/packages/execution-engine/src/agents/claude-planning-agent.ts
+++ b/packages/execution-engine/src/agents/claude-planning-agent.ts
@@ -1,0 +1,31 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface ClaudePlanningAgentConfig {
+  /** Command to invoke the Claude Code CLI. Default: 'claude'. */
+  command?: string;
+}
+
+export class ClaudePlanningAgent implements PlanningAgent {
+  readonly name = 'claude';
+
+  private readonly command: string;
+
+  constructor(config: ClaudePlanningAgentConfig = {}) {
+    this.command = config.command ?? 'claude';
+  }
+
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
+    return {
+      command: this.command,
+      args: [
+        '--dangerously-skip-permissions',
+        ...(options?.model ? ['--model', options.model] : []),
+        '-p',
+        prompt,
+      ],
+    };
+  }
+}

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -11,6 +11,7 @@ export { CursorExecutionAgent, type CursorExecutionAgentConfig } from './cursor-
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 export { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
 export { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
+export { ClaudePlanningAgent, type ClaudePlanningAgentConfig } from './claude-planning-agent.js';
 
 import { AgentRegistry } from '../agent-registry.js';
 import { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
@@ -22,6 +23,7 @@ import { CursorExecutionAgent, type CursorExecutionAgentConfig } from './cursor-
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 import { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
 import { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
+import { ClaudePlanningAgent, type ClaudePlanningAgentConfig } from './claude-planning-agent.js';
 import { CodexSessionDriver } from '../codex-session-driver.js';
 import { ClaudeSessionDriver } from '../claude-session-driver.js';
 import { OmpSessionDriver } from '../omp-session-driver.js';
@@ -39,6 +41,7 @@ export function registerBuiltinAgents(opts?: {
   cursor?: CursorPlanningAgentConfig;
   ompPlanning?: OmpPlanningAgentConfig;
   codexPlanning?: CodexPlanningAgentConfig;
+  claudePlanning?: ClaudePlanningAgentConfig;
 }): AgentRegistry {
   const registry = new AgentRegistry();
   registry.registerExecution(new ClaudeExecutionAgent(opts?.claude), new ClaudeSessionDriver());
@@ -50,5 +53,6 @@ export function registerBuiltinAgents(opts?: {
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
   registry.registerPlanning(new OmpPlanningAgent(opts?.ompPlanning));
   registry.registerPlanning(new CodexPlanningAgent(opts?.codexPlanning));
+  registry.registerPlanning(new ClaudePlanningAgent(opts?.claudePlanning));
   return registry;
 }


### PR DESCRIPTION
## Summary

Slack's Invoker bot ships a "claude" planning preset, but no Claude planning agent was ever registered, so any un-bracketed `@Invoker` message threw "No planning agent registered with name \"claude\"."

This adds `ClaudePlanningAgent` and registers it alongside the existing cursor, omp, and codex planning agents, so the "claude" preset actually resolves.

Class-search note: PR #6515 already made "claude" choosable in the in-app planner dropdown, through a sibling lookup reusing `ClaudeExecutionAgent`. It deliberately left out a `ClaudePlanningAgent` class.

But `runOneShotPlanner` in `slack-surface.ts` calls the planning-agent lookup directly, with no fallback. Same preset name, two independent resolution paths; #6515 fixed one, this fixes the other.

It mirrors the existing planning agents' shape: a one-shot print-mode invocation of the `claude` binary, using the same permission-bypass flag Claude's execution agent already relies on.

## Review Claim

Approve registering a new `ClaudePlanningAgent` (same base shape as cursor/omp/codex) so the pre-existing "claude" Slack harness preset resolves instead of throwing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Confirmed: this is additive-only. `ClaudePlanningAgent` is a new class built the same way as the other planning agents, registered as one more entry in `registerBuiltinAgents`. No existing planning agent (cursor/omp/codex), execution agent, or caller is touched. Before this change, resolving the planning-agent name "claude" always threw; after this change, it resolves to a real agent — there is no prior successful behavior this can regress.

## Slice Rationale

Self-contained: one new agent class, its registration, and matching unit tests. No other planning agent's code changes, so this ships as a single slice rather than bundled with unrelated work.

## Non-goals

Does not touch how Slack picks a preset, how the resulting output is parsed, or DO1's own config/deployment — those are unchanged. Does not add Claude-specific chat/session handling beyond the same one-shot print-mode invocation already used by execution agents.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test claude-planning-agent.test.ts` — 3/3 pass
- [x] `cd packages/execution-engine && pnpm test agent-registry.test.ts` — 29/29 pass (includes updated "registers cursor, omp, codex, and claude planning agents" assertion)
- [x] `pnpm run check:types` — 0 errors
- [x] `cd packages/execution-engine && pnpm test` — full suite, 132/132 test files, 1705 passed / 1 skipped (pre-existing, unrelated)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — Slack's "claude" preset goes back to throwing the pre-existing error; no data or state to clean up.
- Data migration? No

</details>
