### PR TITLE
[Headless executing stall](1) Reap expired-lease tasks without a BrowserWindow

### DIFF
--- a/packages/app/src/__tests__/headless-executing-stall-reap.test.ts
+++ b/packages/app/src/__tests__/headless-executing-stall-reap.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { createRendererTaskFeed } from '../window/renderer-task-feed.js';
+
+describe('headless db-poll executing stall', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reaps an expired-lease running task when getMainWindow() is null', async () => {
+    const now = new Date('2026-08-23T08:00:00.000Z');
+    vi.setSystemTime(now);
+
+    const staleTask = {
+      id: 'wf-headless/impl-06',
+      status: 'running',
+      config: {
+        workflowId: 'wf-headless',
+        runnerKind: 'worktree',
+      },
+      execution: {
+        phase: 'executing',
+        generation: 0,
+        selectedAttemptId: 'attempt-stale',
+        startedAt: new Date(now.getTime() - 30 * 60_000).toISOString(),
+        lastHeartbeatAt: new Date(now.getTime() - 20 * 60_000).toISOString(),
+      },
+    } as unknown as TaskState;
+
+    const handleWorkerResponse = vi.fn();
+    const publishDelta = vi.fn();
+    const requestWorkflowMetadataPublish = vi.fn();
+    const pollLaunchDispatcher = vi.fn();
+
+    const feed = createRendererTaskFeed({
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+      persistence: {
+        listWorkflows: () => [{ id: 'wf-headless', status: 'running' } as never],
+        loadTasks: () => [staleTask],
+        loadTasksForWorkflows: () => [staleTask],
+        loadTask: () => staleTask,
+        loadAttempt: () => ({
+          status: 'running',
+          leaseExpiresAt: new Date(now.getTime() - 5 * 60_000).toISOString(),
+          lastHeartbeatAt: new Date(now.getTime() - 20 * 60_000).toISOString(),
+        }),
+        writeActivityLog: vi.fn(),
+        appendOutputChunk: vi.fn(),
+        getOutputTail: () => [],
+        appendTaskOutput: vi.fn(),
+      },
+      messageBus: { publish: vi.fn() },
+      getOrchestrator: () => ({
+        getAllTasks: () => [staleTask],
+        getMergeNode: () => undefined,
+        syncAllFromDb: vi.fn(),
+        handleWorkerResponse,
+        reclaimStalledFixSession: vi.fn(),
+      }),
+      taskHandles: { has: () => false },
+      taskGraphEventPublisher: { publishDelta },
+      getMainWindow: () => null,
+      setStartupWorkflowId: vi.fn(),
+      requestWorkflowMetadataPublish,
+      scheduleAutoFix: vi.fn(),
+      logAutoFixDebug: vi.fn(),
+      uiPerfStats: {
+        mainDeltaToUi: 0,
+        dbPollCreated: 0,
+        dbPollUpdatedAsCreated: 0,
+        workflowMetadataPublishes: 0,
+        workflowMetadataCoalescedRequests: 0,
+      },
+      traceUiDeltaFlow: false,
+      traceDbPollPerTask: false,
+      traceTaskOutput: false,
+      executingStallTimeoutMs: 120_000,
+      pollLaunchDispatcher,
+    });
+
+    const handle = feed.startDbPolling();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(handleWorkerResponse).toHaveBeenCalledTimes(1);
+    const response = handleWorkerResponse.mock.calls[0]?.[0];
+    expect(response).toMatchObject({
+      actionId: 'wf-headless/impl-06',
+      status: 'failed',
+      outputs: {
+        failureClass: 'liveness_stall',
+      },
+    });
+    expect(String(response.outputs.error)).toContain('attempt lease expired');
+    expect(publishDelta).not.toHaveBeenCalled();
+    expect(requestWorkflowMetadataPublish).not.toHaveBeenCalled();
+    expect(pollLaunchDispatcher).toHaveBeenCalled();
+
+    handle.stop();
+  });
+});

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -203,9 +203,11 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
 
   const startDbPolling = (): RendererTaskFeedStopHandle => {
     const interval = setInterval(() => {
-      const mainWindow = deps.getMainWindow();
-      if (!mainWindow || mainWindow.isDestroyed()) return;
+      // Headless owners have no BrowserWindow. Still run liveness/stall
+      // reaping and launch-dispatcher poll; only UI delta publish needs a window.
       try {
+        const mainWindow = deps.getMainWindow();
+        const canPublishUi = !!mainWindow && !mainWindow.isDestroyed();
         const workflows = deps.persistence.listWorkflows();
 
         if (workflows.length !== lastKnownWorkflowCount) {
@@ -213,7 +215,9 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
           deps.logger.info(msg, { module: 'db-poll' });
           try { deps.persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
           lastKnownWorkflowCount = workflows.length;
-          deps.requestWorkflowMetadataPublish('db-poll-count');
+          if (canPublishUi) {
+            deps.requestWorkflowMetadataPublish('db-poll-count');
+          }
 
           deps.getOrchestrator().syncAllFromDb();
           deps.logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
@@ -351,6 +355,10 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
                 );
                 continue;
               }
+            }
+
+            if (!canPublishUi) {
+              continue;
             }
 
             const snapshot = JSON.stringify(task);


### PR DESCRIPTION
## Summary

Headless owners never opened a BrowserWindow, so db-poll returned before any liveness work.

Expired-lease executing tasks stayed `running` until an owner restart.

This change keeps stall reaping and launch-dispatcher polling active in headless mode.

UI publish stays gated on a live window.

## Review Claim

Approve that headless db-poll reaps expired-lease executing tasks without requiring a BrowserWindow.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Headless owners fail expired-lease `running`/`fixing_with_ai` tasks through the same `liveness_stall` / reclaim path GUI already uses. With a live window, stall detection and UI publish stay as they are; only the early return that skipped the whole poll when `mainWindow` was null is removed.

## Slice Rationale

This is one headless activation-surface behavior change plus its companion coverage in `packages/app`.

## Non-goals

Does not change the `evaluateExecutingStall` predicate or timeout values.

Does not change GUI stall behavior when a window is present.

Does not rebuild or restart the NiceSpeak eval owner in this PR.

## Architecture

### Before

```mermaid
graph TD
    A["db-poll tick"] --> B["getMainWindow()"]
    B --> C{"window live?"}
    C -->|"no"| D["return"]
    C -->|"yes"| E["stall reap + UI publish"]
```

### After

```mermaid
graph TD
    A["db-poll tick"] --> B["getMainWindow()"]
    B --> C{"window live?"}
    C --> D["stall reap always"]
    D --> E{"window live?"}
    E -->|"yes"| F["UI publish"]
    E -->|"no"| G["continue without UI publish"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-executing-stall-reap.test.ts`
- [ ] `pnpm --filter @invoker/app test`

</details>

## Visual Proof

Path under `packages/app/src/window/` trips the UI media gate. This slice does not change visible GUI panels; it only changes headless poll gating. Diagrams below show the headless control-flow change.

![Prior headless db-poll gate](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260823-0905ec/headless-db-poll-prior.png)

Prior diagram: pink card listing null window, immediate return, orphan stays running, owner-boot recovery only.

![Updated headless db-poll gate](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260823-0905ec/headless-db-poll-updated.png)

Updated diagram: green card listing null window, stall reap still runs, UI publish gated off, expired-lease task fails `liveness_stall`.

Manually inspected: opened both PNGs; prior shows the early-return orphan path; updated shows stall reap without UI publish and `liveness_stall` failure.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 76d49602fd`
- Post-revert steps: None
- Data migration? No

</details>
