### PR TITLE
[admin-bypass-repair-bot-thread-pr-10361-eb2543b](1) Document installed helper guidance

### DIFF
--- a/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
+++ b/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
@@ -12,4 +12,20 @@ describe('plan-to-invoker skill contract', () => {
     expect(skill).toContain('show its ordered steps plus `confirmationText`');
     expect(skill).toContain('call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`');
   });
+
+  it('documents always-on install-skills helpers and the local override', () => {
+    const skill = readFileSync(join(repoRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), 'utf8');
+
+    expect(skill).toContain('always on via Cursor `~/.cursor/rules/invoker-execution-precedence.mdc`');
+    expect(skill).toContain('a Codex AGENTS.md marked block');
+    expect(skill).toContain('a Claude UserPromptSubmit hook');
+    expect(skill).toContain(
+      'clean-tree edits stay local; feature work and dirty trees go through this',
+    );
+    expect(skill).toContain('unless the user says "do it locally"');
+    expect(skill).toContain('`install-skills uninstall`. Trigger: "convert to invoker",');
+    expect(skill).toContain(
+      '"/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into',
+    );
+  });
 });

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: plan-to-invoker
 description: >
-  Convert a plan into an Invoker YAML plan file. Trigger: "convert to invoker",
+  Convert a plan into an Invoker YAML plan file. After `install-skills`, this
+  routing is always on via Cursor `~/.cursor/rules/invoker-execution-precedence.mdc`,
+  a Codex AGENTS.md marked block, and a Claude UserPromptSubmit hook. Tiny
+  clean-tree edits stay local; feature work and dirty trees go through this
+  skill unless the user says "do it locally". Uninstall with
+  `install-skills uninstall`. Trigger: "convert to invoker",
   "submit to invoker", "create invoker plan", "invoker-plan-to-invoker",
   "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
   Invoker tasks. For benchmark/direct-output prompts with "Required output path",


### PR DESCRIPTION
## Summary

This review slice documents the installed helpers that send plan work to plan-to-invoker across Cursor, Codex, and Claude.

Focused assertions keep clean-tree, dirty-tree, local override, trigger phrase, and uninstall guidance aligned with the skill description.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1787626500732-7/repair | Resolve bot review thread on PR #10361 | completed |
| wf-1787626500732-7/safe-push | Safely push PR #10361 only if its head did not move | completed (passed) |

</details>

## Review Claim

Approve the plan-to-invoker description and focused assertions as one tooling-policy unit for installed helper guidance.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Assumptions: unconfirmed because publication is headless. This slice only edits skill guidance and a focused test; it does not edit installer writes or execution behavior.

## Slice Rationale

The skill description and its exact assertions belong together because the test prevents the documented helper policy from drifting.

## Non-goals

This slice does not change installer implementation, execution behavior, or unrelated skills.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-to-invoker-skill.test.ts`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/admin-bypass-repair-bot-thread-pr-10361-eb2543b.md --base stack/EdbertChan/pr/install-skills-always-on-routing/install-skills-always-routing-3-expose-uninstall--d7287829`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6228124c3`
- Post-revert steps: None
- Data migration? No

</details>
