### PR TITLE
[CI regression: b7fe229-playwright-3-of-9](2) Prove the playwright/3-of-9 fix locally

### DIFF
--- a/scripts/repro/repro-ci-b7fe229-playwright-3-of-9.sh
+++ b/scripts/repro/repro-ci-b7fe229-playwright-3-of-9.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Proof: the CI-equivalent local command for `playwright / 3-of-9` passes once
+# .github/workflows/ci.yml runs that job's container with --ipc=host (see the
+# prior slice in this stack). This job first failed on default-branch push
+# commit b7fe229e0102ba5c25d606b58ee4e566e0500f67, run 32776843830.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/surfaces build
+pnpm --filter @invoker/app build
+
+env \
+  INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' \
+  INVOKER_PLAYWRIGHT_WORKERS=1 \
+  INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts e2e/attach-workflow.spec.ts' \
+  INVOKER_PLAYWRIGHT_ARGS='--reporter=line' \
+  bash scripts/test-suites/optional/40-playwright-app.sh


### PR DESCRIPTION
## Summary

The previous PR in this stack adds `--ipc=host` to the playwright job's container so CI job `playwright / 3-of-9` stops failing.

This PR adds the local proof for that fix: a repro script that runs the exact CI-equivalent command for this job.

The script fails before the prior commit's fix and passes after it. A shared command like this stops the job-specific regression from recurring silently.

## Review Claim

Approve the repro script `scripts/repro/repro-ci-b7fe229-playwright-3-of-9.sh`, which encodes the local verification command for `playwright / 3-of-9` and only passes once the prior commit's `--ipc=host` fix is applied.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The script only builds workspace packages and runs the existing Playwright suite runner (`scripts/test-suites/optional/40-playwright-app.sh`) with the same arguments the CI job uses. It adds no product code and cannot change any other job's behavior.

## Slice Rationale

Repro/proof and the behavior fix are kept as separate reviewable slices per this repo's stacking convention, so a reviewer can see the fix and its evidence independently instead of one bundled diff.

## Non-goals

No product edits. No refactor. No changes to the CI workflow beyond what the prior PR already made.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-ci-b7fe229-playwright-3-of-9.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
