### PR TITLE
[Worker desired-state SoT](2) Drop worker start booleans from InvokerConfig

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -311,7 +311,6 @@ describe('loadConfig', () => {
 
   it('reads prMaintenance config from user config', () => {
     const prMaintenance = {
-      enabled: true,
       repoRoot: '/srv/invoker',
       env: { INVOKER_PR_CRON_LOCK: '/tmp/pr.lock' },
       intervalMs: 120000,
@@ -344,7 +343,7 @@ describe('loadConfig', () => {
     expect(config.diskHeadroom).toEqual({ cleanupEnabled: false });
   });
 
-  it('defaults opt-in worker gates to undefined when absent', () => {
+  it('defaults removed opt-in worker gates to undefined when absent', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({ defaultBranch: 'main' }),
@@ -355,9 +354,10 @@ describe('loadConfig', () => {
     expect(config.reaper).toBeUndefined();
     expect(config.workflowResume).toBeUndefined();
     expect(config.requeueEnabled).toBeUndefined();
+    expect(config.e2eAutoFixEnabled).toBeUndefined();
   });
 
-  it('reads opt-in worker gates from user config', () => {
+  it('ignores leftover opt-in worker start flags in JSON (migration reads them separately)', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({
@@ -366,16 +366,13 @@ describe('loadConfig', () => {
         reaper: { enabled: false },
         workflowResume: { enabled: true },
         requeueEnabled: true,
+        e2eAutoFixEnabled: true,
       }),
     );
-    const config = loadConfig();
-    expect(config).toMatchObject({
-      infraRepair: { enabled: true },
-      autofix: { enabled: true },
-      reaper: { enabled: false },
-      workflowResume: { enabled: true },
-      requeueEnabled: true,
-    });
+    const config = loadConfig() as Record<string, unknown>;
+    // loadConfig casts JSON through; leftover keys may still appear at runtime
+    // but are not InvokerConfig start gates and must not affect auto-start.
+    expect(config.infraRepair).toEqual({ enabled: true });
   });
 
   it('reads imageStorage from user config', () => {

--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -33,7 +33,6 @@ function makeWorkerDeps(repoRoot: string, token: string): unknown {
     persistence: { enqueueWorkflowMutationIntent: vi.fn(() => 1) },
     invokerConfig: {
       prMaintenance: {
-        enabled: true,
         repoRoot,
         lockPath: join(repoRoot, 'pr-crons.lock'),
         env: { INVOKER_PR_TEST_TOKEN: token },

--- a/packages/app/src/__tests__/registered-owner-workers.test.ts
+++ b/packages/app/src/__tests__/registered-owner-workers.test.ts
@@ -37,27 +37,21 @@ function buildOwnerWorkerDeps(config: InvokerConfig): WorkerRuntimeDependencies 
 }
 
 describe('resolvePrMaintenanceWorkerConfig', () => {
-  it('returns undefined when prMaintenance is absent (disabled by default)', () => {
+  it('returns undefined when prMaintenance is absent', () => {
     expect(resolvePrMaintenanceWorkerConfig({})).toBeUndefined();
   });
 
-  it('returns undefined when prMaintenance is present but not enabled', () => {
+  it('returns launch fields without an enabled gate', () => {
     expect(
       resolvePrMaintenanceWorkerConfig({
         prMaintenance: { repoRoot: '/srv/invoker', intervalMs: 60000 },
       }),
-    ).toBeUndefined();
-    expect(
-      resolvePrMaintenanceWorkerConfig({
-        prMaintenance: { enabled: false, repoRoot: '/srv/invoker' },
-      }),
-    ).toBeUndefined();
+    ).toEqual({ repoRoot: '/srv/invoker', intervalMs: 60000 });
   });
 
-  it('builds the launch config and drops the enabled gate when enabled', () => {
+  it('builds the launch config from present fields', () => {
     const resolved = resolvePrMaintenanceWorkerConfig({
       prMaintenance: {
-        enabled: true,
         repoRoot: '/srv/invoker',
         env: { INVOKER_PR_CRON_LOCK: '/tmp/pr.lock' },
         intervalMs: 120000,
@@ -75,23 +69,19 @@ describe('resolvePrMaintenanceWorkerConfig', () => {
     expect(resolved).not.toHaveProperty('enabled');
   });
 
-  it('omits unset launch fields', () => {
-    expect(
-      resolvePrMaintenanceWorkerConfig({
-        prMaintenance: { enabled: true, repoRoot: '/srv/invoker' },
-      }),
-    ).toEqual({ repoRoot: '/srv/invoker' });
+  it('returns an empty launch object when the block has no launch fields', () => {
+    expect(resolvePrMaintenanceWorkerConfig({ prMaintenance: {} })).toEqual({});
   });
 });
 
 describe('registered owner PR-maintenance worker dependencies', () => {
-  it('leaves prMaintenance deps unset when config is disabled', () => {
+  it('leaves prMaintenance deps unset when config block is absent', () => {
     expect(buildOwnerWorkerDeps({}).prMaintenance).toBeUndefined();
   });
 
-  it('threads the resolved launch config into owner worker deps when enabled', () => {
+  it('threads the resolved launch config into owner worker deps', () => {
     const deps = buildOwnerWorkerDeps({
-      prMaintenance: { enabled: true, intervalMs: 90000, shell: '/bin/bash' },
+      prMaintenance: { intervalMs: 90000, shell: '/bin/bash' },
     });
     expect(deps.prMaintenance).toEqual({ intervalMs: 90000, shell: '/bin/bash' });
   });
@@ -99,7 +89,7 @@ describe('registered owner PR-maintenance worker dependencies', () => {
   it('builds the surviving PR-maintenance workers from the owner deps without starting them', () => {
     const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
     const deps = buildOwnerWorkerDeps({
-      prMaintenance: { enabled: true, intervalMs: 90000 },
+      prMaintenance: { intervalMs: 90000 },
     });
 
     const adminBypass = registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.factory(deps);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -44,19 +44,13 @@ export interface DefaultExecutionConfig {
 }
 
 /**
- * Owner-side PR-maintenance worker config.
+ * Owner-side PR-maintenance worker launch settings.
  *
- * Disabled by default: `enabled` is the gate for building launch dependencies
- * for the surviving `pr-admin-bypass-land` and `pr-orphan-repair` worker
- * paths. The remaining fields tune those shell entrypoints and fall back to
- * the worker defaults when omitted.
+ * Process on/off lives in SQLite `worker_desired_states`, not in this block.
+ * These fields tune the shell entrypoints and fall back to worker defaults
+ * when omitted.
  */
 export interface PrMaintenanceConfig {
-  /**
-   * Gate for building PR-maintenance worker dependencies at owner startup.
-   * Default: false (workers get no launch config).
-   */
-  enabled?: boolean;
   /** Repository root that owns the PR-maintenance shell scripts. Defaults to the Invoker repo root. */
   repoRoot?: string;
   /** Environment overrides forwarded to the shell entrypoint. `undefined` removes a variable. */
@@ -70,7 +64,6 @@ export interface PrMaintenanceConfig {
 }
 
 export interface SlackBugScanConfig {
-  enabled?: boolean;
   intervalMs?: number;
   maxAutoSubmissionsPerDay?: number;
   maxAutoSubmissionsPerTick?: number;
@@ -119,12 +112,6 @@ export interface InvokerConfig {
    * Default: 0 (disabled).
    */
   autoFixRetries?: number;
-  /**
-   * When true, the owner process auto-starts the e2e-autofix worker (runs the
-   * extended battery on a schedule and opens one fix PR per failing suite).
-   * Default: false.
-   */
-  e2eAutoFixEnabled?: boolean;
   /** Cadence for the e2e-autofix worker in milliseconds. Default: 43_200_000 (12h). */
   e2eAutoFixIntervalMs?: number;
   stallRequeueRetries?: number;
@@ -198,39 +185,6 @@ export interface InvokerConfig {
    * Default: false.
    */
   autoFixCi?: boolean;
-  /**
-   * Owner-side infra-repair worker config.
-   * Default: false.
-   */
-  infraRepair?: {
-    enabled?: boolean;
-  };
-  /**
-   * Owner-side autofix worker config.
-   * Default: false.
-   */
-  autofix?: {
-    enabled?: boolean;
-  };
-  /**
-   * Owner-side reaper worker config.
-   * Default: false.
-   */
-  reaper?: {
-    enabled?: boolean;
-  };
-  /**
-   * Owner-side workflow-resume worker config.
-   * Default: false.
-   */
-  workflowResume?: {
-    enabled?: boolean;
-  };
-  /**
-   * Enables stalled-task requeue behavior.
-   * Default: false.
-   */
-  requeueEnabled?: boolean;
   /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
@@ -433,37 +387,20 @@ export interface InvokerConfig {
    */
   externalWorkers?: ExternalWorkerConfig[];
   /**
-   * Owner-side PR-maintenance worker config. Disabled by default; when
-   * `enabled` is true the owner builds launch dependencies for the surviving
-   * PR-maintenance workers from this block.
+   * Owner-side PR-maintenance launch settings (interval, lock, repo root).
+   * Process on/off is SQLite `worker_desired_states`, not a config boolean.
    */
   prMaintenance?: PrMaintenanceConfig;
   /**
-   * Owner-side disk-headroom worker config. `cleanupEnabled` takes precedence
-   * over the legacy `INVOKER_DISK_CLEANUP_ENABLED` env var when set; the worker
-   * falls back to the env var only when this is left unset. Default: enabled.
+   * Owner-side disk-headroom policy. `cleanupEnabled` controls whether the
+   * always-running disk-headroom worker may delete files on critical disks;
+   * it does not start or stop the worker. Takes precedence over the legacy
+   * `INVOKER_DISK_CLEANUP_ENABLED` env var when set. Default: enabled.
    */
   diskHeadroom?: {
     cleanupEnabled?: boolean;
   };
-  /**
-   * Owner-side Claude OAuth refresh worker gate. When enabled, the owner
-   * refreshes its own ~/.claude/.credentials.json ahead of expiry and
-   * distributes the refreshed file to every configured SSH remote target.
-   */
-  claudeOauthRefresh?: {
-    enabled?: boolean;
-  };
   slackBugScan?: SlackBugScanConfig;
-  /**
-   * Owner-side idle-task-cleanup worker gate. The worker itself ships
-   * dry-run-only (see `idle-task-cleanup-worker.ts`'s `FORCE_DRY_RUN`), so
-   * enabling this only turns on the dry-run scan/log, not real mutation.
-   * Default: disabled.
-   */
-  staleTaskCleanup?: {
-    enabled?: boolean;
-  };
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },
@@ -662,17 +599,15 @@ export function resolveSecretsFilePath(config: InvokerConfig): string | undefine
 /**
  * Build PR-maintenance worker launch dependencies from config.
  *
- * Returns `undefined` when the block is absent or `enabled` is not true, so the
- * owner keeps PR-maintenance workers disabled by default. When enabled, returns
- * only the launch fields (the `enabled` gate is dropped) for injection as the
- * worker runtime `prMaintenance` dependency; omitted fields fall back to the
- * worker defaults.
+ * Returns `undefined` when the block is absent or empty. Process on/off is
+ * SQLite desired state; this only threads interval/lock/repoRoot/env/shell
+ * so a started PR-maintenance worker still gets launch settings.
  */
 export function resolvePrMaintenanceWorkerConfig(
   config: InvokerConfig,
 ): PrMaintenanceWorkerConfig | undefined {
   const prMaintenance = config.prMaintenance;
-  if (!prMaintenance?.enabled) {
+  if (!prMaintenance) {
     return undefined;
   }
   const launch: PrMaintenanceWorkerConfig = {};
@@ -681,5 +616,5 @@ export function resolvePrMaintenanceWorkerConfig(
   if (prMaintenance.intervalMs !== undefined) launch.intervalMs = prMaintenance.intervalMs;
   if (prMaintenance.lockPath !== undefined) launch.lockPath = prMaintenance.lockPath;
   if (prMaintenance.shell !== undefined) launch.shell = prMaintenance.shell;
-  return launch;
+  return Object.keys(launch).length > 0 ? launch : {};
 }


### PR DESCRIPTION
## Summary

InvokerConfig no longer carries worker process start/stop booleans.

The prMaintenance block keeps interval, lock, repo root, env, and shell only.

resolvePrMaintenanceWorkerConfig builds launch settings whenever the block is present, without an enabled flag.

## Review Claim

InvokerConfig must not define a boolean that starts or stops an owner worker; prMaintenance is launch settings only.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

InvokerConfig must not define a boolean that gates worker process start; prMaintenance and similar blocks may only carry launch or policy fields, and resolvePrMaintenanceWorkerConfig must not require an enabled flag.

## Slice Rationale

Config shape changes after boot no longer consults those flags, so dropping the fields cannot revive a second on/off source.

## Non-goals

- Changing owner boot auto-start membership logic.
- Changing CLI onboarding or worker toggle writers.
- Changing config-diagnostics wording beyond what this package does not own.

## Architecture

### Before

 prMaintenance.enabled (and sibling start flags) both described intent and gated launch-dep construction.

### After

 those start fields are gone from InvokerConfig; launch-dep construction keys off block presence; leftover JSON keys may still exist at runtime for migration only.

## Test Plan
<details>
<summary>Test plan</summary>

- `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts src/__tests__/registered-owner-workers.test.ts`

</details>

## Revert Plan
<details>
<summary>Revert plan</summary>

- Revert this stack slice commit. InvokerConfig again exposes start booleans and resolvePrMaintenanceWorkerConfig again requires enabled.

</details>
