### PR TITLE
[admin-bypass-repair-bot-thread-pr-10262-a0d33fa](1) Preserve ok:true acknowledgment when merging headless.exec commandResult

### DIFF
--- a/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
+++ b/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../headless.js', () => ({
+  runHeadless: vi.fn(),
+  resolveAgentSession: vi.fn(),
+}));
+
+import { runHeadless } from '../headless.js';
+import { createGuiMutationTaskActions, type GuiMutationTaskActionsContext } from '../ipc/gui-mutation-handlers.js';
+
+function makeContext(): GuiMutationTaskActionsContext {
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), child: vi.fn() };
+  (logger.child as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+  const persistence = {
+    loadWorkflow: vi.fn(() => undefined),
+    listWorkflows: vi.fn(() => []),
+    loadTasks: vi.fn(() => []),
+  };
+  return {
+    logger,
+    persistence,
+    messageBus: {},
+    executorRegistry: {},
+    agentRegistry: {},
+    repoRoot: '/fake/repo',
+    invokerConfig: {},
+    effectiveMaxConcurrency: 1,
+    taskHandles: new Map(),
+    getOrchestrator: () => ({}) as never,
+    setOrchestrator: vi.fn(),
+    getCommandService: () => ({}) as never,
+    setCommandService: vi.fn(),
+    getWorkflowMutationCoordinator: () => null,
+    workflowMutationDispatcher: new Map(),
+    getActiveMutationContext: () => undefined,
+    getRendererTaskFeed: () => ({}) as never,
+    getStartupWorkflowId: () => null,
+    getLaunchDispatcher: () => null,
+    requireTaskExecutor: () => ({}) as never,
+    getTaskExecutor: () => null,
+    rebuildTaskRunner: vi.fn(),
+    initServices: vi.fn(async () => {}),
+    requestWorkflowMetadataPublish: vi.fn(),
+    cancelDeferredWorkflowLaunch: vi.fn(),
+    killRunningTask: vi.fn(async () => {}),
+    buildCommandServiceInvalidationDeps: () => ({}) as never,
+  } as unknown as GuiMutationTaskActionsContext;
+}
+
+describe('executeHeadlessExec no-workflow acknowledgment', () => {
+  it('keeps ok: true after merging a runner result that reports ok: false', async () => {
+    vi.mocked(runHeadless).mockResolvedValue({ ok: false, error: 'boom' });
+    const actions = createGuiMutationTaskActions(makeContext());
+
+    const result = await actions.executeHeadlessExec({ args: ['start-ready'], noTrack: false } as never);
+
+    expect(result).toEqual({ ok: true, error: 'boom' });
+  });
+
+  it('still merges non-ok runner fields through', async () => {
+    vi.mocked(runHeadless).mockResolvedValue({ started: 3 });
+    const actions = createGuiMutationTaskActions(makeContext());
+
+    const result = await actions.executeHeadlessExec({ args: ['start-ready'], noTrack: false } as never);
+
+    expect(result).toEqual({ ok: true, started: 3 });
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -804,8 +804,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     });
     if (!workflowId) {
       return {
-        ok: true,
         ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
+        ok: true,
       };
     }
     orchestrator.syncFromDb(workflowId);


### PR DESCRIPTION
## Summary

The headless exec IPC handler acknowledged commands with `ok: true` before spreading the runner's own command result over it, so a runner-reported `ok: false` silently overwrote the acknowledgment.

The handler now spreads the runner fields first and sets `ok: true` last, so a fire-and-forget headless exec command always acks true regardless of what the runner returned.

This only touches the no-workflow acknowledgment branch returned by `executeHeadlessExec`; every other command path is unchanged.

## Review Claim

Approve reordering the spread in `executeHeadlessExec`'s no-workflow acknowledgment so `ok: true` always wins over a runner-reported `ok: false`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the no-workflow acknowledgment branch of `executeHeadlessExec` changes; the workflow-tracked branch (which calls `orchestrator.syncFromDb`) is untouched. The new regression test pins the corrected precedence: `ok` stays `true` even when the runner reports `ok: false`, and other runner fields still merge through.

## Slice Rationale

This is a single, self-contained one-line ordering fix in the headless exec acknowledgment path, landed together with the regression test that locks in the corrected precedence. There is no other change to bundle it with.

## Non-goals

- The workflow-tracked `executeHeadlessExec` branch (unaffected by this ordering change)
- Any other IPC handler's acknowledgment shape
- Changing what fields `runHeadless` returns

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/headless-exec-ack-ok-precedence.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 21dda54c`
- Post-revert steps: None
- Data migration? No

</details>
