### PR TITLE
[CI regression: a32cd53-required-fast-mergify-admin-requeue](1) Realign admin-bypass repros with the post-#10337 planner

### DIFF
--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Battle-test: the mergify admin-bypass landing brain plans the right action
 # per scenario against a fake GitHub, in dry-run (no mutations):
-#   pr-dirty.json       -> repair_conflict (merge conflict)
+#   pr-dirty.json       -> rebase_onto_master (merge conflict)
 #   pr-ci-failed.json   -> repair_check (failed required check after dequeue)
 #   stack-landable.json -> requeue (clean dequeued bottom PR)
 set -euo pipefail
@@ -40,8 +40,8 @@ run_land() {
 }
 
 out="$(run_land pr-dirty.json)"
-echo "$out" | grep -q "DRY-RUN repair-conflict PR #501" \
-  || fail "pr-dirty: expected repair_conflict plan" "$out"
+echo "$out" | grep -q "DRY-RUN rebase-onto-master PR #501 GitHub reports merge conflict" \
+  || fail "pr-dirty: expected rebase_onto_master plan" "$out"
 
 out="$(run_land pr-ci-failed.json)"
 echo "$out" | grep -q 'DRY-RUN repair-check PR #601 check="PR Body"' \

--- a/scripts/repro/repro-babysit-rebase-onto-base.sh
+++ b/scripts/repro/repro-babysit-rebase-onto-base.sh
@@ -119,24 +119,27 @@ run_worker() {
   python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6201 "$@" 2>&1
 }
 
+# Since #10337 ("Stop blind rebase; unify onto master"), a bottom PR whose
+# base pointer already equals trunk is never locally force-pushed just for
+# stale/diverged content -- see test_stale_base_content_requeues_without_rebase
+# in scripts/test_mergify_admin_requeue_plan.py. The worker must requeue
+# without touching the remote branch, even for this exact #7727 shape.
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"
 fi
 printf '%s\n' "$out1"
 
-echo "$out1" | grep -q 'rebase-onto-base PR #6201 onto=master' || fail 'tick 1 did not plan a rebase-onto-base action' "$out1"
-! echo "$out1" | grep -q 'requeue PR #6201' || fail 'tick 1 requeued a PR whose content was never rebased' "$out1"
-! echo "$out1" | grep -q 'repair-check PR #6201' || fail 'tick 1 spent an agent-repair attempt instead of rebasing' "$out1"
+echo "$out1" | grep -q "requeue PR #6201 head=$STALE_HEAD reason=eligible-when-ready" \
+  || fail 'tick 1 did not requeue the stale-based PR without rebasing' "$out1"
+! echo "$out1" | grep -q 'rebase-onto-base PR #6201' || fail 'tick 1 planned a legacy local rebase-onto-base force-push' "$out1"
+! echo "$out1" | grep -q 'rebase-onto-master PR #6201' || fail 'tick 1 planned an Invoker rebase-onto-master job for stale-base-alone' "$out1"
 
 NEW_REMOTE_HEAD="$(git --git-dir="$REMOTE" rev-parse stack/rebase-onto-base)"
-export NEW_REMOTE_HEAD
-if [ "$NEW_REMOTE_HEAD" = "$STALE_HEAD" ]; then
-  fail 'tick 1 did not push a real rebase to the remote branch'
+if [ "$NEW_REMOTE_HEAD" != "$STALE_HEAD" ]; then
+  fail 'requeue must never force-push; remote branch moved' "$NEW_REMOTE_HEAD"
 fi
-git --git-dir="$REMOTE" merge-base --is-ancestor "$MASTER_HEAD" "$NEW_REMOTE_HEAD" \
-  || fail 'rebased remote head is still not a descendant of master'
 
-python3 - <<'PY' || fail 'expected a rebase-onto-base ledger row, not repair-check' "$(cat "$LEDGER_PATH")"
+python3 - <<'PY' || fail 'expected a requeue ledger row, not a rebase' "$(cat "$LEDGER_PATH")"
 import json
 import os
 from pathlib import Path
@@ -148,36 +151,14 @@ rows = [
 ]
 matches = [
     row for row in rows
-    if row.get("kind") == "rebase-onto-base"
-    and row.get("key") == "master"
+    if row.get("kind") == "requeue"
+    and row.get("key") == "ready"
     and int(row.get("pr", 0)) == 6201
 ]
 if len(matches) != 1:
-    raise SystemExit(f"expected 1 rebase-onto-base row, saw {len(matches)}")
-if any(row.get("kind") == "repair-check" and int(row.get("pr", 0)) == 6201 for row in rows):
-    raise SystemExit("repair-check must not be attempted for a structural stale-base failure")
+    raise SystemExit(f"expected 1 requeue row, saw {len(matches)}")
+if any(row.get("kind") in {"rebase-onto-base", "rebase-onto-master"} and int(row.get("pr", 0)) == 6201 for row in rows):
+    raise SystemExit("a rebase must not be filed for stale-base-alone content")
 PY
-
-# Tick 2: simulate the loader now observing the rebased head (a real cycle
-# would see this via a fresh `gh pr view`). Ancestry is clean now, so the
-# planner must fall through to a normal requeue instead of rebasing again.
-python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-
-state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
-state["prs"][0]["headRefOid"] = os.environ["NEW_REMOTE_HEAD"]
-state["compare_status"][f"master...{os.environ['NEW_REMOTE_HEAD']}"] = "ahead"
-Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
-PY
-
-if ! out2="$(run_worker --dry-run)"; then
-  fail 'tick 2: worker failed' "$out2"
-fi
-printf '%s\n' "$out2"
-
-echo "$out2" | grep -q 'DRY-RUN requeue PR #6201' || fail 'tick 2 did not requeue the now-clean PR' "$out2"
-! echo "$out2" | grep -q 'rebase-onto-base PR #6201' || fail 'tick 2 planned another rebase despite clean ancestry' "$out2"
 
 echo '[repro] passed'

--- a/scripts/repro/worker-routing-driver.mjs
+++ b/scripts/repro/worker-routing-driver.mjs
@@ -110,8 +110,8 @@ const nodeLogText = (leg) => readFileSync(leg.nodeLog, 'utf8');
   assert(leg, has(leg, '[worker:pr-admin-bypass-land] spawning scripts/cron-pr-admin-bypass-land.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
-  assert(leg, has(leg, 'DRY-RUN repair-conflict PR #501'),
-    'conflicted PR triggered the admin-bypass repair-conflict path');
+  assert(leg, has(leg, 'DRY-RUN rebase-onto-master PR #501 GitHub reports merge conflict'),
+    'conflicted PR triggered the admin-bypass rebase-onto-master path');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
<!-- invoker-ci-regression-watch: first-bad-sha=a32cd53dee8d54e1e40ed904455fa1c5fb970fe1; job=required-fast / Mergify Admin Requeue -->

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch push commit a32cd53dee8d54e1e40ed904455fa1c5fb970fe1 in run 32798968580 and stayed red there.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/32798968580/job/97656472866

The cause is PR #10337, which unified the admin-bypass landing planner onto master. A merge conflict now plans `rebase-onto-master`, and an out-of-date base alone now requeues.

Three repro scripts in the required suite still asserted the legacy plans: `repair-conflict` for conflicts and a local `rebase-onto-base` force-push for out-of-date bases.

This slice realigns those assertions with the shipped planner. The second repro now also asserts the remote branch is never force-pushed during a requeue.

## Review Claim

These repro assertions now describe exactly what the planner ships since #10337: a merge conflict plans `rebase-onto-master`, and an out-of-date base alone requeues without any local force-push.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only files under `scripts/repro/` change. No planner, product, or CI-policy code is touched, so runtime behavior is identical; only the required suite's expectations change.

## Slice Rationale

One slice for the failing CI job's root cause: the outdated legacy-plan assertions. The remaining repro for named-check failures is flipped in the next slice with its own claim.

## Non-goals

- No planner or product changes; the shipped #10337 behavior is taken as reviewed truth.
- No test weakening: every legacy assertion is replaced by an equally strict assertion on the new plan, plus negative checks rejecting the legacy plans.
- No unrelated cleanup or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-land-dryrun.sh` (exit 0, `[repro] passed`)
- [x] `bash scripts/repro/repro-babysit-rebase-onto-base.sh` (exit 0, `[repro] passed`)
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but the required job `required-fast / Mergify Admin Requeue` goes red again because the legacy assertions contradict the shipped planner.
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
