### PR TITLE
[Owner exec ack](1) Route standalone exec through executeHeadlessExec

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -17,11 +17,11 @@ function getTranslatorSource(): string {
 }
 
 function getStandaloneClassifierSource(): string {
-  const start = mainSource.indexOf('const classifyStandaloneHeadlessExecMutation =');
-  const end = mainSource.indexOf('        const standaloneWorkflowIdForTaskArg', start);
+  const start = guiMutationHandlersSource.indexOf('function classifyHeadlessExecMutation');
+  const end = guiMutationHandlersSource.indexOf('  async function runWorkflowMutation', start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
-  return mainSource.slice(start, end);
+  return guiMutationHandlersSource.slice(start, end);
 }
 
 function getStandaloneGuiMutationSource(): string {
@@ -111,9 +111,11 @@ describe('GUI mutation translation', () => {
 
   it('classifies delegated standalone workflow delete and detach as workflow-scoped', () => {
     const classifierSource = getStandaloneClassifierSource();
-    expect(classifierSource).toMatch(
-      /case 'delete':\s*case 'delete-workflow':\s*case 'detach-workflow':\s*return \{ workflowId: arg0 === undefined \? undefined : String\(arg0\), priority: 'high' \};/,
-    );
+    expect(classifierSource).toContain("case 'delete':");
+    expect(classifierSource).toContain("case 'delete-workflow':");
+    expect(classifierSource).toContain("case 'detach-workflow':");
+    expect(classifierSource).toContain('workflowId: arg0');
+    expect(classifierSource).toContain("priority: 'high'");
   });
 
   it('handles start-ready in the standalone owner GUI mutation switch', () => {

--- a/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
+++ b/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
@@ -47,6 +47,17 @@ function makeContext(): GuiMutationTaskActionsContext {
   } as unknown as GuiMutationTaskActionsContext;
 }
 
+function extractRequiredKey(stdoutLine: unknown, requiredKey: string): Record<string, unknown> | null {
+  if (!stdoutLine || typeof stdoutLine !== 'object') return null;
+  const parsed = stdoutLine as Record<string, unknown>;
+  if (requiredKey in parsed) return parsed;
+  const response = parsed.response;
+  if (response && typeof response === 'object' && requiredKey in (response as Record<string, unknown>)) {
+    return response as Record<string, unknown>;
+  }
+  return null;
+}
+
 describe('executeHeadlessExec no-workflow acknowledgment', () => {
   it('keeps ok: true after merging a runner result that reports ok: false', async () => {
     vi.mocked(runHeadless).mockResolvedValue({ ok: false, error: 'boom' });
@@ -64,5 +75,43 @@ describe('executeHeadlessExec no-workflow acknowledgment', () => {
     const result = await actions.executeHeadlessExec({ args: ['start-ready'], noTrack: false } as never);
 
     expect(result).toEqual({ ok: true, started: 3 });
+  });
+
+  it('forwards repair-filing insert through the owner ack so the claimer can see inserted', async () => {
+    const liveRow = {
+      id: 2955,
+      kind: 'admin-requeue:check:pr-body',
+      subject: '10242',
+      stateSha: 'd8458e9d528132a59ba4d6f3dbea81c83db9c212',
+    };
+    vi.mocked(runHeadless).mockResolvedValue({ inserted: true, row: liveRow });
+    const ctx = makeContext();
+    const actions = createGuiMutationTaskActions(ctx);
+    ctx.workflowMutationDispatcher.set(
+      'headless.exec',
+      (payload) => actions.executeHeadlessExec(payload as never),
+    );
+
+    const args = [
+      'repair-filing',
+      'insert',
+      '--kind',
+      'admin-requeue:check:pr-body',
+      '--subject',
+      '10242',
+      '--state-sha',
+      liveRow.stateSha,
+    ];
+    const handler = ctx.workflowMutationDispatcher.get('headless.exec');
+    expect(handler).toBeDefined();
+    const response = await handler!({ args, waitForApproval: false, noTrack: true });
+    const envelope = { args, ok: true, response };
+
+    expect(extractRequiredKey({ args, ok: true, response: { ok: true } }, 'inserted')).toBeNull();
+    expect(extractRequiredKey(envelope, 'inserted')).toEqual({
+      inserted: true,
+      row: liveRow,
+      ok: true,
+    });
   });
 });

--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -26,17 +26,19 @@ describe('standalone owner handler ordering', () => {
     ).toBeLessThan(dispatcherIdx);
   });
 
-  it('standalone headless.exec merges runHeadless return into the message-bus ack when unscoped', () => {
+  it('routes standalone exec through executeHeadlessExec instead of a local runHeadless wrapper', () => {
     const source = readFileSync(MAIN, 'utf8');
-    const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
-    const nextHandler = source.indexOf("messageBus.onRequest('headless.gui-mutation'");
-    expect(execIdx, 'standalone headless.exec handler not found').toBeGreaterThan(-1);
-    expect(nextHandler, 'headless.gui-mutation handler not found after headless.exec').toBeGreaterThan(execIdx);
+    const ownerBlockStart = source.indexOf('if (standaloneMode && messageBus)');
+    const cliRunIdx = source.indexOf('await runHeadless(cliArgs, headlessDeps);');
+    expect(ownerBlockStart, 'standalone owner block not found').toBeGreaterThan(-1);
+    expect(cliRunIdx, 'CLI runHeadless(cliArgs) not found').toBeGreaterThan(ownerBlockStart);
 
-    const handler = source.slice(execIdx, nextHandler);
-    expect(handler).toMatch(/commandResult = await runHeadless/);
-    expect(handler).toMatch(/if \(!workflowId\)/);
-    expect(handler).toMatch(/\.\.\.\(commandResult && typeof commandResult === 'object'/);
+    const ownerBlock = source.slice(ownerBlockStart, cliRunIdx);
+    expect(ownerBlock).toContain('createGuiMutationTaskActions');
+    expect(ownerBlock).toContain('standaloneMutationActions.executeHeadlessExec');
+    expect(ownerBlock).not.toContain('standaloneRunHeadlessCommand');
+    expect(ownerBlock).not.toContain('classifyStandaloneHeadlessExecMutation');
+    expect(ownerBlock).not.toMatch(/await runHeadless\(/);
   });
 
   it('guards standalone startup worker writes behind readOnlyMode', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -141,7 +141,6 @@ import { openMainProcessDatabase } from './viewer-db-boundary.js';
 import {
   isHeadlessMutatingCommand,
   isHeadlessReadOnlyCommand,
-  resolveHeadlessTargetWorkflowId,
 } from './headless-command-classification.js';
 import {
   isHeadlessHelpCommand,
@@ -168,7 +167,7 @@ import {
 import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { writeStdoutFlushAndExit, flushStdoutAndStderr } from './headless-stdout-flush.js';
-import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
+import { repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -1017,6 +1016,28 @@ async function tryDelegateHeadlessMutationToExistingOwner(
   }
 }
 
+function createNoopRendererTaskFeed(): RendererTaskFeed {
+  const stopHandle = { stop() {} };
+  return {
+    enqueueTaskOutput() {},
+    flushTaskOutput() {},
+    seedUiSnapshotCache() {},
+    getDetachedViewerTasks: () => [],
+    publishTaskDeltaToRenderer() {},
+    getLastKnownWorkflowCount: () => 0,
+    setLastKnownWorkflowCount() {},
+    getTaskSnapshot: () => undefined,
+    listKnownTaskIds: () => [],
+    clearTaskSnapshots() {},
+    replaceWorkflowRollups() {},
+    rememberTaskState() {},
+    resetSnapshotState() {},
+    receiveTaskDelta() {},
+    startDbPolling: () => stopHandle,
+    startActivityPolling: () => stopHandle,
+  };
+}
+
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
@@ -1673,108 +1694,45 @@ function startHeadlessMode(): void {
           );
         };
 
-        const classifyStandaloneHeadlessExecMutation = (
-          payload: HeadlessExecMutationPayload,
-        ): { workflowId?: string; priority: WorkflowMutationPriority } => {
-          const [command, arg0] = payload.args;
-          if (!command) return { priority: 'normal' };
-
-          switch (command) {
-            case 'set': {
-              const [, subCommand, targetArg] = payload.args;
-              switch (subCommand) {
-                case 'workflow':
-                case 'merge-mode':
-                  return {
-                    workflowId: targetArg === undefined ? undefined : String(targetArg),
-                    priority: 'high',
-                  };
-                case 'command':
-                case 'prompt':
-                case 'executor':
-                case 'agent':
-                case 'fix-prompt':
-                case 'fix-context':
-                case 'gate-policy':
-                case 'task':
-                  return {
-                    workflowId: targetArg === undefined ? undefined : standaloneWorkflowIdForTaskArg(targetArg),
-                    priority: 'high',
-                  };
-                default:
-                  return { priority: 'normal' };
-              }
-            }
-            case 'resume':
-            case 'retry':
-              return {
-                workflowId: arg0 === undefined ? undefined : standaloneWorkflowIdForTaskArg(arg0),
-                priority: 'high',
-              };
-            case 'recreate':
-            case 'cancel-workflow':
-              return { workflowId: arg0 === undefined ? undefined : String(arg0), priority: 'high' };
-            case 'rebase-retry':
-            case 'rebase-recreate':
-              return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
-            case 'cancel':
-            case 'retry-task':
-            case 'recreate-task':
-            case 'delete-task':
-              return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
-            case 'delete':
-            case 'delete-workflow':
-            case 'detach-workflow':
-              return { workflowId: arg0 === undefined ? undefined : String(arg0), priority: 'high' };
-            case 'approve':
-            case 'reject':
-            case 'select':
-            case 'fix':
-            case 'resolve-conflict':
-              return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'normal' };
-            case 'repair-review-gate-ci':
-              return { workflowId: standaloneWorkflowIdForReviewGatePrArg(arg0), priority: 'normal' };
-            default:
-              return { priority: 'normal' };
-          }
-        };
-
-        const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
-          return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
-        };
-        const standaloneWorkflowIdForReviewGatePrArg = (prArg: unknown): string | undefined => {
-          const raw = prArg === undefined ? undefined : String(prArg);
-          if (!raw) return undefined;
-          const prNumber = parseReviewGatePrNumber(raw);
-          if (!prNumber) return undefined;
-          return persistence.findReviewGateByPr(prNumber)?.workflowId;
-        };
-
-        const runStandaloneWorkflowMutation = async <T>(
-          workflowId: string | undefined,
-          priority: WorkflowMutationPriority,
-          channel: string,
-          args: unknown[],
-          op: () => Promise<T>,
-        ): Promise<T> => {
-          if (!workflowId) return op();
-          if (!workflowMutationCoordinator || !workflowMutationDispatcher.has(channel)) {
-            return op();
-          }
-          return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
-        };
+        const standaloneMutationActions = createGuiMutationTaskActions({
+          logger,
+          persistence,
+          messageBus,
+          executorRegistry,
+          agentRegistry,
+          repoRoot,
+          invokerConfig,
+          effectiveMaxConcurrency,
+          taskHandles: standaloneTaskHandles,
+          getOrchestrator: () => orchestrator,
+          setOrchestrator: (nextOrchestrator) => { orchestrator = nextOrchestrator; },
+          getCommandService: () => commandService,
+          setCommandService: (nextCommandService) => { commandService = nextCommandService; },
+          getWorkflowMutationCoordinator: () => workflowMutationCoordinator,
+          workflowMutationDispatcher,
+          getActiveMutationContext: () => activeMutationContext,
+          getRendererTaskFeed: createNoopRendererTaskFeed,
+          getStartupWorkflowId: () => null,
+          getLaunchDispatcher: () => null,
+          requireTaskExecutor: createStandaloneTaskExecutor,
+          getTaskExecutor: () => createStandaloneTaskExecutor(),
+          rebuildTaskRunner: () => {},
+          initServices,
+          requestWorkflowMetadataPublish: () => {},
+          cancelDeferredWorkflowLaunch: () => {},
+          killRunningTask: async (taskId) => {
+            await killRunningTaskExecution({
+              getTaskRunner: createStandaloneTaskExecutor,
+              logger,
+              taskHandles: standaloneTaskHandles,
+            }, taskId);
+          },
+          buildCommandServiceInvalidationDeps,
+        });
 
         if (!workflowMutationDispatcher.has('headless.exec')) {
           workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
-            const payload = payloadArg as HeadlessExecMutationPayload;
-            await runHeadless(payload.args, {
-              ...headlessDeps,
-              waitForApproval: payload.waitForApproval,
-              noTrack: payload.noTrack,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
+            return standaloneMutationActions.executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
           });
         }
         if (!workflowMutationDispatcher.has('invoker:start-ready')) {
@@ -1850,21 +1808,15 @@ function startHeadlessMode(): void {
           });
         }
         {
-          const standaloneRunHeadlessCommand = async (args: string[]): Promise<unknown> => {
-            await runHeadless(args, {
-              ...headlessDeps,
-              waitForApproval: false,
-              noTrack: true,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
-          };
           const standaloneWorkerHandlers = buildWorkerMutationHandlers({
             orchestrator,
             commandService,
             logger,
-            runHeadlessCommand: standaloneRunHeadlessCommand,
+            runHeadlessCommand: (args) => standaloneMutationActions.executeHeadlessExec({
+              args,
+              waitForApproval: false,
+              noTrack: true,
+            }),
             getTaskExecutor: createStandaloneTaskExecutor,
             getMutationTiming: () => activeMutationContext?.mutationTiming,
             contextLabel: 'standalone',
@@ -2047,26 +1999,16 @@ function startHeadlessMode(): void {
             traceId,
           };
           logHeadlessExecReceived(payload, 'standalone', headlessExecMutationContext);
-          const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
+          const { workflowId, priority } = standaloneMutationActions.classifyHeadlessExecMutation(payload);
           const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone', headlessExecMutationContext);
           if (acknowledgement) return acknowledgement;
-          let commandResult: unknown;
-          await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
-            commandResult = await runHeadless(args, {
-              ...headlessDeps,
-              waitForApproval: delegatedWait,
-              noTrack: delegatedNoTrack,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-          });
-          if (!workflowId) {
-            return {
-              ok: true,
-              ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
-            };
-          }
-          return { ok: true };
+          return standaloneMutationActions.runWorkflowMutation(
+            workflowId,
+            priority,
+            'headless.exec',
+            [payload],
+            async () => standaloneMutationActions.executeHeadlessExec(payload),
+          );
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
           noteStandaloneOwnerActivity();


### PR DESCRIPTION
## Summary

The DigitalOcean owner claimed a PR-body repair and never filed it.

The standalone owner had three local exec wrappers that acked success and dropped runner fields.

This slice points dispatcher, worker, and bus at the shared executeHeadlessExec merge path.

## Review Claim

The standalone owner should call executeHeadlessExec for dispatcher, worker, and bus exec instead of local runHeadless wrappers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

GUI executeHeadlessExec is unchanged except that standalone is now a caller.

Unscoped repair-filing still returns `inserted` on the ack.

Fail-closed parse of a missing `inserted` key is unchanged.

CLI stdout for `await runHeadless(cliArgs)` is unchanged.

Workflow-scoped standalone acks now match the GUI shape of `workflowId` plus `tasks`.

## Slice Rationale

#10262 only forwarded the bus copy. The dispatcher and worker copies still dropped the payload.

A shared helper under #10265 would keep three wrappers. This slice points all three sites at the shared path.

## Non-goals

Does not change fail-closed parse behavior.

Does not change GUI executeHeadlessExec internals.

Does not stack under #10265, #10267, or #10268.

Does not change `acknowledgeNoTrackHeadlessExec`.

## Architecture

### Before

```mermaid
graph TD
    A["standalone dispatcher"] --> D["local runHeadless wrapper"]
    B["standalone worker"] --> D
    C["standalone message bus"] --> D
    D --> E["ack is ok true only"]
```

### After

```mermaid
graph TD
    A["standalone dispatcher"] --> D["executeHeadlessExec"]
    B["standalone worker"] --> D
    C["standalone message bus"] --> D
    D --> E["ack is ok true plus runner payload"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/headless-exec-ack-ok-precedence.test.ts src/__tests__/standalone-owner-handler-ordering.test.ts src/__tests__/gui-mutation-translation.test.ts`
- [x] `cd packages/app && pnpm test src/__tests__/headless-repair-filing.test.ts src/__tests__/worker-mutation-channel-repro.test.ts`

</details>

## Visual Proof

This slice does not change a rendered window. `packages/app/src/main.ts` is classified as UI-impacting by path.

![live DigitalOcean owner insert envelope](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260824-20c796/repair-filing-do1-envelope.png)

Live owner insert acked `{ok:true,response:{ok:true}}` with no `inserted` field.

![unscoped executeHeadlessExec ack with runner payload](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260824-20c796/repair-filing-execute-headless-exec-ack.png)

Unscoped exec now keeps `inserted` and `row` on the ack.

Manually inspected: the red-header image shows `response` as `{ "ok": true }` only. The green-header image shows `response.inserted` true with `row.id` 2955.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 08cb44e151bedb31221c95385a356962390039c1`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved headless execution acknowledgements so repair-filing insertion results are correctly returned and visible to the requesting workflow.
  - Improved handling of standalone execution mutations, including workflow actions and task updates.
  - Increased consistency between standalone and GUI-triggered mutation processing.

- **Refactor**
  - Consolidated mutation handling to provide more reliable, consistent execution behavior across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->