### PR TITLE
[install-skills-always-on-routing](1) Add instruction target and uninstall install-mode types

### DIFF
--- a/packages/contracts/src/__tests__/bundled-skills-status.test.ts
+++ b/packages/contracts/src/__tests__/bundled-skills-status.test.ts
@@ -17,6 +17,9 @@ describe('BundledSkillsStatus contract', () => {
       mcpTargets: [
         { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
       ],
+      instructionTargets: [
+        { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/rules/invoker-execution-precedence.mdc', available: true, installed: true, upToDate: true, installedInstructionNames: ['invoker-execution'] },
+      ],
     } satisfies BundledSkillsStatus;
 
     const diagnostics = {
@@ -30,5 +33,6 @@ describe('BundledSkillsStatus contract', () => {
 
     expect(diagnostics.bundledSkills.commandTargets[0]?.installedCommandNames).toEqual(['invoker-plan-to-invoker']);
     expect(diagnostics.bundledSkills.mcpTargets[0]?.serverName).toBe('invoker');
+    expect(diagnostics.bundledSkills.instructionTargets?.[0]?.installedInstructionNames).toEqual(['invoker-execution']);
   });
 });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -799,6 +799,16 @@ export interface HarnessMcpConfigState {
   serverName: string;
 }
 
+export interface HarnessInstructionConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  installedInstructionNames: string[];
+}
+
 export interface BundledSkillsStatus {
   available: boolean;
   promptRecommended: boolean;
@@ -810,9 +820,10 @@ export interface BundledSkillsStatus {
   targets: BundledSkillTargetStatus[];
   commandTargets: HarnessConfigState[];
   mcpTargets: HarnessMcpConfigState[];
+  instructionTargets?: HarnessInstructionConfigState[];
 }
 
-export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';
+export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall' | 'uninstall';
 
 export interface CliInstallerStatus {
   /** Packaged app + bundled binary present + darwin/linux. */


### PR DESCRIPTION
## Summary

Adds an optional instruction-target status shape on bundled helper diagnostics.

Extends the helper install-mode union with uninstall so later slices can reverse those writes.

## Review Claim

Approve the optional `instructionTargets` field and `uninstall` install-mode member on the bundled helpers contract.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

These additions are optional or additive. Existing `install`, `update`, and `reinstall` members stay. This slice does not change installer runtime behavior.

## Slice Rationale

The new status shape must land before the installer uses it. Mixing this contract with installer files would fail the review-unit gate.

## Non-goals

This slice does not change installer behavior, CLI help text, or skill instructions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts exec vitest run src/__tests__/bundled-skills-status.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a2a4204626`
- Post-revert steps: None
- Data migration? No

</details>