### PR TITLE
[PR #9903 rebase](2) domain layer

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -16,6 +16,7 @@ import type {
   InAppPlanningDiscardDraftRequest,
   InAppPlanningDiscardDraftResponse,
   InAppPlanningListSessionsResponse,
+  InAppPlanningRepoBinding,
   InAppPlanningPlanSummary,
   InAppPlanningRebindRepoRequest,
   InAppPlanningRebindRepoResponse,
@@ -436,6 +437,36 @@ function hasDraftPlan(session: Pick<InAppPlanningChatSession, 'draftPlanSummary'
   return Boolean(session.draftPlanText || session.draftPlanSummary);
 }
 
+function planningRepositoryContext(session: InAppPlanningChatSession): string {
+  if (!session.repoUrl || !session.baseBranch) return '';
+  return [
+    'Current planning repository binding:',
+    `- Default every workflow repoUrl to exactly: ${session.repoUrl}`,
+    `- Default every workflow baseBranch to exactly: ${session.baseBranch}`,
+    '- Only target another repository when the user explicitly asks for that repository.',
+  ].join('\n');
+}
+
+async function silentRepoMismatch(
+  session: InAppPlanningChatSession,
+  planText: string,
+): Promise<string | undefined> {
+  if (!session.repoUrl) return undefined;
+  const { parsePlanSubmissionBundle } = await import('./plan-parser.js');
+  const submission = parsePlanSubmissionBundle(planText);
+  const userText = session.messages
+    .filter((message) => message.role === 'user')
+    .map((message) => message.text)
+    .join('\n');
+  return submission.plans
+    .map((plan) => plan.repoUrl)
+    .find((repoUrl): repoUrl is string => Boolean(
+      repoUrl
+      && repoUrl !== session.repoUrl
+      && !userText.includes(repoUrl),
+    ));
+}
+
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
 function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boolean): InAppPlanningSessionRecord {
@@ -676,7 +707,7 @@ function planConversationConfig(
 }
 
 async function createSession(
-  request: Partial<InAppPlanningCreateSessionRequest> | null | undefined,
+  request: (Partial<InAppPlanningCreateSessionRequest> & { repoBinding?: InAppPlanningRepoBinding }) | null | undefined,
   deps: InAppPlannerDeps & {
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
@@ -702,16 +733,19 @@ async function createSession(
     resolveDefaultPlanningConfirmationMode(deps.config),
   );
 
-  const repoUrl = deps.config.defaultRepoUrl;
-  const baseBranch = deps.config.defaultBranch ?? 'main';
+  const repoBinding = request?.repoBinding ?? resolvePlanningRepoBinding(deps.config);
   let worktreeBinding:
     | { repoUrl: string; baseBranch: string; baseCommit: string; worktreePath: string; worktreeBranch: string }
     | undefined;
-  if (deps.repoPool && typeof repoUrl === 'string' && repoUrl.trim()) {
-    const provisioned = await provisionPlanningWorktree(deps.repoPool, { repoUrl, baseBranch, sessionId: id });
+  if (deps.repoPool && repoBinding) {
+    const provisioned = await provisionPlanningWorktree(deps.repoPool, {
+      repoUrl: repoBinding.repoUrl,
+      baseBranch: repoBinding.baseBranch,
+      sessionId: id,
+    });
     worktreeBinding = {
-      repoUrl,
-      baseBranch,
+      repoUrl: repoBinding.repoUrl,
+      baseBranch: repoBinding.baseBranch,
       baseCommit: provisioned.baseCommit,
       worktreePath: provisioned.worktreePath,
       worktreeBranch: provisioned.branch,
@@ -748,6 +782,46 @@ async function createSession(
   deps.sessions.set(session.id, session);
   persistPlanningSession(session, deps.planningSessionStore, false);
   return session;
+}
+
+export function resolvePlanningRepoBinding(config: InvokerConfig): InAppPlanningRepoBinding | undefined {
+  const repoUrl = config.defaultRepoUrl?.trim();
+  if (!repoUrl) return undefined;
+  return { repoUrl, baseBranch: config.defaultBranch ?? 'main' };
+}
+
+async function activatePlanningSessionWorktree(
+  session: InAppPlanningChatSession,
+  deps: InAppPlannerDeps & { repoPool?: PlanningRepoPool },
+): Promise<boolean> {
+  if (!deps.repoPool || !session.repoUrl || !session.baseBranch || session.worktreePath) return false;
+
+  const provisioned = await provisionPlanningWorktree(deps.repoPool, {
+    repoUrl: session.repoUrl,
+    baseBranch: session.baseBranch,
+    sessionId: session.id,
+  });
+  const presets = await resolveHarnessPresets(deps.config);
+  const preset = presets[session.presetKey];
+  if (!preset) throw new Error(`Unknown planner preset "${session.presetKey}".`);
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+  const conversationDeps = {
+    ...deps,
+    workingDir: provisioned.worktreePath,
+    mcpConfigPath: planningMcpConfigPath(provisioned.worktreePath),
+  };
+
+  session.baseCommit = provisioned.baseCommit;
+  session.worktreePath = provisioned.worktreePath;
+  session.worktreeBranch = provisioned.branch;
+  session.conversation = new PlanConversation(planConversationConfig(
+    preset,
+    conversationDeps,
+    session.id,
+    selectHarnessSessionDriver,
+    { conversationalPlanning: true },
+  ));
+  return true;
 }
 
 /**
@@ -891,6 +965,7 @@ export async function sendPlanningChatMessage(
         presetKey: rawRequest?.presetKey,
         title: titleFromMessage(message),
         confirmationMode: requestedConfirmationMode,
+        repoBinding: rawRequest?.repoBinding,
       }, deps);
       if ('error' in created) {
         return { ok: false, sessionId, turnId, error: created.error };
@@ -947,8 +1022,19 @@ export async function sendPlanningChatMessage(
       };
 
       try {
-        const hostedMessage = formatPlanningHostedTurn('in_app', message);
-        if (deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
+        const activatedWorktree = await activatePlanningSessionWorktree(activeSession, deps);
+        persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        const repositoryContext = planningRepositoryContext(activeSession);
+        const previousVisibleAssistantMessage = [...messagesBeforeTurn]
+          .reverse()
+          .find((entry) => entry.role === 'assistant')?.content;
+        const visibleTranscriptContext = previousVisibleAssistantMessage
+          ? `Previous assistant message visible in the Invoker chat:\n${previousVisibleAssistantMessage}`
+          : '';
+        const hostedMessage = [repositoryContext, visibleTranscriptContext, formatPlanningHostedTurn('in_app', message)]
+          .filter(Boolean)
+          .join('\n\n');
+        if (!activatedWorktree && deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
           try {
             await ensurePlanningWorktreeReady(deps.repoPool, {
               repoUrl: activeSession.repoUrl,
@@ -960,9 +1046,9 @@ export async function sendPlanningChatMessage(
             logPlanningWorktreeReadyError(activeSession.id, 'before-send', error);
           }
         }
-        const reply = deps.plannerReplyOverride
+        let reply = deps.plannerReplyOverride
           ? await deps.plannerReplyOverride(hostedMessage)
-          : await activeSession.conversation.sendMessage(message);
+          : await activeSession.conversation.sendMessage(hostedMessage);
         if (deps.plannerReplyOverride) {
           saveOverrideConversation(deps.conversationRepo, activeSession.id, message, reply);
         }
@@ -1019,7 +1105,7 @@ export async function sendPlanningChatMessage(
           } as Extract<InAppPlanningChatResponse, { ok: true }>);
         }
 
-        const review = preparePlanningReview({
+        let review = preparePlanningReview({
           plannerOutput: reply,
           extractDraftPlanText: () => result.planText,
           confirmationMode: activeSession.confirmationMode,
@@ -1040,6 +1126,48 @@ export async function sendPlanningChatMessage(
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
           } as Extract<InAppPlanningChatResponse, { ok: true }>);
+        }
+
+        const mismatchedRepoUrl = await silentRepoMismatch(activeSession, review.planText);
+        if (mismatchedRepoUrl) {
+          const mismatchReply = `Draft rejected because it silently changed repositories to ${mismatchedRepoUrl}. `
+            + `This planning session is bound to ${activeSession.repoUrl}. Name a different repository explicitly if that is intentional.`;
+          const correctionPrompt = `${repositoryContext}\n\nInvoker host feedback:\n${mismatchReply}\n\nRewrite the complete YAML draft now using the bound repository.`;
+          const correctedReply = deps.plannerReplyOverride
+            ? await deps.plannerReplyOverride(correctionPrompt)
+            : await activeSession.conversation.sendMessage(correctionPrompt);
+          const correctedPlanText = deps.plannerReplyOverride
+            ? extractFencedYamlPlanText(correctedReply)
+            : activeSession.conversation.lastTurnDraftPlanText;
+          const correctedReview = correctedPlanText
+            ? preparePlanningReview({
+                plannerOutput: correctedReply,
+                extractDraftPlanText: () => correctedPlanText,
+                confirmationMode: activeSession.confirmationMode,
+              })
+            : undefined;
+          const correctedMismatch = correctedReview && !('kind' in correctedReview)
+            ? await silentRepoMismatch(activeSession, correctedReview.planText)
+            : mismatchedRepoUrl;
+          if (correctedReview && !('kind' in correctedReview) && !correctedMismatch) {
+            reply = correctedReply;
+            review = correctedReview;
+          } else {
+            removePlanDraftSidecarIfPresent(activeSession.id);
+            activeSession.status = 'still_discussing';
+            appendSessionMessage(activeSession, 'assistant', mismatchReply);
+            return finishTurn({
+              ok: true,
+              sessionId: activeSession.id,
+              turnId,
+              reply: mismatchReply,
+              reasoning,
+              confirmationMode: activeSession.confirmationMode,
+              draftPlanAvailable: false,
+              draftPlanSummary: activeSession.draftPlanSummary,
+              draftPlanText: activeSession.draftPlanText,
+            } as Extract<InAppPlanningChatResponse, { ok: true }>);
+          }
         }
 
         let planningDraftId: string | undefined;


### PR DESCRIPTION
## Summary

Reapply PR #9903's backend planning-repo-binding logic in `packages/app/src/in-app-planner.ts` on top of current master.

`createSession` now resolves the session's repository binding on the backend. A request-supplied `repoBinding` wins; otherwise the config default (`defaultRepoUrl`/`defaultBranch`) is used.

Master's eager worktree provisioning at session creation is preserved unchanged. The resolved binding feeds the exact provisioning path master already has.

A new `silentRepoMismatch` check asks the planner once for a corrected draft when a draft silently names a repository different from the session's binding.

The correction runs before master's doctor-approved-draft gate (#10249).

A corrected draft never bypasses doctor approval. With `draftDoctorEnabled` on, the reviewed text must still match the immutable doctor-approved draft, or the turn fails closed.

## Review Claim

`in-app-planner.ts` carries PR #9903's backend-owned `repoBinding` default resolution and silent-mismatch correction, composed with master's doctor-approved-draft gate so neither feature bypasses the other.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the domain layer changes; the contracts layer's `repoBinding` field (previous slice in this stack) is already available. A drift correction must never produce a draft that skips the doctor-approval check when `draftDoctorEnabled` is true.

## Slice Rationale

One layer slice built on the `repoBinding` request field added by the PR below this one in `ipc-channels.ts`; the ui layer builds on this slice later.

## Non-goals

- No contracts or ui work here.
- No refactor and no unrelated cleanup.
- No doc edits.
- No change to `rebindPlanningChatRepo` (pre-existing, unrelated to this reconciliation).

## Architecture

### Before

```mermaid
graph TD
    A["chat turn reply"] --> B["preparePlanningReview"]
    B --> C["doctor-approved draft gate"]
    C --> D["submit or return draft"]
```

### After

```mermaid
graph TD
    A["chat turn reply"] --> B["preparePlanningReview"]
    B --> M["silentRepoMismatch check"]
    M -->|"clean"| C["doctor-approved draft gate"]
    M -->|"mismatch"| R["one corrective planner retry"]
    R --> M2["re-check corrected draft"]
    M2 -->|"clean"| C
    M2 -->|"still mismatched"| X["reject draft, stay discussing"]
    C --> D["submit or return draft"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts` — 79 passed (full file, includes the worktree-provisioning and doctor-approved-draft suites)
- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "doctor-approved"` — 1 passed, no regression
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` (single commit; restores master's planning flow without repo binding)
- Post-revert steps: None
- Data migration? No

</details>
