### PR TITLE
[Owner exec ack](2) Test buildStandaloneHeadlessExecAcknowledgement directly

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
+import { buildStandaloneHeadlessExecAcknowledgement } from '../ipc/gui-mutation-handlers.js';
 
 const MAIN = path.resolve(__dirname, '..', 'main.ts');
 
@@ -26,7 +27,7 @@ describe('standalone owner handler ordering', () => {
     ).toBeLessThan(dispatcherIdx);
   });
 
-  it('standalone headless.exec merges runHeadless return into the message-bus ack when unscoped', () => {
+  it('standalone headless.exec wires runHeadless into buildStandaloneHeadlessExecAcknowledgement', () => {
     const source = readFileSync(MAIN, 'utf8');
     const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
     const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
@@ -35,7 +36,22 @@ describe('standalone owner handler ordering', () => {
 
     const handler = source.slice(execIdx, nextHandler);
     expect(handler).toMatch(/commandResult = await runHeadless/);
-    expect(handler).toMatch(/if \(!workflowId\)/);
-    expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
+    expect(handler).toMatch(/buildStandaloneHeadlessExecAcknowledgement\(workflowId, commandResult\)/);
+  });
+
+  it('merges the runHeadless return into the unscoped message-bus ack', () => {
+    const commandResult = { inserted: true, row: { id: 'task-1' } };
+
+    expect(buildStandaloneHeadlessExecAcknowledgement(undefined, commandResult)).toEqual({
+      ok: true,
+      inserted: true,
+      row: { id: 'task-1' },
+    });
+  });
+
+  it('keeps the workflow-scoped ack as { ok: true } even when runHeadless returned data', () => {
+    const commandResult = { inserted: true, row: { id: 'task-1' } };
+
+    expect(buildStandaloneHeadlessExecAcknowledgement('workflow-123', commandResult)).toEqual({ ok: true });
   });
 });

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -240,6 +240,19 @@ export function acknowledgeNoTrackHeadlessExec(
   throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
 }
 
+export function buildStandaloneHeadlessExecAcknowledgement(
+  workflowId: string | undefined,
+  commandResult: unknown,
+): { ok: true } & Record<string, unknown> {
+  if (!workflowId) {
+    return {
+      ok: true,
+      ...(commandResult && typeof commandResult === 'object' ? (commandResult as Record<string, unknown>) : {}),
+    };
+  }
+  return { ok: true };
+}
+
 function isOwnerReadHandlerMissingError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '');
   const code = typeof error === 'object' && error !== null && 'code' in error

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -242,7 +242,7 @@ import {
   type GuiMutationRegistrationContext,
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
-import { acknowledgeNoTrackHeadlessExec, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
+import { acknowledgeNoTrackHeadlessExec, buildStandaloneHeadlessExecAcknowledgement, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
 import type { GuiMutationTaskActions, HeadlessExecMutationContext, HeadlessRunMutationPayload, HeadlessResumeMutationPayload } from './ipc/gui-mutation-handlers.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import {
@@ -2059,13 +2059,7 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
-          if (!workflowId) {
-            return {
-              ok: true,
-              ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
-            };
-          }
-          return { ok: true };
+          return buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult);
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
           noteStandaloneOwnerActivity();


### PR DESCRIPTION
Extracts the standalone headless.exec ack-merging logic into an
exported, unit-testable function instead of asserting on regex
matches over main.ts source text, per CodeRabbit review on #10262
(thread PRRT_kwDOSFkSDM6bi7Ma). The new tests invoke the function
with a stubbed runHeadless result and assert the exact unscoped ack
(ok/inserted/row) and that the scoped ack stays { ok: true }.

Depends-On: #10262