### PR TITLE
[Worker desired-state SoT](1) Boot from always-on set plus desired state

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -38,4 +38,26 @@ describe('standalone owner handler ordering', () => {
     expect(handler).toMatch(/if \(!workflowId\)/);
     expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
   });
+
+  it('guards standalone startup worker writes behind readOnlyMode', () => {
+    const source = readFileSync(MAIN, 'utf8');
+
+    const dispatcherIdx = source.indexOf('startStandaloneLaunchDispatcher({');
+    const migrateIdx = source.lastIndexOf('migrateWorkerDesiredStateFromLegacyConfig(', dispatcherIdx);
+    const reconcileIdx = source.lastIndexOf('reconcileTerminalWorkerActionsOnStartup(persistence)', dispatcherIdx);
+
+    expect(migrateIdx, 'standalone migrateWorkerDesiredStateFromLegacyConfig call not found').toBeGreaterThan(-1);
+    expect(reconcileIdx, 'standalone reconcileTerminalWorkerActionsOnStartup call not found').toBeGreaterThan(-1);
+    expect(dispatcherIdx, 'startStandaloneLaunchDispatcher call not found').toBeGreaterThan(-1);
+    expect(reconcileIdx).toBeLessThan(dispatcherIdx);
+
+    const migrateGuardStart = source.lastIndexOf('if (!readOnlyMode) {', migrateIdx);
+    const reconcileGuardStart = source.lastIndexOf('if (!readOnlyMode) {', reconcileIdx);
+
+    expect(migrateGuardStart, 'migrateWorkerDesiredStateFromLegacyConfig must be guarded by readOnlyMode').toBeGreaterThan(-1);
+    expect(reconcileGuardStart, 'reconcileTerminalWorkerActionsOnStartup must be guarded by readOnlyMode').toBeGreaterThan(-1);
+
+    expect(source.slice(migrateGuardStart, migrateIdx)).not.toMatch(/\n\s*}\n/);
+    expect(source.slice(reconcileGuardStart, reconcileIdx)).not.toMatch(/\n\s*}\n/);
+  });
 });

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -24,13 +24,17 @@ import {
 import type { WorkerActionRecord } from '@invoker/data-store';
 import type { WorkerStatusSnapshot } from '@invoker/contracts';
 import {
+  ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS,
   autoStartedOwnerWorkerKinds,
   autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
   createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
+  legacyWorkerStartFlagSeeds,
   listWorkerActionHistory,
   listWorkerDecisions,
+  migrateWorkerDesiredStateFromLegacyConfig,
+  PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS,
   toWorkerActionSummary,
 } from '../worker-control.js';
 
@@ -121,54 +125,8 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-type AutoStartConfig = Parameters<typeof autoStartedOwnerWorkerKindsForConfig>[0];
-type AutoStartOptions = Parameters<typeof autoStartedOwnerWorkerKinds>[0];
-
-const AUTO_STARTED_OWNER_WORKER_KIND_CONFIG_CASES = [
-  {},
-  { diskHeadroom: { cleanupEnabled: true } },
-  { diskHeadroom: { cleanupEnabled: false } },
-  { autoApproveAIFixes: true },
-  { autoApproveAIFixes: false },
-  { infraRepair: { enabled: true } },
-  { infraRepair: { enabled: false } },
-  { autofix: { enabled: true } },
-  { autofix: { enabled: false } },
-  { reaper: { enabled: true } },
-  { reaper: { enabled: false } },
-  { workflowResume: { enabled: true } },
-  { workflowResume: { enabled: false } },
-  { requeueEnabled: true },
-  { requeueEnabled: false },
-  { e2eAutoFixEnabled: true },
-  { e2eAutoFixEnabled: false },
-  { prMaintenance: { enabled: true } },
-] satisfies AutoStartConfig[];
-
-const AUTO_STARTED_OWNER_WORKER_KIND_OPTION_CASES = [
-  { prMaintenanceEnabled: true },
-  { prMaintenanceEnabled: false },
-] satisfies AutoStartOptions[];
-
-function withoutDefaultOnKinds(kinds: readonly string[]): string[] {
-  return kinds.filter((kind) => kind !== CLAUDE_OAUTH_REFRESH_WORKER_KIND);
-}
-
-function expectConfigGate(
-  workerKind: string,
-  configWhenTrue: AutoStartConfig,
-  configWhenFalse: AutoStartConfig,
-): void {
-  expect(withoutDefaultOnKinds(autoStartedOwnerWorkerKindsForConfig(configWhenTrue))).toEqual([
-    PR_STATUS_WORKER_KIND,
-    workerKind,
-  ]);
-  expect(withoutDefaultOnKinds(autoStartedOwnerWorkerKindsForConfig(configWhenFalse))).toEqual([PR_STATUS_WORKER_KIND]);
-  expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(workerKind);
-}
-
 function controller(
-  autoStartKinds: readonly string[] = autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }),
+  autoStartKinds: readonly string[] = autoStartedOwnerWorkerKinds(),
   desiredState: Record<string, boolean> = {},
 ) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
@@ -198,6 +156,11 @@ function controller(
   register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
   register(REAPER_WORKER_KIND, 'Reaps stale Invoker-managed artifacts.');
   register(E2E_AUTOFIX_WORKER_KIND, 'Runs the extended e2e battery on a schedule.');
+  register(DISK_HEADROOM_WORKER_KIND, 'Monitors disk headroom.');
+  register(AUTO_APPROVE_WORKER_KIND, 'Auto-approves AI fixes.');
+  register(CLAUDE_OAUTH_REFRESH_WORKER_KIND, 'Refreshes Claude OAuth credentials.');
+  register(IDLE_TASK_CLEANUP_WORKER_KIND, 'Reports idle tasks.');
+  register(REQUEUE_WORKER_KIND, 'Requeues stalled tasks.');
   register('external-preview', 'External preview worker.');
 
   const runtimeDeps = deps();
@@ -216,169 +179,126 @@ function controller(
 }
 
 describe('autoStartedOwnerWorkerKindsForConfig', () => {
-  it('fresh install auto-start config includes pr-status and claude-oauth-refresh', () => {
-    expect(autoStartedOwnerWorkerKindsForConfig({})).toEqual([
+  it('always-on list is pr-status, claude-oauth-refresh, disk-headroom, autoapprove', () => {
+    expect(autoStartedOwnerWorkerKinds()).toEqual([...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS]);
+    expect(ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS).toEqual([
       PR_STATUS_WORKER_KIND,
       CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+      DISK_HEADROOM_WORKER_KIND,
+      AUTO_APPROVE_WORKER_KIND,
     ]);
   });
 
-  it('includes disk-headroom only when diskHeadroom.cleanupEnabled is true', () => {
-    expectConfigGate(
-      DISK_HEADROOM_WORKER_KIND,
-      { diskHeadroom: { cleanupEnabled: true } },
-      { diskHeadroom: { cleanupEnabled: false } },
-    );
-  });
-
-  it('includes claude-oauth-refresh unless claudeOauthRefresh.enabled is explicitly false', () => {
+  it('ignores every legacy config start boolean', () => {
     expect(autoStartedOwnerWorkerKindsForConfig({
-      claudeOauthRefresh: { enabled: true },
-    })).toEqual([PR_STATUS_WORKER_KIND, CLAUDE_OAUTH_REFRESH_WORKER_KIND]);
-    expect(autoStartedOwnerWorkerKindsForConfig({
+      prMaintenance: { enabled: true },
+      e2eAutoFixEnabled: true,
+      infraRepair: { enabled: true },
+      autofix: { enabled: true },
+      reaper: { enabled: true },
+      workflowResume: { enabled: true },
+      requeueEnabled: true,
+      slackBugScan: { enabled: true },
+      staleTaskCleanup: { enabled: true },
       claudeOauthRefresh: { enabled: false },
-    })).toEqual([PR_STATUS_WORKER_KIND]);
-    expect(autoStartedOwnerWorkerKindsForConfig({})).toContain(CLAUDE_OAUTH_REFRESH_WORKER_KIND);
+      diskHeadroom: { cleanupEnabled: false },
+      autoApproveAIFixes: false,
+    })).toEqual([...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS]);
   });
 
-  it('includes auto-approve only when autoApproveAIFixes is true', () => {
-    expectConfigGate(
-      AUTO_APPROVE_WORKER_KIND,
-      { autoApproveAIFixes: true },
-      { autoApproveAIFixes: false },
-    );
+  it('never auto-starts jailbreak-land or opt-in workers from config', () => {
+    expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(PR_JAILBREAK_LAND_WORKER_KIND);
+    expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
+    expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(E2E_AUTOFIX_WORKER_KIND);
+    expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(INFRA_REPAIR_WORKER_KIND);
   });
 
-  it('includes infra-repair only when infraRepair.enabled is true', () => {
-    expectConfigGate(
-      INFRA_REPAIR_WORKER_KIND,
-      { infraRepair: { enabled: true } },
-      { infraRepair: { enabled: false } },
-    );
-  });
-
-  it('surfaces configured-versus-persisted infra-repair suppression on status rows', () => {
-    const setup = controller([INFRA_REPAIR_WORKER_KIND], { [INFRA_REPAIR_WORKER_KIND]: false });
-    setup.controller.startAutoStartedWorkers();
-    const row = setup.controller.snapshot().workers.find((worker) => worker.kind === INFRA_REPAIR_WORKER_KIND);
-    expect(row).toMatchObject({
-      lifecycle: 'stopped',
-      configuredAutoStart: true,
-      desiredEnabled: false,
-      autoStarts: false,
-      suppressedByPersistedStop: true,
-    });
-    expect(setup.logger.warn).toHaveBeenCalledWith(
-      '[worker-control] configured auto-start suppressed by persisted desired state',
-      expect.objectContaining({
-        workerKind: INFRA_REPAIR_WORKER_KIND,
-        configuredAutoStart: true,
-        persistedDesiredEnabled: false,
-      }),
-    );
-  });
-
-  it('includes idle-task-cleanup only when staleTaskCleanup.enabled is true', () => {
-    expectConfigGate(
-      IDLE_TASK_CLEANUP_WORKER_KIND,
-      { staleTaskCleanup: { enabled: true } },
-      { staleTaskCleanup: { enabled: false } },
-    );
-  });
-
-  it('includes autofix only when autofix.enabled is true', () => {
-    expectConfigGate(
-      AUTO_FIX_WORKER_KIND,
-      { autofix: { enabled: true } },
-      { autofix: { enabled: false } },
-    );
-  });
-
-  it('includes reaper only when reaper.enabled is true', () => {
-    expectConfigGate(
-      REAPER_WORKER_KIND,
-      { reaper: { enabled: true } },
-      { reaper: { enabled: false } },
-    );
-  });
-
-  it('includes workflow-resume only when workflowResume.enabled is true', () => {
-    expectConfigGate(
-      WORKFLOW_RESUME_WORKER_KIND,
-      { workflowResume: { enabled: true } },
-      { workflowResume: { enabled: false } },
-    );
-  });
-
-  it('includes requeue only when requeueEnabled is true', () => {
-    expectConfigGate(
-      REQUEUE_WORKER_KIND,
-      { requeueEnabled: true },
-      { requeueEnabled: false },
-    );
-  });
-
-  it('includes e2e-autofix only when e2eAutoFixEnabled is true', () => {
-    expectConfigGate(
-      E2E_AUTOFIX_WORKER_KIND,
-      { e2eAutoFixEnabled: true },
-      { e2eAutoFixEnabled: false },
-    );
-  });
-
-  it('prMaintenance.enabled adds all PR-maintenance workers together', () => {
-    expect(autoStartedOwnerWorkerKindsForConfig({ prMaintenance: { enabled: true } })).toEqual([
-      PR_STATUS_WORKER_KIND,
+  it('PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS lists the four babysitting kinds', () => {
+    expect(PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS).toEqual([
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,
       PR_DUPLICATE_CLOSE_WORKER_KIND,
       PR_AUTO_LABEL_WORKER_KIND,
-      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
     ]);
   });
+});
 
-  it('never auto-starts jailbreak-land for the existing flag cases', () => {
-    for (const config of AUTO_STARTED_OWNER_WORKER_KIND_CONFIG_CASES) {
-      expect(autoStartedOwnerWorkerKindsForConfig(config)).not.toContain(PR_JAILBREAK_LAND_WORKER_KIND);
-    }
-    for (const options of AUTO_STARTED_OWNER_WORKER_KIND_OPTION_CASES) {
-      expect(autoStartedOwnerWorkerKinds(options)).not.toContain(PR_JAILBREAK_LAND_WORKER_KIND);
-    }
+describe('migrateWorkerDesiredStateFromLegacyConfig', () => {
+  it('seeds missing desired-state rows from leftover config start flags', () => {
+    const store = persistence();
+    const seeded = migrateWorkerDesiredStateFromLegacyConfig(store, {
+      prMaintenance: { enabled: true },
+      e2eAutoFixEnabled: true,
+      claudeOauthRefresh: { enabled: false },
+    });
+    expect(seeded.map((row) => row.workerKind).sort()).toEqual([
+      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+      E2E_AUTOFIX_WORKER_KIND,
+      ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS,
+    ].sort());
+    expect(store.setWorkerDesiredState).toHaveBeenCalledWith(PR_ADMIN_BYPASS_LAND_WORKER_KIND, true);
+    expect(store.setWorkerDesiredState).toHaveBeenCalledWith(E2E_AUTOFIX_WORKER_KIND, true);
+    expect(store.setWorkerDesiredState).toHaveBeenCalledWith(CLAUDE_OAUTH_REFRESH_WORKER_KIND, false);
+  });
+
+  it('does not overwrite an existing desired-state row', () => {
+    const store = persistence({ [PR_ADMIN_BYPASS_LAND_WORKER_KIND]: false });
+    migrateWorkerDesiredStateFromLegacyConfig(store, {
+      prMaintenance: { enabled: true },
+    });
+    expect(store.setWorkerDesiredState).not.toHaveBeenCalledWith(PR_ADMIN_BYPASS_LAND_WORKER_KIND, true);
+    expect(store.getWorkerDesiredState(PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.desiredEnabled).toBe(false);
+  });
+
+  it('legacy seeds ignore policy flags', () => {
+    expect(legacyWorkerStartFlagSeeds({
+      autoApproveAIFixes: true,
+      diskHeadroom: { cleanupEnabled: true },
+    } as never)).toEqual([]);
+  });
+
+  it('after migration, flipping a stale config flag does not change auto-start', () => {
+    expect(autoStartedOwnerWorkerKindsForConfig({ prMaintenance: { enabled: false } }))
+      .toEqual(autoStartedOwnerWorkerKindsForConfig({ prMaintenance: { enabled: true } }));
   });
 });
 
 describe('createWorkerRuntimeController', () => {
-  it('auto-start starts every built-in owner worker except workflow-resume and orphan-repair', () => {
+  it('auto-starts only the code always-on workers', () => {
     const setup = controller();
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
+    const lifecycleByKind = (kind: string) =>
+      snapshot.workers.find((worker) => worker.kind === kind)?.lifecycle;
 
-    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === INFRA_REPAIR_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === PR_ORPHAN_REPAIR_WORKER_KIND)?.lifecycle).toBe('stopped');
-    expect(snapshot.workers.find((worker) => worker.kind === PR_ORPHAN_REPAIR_WORKER_KIND)?.startable).toBe(true);
-    expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.lifecycle).toBe('stopped');
-    expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.startable).toBe(true);
-    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
-    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+    expect(lifecycleByKind(PR_STATUS_WORKER_KIND)).toBe('running');
+    expect(lifecycleByKind(CLAUDE_OAUTH_REFRESH_WORKER_KIND)).toBe('running');
+    expect(lifecycleByKind(DISK_HEADROOM_WORKER_KIND)).toBe('running');
+    expect(lifecycleByKind(AUTO_APPROVE_WORKER_KIND)).toBe('running');
+    expect(lifecycleByKind(PR_ADMIN_BYPASS_LAND_WORKER_KIND)).toBe('stopped');
+    expect(lifecycleByKind(PR_ORPHAN_REPAIR_WORKER_KIND)).toBe('stopped');
+    expect(lifecycleByKind(WORKFLOW_RESUME_WORKER_KIND)).toBe('stopped');
+    expect(lifecycleByKind(AUTO_FIX_WORKER_KIND)).toBe('stopped');
+    expect(lifecycleByKind('external-preview')).toBe('stopped');
   });
 
-  it('gates the admin-bypass PR-maintenance workers on prMaintenance.enabled', () => {
-    const setup = controller(autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: false }));
+  it('starts PR-maintenance workers from desired state, not config', () => {
+    const desired = Object.fromEntries(
+      PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS.map((kind) => [kind, true]),
+    );
+    const setup = controller(autoStartedOwnerWorkerKinds(), desired);
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
 
-    const row = snapshot.workers.find((worker) => worker.kind === PR_ADMIN_BYPASS_LAND_WORKER_KIND);
-    expect(row?.lifecycle).toBe('stopped');
-    expect(row?.startable).toBe(true);
-    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+    for (const kind of PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS) {
+      expect(snapshot.workers.find((worker) => worker.kind === kind)?.lifecycle).toBe('running');
+    }
   });
 
   it('restores saved desired worker states over built-in launch defaults', () => {
-    const setup = controller(autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }), {
+    const setup = controller(autoStartedOwnerWorkerKinds(), {
       [PR_STATUS_WORKER_KIND]: false,
       [WORKFLOW_RESUME_WORKER_KIND]: true,
     });
@@ -455,17 +375,30 @@ describe('createWorkerRuntimeController', () => {
     );
   });
 
-  it('auto-starts e2e-autofix only when its kind is in autoStartKinds', () => {
-    const gated = controller([...autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }), E2E_AUTOFIX_WORKER_KIND]);
+  it('auto-starts e2e-autofix only when its kind is desired-enabled', () => {
+    const gated = controller(autoStartedOwnerWorkerKinds(), { [E2E_AUTOFIX_WORKER_KIND]: true });
     gated.controller.startAutoStartedWorkers();
-    const gatedRow = gated.controller.snapshot().workers.find((worker) => worker.kind === E2E_AUTOFIX_WORKER_KIND);
-    expect(gatedRow?.lifecycle).toBe('running');
+    expect(gated.controller.snapshot().workers.find((worker) => worker.kind === E2E_AUTOFIX_WORKER_KIND)?.lifecycle)
+      .toBe('running');
 
     const ungated = controller();
     ungated.controller.startAutoStartedWorkers();
     const ungatedRow = ungated.controller.snapshot().workers.find((worker) => worker.kind === E2E_AUTOFIX_WORKER_KIND);
     expect(ungatedRow?.lifecycle).toBe('stopped');
     expect(ungatedRow?.startable).toBe(true);
+  });
+
+  it('surfaces configured-versus-persisted suppression on status rows', () => {
+    const setup = controller([INFRA_REPAIR_WORKER_KIND], { [INFRA_REPAIR_WORKER_KIND]: false });
+    setup.controller.startAutoStartedWorkers();
+    const row = setup.controller.snapshot().workers.find((worker) => worker.kind === INFRA_REPAIR_WORKER_KIND);
+    expect(row).toMatchObject({
+      lifecycle: 'stopped',
+      configuredAutoStart: true,
+      desiredEnabled: false,
+      autoStarts: false,
+      suppressedByPersistedStop: true,
+    });
   });
 
   it('autofix remains stopped until explicitly started', () => {
@@ -579,7 +512,7 @@ describe('createWorkerRuntimeController', () => {
 
     const snapshot = createLocalWorkerStatusSnapshot({
       registry,
-      autoStartKinds: autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }),
+      autoStartKinds: autoStartedOwnerWorkerKinds(),
       persistence: {
         listWorkerActions: vi.fn(() => [{
           id: 'action-1',

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -227,6 +227,8 @@ import {
   createLocalWorkerStatusSnapshot,
   createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
+  migrateWorkerDesiredStateFromLegacyConfig,
+  type LegacyWorkerStartConfigFlags,
   type WorkerRuntimeController,
 } from './worker-control.js';
 import { runStartReady } from './start-ready.js';
@@ -339,7 +341,6 @@ function buildSlackBugScanWorkerConfig(
   planningCommandBuilder: PlanningCommandBuilder,
   executionAgentRegistry: AgentRegistry,
 ): WorkerRuntimeDependencies['slackBugScan'] {
-  if (!invokerConfig.slackBugScan?.enabled) return undefined;
   const client = createRealSlackBugScanClient();
   if (!client) return undefined;
   return {
@@ -354,9 +355,9 @@ function buildSlackBugScanWorkerConfig(
       executionAgentRegistry,
       logger,
     }),
-    intervalMs: invokerConfig.slackBugScan.intervalMs,
-    maxAutoSubmissionsPerDay: invokerConfig.slackBugScan.maxAutoSubmissionsPerDay,
-    maxAutoSubmissionsPerTick: invokerConfig.slackBugScan.maxAutoSubmissionsPerTick,
+    intervalMs: invokerConfig.slackBugScan?.intervalMs,
+    maxAutoSubmissionsPerDay: invokerConfig.slackBugScan?.maxAutoSubmissionsPerDay,
+    maxAutoSubmissionsPerTick: invokerConfig.slackBugScan?.maxAutoSubmissionsPerTick,
   };
 }
 
@@ -2086,6 +2087,19 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
+        const seededDesiredStates = migrateWorkerDesiredStateFromLegacyConfig(
+          persistence,
+          invokerConfig as LegacyWorkerStartConfigFlags,
+        );
+        if (seededDesiredStates.length > 0) {
+          logger.info(
+            `migrated ${seededDesiredStates.length} legacy worker start flag(s) into desired state`,
+            {
+              module: 'init',
+              seeded: seededDesiredStates.map((seed) => `${seed.workerKind}=${seed.desiredEnabled}`),
+            },
+          );
+        }
         workerRuntimeController = createWorkerRuntimeController({
           registry: createRegisteredWorkerRegistry(),
           deps: buildRegisteredOwnerWorkerDeps(
@@ -3254,6 +3268,19 @@ startMainProcessBootstrap({
     }
 
     if (ownerMode) {
+      const seededDesiredStates = migrateWorkerDesiredStateFromLegacyConfig(
+        persistence,
+        invokerConfig as LegacyWorkerStartConfigFlags,
+      );
+      if (seededDesiredStates.length > 0) {
+        logger.info(
+          `migrated ${seededDesiredStates.length} legacy worker start flag(s) into desired state`,
+          {
+            module: 'init',
+            seeded: seededDesiredStates.map((seed) => `${seed.workerKind}=${seed.desiredEnabled}`),
+          },
+        );
+      }
       workerRuntimeController = createWorkerRuntimeController({
         registry: createRegisteredWorkerRegistry(),
         deps: buildRegisteredOwnerWorkerDeps(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2087,18 +2087,20 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        const seededDesiredStates = migrateWorkerDesiredStateFromLegacyConfig(
-          persistence,
-          invokerConfig as LegacyWorkerStartConfigFlags,
-        );
-        if (seededDesiredStates.length > 0) {
-          logger.info(
-            `migrated ${seededDesiredStates.length} legacy worker start flag(s) into desired state`,
-            {
-              module: 'init',
-              seeded: seededDesiredStates.map((seed) => `${seed.workerKind}=${seed.desiredEnabled}`),
-            },
+        if (!readOnlyMode) {
+          const seededDesiredStates = migrateWorkerDesiredStateFromLegacyConfig(
+            persistence,
+            invokerConfig as LegacyWorkerStartConfigFlags,
           );
+          if (seededDesiredStates.length > 0) {
+            logger.info(
+              `migrated ${seededDesiredStates.length} legacy worker start flag(s) into desired state`,
+              {
+                module: 'init',
+                seeded: seededDesiredStates.map((seed) => `${seed.workerKind}=${seed.desiredEnabled}`),
+              },
+            );
+          }
         }
         workerRuntimeController = createWorkerRuntimeController({
           registry: createRegisteredWorkerRegistry(),
@@ -2115,12 +2117,14 @@ function startHeadlessMode(): void {
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
         });
-        const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
-        if (reconciledWorkerActions > 0) {
-          logger.info(
-            `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
-            { module: 'init' },
-          );
+        if (!readOnlyMode) {
+          const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+          if (reconciledWorkerActions > 0) {
+            logger.info(
+              `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+              { module: 'init' },
+            );
+          }
         }
         workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -35,12 +35,22 @@ import {
 import { SLACK_BUG_SCAN_WORKER_KIND } from '@invoker/slack-bug-scan';
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-/** Worker kinds auto-started on every owner boot, regardless of config. */
+/**
+ * Worker kinds auto-started on every owner boot.
+ * Per-worker SQLite `worker_desired_states` still overrides in both directions.
+ * InvokerConfig must not contain a boolean that auto-starts or stops a worker.
+ */
 export const ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS = [
   PR_STATUS_WORKER_KIND,
+  CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+  DISK_HEADROOM_WORKER_KIND,
+  AUTO_APPROVE_WORKER_KIND,
 ] as const;
 
-/** PR-maintenance worker kind auto-started only when `prMaintenance.enabled` is true. */
+/**
+ * PR-maintenance worker kinds written by the onboarding / `worker toggles`
+ * `pr-maintenance` preset. Not part of the code always-on boot list.
+ */
 export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
@@ -52,25 +62,13 @@ export const SLACK_BUG_SCAN_AUTO_STARTED_WORKER_KINDS = [
   SLACK_BUG_SCAN_WORKER_KIND,
 ] as const;
 
-type AutoStartedOwnerWorkerKindOptions = {
-  prMaintenanceEnabled?: boolean;
-  slackBugScanEnabled?: boolean;
-  diskHeadroomCleanupEnabled?: boolean;
-  autoApproveAIFixes?: boolean;
-  infraRepairEnabled?: boolean;
-  autofixEnabled?: boolean;
-  reaperEnabled?: boolean;
-  workflowResumeEnabled?: boolean;
-  requeueEnabled?: boolean;
-  staleTaskCleanupEnabled?: boolean;
-  claudeOauthRefreshEnabled?: boolean;
-};
-
-type AutoStartedOwnerWorkerKindConfig = {
+/**
+ * Legacy config booleans that used to gate worker auto-start. Read only by
+ * one-shot migration into `worker_desired_states`; ignored for boot thereafter.
+ */
+export type LegacyWorkerStartConfigFlags = {
   prMaintenance?: { enabled?: boolean };
   slackBugScan?: { enabled?: boolean };
-  diskHeadroom?: { cleanupEnabled?: boolean };
-  autoApproveAIFixes?: boolean;
   infraRepair?: { enabled?: boolean };
   autofix?: { enabled?: boolean };
   e2eAutoFixEnabled?: boolean;
@@ -81,87 +79,96 @@ type AutoStartedOwnerWorkerKindConfig = {
   claudeOauthRefresh?: { enabled?: boolean };
 };
 
+type WorkerDesiredStatePersistence = Pick<
+  SQLiteAdapter,
+  'getWorkerDesiredState' | 'setWorkerDesiredState'
+>;
+
 /**
- * Compute the owner worker kinds that auto-start on boot. The PR-maintenance
- * and Slack bug-scan workers are gated on their own `enabled` flags. Saved
- * per-worker desired state still overrides in both directions.
+ * Map leftover config start flags onto worker kinds for one-shot migration.
+ * Policy flags (`autoApproveAIFixes`, `diskHeadroom.cleanupEnabled`) are not
+ * start flags and are not included.
  */
-export function autoStartedOwnerWorkerKinds(
-  options: AutoStartedOwnerWorkerKindOptions = {},
-): readonly string[] {
-  const workerKinds: string[] = [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS];
-  const hasWorkerGateOverrides = [
-    options.diskHeadroomCleanupEnabled,
-    options.autoApproveAIFixes,
-    options.infraRepairEnabled,
-    options.autofixEnabled,
-    options.reaperEnabled,
-    options.workflowResumeEnabled,
-    options.requeueEnabled,
-    options.slackBugScanEnabled,
-    options.staleTaskCleanupEnabled,
-    options.claudeOauthRefreshEnabled,
-  ].some((value) => value !== undefined);
-  if (options.prMaintenanceEnabled && !hasWorkerGateOverrides) {
-    workerKinds.push(PR_ADMIN_BYPASS_LAND_WORKER_KIND, INFRA_REPAIR_WORKER_KIND);
-    return workerKinds;
+export function legacyWorkerStartFlagSeeds(
+  config: LegacyWorkerStartConfigFlags,
+): ReadonlyArray<{ workerKind: string; desiredEnabled: boolean }> {
+  const seeds: Array<{ workerKind: string; desiredEnabled: boolean }> = [];
+  const push = (workerKind: string, desiredEnabled: boolean): void => {
+    seeds.push({ workerKind, desiredEnabled });
+  };
+
+  if (config.prMaintenance?.enabled === true) {
+    for (const workerKind of PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS) {
+      push(workerKind, true);
+    }
   }
-  if (options.prMaintenanceEnabled) {
-    workerKinds.push(...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS);
+  if (config.slackBugScan?.enabled === true) {
+    push(SLACK_BUG_SCAN_WORKER_KIND, true);
   }
-  if (options.diskHeadroomCleanupEnabled) {
-    workerKinds.push(DISK_HEADROOM_WORKER_KIND);
+  if (config.infraRepair?.enabled === true) {
+    push(INFRA_REPAIR_WORKER_KIND, true);
   }
-  if (options.autoApproveAIFixes) {
-    workerKinds.push(AUTO_APPROVE_WORKER_KIND);
+  if (config.autofix?.enabled === true) {
+    push(AUTO_FIX_WORKER_KIND, true);
   }
-  if (options.infraRepairEnabled) {
-    workerKinds.push(INFRA_REPAIR_WORKER_KIND);
+  if (config.e2eAutoFixEnabled === true) {
+    push(E2E_AUTOFIX_WORKER_KIND, true);
   }
-  if (options.autofixEnabled) {
-    workerKinds.push(AUTO_FIX_WORKER_KIND);
+  if (config.reaper?.enabled === true) {
+    push(REAPER_WORKER_KIND, true);
   }
-  if (options.reaperEnabled) {
-    workerKinds.push(REAPER_WORKER_KIND);
+  if (config.workflowResume?.enabled === true) {
+    push(WORKFLOW_RESUME_WORKER_KIND, true);
   }
-  if (options.workflowResumeEnabled) {
-    workerKinds.push(WORKFLOW_RESUME_WORKER_KIND);
+  if (config.requeueEnabled === true) {
+    push(REQUEUE_WORKER_KIND, true);
   }
-  if (options.requeueEnabled) {
-    workerKinds.push(REQUEUE_WORKER_KIND);
+  if (config.staleTaskCleanup?.enabled === true) {
+    push(IDLE_TASK_CLEANUP_WORKER_KIND, true);
   }
-  if (options.slackBugScanEnabled) {
-    workerKinds.push(...SLACK_BUG_SCAN_AUTO_STARTED_WORKER_KINDS);
+  // Default was on (`!== false`); only an explicit false needs a desired-state row.
+  if (config.claudeOauthRefresh?.enabled === false) {
+    push(CLAUDE_OAUTH_REFRESH_WORKER_KIND, false);
   }
-  if (options.staleTaskCleanupEnabled) {
-    workerKinds.push(IDLE_TASK_CLEANUP_WORKER_KIND);
-  }
-  if (options.claudeOauthRefreshEnabled) {
-    workerKinds.push(CLAUDE_OAUTH_REFRESH_WORKER_KIND);
-  }
-  return workerKinds;
+
+  return seeds;
 }
 
-/** Convenience wrapper: derive the auto-start list straight from Invoker config. */
+/**
+ * One-shot: seed missing `worker_desired_states` rows from leftover config
+ * start flags so existing owners keep the workers they already had enabled.
+ * Never overwrites an existing desired-state row. Config flags are ignored
+ * for auto-start after this runs.
+ */
+export function migrateWorkerDesiredStateFromLegacyConfig(
+  persistence: WorkerDesiredStatePersistence,
+  config: LegacyWorkerStartConfigFlags,
+): ReadonlyArray<{ workerKind: string; desiredEnabled: boolean }> {
+  const seeded: Array<{ workerKind: string; desiredEnabled: boolean }> = [];
+  for (const seed of legacyWorkerStartFlagSeeds(config)) {
+    if (persistence.getWorkerDesiredState(seed.workerKind) !== undefined) {
+      continue;
+    }
+    persistence.setWorkerDesiredState(seed.workerKind, seed.desiredEnabled);
+    seeded.push(seed);
+  }
+  return seeded;
+}
+
+/** Code always-on boot list. Desired state remains the overlay. */
+export function autoStartedOwnerWorkerKinds(): readonly string[] {
+  return [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS];
+}
+
+/**
+ * Boot auto-start list. Config booleans are ignored — on/off lives in
+ * `worker_desired_states` (plus the code always-on list). The unused
+ * `_config` parameter is kept so existing call sites compile unchanged.
+ */
 export function autoStartedOwnerWorkerKindsForConfig(
-  config?: AutoStartedOwnerWorkerKindConfig,
+  _config?: unknown,
 ): readonly string[] {
-  const workerKinds = autoStartedOwnerWorkerKinds({
-    prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled),
-    diskHeadroomCleanupEnabled: Boolean(config?.diskHeadroom?.cleanupEnabled),
-    autoApproveAIFixes: Boolean(config?.autoApproveAIFixes),
-    infraRepairEnabled: Boolean(config?.infraRepair?.enabled),
-    autofixEnabled: Boolean(config?.autofix?.enabled),
-    reaperEnabled: Boolean(config?.reaper?.enabled),
-    workflowResumeEnabled: Boolean(config?.workflowResume?.enabled),
-    requeueEnabled: Boolean(config?.requeueEnabled),
-    slackBugScanEnabled: Boolean(config?.slackBugScan?.enabled),
-    staleTaskCleanupEnabled: Boolean(config?.staleTaskCleanup?.enabled),
-    claudeOauthRefreshEnabled: config?.claudeOauthRefresh?.enabled !== false,
-  });
-  return config?.e2eAutoFixEnabled
-    ? [...workerKinds, E2E_AUTOFIX_WORKER_KIND]
-    : workerKinds;
+  return autoStartedOwnerWorkerKinds();
 }
 
 export interface WorkerRuntimeController {


### PR DESCRIPTION
## Summary

Owner boot no longer turns workers on from InvokerConfig start flags.

The code always-on set plus SQLite worker_desired_states decide which owner workers run.

A one-shot migration copies leftover start flags into missing desired-state rows so existing owners keep their prior on set.

A read-only run crashed during standalone startup because that migration, plus a separate startup reconciliation step, wrote through SQLite even while read-only.

Both writes now stay off entirely when readOnlyMode is true, so a read-only run no longer hits `SQLiteAdapter is read-only in this process`.

## Review Claim

Boot auto-start membership comes only from the code always-on set and worker_desired_states, not from InvokerConfig start flags, and the startup migration/reconciliation writes stay off during a read-only run.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Owner boot auto-start membership comes only from ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS plus existing or migrated worker_desired_states rows; leftover InvokerConfig start booleans never add or drop a boot auto-start kind after migration runs.

When the standalone command is read-only, `migrateWorkerDesiredStateFromLegacyConfig` and `reconcileTerminalWorkerActionsOnStartup` are skipped entirely, so no SQLite write is attempted and the command exits the same way other read-only paths already do instead of crashing.

## Slice Rationale

This is the owner-runtime half of the single source of truth. Config shape and toggle writers land in later slices so each Review Unit stays alone.

The read-only guard fixes a bot-reported crash in the exact lines this slice already owns, so it stays folded into this slice instead of becoming a separate PR.

## Non-goals

- Changing InvokerConfig field definitions or resolvePrMaintenanceWorkerConfig.
- Changing onboarding or worker toggle writers.
- Changing config-diagnostics warnings.
- Changing read-only detection for any startup path other than these two calls.

## Architecture

### Before

 autoStartedOwnerWorkerKindsForConfig read many config.enabled flags and mixed them into the boot set.

### After

 autoStartedOwnerWorkerKinds returns only the always-on set; migrateWorkerDesiredStateFromLegacyConfig seeds missing desired-state rows once, and both it and reconcileTerminalWorkerActionsOnStartup are skipped when the command is read-only; desired-state overlay still wins in both directions.

## Visual Proof

This slice does not change a rendered window. `packages/app/src/main.ts` is classified as UI-impacting by path.

![owner boot migration call site and worker-control suite results](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260824-f87322/pr10276-boot-migration-and-tests.png)

The headless owner init path calls `migrateWorkerDesiredStateFromLegacyConfig` before creating the worker runtime controller.

Manually inspected: opened pr10276-boot-migration-and-tests.png and confirmed main.ts lines 2090-2101 call migrateWorkerDesiredStateFromLegacyConfig(persistence, invokerConfig as LegacyWorkerStartConfigFlags) with an info log when seeds are non-empty, and the footer shows Test Files 1 passed (1) and Tests 29 passed (29) for worker-control.test.ts. Both calls now sit inside `if (!readOnlyMode)` guards; that conditional does not change any rendered window.

## Test Plan
<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/standalone-owner-handler-ordering.test.ts`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` for the read-only guard commit, then the boot-migration commit.
- Post-revert steps: None
- Data migration? No

</details>
