### PR TITLE
[admin-bypass-repair-bot-thread-pr-10281-08cb44e](1) Fall through repair-filing insert in acknowledgeNoTrackHeadlessExec

### DIFF
--- a/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
+++ b/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
@@ -188,6 +188,39 @@ describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
     ).toBeUndefined();
   });
 
+  it('falls through for unscoped repair-filing insert instead of requiring a workflow id', () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const result = acknowledgeNoTrackHeadlessExec(
+      {
+        args: ['repair-filing', 'insert', '--kind', 'K', '--subject', 'S', '--state-sha', 'SHA'],
+        noTrack: true,
+      },
+      undefined,
+      'normal',
+      'standalone',
+      {
+        ownerId: 'owner-1',
+        getWorkflowMutationCoordinator: () => ({
+          submit: vi.fn(),
+        }) as never,
+        workflowExists: () => false,
+        logger: logger as never,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('headless.exec start-ready noTrack fallthrough'),
+      expect.objectContaining({ module: 'ipc-delegate' }),
+    );
+  });
+
   it('still rejects other no-track commands without a workflow id', () => {
     const logger = {
       info: vi.fn(),

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -210,7 +210,7 @@ export function acknowledgeNoTrackHeadlessExec(
   const command = Array.isArray(payload.args) ? payload.args[0] : undefined;
   // Global commands are not workflow-scoped. Fall through to inline execution
   // instead of requiring a mutation-intent workflow id.
-  if (command === 'start-ready' || command === 'check-pr-status') {
+  if (command === 'start-ready' || command === 'check-pr-status' || command === 'repair-filing') {
     context.logger.info(
       `headless.exec start-ready noTrack fallthrough ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { workflow: '"<global>"', priority })}`,
       { module: 'ipc-delegate' },


### PR DESCRIPTION
## Summary

The bot reviewer flagged that an unscoped repair-filing insert on PR #10281 acked `{ok:true}` but never filed the repair.

`acknowledgeNoTrackHeadlessExec` only fell through inline for `start-ready` and `check-pr-status`. A `repair-filing` command has no workflow id either, so it was rejected as workflow-not-resolved before it ever reached `executeHeadlessExec`.

This slice adds `repair-filing` to the same inline fallthrough as the other two global, non-workflow-scoped commands.

## Review Claim

`acknowledgeNoTrackHeadlessExec` should fall through inline for an unscoped `repair-filing` command, the same as `start-ready` and `check-pr-status`, instead of requiring a workflow id.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`start-ready` and `check-pr-status` fallthrough behavior is unchanged; `repair-filing` is only added to the same existing condition.

Every other unscoped, workflow-less command still falls through the `else` branch and fails closed exactly as before.

## Slice Rationale

This is a single-condition fix scoped to the exact gap the bot reviewer flagged on PR #10281.

Bundling it into #10281 itself would remix that PR's already-published standalone-owner-ack claim with an unrelated fallthrough fix.

## Non-goals

Does not change `start-ready` or `check-pr-status` fallthrough behavior.

Does not change `executeHeadlessExec` internals.

Does not change fail-closed parse behavior for any other unscoped command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/acknowledge-no-track-start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 37995f80e`
- Post-revert steps: None
- Data migration? No

</details>
