### PR TITLE
[multi-repo-pr-workers](3) Namespace blocked-PR worker decisions as owner/repo#N

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -14,7 +14,11 @@ import {
   resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
   resolveEnabledExecutionAgents,
+  resolvePrMaintenanceTargetRepos,
+  resolvePrMaintenanceWorkerConfig,
+  DEFAULT_PR_MAINTENANCE_TARGET_REPO,
 } from '../config.js';
+import { validateInvokerConfig } from '../config-validation.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -605,5 +609,44 @@ describe('filterPlanningPresets', () => {
   it('normalizes allowlist whitespace and case', () => {
     expect(filterPlanningPresets(presets, { enabledExecutionAgents: [' Claude '] }).map((p) => p.key))
       .toEqual(['claude', 'cursor+claude', 'omp+claude']);
+  });
+});
+
+describe('prMaintenance.targetRepos', () => {
+  it('reads targetRepos from config', () => {
+    expect(resolvePrMaintenanceTargetRepos({
+      prMaintenance: {
+        targetRepos: ['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack'],
+      },
+    })).toEqual(['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack']);
+  });
+
+  it('defaults to the Invoker repo when targetRepos is omitted', () => {
+    expect(resolvePrMaintenanceTargetRepos({})).toEqual([DEFAULT_PR_MAINTENANCE_TARGET_REPO]);
+    expect(resolvePrMaintenanceTargetRepos({
+      prMaintenance: { targetRepos: [] },
+    })).toEqual([DEFAULT_PR_MAINTENANCE_TARGET_REPO]);
+  });
+
+  it('forwards config targetRepos into worker env for shell entrypoints', () => {
+    const launch = resolvePrMaintenanceWorkerConfig({
+      prMaintenance: {
+        targetRepos: ['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack'],
+        env: {
+          INVOKER_GITHUB_TARGET_REPOS: 'should/not-win',
+          INVOKER_GITHUB_TARGET_REPO: 'should/not-win',
+        },
+      },
+    });
+    expect(launch?.env?.INVOKER_GITHUB_TARGET_REPOS).toBe(
+      'Neko-Catpital-Labs/Invoker,EdbertChan/catstack',
+    );
+    expect(launch?.env?.INVOKER_GITHUB_TARGET_REPO).toBe('Neko-Catpital-Labs/Invoker');
+  });
+
+  it('rejects invalid targetRepos entries', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['not-a-repo'] },
+    })).toThrow(/owner\/repo/);
   });
 });

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -649,4 +649,16 @@ describe('prMaintenance.targetRepos', () => {
       prMaintenance: { targetRepos: ['not-a-repo'] },
     })).toThrow(/owner\/repo/);
   });
+
+  it('rejects targetRepos entries with disallowed punctuation', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['owner/bad?name'] },
+    })).toThrow(/owner\/repo/);
+  });
+
+  it('rejects targetRepos entries containing a comma', () => {
+    expect(() => validateInvokerConfig({
+      prMaintenance: { targetRepos: ['owner,other/repo'] },
+    })).toThrow(/owner\/repo/);
+  });
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,5 +1,5 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
-import type { InvokerConfig } from './config.js';
+import { normalizeGithubOwnerRepo, type InvokerConfig } from './config.js';
 
 const builtinAgents = registerBuiltinAgents();
 
@@ -10,6 +10,21 @@ function validateConfiguredModel(agentName: string | undefined, executionModel: 
   const agent = builtinAgents.get(normalizedAgent);
   if (!agent) return;
   assertExecutionModelSupported(agent, normalizedModel);
+}
+
+function validatePrMaintenanceTargetRepos(config: InvokerConfig): void {
+  const targetRepos = config.prMaintenance?.targetRepos;
+  if (targetRepos === undefined) return;
+  if (!Array.isArray(targetRepos)) {
+    throw new Error('prMaintenance.targetRepos must be an array of "owner/repo" strings');
+  }
+  for (const entry of targetRepos) {
+    if (typeof entry !== 'string' || !normalizeGithubOwnerRepo(entry)) {
+      throw new Error(
+        `prMaintenance.targetRepos entries must be "owner/repo" strings; got ${JSON.stringify(entry)}`,
+      );
+    }
+  }
 }
 
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
@@ -38,5 +53,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
 
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
+  validatePrMaintenanceTargetRepos(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -70,7 +70,7 @@ export interface PrMaintenanceConfig {
 
 export const DEFAULT_PR_MAINTENANCE_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
 
-const GITHUB_OWNER_REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+const GITHUB_OWNER_REPO_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/;
 
 /** Normalize and validate a GitHub `owner/repo` string; returns null when invalid. */
 export function normalizeGithubOwnerRepo(value: string): string | null {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -61,6 +61,40 @@ export interface PrMaintenanceConfig {
   lockPath?: string;
   /** Shell executable used to run the entrypoint. Defaults to bash. */
   shell?: string;
+  /**
+   * GitHub `owner/repo` list scanned each PR-maintenance tick (admin-bypass,
+   * orphan repair, duplicate close). When omitted, defaults to the Invoker repo.
+   */
+  targetRepos?: string[];
+}
+
+export const DEFAULT_PR_MAINTENANCE_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
+
+const GITHUB_OWNER_REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Normalize and validate a GitHub `owner/repo` string; returns null when invalid. */
+export function normalizeGithubOwnerRepo(value: string): string | null {
+  const trimmed = value.trim();
+  if (!GITHUB_OWNER_REPO_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Resolve the PR-maintenance scan list from `prMaintenance.targetRepos`.
+ * When omitted or empty, defaults to the Invoker repo only.
+ */
+export function resolvePrMaintenanceTargetRepos(config: InvokerConfig): string[] {
+  const fromConfig = config.prMaintenance?.targetRepos;
+  if (Array.isArray(fromConfig) && fromConfig.length > 0) {
+    const repos: string[] = [];
+    for (const entry of fromConfig) {
+      if (typeof entry !== 'string') continue;
+      const normalized = normalizeGithubOwnerRepo(entry);
+      if (normalized && !repos.includes(normalized)) repos.push(normalized);
+    }
+    if (repos.length > 0) return repos;
+  }
+  return [DEFAULT_PR_MAINTENANCE_TARGET_REPO];
 }
 
 export interface SlackBugScanConfig {
@@ -612,9 +646,18 @@ export function resolvePrMaintenanceWorkerConfig(
   }
   const launch: PrMaintenanceWorkerConfig = {};
   if (prMaintenance.repoRoot !== undefined) launch.repoRoot = prMaintenance.repoRoot;
-  if (prMaintenance.env !== undefined) launch.env = prMaintenance.env;
   if (prMaintenance.intervalMs !== undefined) launch.intervalMs = prMaintenance.intervalMs;
   if (prMaintenance.lockPath !== undefined) launch.lockPath = prMaintenance.lockPath;
   if (prMaintenance.shell !== undefined) launch.shell = prMaintenance.shell;
+
+  const targetRepos = resolvePrMaintenanceTargetRepos(config);
+  // Config is authoritative; always inject the scan list for the shell entrypoints.
+  const env: Record<string, string | undefined> = {
+    ...(prMaintenance.env ?? {}),
+    INVOKER_GITHUB_TARGET_REPOS: targetRepos.join(','),
+    INVOKER_GITHUB_TARGET_REPO: targetRepos[0],
+  };
+  launch.env = env;
+
   return Object.keys(launch).length > 0 ? launch : {};
 }

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -232,16 +232,16 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
     }
     case 'review-gate': {
       const arg = flags.positional[0];
-      if (!arg) throw new Error('Usage: --headless query review-gate <prNumber|prUrl> [--output text|json|jsonl|label]');
-      const prNumber = parsePrNumber(arg);
-      if (!prNumber) throw new Error(`Could not parse a PR number from "${arg}".`);
-      const record = deps.persistence.findReviewGateByPr(prNumber);
+      if (!arg) throw new Error('Usage: --headless query review-gate <prNumber|owner/repo#pr|prUrl> [--output text|json|jsonl|label]');
+      const parsed = parseReviewGatePrArg(arg);
+      if (!parsed) throw new Error(`Could not parse a PR number from "${arg}".`);
+      const record = deps.persistence.findReviewGateByPr(parsed.prNumber, parsed.repo);
       switch (flags.output) {
         case 'label': writeOut(`${record?.workflowId ?? ''}\n`); break;
         case 'json':  writeOut(formatAsJson(record ?? {}) + '\n'); break;
         case 'jsonl': writeOut(formatAsJsonl(record ? [record] : []) + '\n'); break;
         default:      if (!record) {
-          writeOut(`No Invoker workflow found for PR ${prNumber}.\n`);
+          writeOut(`No Invoker workflow found for PR ${parsed.prNumber}.\n`);
           break;
         }
         {
@@ -250,7 +250,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
           const gate = buildReviewGateQueryResponse({ workflowId: record.workflowId, workflow, tasks });
           const substate = gate.substate ?? 'null';
           writeOut(
-            `${record.workflowId}\t${record.reviewId ?? prNumber}\t${record.workflowStatus}\tgen=${record.workflowGeneration}\tsubstate=${substate}\t${record.branch ?? ''}\n`,
+            `${record.workflowId}\t${record.reviewId ?? parsed.prNumber}\t${record.workflowStatus}\tgen=${record.workflowGeneration}\tsubstate=${substate}\t${record.branch ?? ''}\n`,
           );
         }
         break;
@@ -600,15 +600,25 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
 }
 
 /**
- * Parse a PR number from either a bare number (`999`, `#999`) or a full PR URL
- * (`https://github.com/owner/repo/pull/999`). Returns undefined when neither
- * shape matches.
+ * Parse a PR number from either a bare number (`999`, `#999`), `owner/repo#999`,
+ * or a full PR URL (`https://github.com/owner/repo/pull/999`). Returns undefined
+ * when none of those shapes match.
  */
 function parsePrNumber(arg: string): string | undefined {
-  const fromUrl = arg.match(/\/pull\/(\d+)/);
-  if (fromUrl) return fromUrl[1];
+  return parseReviewGatePrArg(arg)?.prNumber;
+}
+
+function parseReviewGatePrArg(arg: string): { prNumber: string; repo?: string } | undefined {
+  const fromUrl = arg.match(/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/i);
+  if (fromUrl) {
+    return { prNumber: fromUrl[3], repo: `${fromUrl[1]}/${fromUrl[2]}` };
+  }
+  const fromNwo = arg.match(/^([^/\s#]+)\/([^/\s#]+)#(\d+)$/);
+  if (fromNwo) {
+    return { prNumber: fromNwo[3], repo: `${fromNwo[1]}/${fromNwo[2]}` };
+  }
   const bare = arg.replace(/^#/, '');
-  return /^\d+$/.test(bare) ? bare : undefined;
+  return /^\d+$/.test(bare) ? { prNumber: bare } : undefined;
 }
 
 async function headlessCosts(

--- a/packages/data-store/src/__tests__/find-review-gate-by-pr.test.ts
+++ b/packages/data-store/src/__tests__/find-review-gate-by-pr.test.ts
@@ -134,4 +134,16 @@ describe('SQLiteAdapter.findReviewGateByPr', () => {
     expect(result?.workflowId).toBe('wf-gen3');
     expect(result?.workflowGeneration).toBe(3);
   });
+
+  it('does not attach a foreign-repo PR number to an Invoker bare review_id', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-invoker'));
+    adapter.saveTask('wf-invoker', makeMergeTask('wf-invoker', {
+      reviewId: '999',
+      reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/999',
+    }));
+
+    expect(adapter.findReviewGateByPr('999', 'EdbertChan/catstack')).toBeUndefined();
+    expect(adapter.findReviewGateByPr('999', 'Neko-Catpital-Labs/Invoker')?.workflowId).toBe('wf-invoker');
+    expect(adapter.findReviewGateByPr('999')?.workflowId).toBe('wf-invoker');
+  });
 });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -399,8 +399,11 @@ export interface PersistenceAdapter {
   loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
   listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
-  /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
-  findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
+  /** Resolve a GitHub PR number back to its Invoker workflow via the merge node.
+   * When `repo` is set (owner/repo), prefer URL matches for that repo; bare
+   * review_id matches are allowed only for the default Invoker repo (or when
+   * `repo` is omitted). */
+  findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined;
 
   // Tasks
   saveTask(workflowId: string, task: TaskState): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1220,8 +1220,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.listWorkflows(options);
   }
 
-  findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
-    return this.workflowRepo.findReviewGateByPr(pr);
+  findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined {
+    return this.workflowRepo.findReviewGateByPr(pr, repo);
   }
 
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[] {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -230,9 +230,13 @@ export class SqliteWorkflowRepository {
     return rows.map((row) => this.rowToWorkflow(row, rollups.get(String(row.id))));
   }
 
-  findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
+  findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined {
     // The PR↔workflow link lives only on the merge node, as either the bare PR
     // number (review_id) or the full PR URL (review_url ending in /pull/<pr>).
+    // Bare-number matches are Invoker-only: other repos must match on URL so
+    // catstack #999 cannot attach to an Invoker workflow whose review_id is 999.
+    const DEFAULT_INVOKER_REPO = 'Neko-Catpital-Labs/Invoker';
+    const allowBareId = !repo || repo === DEFAULT_INVOKER_REPO;
     const rows = this.exec.queryAll(
       `SELECT t.id AS mergeTaskId,
               t.workflow_id AS workflowId,
@@ -252,14 +256,27 @@ export class SqliteWorkflowRepository {
     );
     if (rows.length === 0) return undefined;
 
+    const filtered = rows.filter((row) => {
+      const reviewUrl = row.reviewUrl == null ? '' : String(row.reviewUrl);
+      if (repo) {
+        const needle = `github.com/${repo}/`;
+        if (reviewUrl.toLowerCase().includes(needle.toLowerCase())) return true;
+        // Bare review_id only for Invoker (or when URL is missing on an Invoker lookup).
+        if (allowBareId && (!reviewUrl || String(row.reviewId) === pr)) return true;
+        return false;
+      }
+      return true;
+    });
+    if (filtered.length === 0) return undefined;
+
     // workflows has no status column — status is a derived rollup. Compute it
     // per candidate so re-published PRs (multiple merge nodes) can prefer the
     // live workflow, then the highest generation.
-    const workflowIds = [...new Set(rows.map((row) => String(row.workflowId)))];
+    const workflowIds = [...new Set(filtered.map((row) => String(row.workflowId)))];
     const rollups = this.loadWorkflowRollups(workflowIds);
     const TERMINAL = new Set<WorkflowDerivedStatus>(['completed', 'failed', 'closed']);
 
-    const candidates = rows.map((row) => {
+    const candidates = filtered.map((row) => {
       const workflowStatus = rollups.get(String(row.workflowId))?.status ?? 'pending';
       return { row, workflowStatus, terminal: TERMINAL.has(workflowStatus) };
     });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -545,6 +545,7 @@ interface MergifyCommentBlockedLedgerRow {
   headSha: string;
   key: string;
   detail: string;
+  repo?: string;
 }
 
 function recordAdminBypassBlockedPrRows(
@@ -566,16 +567,18 @@ function recordBlockedPrDecisionRow(
   ledgerPath: string,
 ): void {
   if (!options.store) return;
+  const subjectId = row.repo ? `${row.repo}#${row.pr}` : String(row.pr);
   recordWorkerDecisionRow(options.store, {
     workerKind: options.entrypoint.kind,
     actionType: 'mergify-blocked-pr',
     externalKey: blockedPrDecisionExternalKey(row),
     subjectType: 'pr',
-    subjectId: String(row.pr),
+    subjectId,
     status: 'needs_input',
     summary: row.detail,
     payload: {
       pr: row.pr,
+      ...(row.repo ? { repo: row.repo } : {}),
       ledgerKey: row.key,
       headSha: row.headSha,
       ledgerPath,
@@ -589,17 +592,19 @@ function recordBlockedPrAlertSend(
   ledgerPath: string,
 ): void {
   if (!options.store) return;
+  const subjectId = row.repo ? `${row.repo}#${row.pr}` : String(row.pr);
   recordWorkerDecisionRow(options.store, {
     workerKind: options.entrypoint.kind,
     actionType: 'alert-send',
     externalKey: blockedPrAlertExternalKey(row),
     subjectType: 'pr',
-    subjectId: String(row.pr),
+    subjectId,
     status: 'completed',
     summary: row.detail,
     payload: {
       message: row.detail,
       pr: row.pr,
+      ...(row.repo ? { repo: row.repo } : {}),
       ledgerKey: row.key,
       headSha: row.headSha,
       ledgerPath,
@@ -661,7 +666,11 @@ function parseCommentBlockedLedgerRow(value: unknown): MergifyCommentBlockedLedg
     ? meta.detail.trim()
     : `Mergify repair stopped for PR #${pr}: ${key}`;
 
-  return { pr, headSha, key, detail };
+  const repo = typeof row.repo === 'string' && row.repo.trim().length > 0
+    ? row.repo.trim()
+    : undefined;
+
+  return { pr, headSha, key, detail, ...(repo ? { repo } : {}) };
 }
 
 function parseLedgerPrNumber(value: unknown): number | undefined {
@@ -692,7 +701,8 @@ function resolveHomePath(path: string, env: NodeJS.ProcessEnv): string {
 }
 
 function blockedPrLedgerExternalKey(row: MergifyCommentBlockedLedgerRow): string {
-  return `pr:${row.pr}:ledger:${row.key}:head:${row.headSha}`;
+  const repoPart = row.repo ? `repo:${row.repo}:` : '';
+  return `${repoPart}pr:${row.pr}:ledger:${row.key}:head:${row.headSha}`;
 }
 
 function blockedPrDecisionExternalKey(row: MergifyCommentBlockedLedgerRow): string {


### PR DESCRIPTION
## Summary

Blocked-PR worker decisions used only the PR number as the subject id.

When a ledger row has a repo, the subject is now `owner/repo#N`.

Rows without a repo keep the old numeric subject id.

## Review Claim

Approve namespaced blocked-PR decision subjects so same-number PRs in different repos do not collide.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Rows without `repo` keep the old numeric subject id.

## Slice Rationale

Worker decision identity is a separate claim from review-gate lookup and from cron loops.

## Non-goals

- Does not change how cron finds PRs
- Does not change review-gate mapping
- Does not change config fields

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/pr-maintenance`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
