### PR TITLE
[UI dark theme: black to pink palette](2) build the surfaces package before visual-proof capture

### DIFF
--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -95,7 +95,7 @@ run_capture() {
 
   if [[ "${skip_build}" == "false" ]]; then
     echo "[visual-proof] Building UI and app..." >&2
-    pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build || {
+    pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build || {
       echo "[visual-proof] ERROR: Build failed" >&2
       exit 1
     }


### PR DESCRIPTION
## Summary

Fixes the visual-proof capture script's build step so it builds
`@invoker/surfaces` before `@invoker/app`.

Without this, the app build (and therefore any capture run) failed with
`sh: 1: vite: not found` on a clean checkout, because `@invoker/app`
depends on the `@invoker/surfaces` build output that was never produced.

## Review Claim

`scripts/ui-visual-proof.sh`'s `run_capture` now runs
`pnpm --filter @invoker/surfaces build` between the `@invoker/ui` and
`@invoker/app` build steps.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is a one-line addition to an existing `&&`-chained build
sequence in `scripts/ui-visual-proof.sh`; it does not alter any exit-code
handling, output paths, or existing build steps, so a successful capture
run today keeps succeeding and a build failure still fails the script the
same way.

## Slice Rationale

This is a capture-tooling bug fix, independent of both the new test case in
slice (1) and the CSS palette change plus its screenshot in slice (3).
Bundling it with either would mix a `policy` file with `proof` or
`behavior` files in one PR, which the local PR-body validator rejects.

## Non-goals

Changing any other subcommand (`capture-before`, `compare`, `embed`) or
any build step ordering beyond adding the missing `@invoker/surfaces`
build.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/ui-visual-proof.sh`
- [x] `grep -n "pnpm --filter @invoker/surfaces build" scripts/ui-visual-proof.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
