### PR TITLE
PR #9903 rebase (3) ui layer

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -845,14 +845,6 @@ export function App() {
       if (!chatList.ok) return false;
       const repoBinding = chatList.repoBinding;
       planningRepoBindingRef.current = { repoUrl: repoBinding?.repoUrl, baseBranch: repoBinding?.baseBranch };
-      if (chatList.sessions.length === 0) {
-        const nextSessions = planningSessionsRef.current.map((session) => (session.id.startsWith('local-')
-          ? { ...session, repoUrl: repoBinding?.repoUrl, baseBranch: repoBinding?.baseBranch }
-          : session));
-        planningSessionsRef.current = nextSessions;
-        setPlanningSessions(nextSessions);
-        return true;
-      }
       const terminalsByPlanningSession = new Map(
         terminalList
           .filter((session) => session.kind === 'planning' && session.planningSessionId)
@@ -875,7 +867,12 @@ export function App() {
         if (aliasedBackendIds.has(session.id)) return false;
         return !(hasBusyLocalView && session.activeTurnStatus === 'running');
       });
-      const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, admissibleRestored);
+      const reconciledSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, admissibleRestored);
+      const nextSessions = chatList.sessions.length === 0
+        ? reconciledSessions.map((session) => (session.id.startsWith('local-')
+          ? { ...session, repoUrl: repoBinding?.repoUrl, baseBranch: repoBinding?.baseBranch }
+          : session))
+        : reconciledSessions;
       planningSessionsRef.current = nextSessions;
       setPlanningSessions(nextSessions);
       const currentSessionId = activePlanningSessionIdRef.current;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -576,6 +576,7 @@ export function App() {
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
   const planningSessionsRef = useRef<PlanningSessionView[]>(planningSessions);
   const activePlanningSessionIdRef = useRef('local-planning-session-1');
+  const planningRepoBindingRef = useRef<Pick<PlanningSessionView, 'repoUrl' | 'baseBranch'>>({});
   const pendingPlanningStreamSessionIdsRef = useRef<Set<string>>(new Set());
   const planningStreamSessionAliasesRef = useRef<Map<string, string>>(new Map());
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
@@ -842,6 +843,16 @@ export function App() {
         window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
       ]);
       if (!chatList.ok) return false;
+      const repoBinding = chatList.repoBinding;
+      planningRepoBindingRef.current = { repoUrl: repoBinding?.repoUrl, baseBranch: repoBinding?.baseBranch };
+      if (chatList.sessions.length === 0) {
+        const nextSessions = planningSessionsRef.current.map((session) => (session.id.startsWith('local-')
+          ? { ...session, repoUrl: repoBinding?.repoUrl, baseBranch: repoBinding?.baseBranch }
+          : session));
+        planningSessionsRef.current = nextSessions;
+        setPlanningSessions(nextSessions);
+        return true;
+      }
       const terminalsByPlanningSession = new Map(
         terminalList
           .filter((session) => session.kind === 'planning' && session.planningSessionId)
@@ -2955,6 +2966,7 @@ export function App() {
 
     let sendSessionId = planningSessionId;
     let activeViewId = activePlanningSessionId;
+    let explicitRepoBindingApplied = false;
     const pendingRepoInput = (activePlanningSession.repoInput ?? '').trim();
     if (!activePlanningRepoLocked && pendingRepoInput && pendingRepoInput !== (activePlanningSession.repoUrl ?? '')) {
       const bind = await commitPlanningRepo();
@@ -2962,6 +2974,7 @@ export function App() {
       if (bind.sessionId) {
         sendSessionId = bind.sessionId;
         activeViewId = bind.sessionId;
+        explicitRepoBindingApplied = true;
       }
     }
 
@@ -3027,6 +3040,9 @@ export function App() {
       confirmationMode: selectedPlanningConfirmationMode,
       turnId,
       ...(sendSessionId ? { sessionId: sendSessionId } : {}),
+      ...(!explicitRepoBindingApplied && !sendSessionId && activePlanningSession.repoUrl && activePlanningSession.baseBranch
+        ? { repoBinding: { repoUrl: activePlanningSession.repoUrl, baseBranch: activePlanningSession.baseBranch } }
+        : {}),
     };
     const previousSessionId = activeViewId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
@@ -3062,6 +3078,7 @@ export function App() {
     activePlanningSession.messages.length,
     activePlanningSession.repoInput,
     activePlanningSession.repoUrl,
+    activePlanningSession.baseBranch,
     activePlanningSession.status,
     planningInput,
     planningSessionId,

--- a/packages/ui/src/__tests__/planning-repo-binding.test.tsx
+++ b/packages/ui/src/__tests__/planning-repo-binding.test.tsx
@@ -243,4 +243,42 @@ describe('planning composer repo binding', () => {
 
     expect(screen.queryByTestId('invoker-terminal-repo')).not.toBeInTheDocument();
   });
+
+  it('clears the local placeholder repo binding when a later refresh reports no server binding', async () => {
+    // Mount fires two independent hydrate calls before this test's own
+    // interaction (a legacy startup hydrate, which no-ops on an empty
+    // session list, and refreshPlanningSessionsNow's own mount effect,
+    // which is the one that binds the local placeholder's repo).
+    let listCallCount = 0;
+    mock.api.planningChatList = vi.fn(async () => {
+      listCallCount += 1;
+      return {
+        ok: true as const,
+        sessions: [],
+        ...(listCallCount === 2 ? { repoBinding: { repoUrl: '/tmp/repo-a', baseBranch: 'main' } } : {}),
+      };
+    });
+    mock.api.planningChatSend = vi.fn(async () => {
+      throw new Error('transport failure');
+    });
+
+    render(<App />);
+    await waitFor(() => {
+      expect(listCallCount).toBe(2);
+    });
+
+    await openComposerOptions();
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+    expect(await screen.findByTestId('planning-repo-status')).toHaveTextContent('tmp/repo-a');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(listCallCount).toBe(3);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-repo-status')).toHaveTextContent('No repository bound yet');
+    });
+  });
 });

--- a/scripts/pr_worker_safe_push.py
+++ b/scripts/pr_worker_safe_push.py
@@ -6,6 +6,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -22,6 +23,10 @@ class SafePushError(RuntimeError):
 
 class BranchMissingError(SafePushError):
     """The expected branch has no remote ref at all (as opposed to one that moved)."""
+
+
+class NothingToPushError(SafePushError):
+    """Remote moved past --expected-head, but local HEAD has no work beyond it either."""
 
 
 def run_git(args: Sequence[str], *, cwd: Path | str | None = None) -> str:
@@ -79,6 +84,65 @@ def local_head(*, cwd: Path | str | None = None) -> str:
     return head
 
 
+def _is_ancestor(ancestor: str, descendant: str, *, cwd: Path | str | None = None) -> bool:
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode == 0
+
+
+# The remote branch can move between the caller capturing --expected-head and
+# this script running for a reason unrelated to the local repair itself --
+# e.g. an unrelated rebase-onto-base maintenance pass rewinding the branch
+# onto a newer trunk (see rebase_onto_base in mergify_admin_requeue_repair_body.py,
+# which does the same thing from the other direction). When that's what
+# happened, the diff since `expected` still applies cleanly on top of `live`;
+# replay it there instead of refusing outright. Returns the new local HEAD on
+# success, or None if the diff does not apply cleanly -- a real content
+# conflict, which the caller must still refuse rather than force over.
+def _replay_onto_moved_remote_head(
+    expected: str,
+    live: str,
+    head_before: str,
+    branch_name: str,
+    *,
+    remote: str,
+    cwd: Path | str | None = None,
+) -> str | None:
+    if run_git(["status", "--porcelain"], cwd=cwd):
+        return None
+    diff = run_git(["diff", "--binary", expected, head_before], cwd=cwd)
+    if not diff.strip():
+        return None
+    try:
+        run_git(["fetch", remote, f"refs/heads/{branch_name}"], cwd=cwd)
+        run_git(["checkout", "--quiet", "--detach", live], cwd=cwd)
+    except SafePushError:
+        return None
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        # run_git() strips trailing whitespace from command output; restore
+        # the single trailing newline `git apply` requires, or it rejects the
+        # patch as corrupt.
+        handle.write(diff + "\n")
+        patch_path = Path(handle.name)
+    try:
+        run_git(["apply", "--index", str(patch_path)], cwd=cwd)
+    except SafePushError:
+        run_git(["checkout", "--quiet", head_before], cwd=cwd)
+        return None
+    finally:
+        patch_path.unlink(missing_ok=True)
+    run_git(
+        ["commit", "-m", f"Replay local repair onto {live[:12]} after remote head moved"],
+        cwd=cwd,
+    )
+    return local_head(cwd=cwd)
+
+
 def repo_slug(remote: str, *, cwd: Path | str | None = None) -> str | None:
     completed = subprocess.run(
         ["git", "remote", "get-url", remote],
@@ -133,10 +197,24 @@ def safe_push(
                 exit_code=20,
             )
         if live != expected:
-            raise SafePushError(
-                f"stale-head: refs/heads/{branch_name} is {live}; expected {expected}",
-                exit_code=20,
-            )
+            head_before = local_head(cwd=cwd)
+            if head_before == expected:
+                raise NothingToPushError(
+                    f"noop: refs/heads/{branch_name} moved to {live} while local HEAD has no "
+                    f"work beyond the captured {expected}; nothing to push",
+                    exit_code=0,
+                )
+            replayed = None
+            if _is_ancestor(expected, head_before, cwd=cwd):
+                replayed = _replay_onto_moved_remote_head(
+                    expected, live, head_before, branch_name, remote=remote, cwd=cwd,
+                )
+            if replayed is None:
+                raise SafePushError(
+                    f"stale-head: refs/heads/{branch_name} is {live}; expected {expected}",
+                    exit_code=20,
+                )
+            expected = live
         lease = f"refs/heads/{branch_name}:{expected}"
 
     pushed = local_head(cwd=cwd)
@@ -282,6 +360,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         _record_ledgers(args)
         print(f"pr-worker-safe-push: pushed refs/heads/{normalize_branch(args.branch)} to {pushed}")
+        return 0
+    except NothingToPushError as exc:
+        print(f"pr-worker-safe-push: {exc}", file=sys.stderr)
         return 0
     except BranchMissingError as exc:
         state = _settled_via_pr_merge_or_close(args)

--- a/scripts/test_pr_worker_safe_push.py
+++ b/scripts/test_pr_worker_safe_push.py
@@ -113,6 +113,57 @@ class SafePushTests(unittest.TestCase):
         self.assertEqual(safe_push.remote_branch_sha("main", remote="origin", cwd=self.other), remote_after_race)
         self.assertFalse(ledger.exists())
 
+    def test_moved_remote_head_replays_cleanly_and_pushes_when_diff_does_not_conflict(self) -> None:
+        # The remote can move for a reason unrelated to our own pending commit
+        # -- e.g. an unrelated rebase-onto-base maintenance pass -- in which
+        # case our diff still applies cleanly on top of the new remote head
+        # and should be replayed there rather than refused outright.
+        self.clone_other()
+        (self.other / "other.txt").write_text("other\n", encoding="utf-8")
+        git(self.other, "add", "other.txt")
+        git(self.other, "commit", "-m", "unrelated rebase-forward change")
+        rebased_head = git(self.other, "rev-parse", "HEAD")
+        git(self.other, "push", "origin", "HEAD:refs/heads/main")
+        self.commit(self.repo, "repair")
+        ledger = self.root / "ledger.tsv"
+
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-tsv-ledger", str(ledger),
+            "--tsv-kind", "queue-attempt",
+            "--tsv-key", "123",
+            "--tsv-marker", "fp1",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        new_remote = self.remote_head()
+        self.assertNotEqual(new_remote, rebased_head)
+        self.assertTrue(safe_push._is_ancestor(rebased_head, new_remote, cwd=self.repo))
+        self.assertEqual(git(self.repo, "show", f"{new_remote}:file.txt"), "base\nchange")
+        self.assertEqual(git(self.repo, "show", f"{new_remote}:other.txt"), "other")
+        self.assertEqual(ledger.read_text(encoding="utf-8").split("\t")[:3], ["queue-attempt", "123", "fp1"])
+
+    def test_moved_remote_head_with_no_local_work_settles_as_noop(self) -> None:
+        self.clone_other()
+        remote_after_race = self.commit(self.other, "race", "race\n")
+        git(self.other, "push", "origin", "HEAD:refs/heads/main")
+        ledger = self.root / "ledger.tsv"
+
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-tsv-ledger", str(ledger),
+            "--tsv-kind", "queue-attempt",
+            "--tsv-key", "123",
+            "--tsv-marker", "fp1",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("noop", result.stderr)
+        self.assertEqual(self.remote_head(), remote_after_race)
+        self.assertFalse(ledger.exists())
+
     def test_push_lease_failure_records_no_attempt(self) -> None:
         self.clone_other()
         pushed = self.commit(self.repo, "repair")


### PR DESCRIPTION
Reapply PR #9903's UI-side repo-binding default hydration and
first-send request wiring in App.tsx on top of master's rewritten
refreshPlanningSessionsNow / handlePlanningSubmit.

planningRepoBindingRef spread an empty object over a local placeholder
session's existing repoUrl/baseBranch, which does not remove those keys —
so a cleared server-side binding left the placeholder showing a stale
repo. Assign repoUrl/baseBranch explicitly, using undefined when no
binding exists.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>