### PR TITLE
[Admin-bypass Invoker rebase](1) Stop blind rebase; unify onto master

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -35,7 +35,12 @@ def repair_check_plan_name(pr_number: int, check_name: str, start_head: str) -> 
 
 
 def repair_conflict_plan_name(pr_number: int, start_head: str) -> str:
+    # Legacy name kept for settling pre-unification conflict-repair ledger rows.
     return f"admin-bypass-repair-conflict-pr-{pr_number}-{start_head[:7]}"
+
+
+def rebase_onto_master_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-rebase-onto-master-pr-{pr_number}-{start_head[:7]}"
 
 
 def repair_bot_thread_plan_name(pr_number: int, start_head: str) -> str:
@@ -216,7 +221,25 @@ def build_repair_check_plan(
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 
-def build_repair_conflict_plan(
+def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, trunk: str = "master") -> str:
+    return (
+        f"Rebase this pull request onto `{trunk}`.\n\n"
+        f"Checkout the PR head branch, rebase it onto origin/{trunk} while preserving the PR's intended "
+        "changes, resolve any conflicts if they appear, then commit locally. Do not push.\n\n"
+        "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
+        "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
+        "a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
+        "Then make no commit in this checkout and exit 0.\n\n"
+        "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
+        f"Head SHA: {start_head}\nTrunk: {trunk}\nReason: {reason}\n"
+        f"Work directly on its branch:\n"
+        f"  git fetch origin {pr.head_ref_name} {trunk} && git checkout {pr.head_ref_name}\n"
+        f"  git rebase origin/{trunk}\n"
+    )
+
+
+def build_rebase_onto_master_plan(
     pr: PrSnapshot,
     reason: str,
     *,
@@ -224,21 +247,13 @@ def build_repair_conflict_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = repair_conflict_plan_name(pr.number, start_head)
-    prompt = (
-        "This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
-        "If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
-        "do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
-        "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
-        "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
-        "a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
-        "Then make no commit in this checkout and exit 0.\n\n"
-        "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
-        f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
-        f"Head SHA: {start_head}\nReason: {reason}\n"
-    )
+    name = rebase_onto_master_plan_name(pr.number, start_head)
+    prompt = _rebase_onto_master_prompt(pr, reason, start_head)
     yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
-    yaml_text += _repair_task_yaml(description=f"Repair merge conflict on PR #{pr.number}", prompt=prompt)
+    yaml_text += _repair_task_yaml(
+        description=f"Rebase PR #{pr.number} onto master",
+        prompt=prompt,
+    )
     yaml_text += _safe_push_task_yaml(
         task_id="safe-push",
         description=f"Safely push PR #{pr.number} only if its head did not move",

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -13,8 +13,9 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from .mergify_admin_requeue_plan import (
-        CONFLICT_REPAIR_FILING_KIND,
         REBASE_CONFLICT_REPAIR_FILING_KIND,
+        REBASE_ONTO_MASTER_FILING_KIND,
+        REBASE_ONTO_MASTER_LEDGER_KIND,
         ClaimRepairFiling,
         ReleaseRepairFiling,
         current_bottom_pr,
@@ -37,8 +38,9 @@ except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from mergify_admin_requeue_plan import (
-        CONFLICT_REPAIR_FILING_KIND,
         REBASE_CONFLICT_REPAIR_FILING_KIND,
+        REBASE_ONTO_MASTER_FILING_KIND,
+        REBASE_ONTO_MASTER_LEDGER_KIND,
         ClaimRepairFiling,
         ReleaseRepairFiling,
         current_bottom_pr,
@@ -81,12 +83,12 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{prefix}retarget-base PR #{action.pr_number} from={from_base} to={action.key}")
     elif action.kind == "rebase_onto_base":
         print(f"{prefix}rebase-onto-base PR #{action.pr_number} onto={action.key}")
+    elif action.kind == "rebase_onto_master":
+        print(f"{prefix}rebase-onto-master PR #{action.pr_number} {action.detail}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
         print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
-    elif action.kind == "repair_conflict":
-        print(f"{prefix}repair-conflict PR #{action.pr_number} {action.detail}")
 
 
 def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClient, logger: AdminBypassLogger) -> dict[int, bool]:
@@ -95,8 +97,8 @@ def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClie
     # to one `gh api compare` call per ready-to-land stack per tick, not one
     # per candidate PR scanned. Uses GitHub's compare API instead of a local
     # git checkout so a normal scan never touches the filesystem or shells
-    # out to real git -- `rebase_onto_base` (the executor action, dispatched
-    # only when this signal is true) is the one place that actually clones.
+    # out to real git -- the legacy `rebase_onto_base` executor action (no longer
+    # planned for behind-master alone) is the one place that actually clones.
     stale_base_by_pr: dict[int, bool] = {}
     for stack in stacks:
         bottom = current_bottom_pr(stack, trunk)
@@ -302,18 +304,18 @@ def run_cycle(
                 else:
                     should_poll = True
                 continue
-            elif action.kind == "repair_conflict":
+            elif action.kind == "rebase_onto_master":
                 try:
                     workflow_id = resolve_workflow_for_pr(action.pr_number)
                     if workflow_id:
                         submit_rebase_recreate(workflow_id)
                         ledger.record(
-                            "conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now,
+                            REBASE_ONTO_MASTER_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now,
                             meta={"workflowId": workflow_id, "via": "fastpath"},
                         )
                         progressed = True
                     else:
-                        outcome = repairer.repair_conflict(pr, action.detail, now)
+                        outcome = repairer.rebase_onto_master(pr, action.detail, now)
                         progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1
@@ -328,7 +330,7 @@ def run_cycle(
                         error=str(exc),
                     )
                     if release_repair_filing is not None:
-                        release_repair_filing(CONFLICT_REPAIR_FILING_KIND, str(action.pr_number), pr.head_ref_oid)
+                        release_repair_filing(REBASE_ONTO_MASTER_FILING_KIND, str(action.pr_number), pr.head_ref_oid)
                     should_poll = True
                     continue
                 if progressed:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -39,9 +39,9 @@ except ImportError:
 try:
     from .mergify_admin_requeue_async_repair import (
         _slugify,
+        rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
         repair_check_plan_name,
-        repair_conflict_plan_name,
     )
     from .mergify_admin_requeue_infra_signal import (
         SSH_OAUTH_INFRA_SIGNATURE,
@@ -51,9 +51,9 @@ try:
 except ImportError:
     from mergify_admin_requeue_async_repair import (
         _slugify,
+        rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
         repair_check_plan_name,
-        repair_conflict_plan_name,
     )
     from mergify_admin_requeue_infra_signal import (
         SSH_OAUTH_INFRA_SIGNATURE,
@@ -95,10 +95,12 @@ def mergify_check_state_sha(pr: PrSnapshot, latest: MergifyQueueEvent) -> str:
 
 
 REBASE_CONFLICT_REPAIR_FILING_KIND = "admin-requeue:rebase-conflict"
-CONFLICT_REPAIR_FILING_KIND = "admin-requeue:conflict"
+# Shared by GitHub DIRTY conflicts and no-CI Mergify dequeue-while-behind.
+REBASE_ONTO_MASTER_FILING_KIND = "admin-requeue:rebase-onto-master"
+REBASE_ONTO_MASTER_LEDGER_KIND = "rebase-onto-master"
 
 # Every claim_repair_filing call site below uses `subject=str(pr.number)` --
-# the raw PR number, same shape as repair_check_plan_name/repair_conflict_plan_name
+# the raw PR number, same shape as repair_check_plan_name/rebase_onto_master_plan_name
 # in mergify_admin_requeue_async_repair.py (see that module's plan-naming
 # functions), which have no lineage concept either. PRs get recreated with a
 # new number on retarget under this repo's own `stack/` convention (see
@@ -1020,18 +1022,40 @@ def plan_mergify_queue_repairs(
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
-        if facts.stale_base_by_pr.get(pr.number) and pr.latest_mergify and pr.latest_mergify.failing_checks:
-            return plan_rebase_onto_base(
-                pr, facts.trunk, ledger, max_repair_attempts,
-                "structural stale base is blocking its failing check(s), not a code problem",
-                claim_repair_filing,
-            )
+        # Named CI failures always go to repair_check — never rebase because
+        # the branch is also behind master (see #10242 rewrite incident).
         actions = mergify_failed_check_actions(
             pr, ledger, max_repair_attempts, now, facts.suppressed_failed_checks_by_pr.get(pr.number, ()),
             claim_repair_filing,
         )
         if actions:
             return actions[0]
+        # Dequeued with no named required-check failure AND behind master →
+        # Invoker rebase (timeout / speculative merge onto moved trunk). A green
+        # dequeue that is already based on current master still falls through to
+        # plan_bottom_progress's requeue path.
+        latest = pr.latest_mergify
+        if (
+            latest
+            and latest.state == "dequeued"
+            and latest.head_sha == pr.head_ref_oid
+            and not latest.failing_checks
+            and not any(b.kind == "failed_check" for b in facts.blockers_by_pr[pr.number])
+            and not any(b.kind == "pending_check" for b in facts.blockers_by_pr[pr.number])
+            and not any(b.kind in {"bot_review_thread", "outdated_bot_review_thread"} for b in facts.blockers_by_pr[pr.number])
+            and not (facts.prereq_status and facts.prereq_status.needs_followup_requeue)
+            and facts.stale_base_by_pr.get(pr.number)
+        ):
+            action = plan_invoker_rebase_onto_master(
+                pr,
+                ledger,
+                max_repair_attempts,
+                now,
+                "Mergify dequeued with no named required-check failure while behind master",
+                claim_repair_filing,
+            )
+            if action is not None:
+                return action
     return None
 
 
@@ -1048,31 +1072,19 @@ def plan_direct_repairs(
             continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
-                key = f"conflict:{pr.number}"
-                decision = retry_decision(
-                    ledger, pr.number, pr.head_ref_oid, "conflict-repair", key,
-                    repair_conflict_plan_name(pr.number, pr.head_ref_oid), now, max_repair_attempts,
+                # Legacy conflict-repair filings may still be in flight.
+                legacy_key = f"conflict:{pr.number}"
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+                    continue
+                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+                    continue
+                action = plan_invoker_rebase_onto_master(
+                    pr, ledger, max_repair_attempts, now, blocker.detail, claim_repair_filing,
                 )
-                if decision["action"] == "needs-human":
-                    return cap_action(pr, blocker, blocker.detail)
-                if decision["action"] == "backoff":
-                    continue
-                if not decision["crashed_on_infra"] and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
-                    continue
-                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
-                    continue
-                if claim_repair_filing is not None and claim_repair_filing(
-                    CONFLICT_REPAIR_FILING_KIND, str(pr.number), pr.head_ref_oid,
-                ):
-                    continue
-                return Action("repair_conflict", pr.number, key, blocker.detail)
+                if action is not None:
+                    return action
+                continue
             if blocker.kind == "failed_check":
-                if facts.stale_base_by_pr.get(pr.number):
-                    return plan_rebase_onto_base(
-                        pr, facts.trunk, ledger, max_repair_attempts,
-                        "structural stale base is blocking its failing check(s), not a code problem",
-                        claim_repair_filing,
-                    )
                 decision = retry_decision(
                     ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key,
                     repair_check_plan_name(pr.number, blocker.key, pr.head_ref_oid), now, max_repair_attempts,
@@ -1141,12 +1153,23 @@ def has_active_repair_for_current_blocker(facts: StackFacts, ledger: Ledger, now
                     return True
                 if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "repair-check", check_name, now):
                     return True
+            if not latest.failing_checks:
+                key = f"rebase-onto-master:{pr.number}"
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now):
+                    return True
+                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now):
+                    return True
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
-                key = f"conflict:{pr.number}"
-                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
+                key = f"rebase-onto-master:{pr.number}"
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now):
                     return True
-                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
+                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now):
+                    return True
+                legacy_key = f"conflict:{pr.number}"
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+                    return True
+                if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
                     return True
             elif blocker.kind == "failed_check":
                 if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
@@ -1211,6 +1234,43 @@ def plan_merge_hold_cleanup(facts: StackFacts, ledger: Ledger) -> Action | None:
     return None
 
 
+def plan_invoker_rebase_onto_master(
+    pr: PrSnapshot,
+    ledger: Ledger,
+    max_repair_attempts: int,
+    now: int,
+    reason: str,
+    claim_repair_filing: ClaimRepairFiling | None = None,
+) -> Action | None:
+    """File an Invoker prompt job to rebase the PR onto master (no local force-push)."""
+    key = f"rebase-onto-master:{pr.number}"
+    decision = retry_decision(
+        ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key,
+        rebase_onto_master_plan_name(pr.number, pr.head_ref_oid), now, max_repair_attempts,
+    )
+    if decision["action"] == "needs-human":
+        return cap_action(
+            pr,
+            Blocker(key, "rebase_onto_master", pr.number, reason),
+            reason,
+        )
+    if decision["action"] == "backoff":
+        return None
+    if not decision["crashed_on_infra"] and repair_in_flight(
+        ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now,
+    ):
+        return None
+    if infra_repair_owns_unit(
+        ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now,
+    ):
+        return None
+    if claim_repair_filing is not None and claim_repair_filing(
+        REBASE_ONTO_MASTER_FILING_KIND, str(pr.number), pr.head_ref_oid,
+    ):
+        return None
+    return Action("rebase_onto_master", pr.number, key, reason)
+
+
 def plan_rebase_onto_base(
     pr: PrSnapshot,
     trunk: str,
@@ -1219,6 +1279,9 @@ def plan_rebase_onto_base(
     reason: str,
     claim_repair_filing: ClaimRepairFiling | None = None,
 ) -> Action | None:
+    # Retained for unit tests that pin the legacy Python force-push path.
+    # Production planners no longer call this for behind-master or CI failures;
+    # conflicts and no-CI Mergify dequeues use plan_invoker_rebase_onto_master.
     # Persistent count (count_by_unit), not the head_sha-scoped count() --
     # a rebase attempt changes head_sha by definition, so the head_sha-scoped
     # count could never accumulate past 1 no matter how many times it
@@ -1309,11 +1372,8 @@ def plan_bottom_progress(
                 detail,
             )
         return Action("refresh_stale_queue", bottom.number, STALE_QUEUE_EVENT_REFRESH_KEY, detail)
-    if bottom.base_ref_name == facts.trunk and facts.stale_base_by_pr.get(bottom.number):
-        return plan_rebase_onto_base(
-            bottom, facts.trunk, ledger, max_requeue_attempts,
-            "base pointer moved but content was never rebased", claim_repair_filing,
-        )
+    # Behind master alone is not a rebase trigger: wait / requeue. Rebases are
+    # Invoker jobs for GitHub conflicts and no-CI Mergify dequeues only.
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"
     if latest and latest.state == "dequeued":

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -202,14 +202,15 @@ class AdminBypassRepairer:
         async_repair.submit_async_repair_plan(plan)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
-    def repair_conflict(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
-        check_name = "conflict"
+    def rebase_onto_master(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
+        check_name = "rebase-onto-master"
         start_head = pr.head_ref_oid
-        plan = async_repair.build_repair_conflict_plan(
+        key = f"rebase-onto-master:{pr.number}"
+        plan = async_repair.build_rebase_onto_master_plan(
             pr, reason, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
         )
         self.logger.trace(
-            "admin-bypass-repair-conflict-start",
+            "admin-bypass-rebase-onto-master-start",
             repo=self.repo,
             pr_number=pr.number,
             reason=reason,
@@ -220,7 +221,7 @@ class AdminBypassRepairer:
         )
         # See repair_check: record before submitting so a broken ledger write
         # blocks the submission instead of orphaning a real, running repair.
-        self.ledger.record("conflict-repair", pr.number, start_head, f"conflict:{pr.number}", now)
+        self.ledger.record("rebase-onto-master", pr.number, start_head, key, now)
         async_repair.submit_async_repair_plan(plan)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -11,6 +11,7 @@ try:
     from .mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
     from .mergify_admin_requeue_async_repair import (
+        rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
         repair_check_plan_name,
         repair_conflict_plan_name,
@@ -19,6 +20,7 @@ except ImportError:
     from mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from mergify_admin_requeue_headless_shell import run_headless as _run_headless
     from mergify_admin_requeue_async_repair import (
+        rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
         repair_check_plan_name,
         repair_conflict_plan_name,
@@ -90,7 +92,7 @@ def submit_rebase_recreate(workflow_id: str) -> None:
 # machinery already understands (PR #7484, 2026-08-05: an accepted-but-starved
 # recreate looked "handled" while its three predecessors had already failed).
 
-_FASTPATH_SETTLE_KINDS = ("conflict-repair", "repair-check")
+_FASTPATH_SETTLE_KINDS = ("conflict-repair", "rebase-onto-master", "repair-check")
 _TERMINAL_WORKFLOW_STATUSES = frozenset({"completed", "failed", "cancelled", "review_ready", "merged"})
 _SSH_INFRA_FAILURE_CLASSES = frozenset({
     "ssh-env-invalid-export",
@@ -250,19 +252,20 @@ def list_workflows() -> list[dict] | None:
     return None
 
 
-# repairer.py's ad-hoc repair plans (repair-check, conflict-repair,
-# repair-bot-thread) settle via their own plan's `safe-push` task, which only
-# runs if the upstream `repair` task succeeds. When `repair` itself fails,
-# `safe-push` never runs and the `-settled` row is never written -- the row
-# repairer.py records before submission (see AdminBypassRepairer) carries no
-# meta.workflowId, so settle_workflow_fastpath_rows's lookup can't find it
-# either. Unlike a fast-path rebase-recreate, these plan names are fully
-# deterministic from (pr, headSha, key) via the same *_plan_name() helpers
-# used to build the plan, so the matching workflow can be found by name
-# instead of by a recorded id (PR #9172: a failed repair-bot-thread attempt
-# left `repair_in_flight` believing a repair was still running for the rest
-# of its 90-minute TTL, even though the workflow had already failed).
-_REPAIRER_PLAN_SETTLE_KINDS = ("repair-check", "conflict-repair", "repair-bot-thread")
+# repairer.py's ad-hoc repair plans (repair-check, rebase-onto-master,
+# repair-bot-thread; plus legacy conflict-repair) settle via their own plan's
+# `safe-push` task, which only runs if the upstream `repair` task succeeds.
+# When `repair` itself fails, `safe-push` never runs and the `-settled` row is
+# never written -- the row repairer.py records before submission (see
+# AdminBypassRepairer) carries no meta.workflowId, so
+# settle_workflow_fastpath_rows's lookup can't find it either. Unlike a
+# fast-path rebase-recreate, these plan names are fully deterministic from
+# (pr, headSha, key) via the same *_plan_name() helpers used to build the plan,
+# so the matching workflow can be found by name instead of by a recorded id
+# (PR #9172: a failed repair-bot-thread attempt left `repair_in_flight`
+# believing a repair was still running for the rest of its 90-minute TTL, even
+# though the workflow had already failed).
+_REPAIRER_PLAN_SETTLE_KINDS = ("repair-check", "conflict-repair", "rebase-onto-master", "repair-bot-thread")
 
 
 def _repairer_plan_name(kind: str, pr: int, head: str, key: str) -> str:
@@ -270,6 +273,8 @@ def _repairer_plan_name(kind: str, pr: int, head: str, key: str) -> str:
         return repair_check_plan_name(pr, key, head)
     if kind == "conflict-repair":
         return repair_conflict_plan_name(pr, head)
+    if kind == "rebase-onto-master":
+        return rebase_onto_master_plan_name(pr, head)
     return repair_bot_thread_plan_name(pr, head)
 
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -375,9 +375,9 @@ Failing checks
         stack = StackGroup("s", (pr(2609, merge_state="DIRTY", latest=mergify()),))
         ledger = self.ledger()
         actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_conflict", 2609)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("rebase_onto_master", 2609)])
         for epoch in range(3):
-            ledger.record("conflict-repair", 2609, HEAD, "conflict:2609", epoch)
+            ledger.record("rebase-onto-master", 2609, HEAD, "rebase-onto-master:2609", epoch)
         actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
@@ -391,26 +391,29 @@ Failing checks
             side_effect=lambda plan: submitted.append(plan),
         ):
             for epoch in range(3):
-                repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
-        self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
+                repairer.rebase_onto_master(item, "GitHub reports merge conflict", epoch)
+        self.assertEqual(ledger.count("rebase-onto-master", 2647, HEAD, "rebase-onto-master:2647"), 3)
         self.assertEqual(len(submitted), 3)
         self.assertIn("commit locally. Do not push.", submitted[0].yaml_text)
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_repair_conflict_returns_submitted_and_records_ledger(self):
+    def test_rebase_onto_master_returns_submitted_and_records_ledger(self):
         item = pr(2660, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
         with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
-            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+            result = repairer.rebase_onto_master(item, "GitHub reports merge conflict", 1)
         submit.assert_called_once()
         self.assertEqual(result.status, "submitted")
         self.assertEqual(result.start_head, HEAD)
         self.assertEqual(result.end_head, HEAD)
-        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+        self.assertEqual(
+            ledger.count("rebase-onto-master", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
+            1,
+        )
 
-    def test_repair_conflict_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
+    def test_rebase_onto_master_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
         # The ledger row is written before submission (not after) so a broken
         # ledger write can never leave a real, running repair uncounted. The
         # cost is the mirror case here: if submission itself fails, the
@@ -424,8 +427,11 @@ Failing checks
             side_effect=RuntimeError("submit failed"),
         ):
             with self.assertRaises(RuntimeError):
-                repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+                repairer.rebase_onto_master(item, "GitHub reports merge conflict", 1)
+        self.assertEqual(
+            ledger.count("rebase-onto-master", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
+            1,
+        )
 
     def test_repair_check_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
         item = pr(2662, latest=mergify())

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -52,7 +52,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
             log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
             start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
-        conflict_plan = async_repair.build_repair_conflict_plan(
+        rebase_plan = async_repair.build_rebase_onto_master_plan(
             pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
         bot_thread_plan = async_repair.build_repair_bot_thread_plan(
@@ -60,7 +60,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         )
         for plan, expected_task_ids, expected_merge_mode in (
             (checks_plan, ["repair", "normalize", "safe-push"], "manual"),
-            (conflict_plan, ["repair", "safe-push"], "manual"),
+            (rebase_plan, ["repair", "safe-push"], "manual"),
             (bot_thread_plan, ["repair", "safe-push"], "external_review"),
         ):
             with self.subTest(plan=plan.plan_name):
@@ -154,18 +154,34 @@ class AsyncRepairPlanTests(unittest.TestCase):
         )
         self.assertIn("Queue draft PR: #5854", plan.yaml_text)
 
-    def test_repair_conflict_plan_has_two_tasks_and_no_owner_ledger_path(self):
-        plan = async_repair.build_repair_conflict_plan(
+    def test_rebase_onto_master_plan_has_two_tasks_and_no_owner_ledger_path(self):
+        plan = async_repair.build_rebase_onto_master_plan(
             pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
+        self.assertTrue(plan.plan_name.startswith("admin-bypass-rebase-onto-master-pr-"))
         self.assertIn("id: repair", plan.yaml_text)
         self.assertIn("id: safe-push", plan.yaml_text)
         self.assertNotIn("id: normalize", plan.yaml_text)
         self.assertNotIn("--record-json-ledger", plan.yaml_text)
         self.assertNotIn("--json-kind", plan.yaml_text)
         self.assertNotIn("/tmp/ledger.jsonl", plan.yaml_text)
+        self.assertIn("Rebase this pull request onto `master`", plan.yaml_text)
         self.assertIn("commit locally. Do not push.", plan.yaml_text)
         self.assertNotIn("executionAgent", plan.yaml_text)
+
+    def test_rebase_onto_master_plan_includes_dequeue_reason(self):
+        plan = async_repair.build_rebase_onto_master_plan(
+            pr(),
+            "Mergify dequeued with no named required-check failure",
+            repo="owner/repo",
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertTrue(plan.plan_name.startswith("admin-bypass-rebase-onto-master-pr-"))
+        self.assertIn("Rebase this pull request onto `master`", plan.yaml_text)
+        self.assertIn("id: repair", plan.yaml_text)
+        self.assertIn("id: safe-push", plan.yaml_text)
+        self.assertNotIn("id: normalize", plan.yaml_text)
 
     def test_repair_bot_thread_plan_keeps_thread_id_in_prompt_not_ledger(self):
         plan = async_repair.build_repair_bot_thread_plan(
@@ -184,7 +200,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
                 log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
                 start_head=HEAD, state_file=owner_ledger,
             ),
-            async_repair.build_repair_conflict_plan(
+            async_repair.build_rebase_onto_master_plan(
                 pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=owner_ledger,
             ),
             async_repair.build_repair_bot_thread_plan(

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -382,7 +382,7 @@ class PlanStackActions(PlannerTestCase):
 
     def test_conflict_triggers_claude_repair(self):
         actions = self._plan(pr(merge_state_status="DIRTY"))
-        self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_conflict", 1))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_master", 1))
 
     def test_repair_invalid_conflict_stops_retrying(self):
         ledger = self._ledger()
@@ -492,38 +492,58 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
         self.assertEqual(actions[0].kind, "repair_check")
 
-    def test_failed_check_with_stale_base_skips_agent_repair(self):
-        # PR #7727 incident: no coding-agent repair can fix a git-history
-        # problem. Once the base is known to be structurally stale, the
-        # direct-repair ladder must route to rebase_onto_base, never
-        # repair_check, and must not spend a repair-check ledger attempt.
+    def test_failed_check_with_stale_base_still_repairs_via_agent(self):
+        # Behind master must not steal a named CI failure into a blind rebase.
+        # File repair_check so the failing test/linter can be fixed in place.
         ledger = self._ledger()
         snapshot = pr(number=42, checks={"build": check("failure")})
         actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={42: True})
-        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("rebase_onto_base", 42, "master"))
-        self.assertEqual(ledger.count("repair-check", 42, HEAD, "build"), 0)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("repair_check", 42, "build"))
 
-    def test_failed_check_with_stale_base_skips_agent_repair_via_mergify_dequeue(self):
+    def test_failed_check_with_stale_base_still_repairs_via_mergify_dequeue(self):
         ledger = self._ledger()
         snapshot = pr(number=43, latest_mergify=event(failing=("build",)))
         actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={43: True})
-        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("rebase_onto_base", 43, "master"))
-        self.assertEqual(ledger.count("repair-check", 43, HEAD, "build"), 0)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("repair_check", 43, "build"))
+
+    def test_failed_pr_body_with_stale_base_still_repairs_not_rebases(self):
+        actions = self._plan(
+            pr(number=10242, checks={"PR Body": check("failure", "PR Body")}),
+            required_checks={"PR Body"},
+            stale_base_by_pr={10242: True},
+        )
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "PR Body"))
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
+        self.assertNotEqual(actions[0].kind, "rebase_onto_master")
 
     def test_failed_check_with_clean_base_still_repairs_via_agent(self):
         actions = self._plan(pr(checks={"build": check("failure")}), stale_base_by_pr={1: False})
         self.assertEqual(actions[0].kind, "repair_check")
 
-
     def test_clean_bottom_missing_label_nudges_human(self):
         actions = self._plan(pr())  # green, no admin-bypass label
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
 
-    def test_clean_bottom_dequeued_gets_requeued(self):
+    def test_clean_bottom_dequeued_with_no_ci_failure_rebases_via_invoker(self):
+        # Green Mergify dequeue that is also behind master → Invoker rebase,
+        # not a blind Python force-push and not a bare requeue.
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
-        actions = self._plan(snapshot)
+        actions = self._plan(snapshot, stale_base_by_pr={1: True})
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+        self.assertIn("no named required-check failure", actions[0].detail)
+
+    def test_clean_bottom_dequeued_up_to_date_still_requeues(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
+        actions = self._plan(snapshot, stale_base_by_pr={1: False})
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
 
+    def test_clean_bottom_dequeued_with_named_ci_failure_still_repairs(self):
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="dequeued", failing=("build",)),
+        )
+        actions = self._plan(snapshot, stale_base_by_pr={1: True})
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
     def test_queued_label_with_headless_active_queue_event_waits(self):
         snapshot = pr(labels=frozenset({"admin-bypass", "queued"}), latest_mergify=event(state="queued", head=""))
         actions = self._plan(snapshot)
@@ -597,17 +617,13 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(snapshot)
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
 
-    def test_stale_base_content_rebases_before_requeue(self):
-        # PR #7727 incident: retarget_base already moved the base pointer to
-        # `master`, but the branch content was never rebased. Once the loader
-        # reports the base as `master` again (bottom_topology is now
-        # "current_bottom", not "stale_unowned_base"), the planner must not
-        # requeue a PR whose content still isn't an ancestor of master.
+    def test_stale_base_content_requeues_without_rebase(self):
+        # Behind master alone must not force-push. Requeue (or wait) instead.
         snapshot = pr(number=5885, labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot, stale_base_by_pr={5885: True})
         self.assertEqual(
-            (actions[0].kind, actions[0].pr_number, actions[0].key),
-            ("rebase_onto_base", 5885, "master"),
+            (actions[0].kind, actions[0].pr_number, actions[0].detail),
+            ("requeue", 5885, "eligible-when-ready"),
         )
 
     def test_clean_ancestry_bottom_still_requeues_normally(self):
@@ -619,6 +635,34 @@ class PlanStackActions(PlannerTestCase):
         snapshot = pr(number=5885, labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot, stale_base_by_pr={9999: True})
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
+    def test_dirty_conflict_plans_invoker_rebase_onto_master(self):
+        actions = self._plan(
+            pr(
+                number=77,
+                labels=frozenset({"admin-bypass"}),
+                merge_state_status="DIRTY",
+                mergeable="CONFLICTING",
+            ),
+        )
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_master", 77))
+        self.assertEqual(actions[0].key, "rebase-onto-master:77")
+
+    def test_conflict_and_dequeue_share_rebase_onto_master_retry_budget(self):
+        ledger = self._ledger()
+        for epoch in range(3):
+            ledger.record("rebase-onto-master", 1, HEAD, "rebase-onto-master:1", epoch)
+        dirty = self._plan(
+            pr(labels=frozenset({"admin-bypass"}), merge_state_status="DIRTY"),
+            ledger=ledger,
+        )
+        self.assertEqual(dirty[0].kind, "comment_blocked")
+        dequeue = self._plan(
+            pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued")),
+            ledger=ledger,
+            stale_base_by_pr={1: True},
+        )
+        self.assertEqual(dequeue[0].kind, "comment_blocked")
 
     def test_upper_human_decision_does_not_block_clean_bottom_requeue(self):
         bottom = pr(number=10, head_ref_name="stack/bottom", labels=frozenset({"admin-bypass"}))
@@ -896,7 +940,8 @@ class ClaimRepairFilingGate(PlannerTestCase):
         self.assertEqual(p.repair_filing_kind_for_check("build"), "admin-requeue:check:build")
         self.assertEqual(p.repair_filing_kind_for_check("quality / Dependency Cruise"), "admin-requeue:check:quality-dependency-cruise")
 
-    def test_rebase_conflict_kind_matches_the_spec_worked_example(self):
+    def test_rebase_onto_master_kind_matches_the_spec_worked_example(self):
+        self.assertEqual(p.REBASE_ONTO_MASTER_FILING_KIND, "admin-requeue:rebase-onto-master")
         self.assertEqual(p.REBASE_CONFLICT_REPAIR_FILING_KIND, "admin-requeue:rebase-conflict")
 
     def test_duplicate_claim_suppresses_repair_check_action(self):
@@ -936,16 +981,13 @@ class ClaimRepairFilingGate(PlannerTestCase):
         # MergifyRequeueAttemptStateShaCollisionRepro for why.
         self.assertEqual(calls, [("admin-requeue:check:build", "1", f"{HEAD}:cm1")])
 
-    def test_duplicate_claim_suppresses_rebase_onto_base_action(self):
-        # Same fixture as test_failed_check_with_stale_base_skips_agent_repair
-        # in PlanStackActions, which proves the un-gated (claim_repair_filing=None)
-        # case returns the rebase_onto_base Action -- this proves a duplicate
-        # claim suppresses it instead.
+    def test_duplicate_claim_suppresses_stale_failed_check_repair(self):
+        # Stale + failed check now plans repair_check (not rebase_onto_base).
         snapshot = pr(number=42, checks={"build": check("failure")})
         actions = self._plan(snapshot, lambda kind, subject, sha: True, stale_base_by_pr={42: True})
         self.assertEqual(actions, ())
 
-    def test_fresh_claim_lets_rebase_onto_base_action_through(self):
+    def test_fresh_claim_lets_stale_failed_check_repair_through(self):
         snapshot = pr(number=42, checks={"build": check("failure")})
         calls = []
         actions = self._plan(
@@ -953,8 +995,34 @@ class ClaimRepairFilingGate(PlannerTestCase):
             lambda kind, subject, sha: calls.append((kind, subject, sha)) or False,
             stale_base_by_pr={42: True},
         )
-        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_base", 42))
-        self.assertEqual(calls, [("admin-requeue:rebase-conflict", "42", HEAD)])
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_check", 42))
+        self.assertEqual(calls, [("admin-requeue:check:build", "42", HEAD)])
+
+    def test_duplicate_claim_suppresses_no_ci_dequeue_rebase(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
+        actions = self._plan(snapshot, lambda kind, subject, sha: True, stale_base_by_pr={1: True})
+        self.assertNotEqual(actions[0].kind if actions else None, "rebase_onto_master")
+
+    def test_fresh_claim_lets_no_ci_dequeue_rebase_through(self):
+        calls = []
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
+        actions = self._plan(
+            snapshot,
+            lambda kind, subject, sha: calls.append((kind, subject, sha)) or False,
+            stale_base_by_pr={1: True},
+        )
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+        self.assertEqual(calls, [(p.REBASE_ONTO_MASTER_FILING_KIND, "1", HEAD)])
+
+    def test_fresh_claim_lets_dirty_conflict_rebase_through(self):
+        calls = []
+        snapshot = pr(labels=frozenset({"admin-bypass"}), merge_state_status="DIRTY")
+        actions = self._plan(
+            snapshot,
+            lambda kind, subject, sha: calls.append((kind, subject, sha)) or False,
+        )
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+        self.assertEqual(calls, [(p.REBASE_ONTO_MASTER_FILING_KIND, "1", HEAD)])
 
     def test_claim_does_not_consume_a_repair_check_ledger_attempt(self):
         # A duplicate claim is a cross-system dedup skip, not a real attempt
@@ -1044,10 +1112,10 @@ class PlanDirectRepairsUnguardedSecondPathRepro(PlannerTestCase):
     def test_duplicate_claim_is_not_honored_by_plan_direct_repairs_conflict_path(self):
         snapshot = pr(mergeable="CONFLICTING")
         actions = self._plan(snapshot, claim_repair_filing=lambda kind, subject, sha: True)
-        repair_conflict_actions = [a for a in actions if a.kind == "repair_conflict"]
+        rebase_actions = [a for a in actions if a.kind == "rebase_onto_master"]
         self.assertEqual(
-            repair_conflict_actions, [],
-            "plan_direct_repairs' own conflict path refiled a repair_conflict the ledger "
+            rebase_actions, [],
+            "plan_direct_repairs' own conflict path refiled a rebase_onto_master the ledger "
             "already said was claimed elsewhere -- it is not gated by claim_repair_filing",
         )
 
@@ -1310,13 +1378,13 @@ class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
 
     def test_plan_direct_repairs_conflict_resubmits_instead_of_blocking(self):
         ledger = self._ledger()
-        key = "conflict:1"
-        ledger.record("conflict-repair", 1, HEAD, key, epoch=NOW - 100)
+        key = "rebase-onto-master:1"
+        ledger.record("rebase-onto-master", 1, HEAD, key, epoch=NOW - 100)
         snapshot = pr(labels=frozenset({"admin-bypass"}), merge_state_status="DIRTY", mergeable="CONFLICTING")
         facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
         with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
             action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
-        self.assertEqual((action.kind, action.key), ("repair_conflict", key))
+        self.assertEqual((action.kind, action.key), ("rebase_onto_master", key))
 
     def test_plan_bot_thread_repairs_resubmits_instead_of_blocking(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

Admin-bypass was force-pushing PRs that were only behind master. That rewrite dropped unpushed repair commits, including on #10242.

This change stops that path. Behind and clean now only requeues. Named CI failures still go to repair, even when the branch is also behind.

GitHub merge conflicts and Mergify dequeues with no named CI failure while behind both file one Invoker rebase-onto-master job. They share one filing kind and retry budget.

## Review Claim

Approve that admin-bypass Invoker-rebases only for conflict or no-CI dequeue-while-behind, via one shared `rebase_onto_master` job, and never force-pushes solely for being behind or for named CI failures.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Conflict and no-CI-dequeue-while-behind both file the same Invoker rebase-onto-master job and share one filing/retry budget. Named CI failures still never rebase. Behind and clean still requeues without force-push.

## Slice Rationale

One policy surface: when to rebase, and that both rebase triggers are the same Invoker job. Splitting stop-blind from unify would land a short-lived dual-name state.

## Non-goals

Does not change CI `repair_check` policy beyond refusing rebase for named failures.

Does not change `pr-jailbreak-land`, `pr-auto-label`, `pr-orphan-repair`, or `pr-duplicate-close`.

Does not raise the repair attempt cap.

Does not fix `safe-push` stale-head handling.

Leaves legacy Python `rebase_onto_base` helpers for unit tests; production planners no longer call them for behind-master or CI.

## Architecture

### Before

```mermaid
graph TD
    behind["Behind master"] --> forcePush["Python rebase_onto_base force-push"]
    conflict["DIRTY conflict"] --> repairConflict["repair_conflict job"]
    dequeue["Dequeued, no named CI, behind"] --> other["requeue or separate path"]
    namedCi["Named CI failure"] --> maybeRebase["Could rebase if also behind"]
```

### After

```mermaid
graph TD
    behind["Behind and clean"] --> requeue["requeue only"]
    conflict["DIRTY conflict"] --> oneJob["rebase_onto_master Invoker job"]
    dequeue["Dequeued, no named CI, behind"] --> oneJob
    namedCi["Named CI failure"] --> repairCheck["repair_check only"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_repairer scripts.test_mergify_admin_requeue`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0e5f2ce8f2`
- Post-revert steps: None
- Data migration? No

</details>
