### PR TITLE
[Owner exec ack](2b) Wire main.ts to buildStandaloneHeadlessExecAcknowledgement

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -27,7 +27,7 @@ describe('standalone owner handler ordering', () => {
     ).toBeLessThan(dispatcherIdx);
   });
 
-  it('standalone headless.exec merges runHeadless return into the message-bus ack when unscoped', () => {
+  it('standalone headless.exec wires runHeadless into buildStandaloneHeadlessExecAcknowledgement', () => {
     const source = readFileSync(MAIN, 'utf8');
     const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
     const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
@@ -36,8 +36,7 @@ describe('standalone owner handler ordering', () => {
 
     const handler = source.slice(execIdx, nextHandler);
     expect(handler).toMatch(/commandResult = await runHeadless/);
-    expect(handler).toMatch(/if \(!workflowId\)/);
-    expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
+    expect(handler).toMatch(/buildStandaloneHeadlessExecAcknowledgement\(workflowId, commandResult\)/);
   });
 
   it('merges the runHeadless return into the unscoped message-bus ack', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -242,7 +242,7 @@ import {
   type GuiMutationRegistrationContext,
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
-import { acknowledgeNoTrackHeadlessExec, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
+import { acknowledgeNoTrackHeadlessExec, buildStandaloneHeadlessExecAcknowledgement, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
 import type { GuiMutationTaskActions, HeadlessExecMutationContext, HeadlessRunMutationPayload, HeadlessResumeMutationPayload } from './ipc/gui-mutation-handlers.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import {
@@ -2059,13 +2059,7 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
-          if (!workflowId) {
-            return {
-              ok: true,
-              ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
-            };
-          }
-          return { ok: true };
+          return buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult);
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
           noteStandaloneOwnerActivity();


### PR DESCRIPTION
main.ts now calls the extracted function instead of inlining the
unscoped/scoped ack merge. Updates the ordering test's source-text
assertion to match the new call site.

Depends-On: #10265