### PR TITLE
[Sticky admin-bypass host](1) Document sticky host in invoker-ops

### DIFF
--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -28,9 +28,9 @@ Use Invoker commands first. Direct database reads are only allowed when the user
 
 Admin-bypass babysitting (`pr-admin-bypass-land` / `mergify_admin_requeue`, repair-filing claims, retry-cap ledger clears, and requeue for a named admin-bypass PR) is host-sticky for the session.
 
-If this session already named Digital Ocean 1 / `remote_digital_ocean_1` / DO1 for that class of work, or already ran deploy/reset/repair against DO1 for admin-bypass PRs, later reset-retries / repair / requeue / ledger edits for those PRs must target DO1 unless the user explicitly says local / this Mac.
+If this session already named a remote host for that class of work, or already ran deploy/reset/repair against that host for admin-bypass PRs, later reset-retries / repair / requeue / ledger edits for those PRs must target the same host unless the user explicitly says local / this machine.
 
-Do not clear `~/.invoker/mergify-admin-requeue-state.jsonl` on the Mac and submit repair via the local owner when the live babysitter ledger and cron live on DO1 — that is the wrong machine even when the local dry-run plans the same action.
+Do not clear `~/.invoker/mergify-admin-requeue-state.jsonl` on a different machine and submit repair via that owner when the live babysitter ledger and cron live on the session's chosen host — that is the wrong machine even when a local dry-run plans the same action.
 
 Require an explicit "local" / "this machine" to switch hosts mid-session.
 

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -24,6 +24,16 @@ Do not query or mutate the SQLite database directly for normal operations.
 
 Use Invoker commands first. Direct database reads are only allowed when the user explicitly asks to debug persistence/storage internals, or when the Invoker command surface itself is the broken thing being investigated.
 
+## Sticky admin-bypass host
+
+Admin-bypass babysitting (`pr-admin-bypass-land` / `mergify_admin_requeue`, repair-filing claims, retry-cap ledger clears, and requeue for a named admin-bypass PR) is host-sticky for the session.
+
+If this session already named Digital Ocean 1 / `remote_digital_ocean_1` / DO1 for that class of work, or already ran deploy/reset/repair against DO1 for admin-bypass PRs, later reset-retries / repair / requeue / ledger edits for those PRs must target DO1 unless the user explicitly says local / this Mac.
+
+Do not clear `~/.invoker/mergify-admin-requeue-state.jsonl` on the Mac and submit repair via the local owner when the live babysitter ledger and cron live on DO1 — that is the wrong machine even when the local dry-run plans the same action.
+
+Require an explicit "local" / "this machine" to switch hosts mid-session.
+
 ## Safe command map
 
 ### List workflows


### PR DESCRIPTION
## Summary

The sticky-host rule now follows whatever remote this session already chose.

It no longer names a vendor machine. Other clones of this repo can use their own hosts.

## Review Claim

Approve that admin-bypass reset, repair, and requeue stay on the session's chosen host unless the user says local.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Skill text only. No product runtime, ledger, or cron behavior changes until an agent follows the updated instruction.

## Slice Rationale

One docs claim. Naming a specific cloud host would overfit this repo to one operator's machines.

## Non-goals

Does not change `mergify_admin_requeue` code or deploy.

Does not change default execution for non-admin-bypass work.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git grep -E 'Digital Ocean|DO1|remote_digital_ocean' -- skills/invoker-ops/SKILL.md` exits 1
- [x] `git grep -q 'Sticky admin-bypass host' -- skills/invoker-ops/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 033a207de0`
- Post-revert steps: None
- Data migration? No

</details>
