### PR TITLE
[Owner exec ack](1) Forward runner payload on standalone message-bus ack

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -25,4 +25,17 @@ describe('standalone owner handler ordering', () => {
       'INV-192: startStandaloneLaunchDispatcher must run after headless.exec is registered',
     ).toBeLessThan(dispatcherIdx);
   });
+
+  it('standalone headless.exec merges runHeadless return into the message-bus ack when unscoped', () => {
+    const source = readFileSync(MAIN, 'utf8');
+    const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
+    const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
+    expect(execIdx, 'standalone headless.exec handler not found').toBeGreaterThan(-1);
+    expect(nextHandler, 'headless.gui-mutation handler not found after headless.exec').toBeGreaterThan(execIdx);
+
+    const handler = source.slice(execIdx, nextHandler);
+    expect(handler).toMatch(/commandResult = await runHeadless/);
+    expect(handler).toMatch(/if \(!workflowId\)/);
+    expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2049,8 +2049,9 @@ function startHeadlessMode(): void {
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
           const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone', headlessExecMutationContext);
           if (acknowledgement) return acknowledgement;
+          let commandResult: unknown;
           await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
-            await runHeadless(args, {
+            commandResult = await runHeadless(args, {
               ...headlessDeps,
               waitForApproval: delegatedWait,
               noTrack: delegatedNoTrack,
@@ -2058,6 +2059,12 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
+          if (!workflowId) {
+            return {
+              ok: true,
+              ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
+            };
+          }
           return { ok: true };
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {


### PR DESCRIPTION
## Summary

The DigitalOcean owner claimed a conflict repair and never filed it.

The standalone owner exec path acked success on the message bus and dropped the inner runner payload.

Callers that need the insert field then fail closed and leave the claim row behind.

This slice forwards that payload on the unscoped message bus ack, matching the GUI owner path.

## Review Claim

The standalone owner exec handler should merge the inner runner return into the message bus ack when the mutation is not workflow-scoped.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Unscoped exec still returns `{ ok: true }`. Extra fields are the inner runner payload. Workflow-scoped exec still returns `{ ok: true }` only. A second insert of the same key still reports `inserted: false`. Unparseable payloads still fail closed. Conflict rebase is unchanged.

## Slice Rationale

This is the message bus owner path that currently drops the runner payload.

The GUI path already merges it.

A broader owner-runtime rewrite is out of scope.

## Non-goals

Does not change conflict rebase.

Does not change the GUI exec path.

Does not change fail-closed parse behavior.

## Architecture

### Before

```mermaid
graph TD
    A["standalone exec handler"] --> B["inner runner"]
    A --> C["message bus ack is ok true only"]
```

### After

```mermaid
graph TD
    A["standalone exec handler"] --> B["inner runner"]
    B --> C["message bus ack is ok true plus runner payload"]
```

## Visual Proof

This slice does not change a rendered window. `packages/app/src/main.ts` is classified as UI-impacting by path.

![live DigitalOcean owner insert envelope](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260823-5157f2/repair-filing-do1-envelope.png)

Live owner insert acked `{ok:true,response:{ok:true}}` with no `inserted` field.

![unscoped message bus ack with runner payload](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260823-5157f2/repair-filing-handler-merge.png)

Unscoped exec now spreads the inner runner object onto `{ok:true}`.

Manually inspected: the live envelope image shows `response` as `{ok:true}` only, with a missing `inserted` key. The merge image shows `inserted` and `row` on the unscoped message bus ack, and notes that a duplicate key still reports `inserted: false`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/standalone-owner-handler-ordering.test.ts`
- [x] Live DigitalOcean owner insert of a unique repair-filing key returned `{ok:true,response:{ok:true}}` with no `inserted` field, and the claimer fail-closed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
