### PR TITLE
[install-skills-always-on-routing](3) Expose uninstall and instruction targets on install-skills

### DIFF
--- a/packages/app/src/__tests__/headless-install-skills.test.ts
+++ b/packages/app/src/__tests__/headless-install-skills.test.ts
@@ -16,6 +16,9 @@ function makeStatus() {
     mcpTargets: [
       { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
     ],
+    instructionTargets: [
+      { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/rules/invoker-execution-precedence.mdc', available: true, installed: true, upToDate: true, installedInstructionNames: ['invoker-execution'] },
+    ],
   };
 }
 
@@ -39,8 +42,22 @@ describe('headless install-skills', () => {
     expect(output).toContain('Skill target (Codex): /tmp/.codex/skills');
     expect(output).toContain('Command target (OMP): /tmp/.omp/agent/commands');
     expect(output).toContain('MCP target (OMP): /tmp/.omp/agent/mcp.json');
+    expect(output).toContain('Instruction target (Cursor): /tmp/.cursor/rules/invoker-execution-precedence.mdc');
     expect(output).toContain('- invoker-plan-to-invoker');
     expect(output).toContain('- invoker-make-pr');
+  });
+
+  it('prints Uninstalled when install-skills uninstall runs', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const installBundledSkills = vi.fn(() => makeStatus());
+
+    await runHeadless(['install-skills', 'uninstall'], {
+      installBundledSkills,
+    } as unknown as HeadlessDeps);
+
+    expect(installBundledSkills).toHaveBeenCalledWith('uninstall');
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('Uninstalled 2 bundled AI helpers with prefix "invoker-".');
   });
 
   it('throws a clear error when helper installation is unavailable', async () => {
@@ -56,6 +73,7 @@ describe('headless install-skills', () => {
 
     const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
     expect(output).toContain('install-skills [install|update|reinstall]          Install bundled Invoker AI helpers');
+    expect(output).toContain('install-skills uninstall                            Remove bundled Invoker AI helpers');
     expect(output).toContain('set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)');
   });
 });

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -57,6 +57,7 @@ ${BOLD}Respond:${RESET}
 
 ${BOLD}Configure:${RESET}
   install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
+  install-skills uninstall                            Remove bundled Invoker AI helpers
   set command <taskId> <cmd>                          Edit task command and re-run
   set prompt <taskId> <text>                          Edit task prompt and re-run
   set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -295,7 +295,8 @@ async function headlessInstallSkills(
     throw new Error('Bundled AI helper installation is not available in this runtime.');
   }
   const status = deps.installBundledSkills(mode ?? 'install');
-  process.stdout.write(`Installed ${status.bundledSkillNames.length} bundled AI helpers with prefix "${status.managedPrefix}".\n`);
+  const verb = mode === 'uninstall' ? 'Uninstalled' : 'Installed';
+  process.stdout.write(`${verb} ${status.bundledSkillNames.length} bundled AI helpers with prefix "${status.managedPrefix}".\n`);
   for (const target of status.targets) {
     process.stdout.write(`Skill target (${target.name}): ${target.path}\n`);
   }
@@ -304,6 +305,9 @@ async function headlessInstallSkills(
   }
   for (const target of status.mcpTargets) {
     process.stdout.write(`MCP target (${target.name}): ${target.path}\n`);
+  }
+  for (const target of status.instructionTargets ?? []) {
+    process.stdout.write(`Instruction target (${target.name}): ${target.path}\n`);
   }
   for (const skillName of status.bundledSkillNames) {
     process.stdout.write(`- ${status.managedPrefix}${skillName}\n`);
@@ -338,7 +342,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<u
       return headlessRepairFiling(args.slice(1), deps);
     case 'install-skills':
       await headlessInstallSkills(
-        args[1] === 'reinstall' || args[1] === 'update' ? args[1] : 'install',
+        args[1] === 'reinstall' || args[1] === 'update' || args[1] === 'uninstall' ? args[1] : 'install',
         deps,
       );
       break;

--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -141,7 +142,7 @@ describe('bundled-skills', () => {
       const expectedTargets = [
         join(codexHome, '.codex', 'skills'),
         join(codexHome, '.claude', 'skills'),
-        join(codexHome, '.cursor', 'skills-cursor'),
+        join(codexHome, '.cursor', 'skills'),
         join(codexHome, '.omp', 'agent', 'skills'),
       ];
 
@@ -632,6 +633,199 @@ describe('bundled-skills', () => {
 
       const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
       expect(manifest.sourceRepoRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('installs always-on routing into Cursor rules, Codex AGENTS.md, and a Claude hook', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-instruction-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(join(fakeHome, '.codex', 'AGENTS.md'), '# Personal rules\n\nKeep me.\n');
+      mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+      writeFileSync(join(fakeHome, '.claude', 'settings.json'), `${JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: 'python3 other.py' }] },
+          ],
+        },
+      }, null, 2)}\n`);
+      const ownedClaude = join(fakeHome, 'elsewhere', 'CLAUDE.md');
+      mkdirSync(join(fakeHome, 'elsewhere'), { recursive: true });
+      writeFileSync(ownedClaude, 'owned elsewhere\n');
+      symlinkSync(ownedClaude, join(fakeHome, '.claude', 'CLAUDE.md'));
+
+      const installed = installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const cursorRule = join(fakeHome, '.cursor', 'rules', 'invoker-execution-precedence.mdc');
+      const agents = readFileSync(join(fakeHome, '.codex', 'AGENTS.md'), 'utf-8');
+      const settings = JSON.parse(readFileSync(join(fakeHome, '.claude', 'settings.json'), 'utf-8'));
+      const hookScript = join(invokerHomeRoot, 'hooks', 'invoker-execution', 'claude_prompt_submit.mjs');
+
+      expect(existsSync(join(fakeHome, '.cursor', 'skills', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(true);
+      expect(existsSync(cursorRule)).toBe(true);
+      expect(readFileSync(cursorRule, 'utf-8')).toContain('alwaysApply: true');
+      expect(agents).toContain('# Personal rules');
+      expect(agents).toContain('<!-- invoker-execution -->');
+      expect(settings.hooks.UserPromptSubmit).toHaveLength(2);
+      expect(settings.hooks.UserPromptSubmit[0].hooks[0].command).toBe('python3 other.py');
+      expect(settings.hooks.UserPromptSubmit[1].hooks[0].command).toContain('invoker-execution/claude_prompt_submit');
+      expect(readFileSync(ownedClaude, 'utf-8')).toBe('owned elsewhere\n');
+      expect(installed.instructionTargets?.every((target) => target.installed && target.upToDate)).toBe(true);
+
+      const hookResult = spawnSync(process.execPath, [hookScript], {
+        input: '{"prompt":"add a feature"}',
+        encoding: 'utf8',
+      });
+      expect(hookResult.status).toBe(0);
+      expect(JSON.parse(hookResult.stdout).hookSpecificOutput.additionalContext).toContain('Invoker execution routing');
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+      expect(readFileSync(join(fakeHome, '.codex', 'AGENTS.md'), 'utf-8').split('<!-- invoker-execution -->')).toHaveLength(2);
+      expect(JSON.parse(readFileSync(join(fakeHome, '.claude', 'settings.json'), 'utf-8')).hooks.UserPromptSubmit).toHaveLength(2);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('uninstall reverses installer writes and leaves unrelated harness files', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-uninstall-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(join(fakeHome, '.codex', 'AGENTS.md'), 'Keep me.\n');
+      mkdirSync(join(fakeHome, '.cursor', 'skills-cursor', 'invoker-plan-to-invoker'), { recursive: true });
+      writeFileSync(join(fakeHome, '.cursor', 'skills-cursor', 'invoker-plan-to-invoker', 'SKILL.md'), 'legacy\n');
+
+      const deps = {
+        isPackaged: true as const,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      };
+      installBundledSkills(deps);
+      const uninstalled = installBundledSkills(deps, 'uninstall');
+
+      expect(existsSync(join(fakeHome, '.cursor', 'skills', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(false);
+      expect(existsSync(join(fakeHome, '.cursor', 'skills-cursor', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(false);
+      expect(existsSync(join(fakeHome, '.cursor', 'rules', 'invoker-execution-precedence.mdc'))).toBe(false);
+      expect(existsSync(join(invokerHomeRoot, 'bundled-skills.json'))).toBe(false);
+      expect(existsSync(join(invokerHomeRoot, 'hooks', 'invoker-execution', 'claude_prompt_submit.mjs'))).toBe(false);
+      expect(readFileSync(join(fakeHome, '.codex', 'AGENTS.md'), 'utf-8')).toContain('Keep me.');
+      expect(readFileSync(join(fakeHome, '.codex', 'AGENTS.md'), 'utf-8')).not.toContain('invoker-execution');
+      expect(uninstalled.instructionTargets?.every((target) => !target.installed)).toBe(true);
+      expect(uninstalled.targets.every((target) => !target.installed)).toBe(true);
+
+      expect(() => installBundledSkills(deps, 'uninstall')).not.toThrow();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('refuses to rewrite invalid Claude settings.json', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-invalid-settings-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      const settingsPath = join(fakeHome, '.claude', 'settings.json');
+      mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+      writeFileSync(settingsPath, '[]');
+
+      expect(() => installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      })).toThrow(`Invalid Claude settings at ${settingsPath}: expected a JSON object`);
+      expect(readFileSync(settingsPath, 'utf-8')).toBe('[]');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('marks instruction targets stale when the recorded instruction hash changes', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-stale-instruction-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifestPath = join(invokerHomeRoot, 'bundled-skills.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      manifest.instructionHash = 'stale';
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const status = resolveBundledSkillsStatus({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+      expect(status.instructionTargets?.every((target) => target.installed)).toBe(true);
+      expect(status.instructionTargets?.every((target) => !target.upToDate)).toBe(true);
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/contracts/src/__tests__/bundled-skills-status.test.ts
+++ b/packages/contracts/src/__tests__/bundled-skills-status.test.ts
@@ -17,6 +17,9 @@ describe('BundledSkillsStatus contract', () => {
       mcpTargets: [
         { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
       ],
+      instructionTargets: [
+        { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/rules/invoker-execution-precedence.mdc', available: true, installed: true, upToDate: true, installedInstructionNames: ['invoker-execution'] },
+      ],
     } satisfies BundledSkillsStatus;
 
     const diagnostics = {
@@ -30,5 +33,6 @@ describe('BundledSkillsStatus contract', () => {
 
     expect(diagnostics.bundledSkills.commandTargets[0]?.installedCommandNames).toEqual(['invoker-plan-to-invoker']);
     expect(diagnostics.bundledSkills.mcpTargets[0]?.serverName).toBe('invoker');
+    expect(diagnostics.bundledSkills.instructionTargets?.[0]?.installedInstructionNames).toEqual(['invoker-execution']);
   });
 });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -799,6 +799,16 @@ export interface HarnessMcpConfigState {
   serverName: string;
 }
 
+export interface HarnessInstructionConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  installedInstructionNames: string[];
+}
+
 export interface BundledSkillsStatus {
   available: boolean;
   promptRecommended: boolean;
@@ -810,9 +820,10 @@ export interface BundledSkillsStatus {
   targets: BundledSkillTargetStatus[];
   commandTargets: HarnessConfigState[];
   mcpTargets: HarnessMcpConfigState[];
+  instructionTargets?: HarnessInstructionConfigState[];
 }
 
-export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';
+export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall' | 'uninstall';
 
 export interface CliInstallerStatus {
   /** Packaged app + bundled binary present + darwin/linux. */

--- a/packages/shell/src/always-on/fragments.ts
+++ b/packages/shell/src/always-on/fragments.ts
@@ -1,0 +1,57 @@
+export const EXECUTION_ROUTING_FRAGMENT = `# Invoker execution routing
+
+When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
+
+- Read-only questions: stay local.
+- Tiny edits (one file, not a feature, working tree clean): stay local.
+- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill, then plan, review, one approval, submit.
+- Announce the route in one line so the user can interrupt with “do it locally.”
+- Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- If MCP and CLI are both missing: stay local.
+
+Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
+Plain approval stops after workflow handoff; do not publish PRs unless the user asks.
+`;
+
+export const CURSOR_RULE_CONTENTS = `---
+description: Feature work and dirty-tree edits go through Invoker; tiny clean-tree edits stay local
+alwaysApply: true
+---
+
+# Invoker execution routing
+
+When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
+
+- Read-only questions: stay local.
+- Tiny edits (one file, not a feature, working tree clean): stay local.
+- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill (\`~/.cursor/skills/invoker-plan-to-invoker/SKILL.md\` or \`~/.claude/skills/invoker-plan-to-invoker/SKILL.md\`), then plan, review, one approval, submit.
+- Announce the route in one line so the user can interrupt with “do it locally.”
+- Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- If MCP and CLI are both missing: stay local.
+
+Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
+Plain approval stops after workflow handoff; do not publish PRs unless the user asks.
+`;
+
+export const CLAUDE_HOOK_SCRIPT = `#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const additionalContext = ${JSON.stringify(EXECUTION_ROUTING_FRAGMENT.trim())};
+
+function main() {
+  try {
+    JSON.parse(readFileSync(0, 'utf8'));
+  } catch {
+    return;
+  }
+  if (!additionalContext) return;
+  process.stdout.write(\`\${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext,
+    },
+  })}\\n\`);
+}
+
+main();
+`;

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { resolveInvokerHomeRoot, type IsInstalled } from '@invoker/contracts';
 import type {
   HarnessConfigState,
+  HarnessInstructionConfigState,
   HarnessMcpConfigState,
   BundledSkillsInstallMode,
   BundledSkillsStatus,
@@ -13,12 +14,17 @@ import type {
 } from '@invoker/contracts';
 
 import { commandExists } from './command-exists.js';
+import { CLAUDE_HOOK_SCRIPT, CURSOR_RULE_CONTENTS, EXECUTION_ROUTING_FRAGMENT } from './always-on/fragments.js';
 
 const MANAGED_PREFIX = 'invoker-';
 const MANIFEST_FILE = 'bundled-skills.json';
 const OMP_MCP_SCHEMA_URL = 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json';
 const INVOKER_MCP_SERVER = { type: 'stdio', command: 'invoker-cli', args: ['mcp'] } as const;
 const INVOKER_MCP_SERVER_NAME = 'invoker';
+const INSTRUCTION_BEGIN = '<!-- invoker-execution -->';
+const INSTRUCTION_END = '<!-- /invoker-execution -->';
+const CURSOR_RULE_FILE = 'invoker-execution-precedence.mdc';
+const CLAUDE_HOOK_MARKER = 'invoker-execution/claude_prompt_submit';
 
 interface BundledSkillsManifest {
   bundledHash: string;
@@ -28,6 +34,8 @@ interface BundledSkillsManifest {
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
   commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
   mcpTargets?: Record<string, { path: string; serverName: string }>;
+  instructionTargets?: Record<string, { path: string; installedInstructionNames: string[] }>;
+  instructionHash?: string;
   /**
    * The Invoker source checkout these skills were bundled from (unset for
    * packaged Electron builds, whose resources dir isn't a real checkout).
@@ -150,7 +158,7 @@ function resolveCursorTarget(): BundledSkillTargetStatus {
   return {
     id: 'cursor',
     name: 'Cursor',
-    path: path.join(homedir(), '.cursor', 'skills-cursor'),
+    path: path.join(homedir(), '.cursor', 'skills'),
     available: true,
     installed: false,
     upToDate: false,
@@ -600,10 +608,299 @@ function installMcpTarget(target: McpTargetCandidate): void {
   installJsonMcpTarget(target, defaultConfig);
 }
 
+function uninstallJsonMcpTarget(target: McpTargetCandidate): void {
+  if (!existsSync(target.path)) return;
+  const config = readMutableJsonMcpConfig(target.path, {});
+  if (!isJsonRecord(config.mcpServers) || !(target.serverName in config.mcpServers)) return;
+  const { [target.serverName]: _removed, ...rest } = config.mcpServers;
+  config.mcpServers = rest;
+  writeFileAtomic(target.path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function uninstallTomlMcpTarget(target: McpTargetCandidate): void {
+  if (!existsSync(target.path)) return;
+  const existing = readFileSync(target.path, 'utf-8');
+  const range = findTomlInvokerServerBlockRange(existing, target.serverName);
+  if (!range) return;
+  const lines = existing.split('\n');
+  const next = [...lines.slice(0, range.start), ...lines.slice(range.end)].join('\n').replace(/\n{3,}/g, '\n\n');
+  writeFileAtomic(target.path, next.endsWith('\n') ? next : `${next}\n`);
+}
+
+function uninstallMcpTarget(target: McpTargetCandidate): void {
+  if (target.format === 'toml') {
+    uninstallTomlMcpTarget(target);
+    return;
+  }
+  uninstallJsonMcpTarget(target);
+}
+
+function hashAlwaysOnFragments(): string {
+  const hash = createHash('sha256');
+  hash.update(CURSOR_RULE_CONTENTS);
+  hash.update('\0');
+  hash.update(EXECUTION_ROUTING_FRAGMENT);
+  hash.update('\0');
+  hash.update(CLAUDE_HOOK_SCRIPT);
+  return hash.digest('hex');
+}
+
+function resolveCursorRulePath(): string {
+  return path.join(homedir(), '.cursor', 'rules', CURSOR_RULE_FILE);
+}
+
+function resolveCodexAgentsPath(): string {
+  return path.join(homedir(), '.codex', 'AGENTS.md');
+}
+
+function resolveClaudeSettingsPath(): string {
+  return path.join(homedir(), '.claude', 'settings.json');
+}
+
+function resolveLegacyCursorSkillsPath(): string {
+  return path.join(homedir(), '.cursor', 'skills-cursor');
+}
+
+function resolveHookInstallDir(invokerHomeRoot: string): string {
+  return path.join(invokerHomeRoot, 'hooks', 'invoker-execution');
+}
+
+function assertNotSymlink(filePath: string): void {
+  if (existsSync(filePath) && lstatSync(filePath).isSymbolicLink()) {
+    throw new Error(`Refusing to write through symlink: ${filePath}`);
+  }
+}
+
+function wrapInstructionFragment(fragment: string): string {
+  return `${INSTRUCTION_BEGIN}\n${fragment.trim()}\n${INSTRUCTION_END}\n`;
+}
+
+function mergeMarkedBlock(existing: string, fragment: string): string {
+  const block = wrapInstructionFragment(fragment);
+  if (existing.includes(INSTRUCTION_BEGIN)) {
+    const start = existing.indexOf(INSTRUCTION_BEGIN);
+    let end = existing.indexOf(INSTRUCTION_END, start);
+    if (end === -1) return `${existing.slice(0, start)}${block}`;
+    end += INSTRUCTION_END.length;
+    if (existing[end] === '\n') end += 1;
+    return `${existing.slice(0, start)}${block}${existing.slice(end)}`;
+  }
+  const sep = existing && !existing.endsWith('\n') ? '\n' : '';
+  const extra = existing ? '\n' : '';
+  return `${existing}${sep}${extra}${block}`;
+}
+
+function removeMarkedBlock(existing: string): string {
+  const start = existing.indexOf(INSTRUCTION_BEGIN);
+  if (start === -1) return existing;
+  let end = existing.indexOf(INSTRUCTION_END, start);
+  if (end === -1) return existing.slice(0, start);
+  end += INSTRUCTION_END.length;
+  if (existing[end] === '\n') end += 1;
+  return `${existing.slice(0, start)}${existing.slice(end)}`.replace(/\n{3,}/g, '\n\n');
+}
+
+function isClaudeHookEntry(entry: unknown): boolean {
+  if (!isJsonRecord(entry) || !Array.isArray(entry.hooks)) return false;
+  return entry.hooks.some((hook) => isJsonRecord(hook) && typeof hook.command === 'string' && hook.command.includes(CLAUDE_HOOK_MARKER));
+}
+
+function installCursorRule(): string {
+  const rulePath = resolveCursorRulePath();
+  assertNotSymlink(rulePath);
+  mkdirSync(path.dirname(rulePath), { recursive: true });
+  writeFileSync(rulePath, CURSOR_RULE_CONTENTS);
+  return rulePath;
+}
+
+function installCodexAgentsBlock(): string {
+  const agentsPath = resolveCodexAgentsPath();
+  assertNotSymlink(agentsPath);
+  mkdirSync(path.dirname(agentsPath), { recursive: true });
+  const existing = existsSync(agentsPath) ? readFileSync(agentsPath, 'utf8') : '';
+  writeFileAtomic(agentsPath, mergeMarkedBlock(existing, EXECUTION_ROUTING_FRAGMENT));
+  return agentsPath;
+}
+
+function installClaudeHook(invokerHomeRoot: string): string {
+  const hookDir = resolveHookInstallDir(invokerHomeRoot);
+  mkdirSync(hookDir, { recursive: true });
+  const destScript = path.join(hookDir, 'claude_prompt_submit.mjs');
+  writeFileSync(destScript, CLAUDE_HOOK_SCRIPT);
+  chmodSync(destScript, 0o755);
+
+  const settingsPath = resolveClaudeSettingsPath();
+  assertNotSymlink(settingsPath);
+  let settings: JsonRecord = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8')) as unknown;
+      if (!isJsonRecord(parsed)) throw new Error('not object');
+      settings = parsed;
+    } catch {
+      throw new Error(`Invalid Claude settings at ${settingsPath}: expected a JSON object`);
+    }
+  }
+  const hooksRoot = isJsonRecord(settings.hooks) ? settings.hooks : {};
+  const existingEntries = Array.isArray(hooksRoot.UserPromptSubmit) ? hooksRoot.UserPromptSubmit : [];
+  const kept = existingEntries.filter((entry) => !isClaudeHookEntry(entry));
+  kept.push({
+    hooks: [
+      {
+        type: 'command',
+        command: `node ${destScript}`,
+        timeout: 10,
+      },
+    ],
+  });
+  settings.hooks = { ...hooksRoot, UserPromptSubmit: kept };
+  mkdirSync(path.dirname(settingsPath), { recursive: true });
+  writeFileAtomic(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+  return settingsPath;
+}
+
+function uninstallCursorRule(): void {
+  const rulePath = resolveCursorRulePath();
+  if (!existsSync(rulePath)) return;
+  if (lstatSync(rulePath).isSymbolicLink()) return;
+  rmSync(rulePath);
+}
+
+function uninstallCodexAgentsBlock(): void {
+  const agentsPath = resolveCodexAgentsPath();
+  if (!existsSync(agentsPath) || lstatSync(agentsPath).isSymbolicLink()) return;
+  const next = removeMarkedBlock(readFileSync(agentsPath, 'utf8')).trim();
+  if (!next) {
+    rmSync(agentsPath);
+    return;
+  }
+  writeFileAtomic(agentsPath, `${next}\n`);
+}
+
+function uninstallClaudeHook(invokerHomeRoot: string): void {
+  const settingsPath = resolveClaudeSettingsPath();
+  if (existsSync(settingsPath) && !lstatSync(settingsPath).isSymbolicLink()) {
+    let settings: JsonRecord;
+    try {
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8')) as unknown;
+      if (!isJsonRecord(parsed)) throw new Error('not object');
+      settings = parsed;
+    } catch {
+      throw new Error(`Invalid Claude settings at ${settingsPath}: expected a JSON object`);
+    }
+    if (isJsonRecord(settings.hooks) && Array.isArray(settings.hooks.UserPromptSubmit)) {
+      settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter((entry) => !isClaudeHookEntry(entry));
+      writeFileAtomic(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+    }
+  }
+  rmSync(resolveHookInstallDir(invokerHomeRoot), { recursive: true, force: true });
+}
+
+function cursorRuleInstalled(): boolean {
+  return existsSync(resolveCursorRulePath()) && readFileSync(resolveCursorRulePath(), 'utf8').includes('Invoker execution routing');
+}
+
+function codexAgentsInstalled(): boolean {
+  const agentsPath = resolveCodexAgentsPath();
+  return existsSync(agentsPath) && readFileSync(agentsPath, 'utf8').includes(INSTRUCTION_BEGIN);
+}
+
+function claudeHookInstalled(): boolean {
+  const settingsPath = resolveClaudeSettingsPath();
+  if (!existsSync(settingsPath)) return false;
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as unknown;
+    if (!isJsonRecord(settings) || !isJsonRecord(settings.hooks) || !Array.isArray(settings.hooks.UserPromptSubmit)) return false;
+    return settings.hooks.UserPromptSubmit.some((entry) => isClaudeHookEntry(entry));
+  } catch {
+    return false;
+  }
+}
+
+function resolveInstructionTargets(): HarnessInstructionConfigState[] {
+  return [
+    {
+      id: 'cursor',
+      name: 'Cursor',
+      path: resolveCursorRulePath(),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedInstructionNames: [],
+    },
+    {
+      id: 'codex',
+      name: 'Codex',
+      path: resolveCodexAgentsPath(),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedInstructionNames: [],
+    },
+    {
+      id: 'claude',
+      name: 'Claude',
+      path: resolveClaudeSettingsPath(),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedInstructionNames: [],
+    },
+  ].map((target) => {
+    const installed = target.id === 'cursor'
+      ? cursorRuleInstalled()
+      : target.id === 'codex'
+        ? codexAgentsInstalled()
+        : claudeHookInstalled();
+    return { ...target, installed, installedInstructionNames: installed ? ['invoker-execution'] : [] };
+  });
+}
+
+function buildInstructionTargetStatus(
+  target: HarnessInstructionConfigState,
+  instructionHash: string,
+  manifest: BundledSkillsManifest | null,
+): HarnessInstructionConfigState {
+  const manifestTarget = manifest?.instructionTargets?.[target.id];
+  const upToDate = target.installed
+    && manifest?.instructionHash === instructionHash
+    && manifestTarget?.path === target.path
+    && (manifestTarget.installedInstructionNames ?? []).includes('invoker-execution');
+  return { ...target, upToDate };
+}
+
+function installInstructionTargets(invokerHomeRoot: string): BundledSkillsManifest['instructionTargets'] {
+  return {
+    cursor: { path: installCursorRule(), installedInstructionNames: ['invoker-execution'] },
+    codex: { path: installCodexAgentsBlock(), installedInstructionNames: ['invoker-execution'] },
+    claude: { path: installClaudeHook(invokerHomeRoot), installedInstructionNames: ['invoker-execution'] },
+  };
+}
+
+function removeManagedSkillDirs(targetPath: string, names: string[]): void {
+  if (!existsSync(targetPath)) return;
+  for (const name of names) {
+    rmSync(path.join(targetPath, name), { recursive: true, force: true });
+  }
+}
+
+function removeManagedCommandFiles(targetPath: string, fileNames: string[]): void {
+  if (!existsSync(targetPath)) return;
+  for (const fileName of fileNames) {
+    const filePath = path.join(targetPath, fileName);
+    if (existsSync(filePath) && !lstatSync(filePath).isSymbolicLink()) rmSync(filePath);
+  }
+}
+
 export function resolveBundledSkillsStatus(context: BundledSkillsContext): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
+  const instructionHash = hashAlwaysOnFragments();
+  const manifest = readManifest(invokerHomeRoot);
+  const instructionTargets = resolveInstructionTargets().map((target) =>
+    buildInstructionTargetStatus(target, instructionHash, manifest),
+  );
   if (!sourceRoot) {
     return {
       available: false,
@@ -613,13 +910,13 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
       targets: resolveManagedTargets(),
       commandTargets: resolveManagedCommandTargets(),
       mcpTargets: resolveManagedMcpTargets(isInstalled),
+      instructionTargets,
     };
   }
 
   const bundledSkillNames = listBundledSkillNames(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
   const bundledHash = hashDirectory(sourceRoot);
-  const manifest = readManifest(invokerHomeRoot);
   const targets = resolveManagedTargets().map((target) =>
     buildTargetStatus(target, installedNames, bundledHash, manifest),
   );
@@ -637,6 +934,7 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
       targets.some((target) => !target.upToDate)
       || commandTargets.some((target) => !target.upToDate)
       || mcpTargets.some((target) => !target.upToDate)
+      || instructionTargets.some((target) => !target.upToDate)
     ),
     sourcePath: sourceRoot,
     managedPrefix: MANAGED_PREFIX,
@@ -646,6 +944,7 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
     targets,
     commandTargets,
     mcpTargets,
+    instructionTargets,
   };
 }
 
@@ -655,6 +954,9 @@ export function installBundledSkills(
 ): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
+  if (mode === 'uninstall') {
+    return uninstallBundledSkills(context);
+  }
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
   if (!sourceRoot) {
     throw new Error('Bundled skills are not available in this app build.');
@@ -714,6 +1016,9 @@ export function installBundledSkills(
     }
   }
 
+  const instructionHash = hashAlwaysOnFragments();
+  const manifestInstructionTargets = installInstructionTargets(invokerHomeRoot);
+
   const manifest: BundledSkillsManifest = {
     bundledHash,
     bundledSkillNames,
@@ -722,6 +1027,8 @@ export function installBundledSkills(
     targets: manifestTargets,
     commandTargets: manifestCommandTargets,
     mcpTargets: manifestMcpTargets,
+    instructionTargets: manifestInstructionTargets,
+    instructionHash,
     sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
   };
 
@@ -736,6 +1043,61 @@ export function installBundledSkills(
     ...status,
     promptRecommended: context.isPackaged && mode === 'install' ? false : status.promptRecommended,
   };
+}
+
+function managedNamesFromManifestOrPrefix(manifest: BundledSkillsManifest | null, targetPath: string): string[] {
+  const recorded = manifest?.targets
+    ? Object.values(manifest.targets).find((entry) => entry.path === targetPath)?.installedSkillNames
+    : undefined;
+  if (recorded && recorded.length > 0) return recorded;
+  if (!existsSync(targetPath)) return [];
+  return readdirSync(targetPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(MANAGED_PREFIX))
+    .map((entry) => entry.name);
+}
+
+function managedCommandFilesFromManifestOrPrefix(manifest: BundledSkillsManifest | null, targetPath: string): string[] {
+  const recorded = manifest?.commandTargets
+    ? Object.values(manifest.commandTargets).find((entry) => entry.path === targetPath)?.installedCommandNames
+    : undefined;
+  if (recorded && recorded.length > 0) return recorded.map((name) => name.endsWith('.md') ? name : `${name}.md`);
+  if (!existsSync(targetPath)) return [];
+  return readdirSync(targetPath).filter((name) => name.startsWith(MANAGED_PREFIX) && name.endsWith('.md'));
+}
+
+function uninstallBundledSkills(context: BundledSkillsContext): BundledSkillsStatus {
+  const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
+  const isInstalled = context.isInstalled ?? commandExists;
+  const manifest = readManifest(invokerHomeRoot);
+  const sourceRoot = resolveBundledSkillsSourceRoot(context);
+  const expectedNames = sourceRoot ? prefixedSkillNames(listBundledSkillNames(sourceRoot)) : [];
+  const commandFiles = sourceRoot ? listCommandNames(sourceRoot) : [];
+
+  for (const target of resolveManagedTargets()) {
+    const names = managedNamesFromManifestOrPrefix(manifest, target.path);
+    removeManagedSkillDirs(target.path, names.length > 0 ? names : expectedNames);
+  }
+  removeManagedSkillDirs(resolveLegacyCursorSkillsPath(), expectedNames.length > 0 ? expectedNames : managedNamesFromManifestOrPrefix(manifest, resolveLegacyCursorSkillsPath()));
+
+  for (const target of resolveManagedCommandTargets()) {
+    const files = managedCommandFilesFromManifestOrPrefix(manifest, target.path);
+    removeManagedCommandFiles(target.path, files.length > 0 ? files : commandFiles);
+  }
+
+  for (const target of resolveManagedMcpTargets(isInstalled)) {
+    try {
+      uninstallMcpTarget(target);
+    } catch {
+      continue;
+    }
+  }
+
+  uninstallCursorRule();
+  uninstallCodexAgentsBlock();
+  uninstallClaudeHook(invokerHomeRoot);
+  rmSync(resolveManifestPath(invokerHomeRoot), { force: true });
+
+  return resolveBundledSkillsStatus(context);
 }
 
 export function resolveInstalledBundledSkillDir(skillName: string): string {


### PR DESCRIPTION
## Summary

Headless `install-skills` now accepts uninstall and prints each instruction target.

Help output gains a dedicated uninstall line. The existing install line stays.

## Review Claim

Approve headless `install-skills` accepting uninstall and printing instruction targets.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Uninstall is an extra install-skills mode. Existing install, update, and reinstall paths stay. Help still documents the old install line unchanged.

## Slice Rationale

Headless wiring is a separate activation surface from the installer itself. Splitting it keeps the diff in one package area.

## Non-goals

This slice does not change installer writes or skill text.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-install-skills.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0a19389f22`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10359