### PR TITLE
[Worker desired-state SoT](4) Stop warning about missing infraRepair.enabled

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -170,18 +170,34 @@ describe('invoker-cli', () => {
     const dir = makeTempDir('invoker-worker-toggles-');
     const configPath = join(dir, 'config.json');
     const saved = process.env.INVOKER_REPO_CONFIG_PATH;
+    const savedDb = process.env.INVOKER_DB_DIR;
     process.env.INVOKER_REPO_CONFIG_PATH = configPath;
+    process.env.INVOKER_DB_DIR = dir;
+    writeFileSync(configPath, '{}');
     const output = captureProcessOutput();
     try {
       const code = await main(['worker', 'toggles', '--enable', 'e2e-autofix']);
 
       expect(code).toBe(0);
       expect(output.stdout).toContain('E2E auto-fix: on');
-      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({ e2eAutoFixEnabled: true });
+      const writtenConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+      expect(writtenConfig).toEqual({});
+      const { SQLiteAdapter } = await import('@invoker/data-store');
+      const db = await SQLiteAdapter.create(join(dir, 'invoker.db'), {
+        outputDir: join(dir, 'outputs'),
+        ownerCapability: true,
+      });
+      try {
+        expect(db.getWorkerDesiredState('e2e-autofix')?.desiredEnabled).toBe(true);
+      } finally {
+        db.close();
+      }
     } finally {
       output.restore();
       if (saved === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
       else process.env.INVOKER_REPO_CONFIG_PATH = saved;
+      if (savedDb === undefined) delete process.env.INVOKER_DB_DIR;
+      else process.env.INVOKER_DB_DIR = savedDb;
     }
   });
 

--- a/packages/cli/src/__tests__/onboarding-invariants.test.ts
+++ b/packages/cli/src/__tests__/onboarding-invariants.test.ts
@@ -4,7 +4,7 @@ import {
   assertNoSecretPrinted,
   assertOptionalToolPromptedBeforeInstall,
   assertRemoteTargetOnlyPersistedAfterAllChecksPass,
-  assertWorkerToggleHasSingleConfigSource,
+  assertWorkerToggleHasSingleSource,
 } from '../onboarding-invariants.js';
 
 describe('assertOptionalToolPromptedBeforeInstall', () => {
@@ -102,23 +102,41 @@ describe('assertNoSecretPrinted', () => {
   });
 });
 
-describe('assertWorkerToggleHasSingleConfigSource', () => {
-  it('passes for a real dotted InvokerConfig path', () => {
-    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'pr-maintenance', configPath: 'prMaintenance.enabled' })).not.toThrow();
+describe('assertWorkerToggleHasSingleSource', () => {
+  it('passes for a desired-state start preset', () => {
+    expect(() => assertWorkerToggleHasSingleSource({
+      id: 'pr-maintenance',
+      workerKinds: ['pr-admin-bypass-land', 'pr-orphan-repair'],
+    })).not.toThrow();
   });
 
-  it('passes for a real top-level InvokerConfig field', () => {
-    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'e2e-autofix', configPath: 'e2eAutoFixEnabled' })).not.toThrow();
+  it('passes for a policy config path', () => {
+    expect(() => assertWorkerToggleHasSingleSource({
+      id: 'auto-approve',
+      configPath: 'autoApproveAIFixes',
+    })).not.toThrow();
   });
 
   it('rejects a bare env var name — the exact disk-headroom-cleanup regression', () => {
-    expect(() => assertWorkerToggleHasSingleConfigSource({
+    expect(() => assertWorkerToggleHasSingleSource({
       id: 'disk-headroom-cleanup',
       configPath: 'INVOKER_DISK_CLEANUP_ENABLED',
     })).toThrow(/bare env var name/);
   });
 
-  it('rejects a malformed configPath', () => {
-    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'bad', configPath: 'foo..bar' })).toThrow(/malformed configPath/);
+  it('rejects a config start flag path', () => {
+    expect(() => assertWorkerToggleHasSingleSource({
+      id: 'pr-maintenance',
+      configPath: 'prMaintenance.enabled',
+    })).toThrow(/worker start flag/);
+  });
+
+  it('rejects declaring both or neither source', () => {
+    expect(() => assertWorkerToggleHasSingleSource({ id: 'bad' })).toThrow(/exactly one/);
+    expect(() => assertWorkerToggleHasSingleSource({
+      id: 'bad',
+      workerKinds: ['x'],
+      configPath: 'autoApproveAIFixes',
+    })).toThrow(/exactly one/);
   });
 });

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -303,17 +303,17 @@ describe('runSetup', () => {
     }
   });
 
-  it('writes only the worker toggle the user says yes to, leaving the rest unset', async () => {
+  it('writes start toggles to desired state and policy toggles to config', async () => {
     const home = mkdtempSync(join(tmpdir(), 'invoker-setup-toggles-'));
     const saved = { HOME: process.env.HOME };
     const lines: string[] = [];
     try {
       process.env.HOME = home;
 
-      // Prompt order: Slack, machines, then the 4 worker toggles in
-      // ONBOARDING_WORKER_TOGGLES order (PR maintenance, e2e auto-fix,
-      // auto-approve, disk-headroom cleanup).
-      const answers = ['n', 'n', 'n', 'y', 'n', 'y'];
+      // Prompt order: Slack, machines, then ONBOARDING_WORKER_TOGGLES
+      // (PR maintenance, e2e auto-fix, auto-approve, disk-headroom cleanup,
+      // idle-task cleanup).
+      const answers = ['n', 'n', 'n', 'y', 'y', 'y', 'n'];
       const code = await runSetup([], {
         print: (line) => lines.push(line),
         prompt: async () => answers.shift() ?? 'n',
@@ -321,8 +321,23 @@ describe('runSetup', () => {
 
       expect(code).toBe(0);
       const configPath = join(home, '.invoker', 'config.json');
-      const config = JSON.parse(readFileSync(configPath, 'utf8'));
-      expect(config).toEqual({ e2eAutoFixEnabled: true });
+      const writtenOnboardingConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+      expect(writtenOnboardingConfig).toEqual({ autoApproveAIFixes: true });
+      expect(writtenOnboardingConfig).not.toHaveProperty('e2eAutoFixEnabled');
+      expect(writtenOnboardingConfig).not.toHaveProperty('prMaintenance');
+
+      const { SQLiteAdapter } = await import('@invoker/data-store');
+      const db = await SQLiteAdapter.create(join(home, '.invoker', 'invoker.db'), {
+        outputDir: join(home, '.invoker', 'outputs'),
+        ownerCapability: true,
+      });
+      try {
+        expect(db.getWorkerDesiredState('e2e-autofix')?.desiredEnabled).toBe(true);
+        expect(db.getWorkerDesiredState('pr-admin-bypass-land')).toBeUndefined();
+        expect(db.getWorkerDesiredState('idle-task-cleanup')).toBeUndefined();
+      } finally {
+        db.close();
+      }
       expect(lines.join('\n')).toContain('Worker toggles');
     } finally {
       restoreEnv('HOME', saved.HOME);
@@ -953,6 +968,7 @@ describe('runSetup in a non-interactive shell', () => {
     expect(code).toBe(0);
     expect(lines.join('\n')).toContain('Worker toggles');
     expect(lines.join('\n')).toContain('PR maintenance: off');
+    expect(lines.join('\n')).toMatch(/Worker toggles — .*PR maintenance: off/);
   });
 
   it('skips Slack under --yes rather than starting a flow it cannot finish', async () => {

--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -1,47 +1,63 @@
 import { describe, expect, it } from 'vitest';
 
-import { assertWorkerToggleHasSingleConfigSource } from '../onboarding-invariants.js';
+import { assertWorkerToggleHasSingleSource } from '../onboarding-invariants.js';
 import {
+  applyDesiredStateWorkerToggle,
   applyWorkerToggle,
   findWorkerToggle,
+  isDesiredStateWorkerToggle,
+  isPolicyWorkerToggle,
   ONBOARDING_WORKER_TOGGLES,
+  PR_MAINTENANCE_TOGGLE_WORKER_KINDS,
+  WORKER_TOGGLES,
+  readDesiredStateWorkerToggleValue,
   readWorkerToggleValue,
 } from '../worker-toggles.js';
 
 describe('ONBOARDING_WORKER_TOGGLES', () => {
-  it('has a unique id and a real InvokerConfig-backed path for every toggle', () => {
+  it('has a unique id and exactly one of workerKinds or configPath for every toggle', () => {
     const ids = ONBOARDING_WORKER_TOGGLES.map((spec) => spec.id);
     expect(new Set(ids).size).toBe(ids.length);
     for (const spec of ONBOARDING_WORKER_TOGGLES) {
-      // Guards the exact disk-headroom-cleanup regression found this session:
-      // a toggle backed by a bare env var instead of a real config field.
-      expect(() => assertWorkerToggleHasSingleConfigSource(spec)).not.toThrow();
+      expect(() => assertWorkerToggleHasSingleSource(spec)).not.toThrow();
     }
+  });
+
+  it('maps pr-maintenance to the four babysitting worker kinds', () => {
+    const spec = findWorkerToggle('pr-maintenance')!;
+    expect(isDesiredStateWorkerToggle(spec)).toBe(true);
+    expect(spec.workerKinds).toEqual([...PR_MAINTENANCE_TOGGLE_WORKER_KINDS]);
+  });
+
+  it('exposes pr-status and autofix as desired-state toggles for CLI', () => {
+    const prStatus = findWorkerToggle('pr-status')!;
+    const autofix = findWorkerToggle('autofix')!;
+    expect(isDesiredStateWorkerToggle(prStatus)).toBe(true);
+    expect(isDesiredStateWorkerToggle(autofix)).toBe(true);
+    expect(prStatus.workerKinds).toEqual(['pr-status']);
+    expect(autofix.workerKinds).toEqual(['autofix']);
+    expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'pr-status')).toBe(false);
+    expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'autofix')).toBe(false);
+    expect(WORKER_TOGGLES.some((spec) => spec.id === 'pr-status')).toBe(true);
   });
 });
 
-describe('applyWorkerToggle / readWorkerToggleValue', () => {
-  it('sets and reads a top-level boolean field', () => {
-    const spec = findWorkerToggle('e2e-autofix')!;
-    const config = applyWorkerToggle({}, spec, true);
-    expect(config).toEqual({ e2eAutoFixEnabled: true });
-    expect(readWorkerToggleValue(config, spec)).toBe(true);
+describe('policy applyWorkerToggle / readWorkerToggleValue', () => {
+  it('sets and reads a top-level policy field', () => {
+    const spec = findWorkerToggle('auto-approve')!;
+    const policyConfig = applyWorkerToggle({}, spec, true);
+    expect(policyConfig).toEqual({ autoApproveAIFixes: true });
+    expect(readWorkerToggleValue(policyConfig, spec)).toBe(true);
   });
 
-  it('sets and reads a nested boolean field, preserving sibling keys', () => {
-    const spec = findWorkerToggle('pr-maintenance')!;
-    const config = applyWorkerToggle({ prMaintenance: { repoRoot: '/srv/invoker' } }, spec, true);
-    expect(config).toEqual({ prMaintenance: { repoRoot: '/srv/invoker', enabled: true } });
-    expect(readWorkerToggleValue(config, spec)).toBe(true);
-  });
-
-  it('creates the nested object when it does not exist yet', () => {
+  it('sets and reads a nested policy field, preserving sibling keys', () => {
     const spec = findWorkerToggle('disk-headroom-cleanup')!;
-    const config = applyWorkerToggle({}, spec, false);
-    expect(config).toEqual({ diskHeadroom: { cleanupEnabled: false } });
+    const nestedPolicyConfig = applyWorkerToggle({ diskHeadroom: { other: 1 } } as never, spec, false);
+    expect(nestedPolicyConfig).toEqual({ diskHeadroom: { other: 1, cleanupEnabled: false } });
+    expect(readWorkerToggleValue(nestedPolicyConfig, spec)).toBe(false);
   });
 
-  it('returns undefined for an unset toggle, not a false default', () => {
+  it('returns undefined for an unset policy toggle, not a false default', () => {
     const spec = findWorkerToggle('auto-approve')!;
     expect(readWorkerToggleValue({}, spec)).toBeUndefined();
   });
@@ -51,11 +67,62 @@ describe('applyWorkerToggle / readWorkerToggleValue', () => {
     expect(spec.description).toContain('autoApproveAuthors');
   });
 
+  it('rejects applying a desired-state toggle through applyWorkerToggle', () => {
+    const spec = findWorkerToggle('pr-maintenance')!;
+    expect(() => applyWorkerToggle({}, spec, true)).toThrow(/desired state/);
+  });
+
   it('does not mutate the input config object', () => {
-    const spec = findWorkerToggle('e2e-autofix')!;
+    const spec = findWorkerToggle('auto-approve')!;
     const original = { defaultBranch: 'main' };
     const updated = applyWorkerToggle(original, spec, true);
     expect(original).toEqual({ defaultBranch: 'main' });
     expect(updated).not.toBe(original);
+  });
+});
+
+describe('desired-state worker toggles', () => {
+  function memoryStore(initial: Record<string, boolean> = {}) {
+    const desired = new Map(Object.entries(initial));
+    return {
+      getWorkerDesiredState: (workerKind: string) => (
+        desired.has(workerKind)
+          ? { desiredEnabled: desired.get(workerKind) === true }
+          : undefined
+      ),
+      setWorkerDesiredState: (workerKind: string, desiredEnabled: boolean) => {
+        desired.set(workerKind, desiredEnabled);
+        return { workerKind, desiredEnabled };
+      },
+      desired,
+    };
+  }
+
+  it('writes every mapped worker kind for pr-maintenance', () => {
+    const store = memoryStore();
+    const spec = findWorkerToggle('pr-maintenance')!;
+    expect(isDesiredStateWorkerToggle(spec)).toBe(true);
+    applyDesiredStateWorkerToggle(store, spec, true);
+    expect([...store.desired.entries()].sort()).toEqual(
+      PR_MAINTENANCE_TOGGLE_WORKER_KINDS.map((kind) => [kind, true]).sort(),
+    );
+  });
+
+  it('reads true only when every mapped kind is desired-enabled', () => {
+    const spec = findWorkerToggle('pr-maintenance')!;
+    expect(isDesiredStateWorkerToggle(spec)).toBe(true);
+    const partial = memoryStore({ [PR_MAINTENANCE_TOGGLE_WORKER_KINDS[0]]: true });
+    expect(readDesiredStateWorkerToggleValue(partial, spec)).toBeUndefined();
+
+    const store = memoryStore();
+    applyDesiredStateWorkerToggle(store, spec, true);
+    expect(readDesiredStateWorkerToggleValue(store, spec)).toBe(true);
+    applyDesiredStateWorkerToggle(store, spec, false);
+    expect(readDesiredStateWorkerToggleValue(store, spec)).toBe(false);
+  });
+
+  it('policy toggles are not desired-state toggles', () => {
+    expect(isPolicyWorkerToggle(findWorkerToggle('auto-approve')!)).toBe(true);
+    expect(isDesiredStateWorkerToggle(findWorkerToggle('auto-approve')!)).toBe(false);
   });
 });

--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -121,6 +121,14 @@ describe('desired-state worker toggles', () => {
     expect(readDesiredStateWorkerToggleValue(store, spec)).toBe(false);
   });
 
+  it('returns undefined for a missing row even after an earlier disabled row', () => {
+    const spec = findWorkerToggle('pr-maintenance')!;
+    const partialWithEarlyDisabled = memoryStore({
+      [PR_MAINTENANCE_TOGGLE_WORKER_KINDS[0]]: false,
+    });
+    expect(readDesiredStateWorkerToggleValue(partialWithEarlyDisabled, spec)).toBeUndefined();
+  });
+
   it('policy toggles are not desired-state toggles', () => {
     expect(isPolicyWorkerToggle(findWorkerToggle('auto-approve')!)).toBe(true);
     expect(isDesiredStateWorkerToggle(findWorkerToggle('auto-approve')!)).toBe(false);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,7 +51,18 @@ import {
 } from './live-owner-bus.js';
 import { runMcpServer } from './mcp-server.js';
 import { defaultConfigPath, runDoctor, runSetup } from './onboarding.js';
-import { applyWorkerToggle, findWorkerToggle, ONBOARDING_WORKER_TOGGLES, readWorkerToggleValue } from './worker-toggles.js';
+import {
+  applyDesiredStateWorkerToggle,
+  applyWorkerToggle,
+  findWorkerToggle,
+  isDesiredStateWorkerToggle,
+  isPolicyWorkerToggle,
+  ONBOARDING_WORKER_TOGGLES,
+  WORKER_TOGGLES,
+  openWorkerDesiredStateStore,
+  readDesiredStateWorkerToggleValue,
+  readWorkerToggleValue,
+} from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
 const VERSION = '0.0.12';
@@ -198,7 +209,7 @@ function usage(): string {
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
-    '  worker toggles      Show or set the on/off state of optional owner workers (PR maintenance, e2e auto-fix, auto-approve, disk-headroom cleanup).',
+    '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
     '  auto-approve-authors  Show or set GitHub logins in config.json that auto-approve may act on. Does not enable the auto-approve toggle.',
     '',
     'Options:',
@@ -911,11 +922,11 @@ function printWorkerKinds<TDeps>(registry: WorkerRegistry<TDeps>): void {
 
 /**
  * `invoker-cli worker toggles [--enable <id>|--disable <id> ...]`
- * With no flags, prints each toggle's current state. Each flag applies
- * immediately, writing to ~/.invoker/config.json (or INVOKER_REPO_CONFIG_PATH).
+ * Start presets write SQLite desired state; policy toggles write config.
+ * When an owner is live, start presets also request live start/stop.
  */
-function runWorkerTogglesCommand(args: string[]): number {
-  const changes: Array<{ spec: ReturnType<typeof findWorkerToggle>; enabled: boolean }> = [];
+async function runWorkerTogglesCommand(args: string[]): Promise<number> {
+  const changes: Array<{ spec: NonNullable<ReturnType<typeof findWorkerToggle>>; enabled: boolean }> = [];
   for (let i = 0; i < args.length; i += 1) {
     const flag = args[i];
     if (flag !== '--enable' && flag !== '--disable') {
@@ -924,7 +935,7 @@ function runWorkerTogglesCommand(args: string[]): number {
     const id = args[++i];
     const spec = id ? findWorkerToggle(id) : undefined;
     if (!spec) {
-      const knownIds = ONBOARDING_WORKER_TOGGLES.map((toggle) => toggle.id).join(', ');
+      const knownIds = WORKER_TOGGLES.map((toggle) => toggle.id).join(', ');
       throw new Error(`Unknown worker toggle id: "${id ?? ''}". Known ids: ${knownIds}`);
     }
     changes.push({ spec, enabled: flag === '--enable' });
@@ -932,26 +943,78 @@ function runWorkerTogglesCommand(args: string[]): number {
 
   if (changes.length > 0) {
     const configPath = defaultConfigPath();
-    updateInvokerConfigFile(configPath, (config) => {
-      for (const { spec, enabled } of changes) {
-        Object.assign(config, applyWorkerToggle(config, spec!, enabled));
+    const policyChanges = changes.filter((change) => isPolicyWorkerToggle(change.spec));
+    const desiredChanges = changes.filter((change) => isDesiredStateWorkerToggle(change.spec));
+
+    if (policyChanges.length > 0) {
+      updateInvokerConfigFile(configPath, (config) => {
+        for (const { spec, enabled } of policyChanges) {
+          Object.assign(config, applyWorkerToggle(config, spec, enabled));
+        }
+      });
+    }
+
+    if (desiredChanges.length > 0) {
+      const store = await openWorkerDesiredStateStore();
+      try {
+        for (const { spec, enabled } of desiredChanges) {
+          applyDesiredStateWorkerToggle(store, spec, enabled);
+        }
+      } finally {
+        store.close?.();
       }
-    });
+      await tryLiveDesiredStateWorkerControl(desiredChanges);
+    }
+
     for (const { spec, enabled } of changes) {
-      process.stdout.write(`${spec!.label}: ${enabled ? 'on' : 'off'}\n`);
+      process.stdout.write(`${spec.label}: ${enabled ? 'on' : 'off'}\n`);
     }
     return 0;
   }
 
   const config = readInvokerConfigFile(defaultConfigPath());
-  process.stdout.write('Worker toggles\n');
-  for (const spec of ONBOARDING_WORKER_TOGGLES) {
-    const value = readWorkerToggleValue(config, spec);
-    const enabled = value ?? spec.defaultEnabled ?? false;
-    const state = enabled ? 'on' : 'off';
-    process.stdout.write(`  ${spec.label}: ${value === undefined ? `${state} (default)` : state} — ${spec.description}\n`);
+  const store = await openWorkerDesiredStateStore();
+  try {
+    process.stdout.write('Worker toggles\n');
+    for (const spec of WORKER_TOGGLES) {
+      let value: boolean | undefined;
+      if (isDesiredStateWorkerToggle(spec)) {
+        value = readDesiredStateWorkerToggleValue(store, spec);
+      } else {
+        value = readWorkerToggleValue(config, spec);
+      }
+      const enabled = value ?? spec.defaultEnabled ?? false;
+      const state = enabled ? 'on' : 'off';
+      process.stdout.write(`  ${spec.label}: ${value === undefined ? `${state} (default)` : state} — ${spec.description}\n`);
+    }
+  } finally {
+    store.close?.();
   }
   return 0;
+}
+
+async function tryLiveDesiredStateWorkerControl(
+  changes: ReadonlyArray<{ spec: Extract<NonNullable<ReturnType<typeof findWorkerToggle>>, { workerKinds: readonly string[] }>; enabled: boolean }>,
+): Promise<void> {
+  let bus: MessageBus | undefined;
+  try {
+    bus = await createDefaultMessageBus();
+    const owner = await discoverLiveOwner(bus);
+    if (!owner) return;
+    for (const { spec, enabled } of changes) {
+      for (const kind of spec.workerKinds) {
+        await bus.request('headless.gui-mutation', {
+          channel: enabled ? 'invoker:start-worker' : 'invoker:stop-worker',
+          args: [kind],
+        });
+      }
+    }
+  } catch {
+    // Desired state is already persisted; live apply is best-effort.
+  } finally {
+    const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
+    if (disconnect) disconnect.call(bus);
+  }
 }
 
 function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorkerRuntime {
@@ -1081,7 +1144,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
       if (subcommand === 'toggles') {
-        return runWorkerTogglesCommand(argv.slice(2));
+        return await runWorkerTogglesCommand(argv.slice(2));
       }
       const registry = registerExternalWorkers(
         registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),

--- a/packages/cli/src/onboarding-invariants.ts
+++ b/packages/cli/src/onboarding-invariants.ts
@@ -75,16 +75,47 @@ export function assertNoSecretPrinted(printedLines: readonly string[], secretVal
 }
 
 /**
- * Guards the disk-headroom-cleanup regression: a worker toggle's configPath
- * must look like a real dotted InvokerConfig field, never a bare env var
- * name. This is what would have caught `INVOKER_DISK_CLEANUP_ENABLED` being
- * used as a toggle's source of truth instead of a config field.
+ * Guards worker-toggle source-of-truth: start presets declare worker kinds
+ * (SQLite desired state), policy toggles declare a real InvokerConfig path —
+ * never a bare env var and never a config start boolean like
+ * `prMaintenance.enabled`.
  */
+export function assertWorkerToggleHasSingleSource(spec: {
+  id: string;
+  workerKinds?: readonly string[];
+  configPath?: string;
+}): void {
+  const hasKinds = Array.isArray(spec.workerKinds) && spec.workerKinds.length > 0;
+  const hasPath = typeof spec.configPath === 'string' && spec.configPath.length > 0;
+  if (hasKinds === hasPath) {
+    throw new Error(
+      `worker toggle "${spec.id}" must declare exactly one of workerKinds (desired-state start) or configPath (policy)`,
+    );
+  }
+  if (hasKinds) {
+    for (const workerKind of spec.workerKinds!) {
+      if (typeof workerKind !== 'string' || workerKind.trim().length === 0) {
+        throw new Error(`worker toggle "${spec.id}" has an empty workerKinds entry`);
+      }
+    }
+    return;
+  }
+  const configPath = spec.configPath!;
+  if (/^[A-Z][A-Z0-9_]*$/.test(configPath)) {
+    throw new Error(`worker toggle "${spec.id}" is backed by what looks like a bare env var name ("${configPath}") instead of an InvokerConfig field`);
+  }
+  if (!/^[a-zA-Z][a-zA-Z0-9]*(\.[a-zA-Z][a-zA-Z0-9]*)?$/.test(configPath)) {
+    throw new Error(`worker toggle "${spec.id}" has a malformed configPath "${configPath}"`);
+  }
+  const leaf = configPath.split('.').pop() ?? configPath;
+  if (leaf === 'enabled' || leaf === 'e2eAutoFixEnabled' || leaf === 'requeueEnabled') {
+    throw new Error(
+      `worker toggle "${spec.id}" configPath "${configPath}" looks like a worker start flag; start toggles must use workerKinds`,
+    );
+  }
+}
+
+/** @deprecated Use assertWorkerToggleHasSingleSource. */
 export function assertWorkerToggleHasSingleConfigSource(spec: { id: string; configPath: string }): void {
-  if (/^[A-Z][A-Z0-9_]*$/.test(spec.configPath)) {
-    throw new Error(`worker toggle "${spec.id}" is backed by what looks like a bare env var name ("${spec.configPath}") instead of an InvokerConfig field`);
-  }
-  if (!/^[a-zA-Z][a-zA-Z0-9]*(\.[a-zA-Z][a-zA-Z0-9]*)?$/.test(spec.configPath)) {
-    throw new Error(`worker toggle "${spec.id}" has a malformed configPath "${spec.configPath}"`);
-  }
+  assertWorkerToggleHasSingleSource(spec);
 }

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -27,7 +27,7 @@ import { parsePlanFile } from '@invoker/workflow-core';
 import { formatCaughtException, logCaughtException } from './logging.js';
 import { installBundledSkills } from './bundled-skills.js';
 import { runRemoteDoctorChecks } from './remote-doctor.js';
-import { applyWorkerToggle, ONBOARDING_WORKER_TOGGLES, readWorkerToggleValue } from './worker-toggles.js';
+import { applyWorkerToggle, isDesiredStateWorkerToggle, isPolicyWorkerToggle, ONBOARDING_WORKER_TOGGLES, openWorkerDesiredStateStore, applyDesiredStateWorkerToggle, readDesiredStateWorkerToggleValue, readWorkerToggleValue } from './worker-toggles.js';
 
 // ── Paths ────────────────────────────────────────────────────
 
@@ -1085,21 +1085,35 @@ async function runMachinesSetupJson(io: SetupIO, options: SetupDeps): Promise<nu
 async function runWorkerTogglesInteractive(io: SetupIO, assumeYes: boolean): Promise<void> {
   const configPath = defaultConfigPath();
   let config = readInvokerConfigFile(configPath);
-  let changed = false;
+  let configChanged = false;
   const summary: string[] = [];
+  const desiredStore = await openWorkerDesiredStateStore();
 
-  for (const spec of ONBOARDING_WORKER_TOGGLES) {
-    io.print(`\n${spec.label}: ${spec.description}`);
-    const current = readWorkerToggleValue(config, spec) ?? spec.defaultEnabled ?? false;
-    const enable = assumeYes ? current : await promptYes(io, `Enable ${spec.label}? [y/N] `);
-    if (enable !== current) {
-      config = applyWorkerToggle(config, spec, enable);
-      changed = true;
+  try {
+    for (const spec of ONBOARDING_WORKER_TOGGLES) {
+      io.print(`\n${spec.label}: ${spec.description}`);
+      let current: boolean;
+      if (isDesiredStateWorkerToggle(spec)) {
+        current = readDesiredStateWorkerToggleValue(desiredStore, spec) ?? spec.defaultEnabled ?? false;
+      } else {
+        current = readWorkerToggleValue(config, spec) ?? spec.defaultEnabled ?? false;
+      }
+      const enable = assumeYes ? current : await promptYes(io, `Enable ${spec.label}? [y/N] `);
+      if (enable !== current) {
+        if (isDesiredStateWorkerToggle(spec)) {
+          applyDesiredStateWorkerToggle(desiredStore, spec, enable);
+        } else if (isPolicyWorkerToggle(spec)) {
+          config = applyWorkerToggle(config, spec, enable);
+          configChanged = true;
+        }
+      }
+      summary.push(`${spec.label}: ${enable ? 'on' : 'off'}`);
     }
-    summary.push(`${spec.label}: ${enable ? 'on' : 'off'}`);
+  } finally {
+    desiredStore.close?.();
   }
 
-  if (changed) {
+  if (configChanged) {
     writeInvokerConfigFile(configPath, config);
   }
 

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -1,38 +1,90 @@
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 import type { InvokerConfigRecord } from '@invoker/contracts';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  AUTO_FIX_WORKER_KIND,
+  E2E_AUTOFIX_WORKER_KIND,
+  IDLE_TASK_CLEANUP_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_AUTO_LABEL_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
+} from '@invoker/execution-engine';
 
 /**
- * Dotted config paths for the workers this wizard exposes as on/off toggles.
- * Every path is backed by a real `InvokerConfig` field read at owner boot —
- * never a bare env var — see onboarding-invariants.ts's
- * assertWorkerToggleHasSingleConfigSource for the guard against that drifting.
+ * Policy toggles still write an InvokerConfig boolean. Start toggles write
+ * SQLite `worker_desired_states` for one or more worker kinds — never a
+ * config start flag. See onboarding-invariants.ts.
  */
 export type WorkerToggleConfigPath =
-  | 'prMaintenance.enabled'
-  | 'e2eAutoFixEnabled'
   | 'autoApproveAIFixes'
-  | 'diskHeadroom.cleanupEnabled'
-  | 'staleTaskCleanup.enabled';
+  | 'diskHeadroom.cleanupEnabled';
 
-export interface WorkerToggleSpec {
-  id: string;
-  label: string;
-  description: string;
-  configPath: WorkerToggleConfigPath;
-  defaultEnabled?: boolean;
-}
+export type WorkerToggleSpec =
+  | {
+      id: string;
+      label: string;
+      description: string;
+      /** Writes SQLite desired state for these worker kinds. */
+      workerKinds: readonly string[];
+      configPath?: undefined;
+      defaultEnabled?: boolean;
+      /** When false, setup wizard skips this toggle; CLI `worker toggles` still lists it. */
+      includeInOnboarding?: boolean;
+    }
+  | {
+      id: string;
+      label: string;
+      description: string;
+      /** Writes a policy boolean in config (not process on/off). */
+      configPath: WorkerToggleConfigPath;
+      workerKinds?: undefined;
+      defaultEnabled?: boolean;
+      includeInOnboarding?: boolean;
+    };
 
-export const ONBOARDING_WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
+/** PR-maintenance onboarding preset → the four babysitting worker kinds. */
+export const PR_MAINTENANCE_TOGGLE_WORKER_KINDS = [
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
+  PR_AUTO_LABEL_WORKER_KIND,
+] as const;
+
+/**
+ * All CLI-controllable worker toggles. Setup wizard uses
+ * {@link ONBOARDING_WORKER_TOGGLES} (excludes always-on kinds that are noisy
+ * to re-prompt).
+ */
+export const WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
+  {
+    id: 'pr-status',
+    label: 'PR status',
+    description: 'Polls GitHub PR / merge-gate status for open tasks. On by default with the owner; turn off only if you want to stop that polling.',
+    workerKinds: [PR_STATUS_WORKER_KIND],
+    defaultEnabled: true,
+    includeInOnboarding: false,
+  },
+  {
+    id: 'autofix',
+    label: 'Autofix',
+    description: 'Owner autofix worker that opens repair workflows for failing CI / stuck tasks.',
+    workerKinds: [AUTO_FIX_WORKER_KIND],
+    includeInOnboarding: false,
+  },
   {
     id: 'pr-maintenance',
     label: 'PR maintenance',
     description: 'Babysits open PRs: re-queues stuck merges, closes duplicates, repairs orphaned stack fragments.',
-    configPath: 'prMaintenance.enabled',
+    workerKinds: PR_MAINTENANCE_TOGGLE_WORKER_KINDS,
   },
   {
     id: 'e2e-autofix',
     label: 'E2E auto-fix',
     description: 'Runs the extended test battery on a schedule and opens a fix PR when it finds a failing suite.',
-    configPath: 'e2eAutoFixEnabled',
+    workerKinds: [E2E_AUTOFIX_WORKER_KIND],
   },
   {
     id: 'auto-approve',
@@ -51,9 +103,13 @@ export const ONBOARDING_WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
     id: 'idle-task-cleanup',
     label: 'Idle task cleanup',
     description: 'Reports stale failed/completed/review_ready admin-bypass-repair and e2e-repair tasks. Dry-run only for now — it logs what it would close, it does not close anything yet.',
-    configPath: 'staleTaskCleanup.enabled',
+    workerKinds: [IDLE_TASK_CLEANUP_WORKER_KIND],
   },
 ] as const;
+
+export const ONBOARDING_WORKER_TOGGLES: readonly WorkerToggleSpec[] = WORKER_TOGGLES.filter(
+  (spec) => spec.includeInOnboarding !== false,
+);
 
 function splitConfigPath(path: WorkerToggleConfigPath): [string, string | undefined] {
   const [head, tail] = path.split('.', 2);
@@ -66,8 +122,23 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-/** Reads a toggle's current value from config; `undefined` means "unset" (worker uses its own default). */
+export function isPolicyWorkerToggle(
+  spec: WorkerToggleSpec,
+): spec is Extract<WorkerToggleSpec, { configPath: WorkerToggleConfigPath }> {
+  return typeof spec.configPath === 'string';
+}
+
+export function isDesiredStateWorkerToggle(
+  spec: WorkerToggleSpec,
+): spec is Extract<WorkerToggleSpec, { workerKinds: readonly string[] }> {
+  return Array.isArray(spec.workerKinds) && spec.workerKinds.length > 0;
+}
+
+/** Reads a policy toggle from config; `undefined` means unset. */
 export function readWorkerToggleValue(config: InvokerConfigRecord, spec: WorkerToggleSpec): boolean | undefined {
+  if (!isPolicyWorkerToggle(spec)) {
+    return undefined;
+  }
   const [head, tail] = splitConfigPath(spec.configPath);
   if (!tail) {
     const value = config[head];
@@ -78,12 +149,17 @@ export function readWorkerToggleValue(config: InvokerConfigRecord, spec: WorkerT
   return typeof value === 'boolean' ? value : undefined;
 }
 
-/** Pure setter — returns a new config record with the toggle applied, does not write to disk. */
+/** Pure setter for policy toggles — does not write to disk. */
 export function applyWorkerToggle(
   config: InvokerConfigRecord,
   spec: WorkerToggleSpec,
   enabled: boolean,
 ): InvokerConfigRecord {
+  if (!isPolicyWorkerToggle(spec)) {
+    throw new Error(
+      `worker toggle "${spec.id}" writes desired state, not config; use applyDesiredStateWorkerToggle`,
+    );
+  }
   const [head, tail] = splitConfigPath(spec.configPath);
   if (!tail) {
     return { ...config, [head]: enabled };
@@ -93,5 +169,62 @@ export function applyWorkerToggle(
 }
 
 export function findWorkerToggle(id: string): WorkerToggleSpec | undefined {
-  return ONBOARDING_WORKER_TOGGLES.find((spec) => spec.id === id);
+  return WORKER_TOGGLES.find((spec) => spec.id === id);
+}
+
+function resolveInvokerDbPath(): string {
+  if (process.env.INVOKER_DB_DIR) {
+    return join(process.env.INVOKER_DB_DIR, 'invoker.db');
+  }
+  const configPath = process.env.INVOKER_REPO_CONFIG_PATH;
+  if (configPath) {
+    return join(dirname(configPath), 'invoker.db');
+  }
+  return join(homedir(), '.invoker', 'invoker.db');
+}
+
+function resolveInvokerOutputDir(dbPath: string): string {
+  return join(dirname(dbPath), 'outputs');
+}
+
+export type WorkerDesiredStateStore = {
+  getWorkerDesiredState(workerKind: string): { desiredEnabled: boolean } | undefined;
+  setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): unknown;
+  close?: () => void;
+};
+
+/** True when every mapped worker kind is desired-enabled. */
+export function readDesiredStateWorkerToggleValue(
+  store: Pick<WorkerDesiredStateStore, 'getWorkerDesiredState'>,
+  spec: Extract<WorkerToggleSpec, { workerKinds: readonly string[] }>,
+): boolean | undefined {
+  let sawAny = false;
+  for (const workerKind of spec.workerKinds) {
+    const row = store.getWorkerDesiredState(workerKind);
+    if (!row) return undefined;
+    sawAny = true;
+    if (!row.desiredEnabled) return false;
+  }
+  return sawAny ? true : undefined;
+}
+
+/** Writes desiredEnabled for every worker kind in a start-preset toggle. */
+export function applyDesiredStateWorkerToggle(
+  store: Pick<WorkerDesiredStateStore, 'setWorkerDesiredState'>,
+  spec: Extract<WorkerToggleSpec, { workerKinds: readonly string[] }>,
+  enabled: boolean,
+): void {
+  for (const workerKind of spec.workerKinds) {
+    store.setWorkerDesiredState(workerKind, enabled);
+  }
+}
+
+/** Open the owner DB for toggle read/write. Caller must close. */
+export async function openWorkerDesiredStateStore(
+  dbPath: string = resolveInvokerDbPath(),
+): Promise<WorkerDesiredStateStore> {
+  return SQLiteAdapter.create(dbPath, {
+    outputDir: resolveInvokerOutputDir(dbPath),
+    ownerCapability: true,
+  });
 }

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -199,13 +199,14 @@ export function readDesiredStateWorkerToggleValue(
   spec: Extract<WorkerToggleSpec, { workerKinds: readonly string[] }>,
 ): boolean | undefined {
   let sawAny = false;
+  let allEnabled = true;
   for (const workerKind of spec.workerKinds) {
     const row = store.getWorkerDesiredState(workerKind);
     if (!row) return undefined;
     sawAny = true;
-    if (!row.desiredEnabled) return false;
+    if (!row.desiredEnabled) allEnabled = false;
   }
-  return sawAny ? true : undefined;
+  return sawAny ? allEnabled : undefined;
 }
 
 /** Writes desiredEnabled for every worker kind in a start-preset toggle. */

--- a/packages/contracts/src/__tests__/config-diagnostics.test.ts
+++ b/packages/contracts/src/__tests__/config-diagnostics.test.ts
@@ -265,7 +265,7 @@ describe('collectInvokerConfigDiagnostics', () => {
     expect(diagnostics.filter((entry) => entry.severity === 'error').length).toBeGreaterThan(3);
   });
 
-  it('warns when SSH remoteTargets exist but infraRepair is not enabled', () => {
+  it('does not warn about removed infraRepair.enabled config gate', () => {
     const sshTarget = {
       host: '203.0.113.10',
       user: 'invoker',
@@ -273,16 +273,6 @@ describe('collectInvokerConfigDiagnostics', () => {
     };
     expect(warnings({
       remoteTargets: { box: sshTarget },
-    })).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        severity: 'warning',
-        path: 'infraRepair.enabled',
-        message: expect.stringContaining('infraRepair.enabled is not true'),
-      }),
-    ]));
-    expect(warnings({
-      remoteTargets: { box: sshTarget },
-      infraRepair: { enabled: true },
-    })).toEqual([]);
+    }).filter((entry) => entry.path === 'infraRepair.enabled')).toEqual([]);
   });
 });

--- a/packages/contracts/src/config-diagnostics.ts
+++ b/packages/contracts/src/config-diagnostics.ts
@@ -301,26 +301,8 @@ export function collectInvokerConfigDiagnostics(config: unknown): ConfigDiagnost
 
   checkRoutingRules(collector, config, poolIds);
   checkHeavyweightRouting(collector, config, poolIds);
-  checkInfraRepairVisibility(collector, config, remoteTargetIds);
 
   return collector.diagnostics;
-}
-
-function checkInfraRepairVisibility(
-  collector: DiagnosticCollector,
-  config: UnknownRecord,
-  remoteTargetIds: Set<string>,
-): void {
-  if (remoteTargetIds.size === 0) return;
-  const infraRepair = config.infraRepair;
-  const enabled = isRecord(infraRepair) && infraRepair.enabled === true;
-  if (enabled) return;
-  collector.warning(
-    'infraRepair.enabled',
-    'SSH remoteTargets are configured but infraRepair.enabled is not true; '
-      + 'SSH infra failures will burn Mergify/autofix budgets instead of being machine-repaired. '
-      + 'Enable infraRepair.enabled and start the infra-repair worker explicitly when ready.',
-  );
 }
 
 export function hasBlockingConfigDiagnostic(diagnostics: readonly ConfigDiagnostic[]): boolean {


### PR DESCRIPTION
## Summary

Config diagnostics no longer emit a warning when infraRepair.enabled is absent.

SSH remoteTargets alone do not imply a missing worker start flag that must be set in config.

## Review Claim

Config diagnostics must not treat worker process on/off as a config boolean obligation.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Config diagnostics must not warn about missing worker start booleans; process on/off is not a contracts or diagnostics concern.

## Slice Rationale

This warning only made sense while infraRepair.enabled was a real start gate. It lands last after the behavior and config slices retire that gate.

## Non-goals

- Changing owner boot auto-start membership.
- Changing InvokerConfig field definitions.
- Changing onboarding or worker toggle writers.

## Test Plan
<details>
<summary>Test plan</summary>

- `cd packages/contracts && pnpm exec vitest run src/__tests__/config-diagnostics.test.ts`

</details>

## Revert Plan
<details>
<summary>Revert plan</summary>

- Revert this stack slice commit. Diagnostics again warn when remoteTargets exist without infraRepair.enabled.

</details>

Depends-On: #10278