### PR TITLE
[UI dark theme: black to pink palette](1) add pink-theme-dark-home visual proof spec

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -22,6 +22,7 @@ import {
   assertPageScreenshot,
   getTasks,
   openPlanGraph,
+  waitForStableUI,
   E2E_REPO_URL,
 } from './fixtures/electron-app.js';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -1493,6 +1494,14 @@ test.describe('Visual proof capture', () => {
     await expect(page.locator('.react-flow__node[data-testid$="task-beta"]')).toBeVisible();
     await captureScreenshot(page, 'dag-loaded');
     await assertPageScreenshot(page, 'dag-loaded');
+  });
+
+  test('pink-theme-dark-home', async ({ page }) => {
+    await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
+    await expect(page.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
+    await expect(page.locator('.react-flow__node[data-testid$="task-beta"]')).toBeVisible();
+    await waitForStableUI(page);
+    await captureScreenshot(page, 'pink-theme-dark-home');
   });
 
   test('system setup readiness report shows a failing default preset check', async ({ page, electronApp }) => {


### PR DESCRIPTION
## Summary

Adds one Playwright capture case to `visual-proof.spec.ts` that screenshots
the main app surface (DAG view with a loaded plan).

This gives the pink dark-theme palette change in slice (3) a dedicated,
named capture state instead of reusing an unrelated existing screenshot.

## Review Claim

`packages/app/e2e/visual-proof.spec.ts` gains one capture case,
`pink-theme-dark-home`, that screenshots the DAG view with a loaded plan so
the pink dark theme can be captured.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only adds a new test case using existing helpers (`loadPlanAndSelectWorkflow`,
`captureScreenshot`, `waitForStableUI`); no existing test case or fixture is
modified, so current capture states keep producing identical output.

## Slice Rationale

Capture spec is test-only scaffolding for visual proof, kept separate from
the capture-script build fix in slice (2) and from the CSS palette edit it
photographs in slice (3), since each has a different Review Unit.

## Non-goals

Modifying existing capture states or app code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx playwright test e2e/visual-proof.spec.ts -g "pink-theme-dark-home" --list`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
