### PR TITLE
CI regression: a32cd53-required-fast-pr-babysit-harness

### DIFF
--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Battle-test: the mergify admin-bypass landing brain plans the right action
 # per scenario against a fake GitHub, in dry-run (no mutations):
-#   pr-dirty.json       -> repair_conflict (merge conflict)
+#   pr-dirty.json       -> rebase_onto_master (merge conflict)
 #   pr-ci-failed.json   -> repair_check (failed required check after dequeue)
 #   stack-landable.json -> requeue (clean dequeued bottom PR)
 set -euo pipefail
@@ -40,8 +40,8 @@ run_land() {
 }
 
 out="$(run_land pr-dirty.json)"
-echo "$out" | grep -q "DRY-RUN repair-conflict PR #501" \
-  || fail "pr-dirty: expected repair_conflict plan" "$out"
+echo "$out" | grep -q "DRY-RUN rebase-onto-master PR #501" \
+  || fail "pr-dirty: expected rebase_onto_master plan" "$out"
 
 out="$(run_land pr-ci-failed.json)"
 echo "$out" | grep -q 'DRY-RUN repair-check PR #601 check="PR Body"' \

--- a/scripts/repro/worker-routing-driver.mjs
+++ b/scripts/repro/worker-routing-driver.mjs
@@ -110,8 +110,8 @@ const nodeLogText = (leg) => readFileSync(leg.nodeLog, 'utf8');
   assert(leg, has(leg, '[worker:pr-admin-bypass-land] spawning scripts/cron-pr-admin-bypass-land.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
-  assert(leg, has(leg, 'DRY-RUN repair-conflict PR #501'),
-    'conflicted PR triggered the admin-bypass repair-conflict path');
+  assert(leg, has(leg, 'DRY-RUN rebase-onto-master PR #501'),
+    'conflicted PR triggered the admin-bypass rebase-onto-master path');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `required-fast / PR Babysit Harness` CI job broke because two repro/test scripts still expected the old `repair-conflict` dry-run action name.

An earlier change on master (`64937b333`, "Stop blind rebase; unify onto master") renamed the admin-bypass landing brain's conflict action from `repair_conflict` to `rebase_onto_master`.

The dry-run output changed from `DRY-RUN repair-conflict PR #501` to `DRY-RUN rebase-onto-master PR #501`.

Two harness scripts under `scripts/repro/` still asserted the old string, so they failed against already-correct production output. This change updates those two assertions to match current behavior.

## Review Claim

Approve updating the two `scripts/repro/*` assertions that check the admin-bypass dry-run action name, changing the expected string from `repair-conflict` to `rebase-onto-master`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Both edited files are read-only test/repro harnesses under `scripts/repro/`. Neither file is imported by product code, so this change cannot alter any runtime behavior; it only changes which string the harness asserts against already-shipped production output.

## Slice Rationale

This is the single root cause of the `required-fast / PR Babysit Harness` regression: two assertions in the repro harness expected an action name already renamed on master. Both edits are the same class of fix (matching an already-landed rename), so they are bundled in one slice instead of authored as separate PRs.

## Non-goals

This PR does not touch the admin-bypass landing brain or any other product code — the rename it asserts against already landed in `64937b333`. It does not address the same `repair_conflict` naming still used by the unrelated `mergify_admin_requeue_*` subsystem (a different plan-name helper for a different job), which is out of scope for this job-scoped fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-suites/required/28-pr-babysit-harness.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>