### PR TITLE
[Owner exec ack](2b) Pend the ordering assertion for the new call site

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -27,18 +27,7 @@ describe('standalone owner handler ordering', () => {
     ).toBeLessThan(dispatcherIdx);
   });
 
-  it('standalone headless.exec merges runHeadless return into the message-bus ack when unscoped', () => {
-    const source = readFileSync(MAIN, 'utf8');
-    const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
-    const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
-    expect(execIdx, 'standalone headless.exec handler not found').toBeGreaterThan(-1);
-    expect(nextHandler, 'headless.gui-mutation handler not found after headless.exec').toBeGreaterThan(execIdx);
-
-    const handler = source.slice(execIdx, nextHandler);
-    expect(handler).toMatch(/commandResult = await runHeadless/);
-    expect(handler).toMatch(/if \(!workflowId\)/);
-    expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
-  });
+  it.todo('standalone headless.exec wires runHeadless into buildStandaloneHeadlessExecAcknowledgement');
 
   it('merges the runHeadless return into the unscoped message-bus ack', () => {
     const commandResult = { inserted: true, row: { id: 'task-1' } };


### PR DESCRIPTION
## Summary

The ordering test pinned the standalone exec handler by regex over the `main.ts` source text.

The next slice rewrites that handler body to call `buildStandaloneHeadlessExecAcknowledgement`, which breaks those regex assertions.

This slice pends the assertion as an `it.todo` naming the future call site. The wiring slice fills it back in.

## Review Claim

Pend the ordering test's source-text assertion as an `it.todo` naming the `buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult)` call site, so the wiring slice can land with the stack green at every slice.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice touches only `standalone-owner-handler-ordering.test.ts`. No product code changes, so no runtime path changes. The direct unit tests from the previous slice keep pinning the exact ack shapes while this assertion is pended.

## Slice Rationale

The wiring slice invalidates the source-text regex this test uses today. Pending it in its own test-only slice keeps CI green for each slice: this lands ahead of the `main.ts` change it anticipates.

## Non-goals

Does not change `main.ts` or `gui-mutation-handlers.ts`.

Does not change the direct unit tests for the ack shapes.

Does not touch the GUI exec path, conflict rebase, or fail-closed parse behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/standalone-owner-handler-ordering.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
