### PR TITLE
[multi-repo-pr-workers](1) Add prMaintenance.targetRepos for multi-repo PR scans

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -14,7 +14,11 @@ import {
   resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
   resolveEnabledExecutionAgents,
+  resolvePrMaintenanceTargetRepos,
+  resolvePrMaintenanceWorkerConfig,
+  DEFAULT_PR_MAINTENANCE_TARGET_REPO,
 } from '../config.js';
+import { validateInvokerConfig } from '../config-validation.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -605,5 +609,44 @@ describe('filterPlanningPresets', () => {
   it('normalizes allowlist whitespace and case', () => {
     expect(filterPlanningPresets(presets, { enabledExecutionAgents: [' Claude '] }).map((p) => p.key))
       .toEqual(['claude', 'cursor+claude', 'omp+claude']);
+  });
+});
+
+describe('prMaintenance.targetRepos', () => {
+  it('reads targetRepos from config', () => {
+    expect(resolvePrMaintenanceTargetRepos({
+      prMaintenance: {
+        targetRepos: ['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack'],
+      },
+    })).toEqual(['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack']);
+  });
+
+  it('defaults to the Invoker repo when targetRepos is omitted', () => {
+    expect(resolvePrMaintenanceTargetRepos({})).toEqual([DEFAULT_PR_MAINTENANCE_TARGET_REPO]);
+    expect(resolvePrMaintenanceTargetRepos({
+      prMaintenance: { targetRepos: [] },
+    })).toEqual([DEFAULT_PR_MAINTENANCE_TARGET_REPO]);
+  });
+
+  it('forwards config targetRepos into worker env for shell entrypoints', () => {
+    const launch = resolvePrMaintenanceWorkerConfig({
+      prMaintenance: {
+        targetRepos: ['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack'],
+        env: {
+          INVOKER_GITHUB_TARGET_REPOS: 'should/not-win',
+          INVOKER_GITHUB_TARGET_REPO: 'should/not-win',
+        },
+      },
+    });
+    expect(launch?.env?.INVOKER_GITHUB_TARGET_REPOS).toBe(
+      'Neko-Catpital-Labs/Invoker,EdbertChan/catstack',
+    );
+    expect(launch?.env?.INVOKER_GITHUB_TARGET_REPO).toBe('Neko-Catpital-Labs/Invoker');
+  });
+
+  it('rejects invalid targetRepos entries', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['not-a-repo'] },
+    })).toThrow(/owner\/repo/);
   });
 });

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -649,4 +649,16 @@ describe('prMaintenance.targetRepos', () => {
       prMaintenance: { targetRepos: ['not-a-repo'] },
     })).toThrow(/owner\/repo/);
   });
+
+  it('rejects targetRepos entries with disallowed punctuation', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['owner/bad?name'] },
+    })).toThrow(/owner\/repo/);
+  });
+
+  it('rejects targetRepos entries containing a comma', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['owner,other/repo'] },
+    })).toThrow(/owner\/repo/);
+  });
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,5 +1,5 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
-import type { InvokerConfig } from './config.js';
+import { normalizeGithubOwnerRepo, type InvokerConfig } from './config.js';
 
 const builtinAgents = registerBuiltinAgents();
 
@@ -10,6 +10,21 @@ function validateConfiguredModel(agentName: string | undefined, executionModel: 
   const agent = builtinAgents.get(normalizedAgent);
   if (!agent) return;
   assertExecutionModelSupported(agent, normalizedModel);
+}
+
+function validatePrMaintenanceTargetRepos(config: InvokerConfig): void {
+  const targetRepos = config.prMaintenance?.targetRepos;
+  if (targetRepos === undefined) return;
+  if (!Array.isArray(targetRepos)) {
+    throw new Error('prMaintenance.targetRepos must be an array of "owner/repo" strings');
+  }
+  for (const entry of targetRepos) {
+    if (typeof entry !== 'string' || !normalizeGithubOwnerRepo(entry)) {
+      throw new Error(
+        `prMaintenance.targetRepos entries must be "owner/repo" strings; got ${JSON.stringify(entry)}`,
+      );
+    }
+  }
 }
 
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
@@ -38,5 +53,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
 
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
+  validatePrMaintenanceTargetRepos(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -70,7 +70,7 @@ export interface PrMaintenanceConfig {
 
 export const DEFAULT_PR_MAINTENANCE_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
 
-const GITHUB_OWNER_REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+const GITHUB_OWNER_REPO_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/;
 
 /** Normalize and validate a GitHub `owner/repo` string; returns null when invalid. */
 export function normalizeGithubOwnerRepo(value: string): string | null {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -61,6 +61,40 @@ export interface PrMaintenanceConfig {
   lockPath?: string;
   /** Shell executable used to run the entrypoint. Defaults to bash. */
   shell?: string;
+  /**
+   * GitHub `owner/repo` list scanned each PR-maintenance tick (admin-bypass,
+   * orphan repair, duplicate close). When omitted, defaults to the Invoker repo.
+   */
+  targetRepos?: string[];
+}
+
+export const DEFAULT_PR_MAINTENANCE_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
+
+const GITHUB_OWNER_REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Normalize and validate a GitHub `owner/repo` string; returns null when invalid. */
+export function normalizeGithubOwnerRepo(value: string): string | null {
+  const trimmed = value.trim();
+  if (!GITHUB_OWNER_REPO_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Resolve the PR-maintenance scan list from `prMaintenance.targetRepos`.
+ * When omitted or empty, defaults to the Invoker repo only.
+ */
+export function resolvePrMaintenanceTargetRepos(config: InvokerConfig): string[] {
+  const fromConfig = config.prMaintenance?.targetRepos;
+  if (Array.isArray(fromConfig) && fromConfig.length > 0) {
+    const repos: string[] = [];
+    for (const entry of fromConfig) {
+      if (typeof entry !== 'string') continue;
+      const normalized = normalizeGithubOwnerRepo(entry);
+      if (normalized && !repos.includes(normalized)) repos.push(normalized);
+    }
+    if (repos.length > 0) return repos;
+  }
+  return [DEFAULT_PR_MAINTENANCE_TARGET_REPO];
 }
 
 export interface SlackBugScanConfig {
@@ -612,9 +646,18 @@ export function resolvePrMaintenanceWorkerConfig(
   }
   const launch: PrMaintenanceWorkerConfig = {};
   if (prMaintenance.repoRoot !== undefined) launch.repoRoot = prMaintenance.repoRoot;
-  if (prMaintenance.env !== undefined) launch.env = prMaintenance.env;
   if (prMaintenance.intervalMs !== undefined) launch.intervalMs = prMaintenance.intervalMs;
   if (prMaintenance.lockPath !== undefined) launch.lockPath = prMaintenance.lockPath;
   if (prMaintenance.shell !== undefined) launch.shell = prMaintenance.shell;
+
+  const targetRepos = resolvePrMaintenanceTargetRepos(config);
+  // Config is authoritative; always inject the scan list for the shell entrypoints.
+  const env: Record<string, string | undefined> = {
+    ...(prMaintenance.env ?? {}),
+    INVOKER_GITHUB_TARGET_REPOS: targetRepos.join(','),
+    INVOKER_GITHUB_TARGET_REPO: targetRepos[0],
+  };
+  launch.env = env;
+
   return Object.keys(launch).length > 0 ? launch : {};
 }


### PR DESCRIPTION
## Summary

PR maintenance needs config-owned GitHub owner/repo targets.

This adds `prMaintenance.targetRepos`. When omitted, only Invoker is used.

Env vars do not choose those targets.

## Review Claim

Approve config-owned `prMaintenance.targetRepos` for PR-maintenance workers.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Config owns the targets; omit defaults to Invoker only; merge-gate publish stays single-repo and untouched.

## Slice Rationale

This field must land before workers and cron consume it.

## Non-goals

- Does not change cron or Mergify loops
- Does not change review-gate lookup
- Does not change merge-gate publish targeting

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR maintenance can now scan one or more configured repositories.
  * When no repositories are specified, scanning defaults to the Invoker repository.
  * Custom repository settings are passed through consistently to PR maintenance workers.
* **Bug Fixes**
  * Added validation to reject incorrectly formatted repository names and provide clearer configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->