### PR TITLE
[CI regression: a32cd53-required-fast-mergify-admin-requeue](2) Pin repair-check for named check failures

### DIFF
--- a/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
+++ b/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
@@ -44,9 +44,14 @@ SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/7727"
 
 # PR #7727 incident shape, with real git history: a required check ("PR
-# Body") is failing because the branch carries a pre-squash duplicate of
-# already-landed content, not because of anything a code change could fix.
-# Before this fix, the worker spent all of its repair-check attempts on it.
+# Body") is failing while the branch also carries a pre-squash duplicate of
+# already-landed content (base status "diverged", not just "behind"). Since
+# #10337 ("Stop blind rebase; unify onto master"), a named required-check
+# failure always goes to repair_check, even when the base is stale/diverged
+# -- see test_failed_pr_body_with_stale_base_still_repairs_not_rebases in
+# scripts/test_mergify_admin_requeue_plan.py. A blind local rebase-onto-base
+# force-push must never be planned for a named check failure; only the
+# repair agent can tell whether "PR Body" needs a body edit or a split.
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
@@ -123,10 +128,11 @@ if ! out1="$(run_worker)"; then
 fi
 printf '%s\n' "$out1"
 
-echo "$out1" | grep -q 'rebase-onto-base PR #7727 onto=master' || fail 'tick 1 did not route the failing check to rebase-onto-base' "$out1"
-! echo "$out1" | grep -q 'repair-check PR #7727' || fail 'tick 1 spent an agent-repair attempt on a structural stale-base failure' "$out1"
+echo "$out1" | grep -q 'repair-check PR #7727 check="PR Body"' || fail 'tick 1 did not route the failing check to repair-check' "$out1"
+! echo "$out1" | grep -q 'rebase-onto-base PR #7727' || fail 'tick 1 planned a legacy local rebase-onto-base force-push for a named check failure' "$out1"
+! echo "$out1" | grep -q 'rebase-onto-master PR #7727' || fail 'tick 1 planned an Invoker rebase-onto-master job for a named check failure' "$out1"
 
-python3 - <<PY || fail 'expected a rebase-onto-base ledger row and zero repair-check rows' "$(cat "$LEDGER_PATH")"
+python3 - <<PY || fail 'expected a repair-check ledger row and zero rebase rows' "$(cat "$LEDGER_PATH")"
 import json
 from pathlib import Path
 
@@ -135,10 +141,10 @@ rows = [
     for line in Path("$LEDGER_PATH").read_text(encoding="utf-8").splitlines()
     if line.strip()
 ]
-if not any(row.get("kind") == "rebase-onto-base" and int(row.get("pr", 0)) == 7727 for row in rows):
-    raise SystemExit("missing rebase-onto-base ledger row for PR #7727")
-if any(row.get("kind") == "repair-check" and int(row.get("pr", 0)) == 7727 for row in rows):
-    raise SystemExit("repair-check must never be attempted for a structural stale-base failure")
+if not any(row.get("kind") == "repair-check" and int(row.get("pr", 0)) == 7727 for row in rows):
+    raise SystemExit("missing repair-check ledger row for PR #7727")
+if any(row.get("kind") in {"rebase-onto-base", "rebase-onto-master"} and int(row.get("pr", 0)) == 7727 for row in rows):
+    raise SystemExit("a rebase must never be planned for a named required-check failure")
 PY
 
 echo '[repro] passed'


### PR DESCRIPTION
## Summary

PR #10337 also changed how the worker handles a named required-check failure on a PR whose base is out of date or diverged: it now always plans `repair-check`.

The #7727-shape repro still demanded the legacy behavior, a blind local `rebase-onto-base` force-push instead of any agent repair attempt.

This slice flips that repro to expect `repair-check` for the failing "PR Body" check and to fail on any rebase plan, matching `test_failed_pr_body_with_stale_base_still_repairs_not_rebases`.

Only the repair agent can tell whether a failing "PR Body" check needs a body edit or a PR restructure, so a rebase must never preempt it.

## Review Claim

This repro now pins the shipped rule: a named required-check failure always gets `repair-check`, never a local or Invoker rebase, even when the base has diverged.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only one repro script under `scripts/repro/` changes. The verification command and all product code are identical before and after this slice.

## Slice Rationale

One proof slice pinning the named-check-failure rule, kept apart from the previous slice's assertion realignment so each repro change carries exactly one claim.

## Non-goals

- No planner or product changes.
- No changes to the other repro scripts or to the required-suite runner.
- No test weakening: the repro keeps its ledger-row checks and adds negative assertions against both rebase kinds.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh` (exit 0, `[repro] passed`)
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but the required job `required-fast / Mergify Admin Requeue` goes red again because this repro would reassert the pre-#10337 behavior.
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
