### PR TITLE
[install-skills-always-on-routing](5) Document always-on helpers in invoker-setup

### DIFF
--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -113,6 +113,11 @@ canonical tools, config, planning-tools, and default-preset readiness as `invoke
 default preset's tool is missing, the readiness check reports an error while startup still continues,
 and if Slack env is incomplete it logs exactly which variable is missing and to run `invoker-cli setup slack`.
 
+`invoker-cli setup` also writes Invoker-owned always-on harness instructions: a Cursor rule, a Codex
+AGENTS.md marked block, and a Claude UserPromptSubmit hook. Feature work then goes through the
+installed `invoker-plan-to-invoker` skill unless the user says "do it locally". Remove those helpers
+with `install-skills uninstall`. That does not delete the Invoker app or `~/.invoker`.
+
 ## Hard rules
 
 - Never write secrets anywhere except `~/.invoker/.env` (the wizard writes it `0600`). Never echo full

--- a/skills/invoker-setup/scripts/check-skill-contract.sh
+++ b/skills/invoker-setup/scripts/check-skill-contract.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill="$(cd "$(dirname "$0")/.." && pwd)/SKILL.md"
+
+grep -q 'always-on harness instructions' "$skill"
+grep -Fq 'unless the user says "do it locally"' "$skill"
+grep -Fq '`install-skills uninstall`' "$skill"
+grep -Fq 'does not delete the Invoker app or `~/.invoker`' "$skill"


### PR DESCRIPTION
## Summary

invoker-setup now mentions the always-on harness helpers that setup already installs.

It also names `install-skills uninstall` and says the Invoker app is left in place.

## Review Claim

Approve the invoker-setup note that setup installs always-on helpers and that uninstall leaves the app in place.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This is documentation only. It does not change installer writes. Uninstall still does not delete the Invoker app or `~/.invoker`.

## Slice Rationale

invoker-setup is a docs unit. It stays off the installer and plan-to-invoker slices so the review-unit gate can pass.

## Non-goals

This slice does not change installer code or plan-to-invoker skill text.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/invoker-setup/scripts/check-skill-contract.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f62001ec40`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10361