### PR TITLE
[Owner exec ack](2c)[REFACTOR: Extract Method] Wire main.ts to buildStandaloneHeadlessExecAcknowledgement

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -27,7 +27,17 @@ describe('standalone owner handler ordering', () => {
     ).toBeLessThan(dispatcherIdx);
   });
 
-  it.todo('standalone headless.exec wires runHeadless into buildStandaloneHeadlessExecAcknowledgement');
+  it('standalone headless.exec wires runHeadless into buildStandaloneHeadlessExecAcknowledgement', () => {
+    const source = readFileSync(MAIN, 'utf8');
+    const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
+    const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
+    expect(execIdx, 'standalone headless.exec handler not found').toBeGreaterThan(-1);
+    expect(nextHandler, 'headless.gui-mutation handler not found after headless.exec').toBeGreaterThan(execIdx);
+
+    const handler = source.slice(execIdx, nextHandler);
+    expect(handler).toMatch(/commandResult = await runHeadless/);
+    expect(handler).toMatch(/buildStandaloneHeadlessExecAcknowledgement\(workflowId, commandResult\)/);
+  });
 
   it('merges the runHeadless return into the unscoped message-bus ack', () => {
     const commandResult = { inserted: true, row: { id: 'task-1' } };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -242,7 +242,7 @@ import {
   type GuiMutationRegistrationContext,
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
-import { acknowledgeNoTrackHeadlessExec, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
+import { acknowledgeNoTrackHeadlessExec, buildStandaloneHeadlessExecAcknowledgement, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
 import type { GuiMutationTaskActions, HeadlessExecMutationContext, HeadlessRunMutationPayload, HeadlessResumeMutationPayload } from './ipc/gui-mutation-handlers.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import {
@@ -2059,13 +2059,7 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
-          if (!workflowId) {
-            return {
-              ok: true,
-              ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
-            };
-          }
-          return { ok: true };
+          return buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult);
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
           noteStandaloneOwnerActivity();


### PR DESCRIPTION
## Summary

The standalone exec handler in `main.ts` still inlined the unscoped/scoped ack merge that the earlier slice made directly testable as `buildStandaloneHeadlessExecAcknowledgement`.

This slice replaces that inline block with one call to the function.

It also fills in the ordering assertion pended in the previous slice, which now checks the real call site in `main.ts`.

## Review Claim

The standalone exec handler in `main.ts` should return `buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult)` in place of its inline ack merge, with the message bus ack unchanged for both scoped and unscoped mutations.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The function returns exactly what the replaced inline block returned: unscoped acks are `{ ok: true }` spread with the runner payload, scoped acks stay `{ ok: true }` only. The direct unit tests from the earlier slice pin those input/output pairs, and the restored ordering assertion checks the new call site.

## Slice Rationale

The earlier slices added the function with direct tests and pended the source-text assertion. This slice carries only the `main.ts` handler change plus the restored assertion, so the reviewer approves one wiring change.

## Non-goals

No behavior change: scoped and unscoped acks keep their exact shapes.

Does not change the GUI exec path.

Does not change conflict rebase or fail-closed parse behavior.

Does not add new ack fields beyond what slice (1) already forwards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/standalone-owner-handler-ordering.test.ts`

</details>

## Visual Proof

This slice does not change a rendered window. `packages/app/src/main.ts` is classified as UI-impacting by path.

![wired call site and passing ordering assertion at head 73b6a303b](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260824-8355a6/pr10268-wired-call-site-and-test.png)

The standalone exec handler now returns the function call on `main.ts` line 2062, and the ordering test file passes at this head.

Manually inspected: the image shows `main.ts` lines 2050-2063 at commit 73b6a303b with `return buildStandaloneHeadlessExecAcknowledgement(workflowId, commandResult);` on line 2062, and a vitest run at this checkout reporting `Test Files 1 passed (1)` and `Tests 4 passed (4)` for `standalone-owner-handler-ordering.test.ts`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
