### PR TITLE
[Auto-approve authors](1) Fail closed when the mapped PR author is not allowlisted

### DIFF
--- a/packages/app/src/auto-approve-author-gate.ts
+++ b/packages/app/src/auto-approve-author-gate.ts
@@ -7,7 +7,7 @@ import {
   type AutoApproveAuthorGateResult,
 } from '@invoker/execution-engine';
 
-import { DEFAULT_PR_MAINTENANCE_TARGET_REPO, loadConfig } from './config.js';
+import { loadConfig } from './config.js';
 
 export type { AutoApproveAuthorGateResult };
 
@@ -15,7 +15,7 @@ export type { AutoApproveAuthorGateResult };
 export function buildPersistedAutoApproveAuthorGate(
   persistence: Pick<SQLiteAdapter, 'loadTask' | 'loadTasks'>,
 ): (taskId: string) => Promise<AutoApproveAuthorGateResult> {
-  const defaultRepo = process.env.INVOKER_GITHUB_TARGET_REPO?.trim() || DEFAULT_PR_MAINTENANCE_TARGET_REPO;
+  const defaultRepo = process.env.INVOKER_GITHUB_TARGET_REPO?.trim() || 'Neko-Catpital-Labs/Invoker';
   return createPersistedAutoApproveAuthorGate({
     readAllowlist: () => {
       try {

--- a/packages/app/src/auto-approve-author-gate.ts
+++ b/packages/app/src/auto-approve-author-gate.ts
@@ -1,0 +1,38 @@
+import type { SQLiteAdapter } from '@invoker/data-store';
+import {
+  authorsFromConfigValue,
+  createGithubPrAuthorLookup,
+  createPersistedAutoApproveAuthorGate,
+  spawnPrMaintenanceCommand,
+  type AutoApproveAuthorGateResult,
+} from '@invoker/execution-engine';
+
+import { DEFAULT_PR_MAINTENANCE_TARGET_REPO, loadConfig } from './config.js';
+
+export type { AutoApproveAuthorGateResult };
+
+/** Owner-side PR-author gate. Re-reads `autoApproveAuthors` from config.json on every call. */
+export function buildPersistedAutoApproveAuthorGate(
+  persistence: Pick<SQLiteAdapter, 'loadTask' | 'loadTasks'>,
+): (taskId: string) => Promise<AutoApproveAuthorGateResult> {
+  const defaultRepo = process.env.INVOKER_GITHUB_TARGET_REPO?.trim() || DEFAULT_PR_MAINTENANCE_TARGET_REPO;
+  return createPersistedAutoApproveAuthorGate({
+    readAllowlist: () => {
+      try {
+        return authorsFromConfigValue(
+          (loadConfig() as { autoApproveAuthors?: unknown }).autoApproveAuthors,
+        );
+      } catch (err) {
+        console.error('[auto-approve-authors] failed to read config.json', err);
+        return { ok: false, reason: 'unreadable' };
+      }
+    },
+    loadTask: (taskId) => persistence.loadTask(taskId),
+    loadTasks: (workflowId) => persistence.loadTasks(workflowId),
+    lookupPrAuthor: createGithubPrAuthorLookup({
+      run: spawnPrMaintenanceCommand,
+      defaultRepo,
+    }),
+    defaultRepo,
+  });
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -126,6 +126,7 @@ import {
   resolveAutoApproveAIFixes,
   resolveAutoFixRetries,
 } from './autofix-defaults.js';
+import { buildPersistedAutoApproveAuthorGate } from './auto-approve-author-gate.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
   assertExecutionCapacityInvariant,
@@ -428,6 +429,7 @@ function buildRegisteredOwnerWorkerDeps(
     e2eAutoFix: { intervalMs: invokerConfig.e2eAutoFixIntervalMs },
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),
+      authorGate: buildPersistedAutoApproveAuthorGate(persistence),
     },
     slackBugScan: buildSlackBugScanWorkerConfig(planningCommandBuilder, executionAgentRegistry),
     idleTaskCleanup: {

--- a/packages/execution-engine/src/__tests__/auto-approve-author-allowlist.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-author-allowlist.test.ts
@@ -1,0 +1,131 @@
+import type { TaskState } from '@invoker/workflow-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  authorsFromConfigValue,
+  createGithubPrAuthorLookup,
+  createPersistedAutoApproveAuthorGate,
+  evaluateAutoApproveAuthorGate,
+  mappedPrFromWorkflowTasks,
+  normalizeAutoApproveAuthors,
+  parseGithubPrRef,
+} from '../workers/auto-approve-author-allowlist.js';
+
+function task(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/__merge__wf-1',
+    description: 'Merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    config: { id: '__merge__wf-1', workflowId: 'wf-1', isMergeNode: true, ...config },
+    execution: {
+      generation: 1,
+      reviewId: '99',
+      reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/99',
+      ...execution,
+    },
+    taskStateVersion: 1,
+    ...rest,
+  } as TaskState;
+}
+
+describe('auto-approve authors in config.json', () => {
+  it('normalizes logins and de-dupes case-insensitively', () => {
+    expect(normalizeAutoApproveAuthors(['EdbertChan', 'edbertchan', ' OtherUser ', ''])).toEqual([
+      'EdbertChan',
+      'OtherUser',
+    ]);
+  });
+
+  it('fails closed when the config key is missing, empty, or not a string array', () => {
+    expect(authorsFromConfigValue(undefined)).toEqual({ ok: false, reason: 'missing' });
+    expect(authorsFromConfigValue([])).toEqual({ ok: false, reason: 'empty' });
+    expect(authorsFromConfigValue(['  '])).toEqual({ ok: false, reason: 'empty' });
+    expect(authorsFromConfigValue('EdbertChan')).toEqual({ ok: false, reason: 'unreadable' });
+    expect(authorsFromConfigValue([42])).toEqual({ ok: false, reason: 'unreadable' });
+  });
+
+  it('re-reads whatever the config callback returns each call', async () => {
+    let value: unknown = ['EdbertChan'];
+    const gate = createPersistedAutoApproveAuthorGate({
+      readAllowlist: () => authorsFromConfigValue(value),
+      loadTask: (taskId) => task({ id: taskId }),
+      loadTasks: () => [task()],
+      lookupPrAuthor: async () => 'EdbertChan',
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+    });
+    expect(await gate('wf-1/task-1')).toMatchObject({ allowed: true, author: 'EdbertChan' });
+    value = ['SomeoneElse'];
+    expect(await gate('wf-1/task-1')).toEqual({ allowed: false, reason: 'author-not-allowlisted' });
+  });
+});
+
+describe('PR mapping and author gate', () => {
+  it('parses a PR number and repo from a GitHub URL', () => {
+    expect(parseGithubPrRef(undefined, 'https://github.com/Neko-Catpital-Labs/Invoker/pull/99/files'))
+      .toEqual({ repo: 'Neko-Catpital-Labs/Invoker', number: '99' });
+    expect(parseGithubPrRef('#12', undefined)).toEqual({ number: '12' });
+    expect(parseGithubPrRef('nope', 'not-a-url')).toBeNull();
+  });
+
+  it('reads review id/url off the merge node', () => {
+    expect(mappedPrFromWorkflowTasks([task()])).toEqual({
+      reviewId: '99',
+      reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/99',
+    });
+    expect(mappedPrFromWorkflowTasks([task({
+      config: { isMergeNode: false },
+      execution: { reviewId: undefined, reviewUrl: undefined },
+    })])).toBeNull();
+  });
+
+  it('allows only allowlisted PR authors and fails closed otherwise', () => {
+    const allowlist = { ok: true as const, authors: new Set(['edbertchan']) };
+    const mappedPr = { reviewId: '99', reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/99' };
+    expect(evaluateAutoApproveAuthorGate({
+      allowlist,
+      mappedPr,
+      prAuthor: 'EdbertChan',
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+    })).toEqual({
+      allowed: true,
+      author: 'EdbertChan',
+      prNumber: '99',
+      repo: 'Neko-Catpital-Labs/Invoker',
+    });
+    expect(evaluateAutoApproveAuthorGate({
+      allowlist,
+      mappedPr,
+      prAuthor: 'someone-else',
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+    })).toEqual({ allowed: false, reason: 'author-not-allowlisted' });
+    expect(evaluateAutoApproveAuthorGate({
+      allowlist: { ok: false, reason: 'missing' },
+      mappedPr,
+      prAuthor: 'EdbertChan',
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+    })).toEqual({ allowed: false, reason: 'allowlist-missing' });
+    expect(evaluateAutoApproveAuthorGate({
+      allowlist,
+      mappedPr: null,
+      prAuthor: 'EdbertChan',
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+    })).toEqual({ allowed: false, reason: 'no-mapped-pr' });
+  });
+
+  it('looks up the PR author with gh', async () => {
+    const lookup = createGithubPrAuthorLookup({
+      defaultRepo: 'Neko-Catpital-Labs/Invoker',
+      run: async () => ({
+        code: 0,
+        signal: null,
+        stdout: JSON.stringify({ author: { login: 'EdbertChan' } }),
+        stderr: '',
+        timedOut: false,
+      }),
+    });
+    expect(await lookup({ number: '99' })).toBe('EdbertChan');
+  });
+});

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -13,6 +13,7 @@ import {
   type AutoApproveCandidate,
   type AutoApproveWorkerStore,
 } from '../workers/auto-approve-worker.js';
+import type { AutoApproveAuthorGateResult } from '../workers/auto-approve-author-allowlist.js';
 
 const logger = {
   info: vi.fn(),
@@ -116,6 +117,15 @@ function candidate(overrides: Partial<AutoApproveCandidate> = {}): AutoApproveCa
   };
 }
 
+async function allowOwnPr(): Promise<AutoApproveAuthorGateResult> {
+  return {
+    allowed: true,
+    author: 'EdbertChan',
+    prNumber: '1',
+    repo: 'Neko-Catpital-Labs/Invoker',
+  };
+}
+
 describe('autoapprove worker', () => {
   it('scan candidates include only awaiting approval tasks with pending fix errors', () => {
     const eligible = task();
@@ -132,7 +142,7 @@ describe('autoapprove worker', () => {
     const { store } = makeStore([task({ execution: { pendingFixError: undefined } })]);
     const submitter = { submit: vi.fn() };
 
-    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+    await createAutoApproveTick({ store, submitter, logger, enabled: true, authorGate: allowOwnPr })({
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
@@ -170,7 +180,7 @@ describe('autoapprove worker', () => {
     const { store, writes } = makeStore([reviewReadyGate], [], [{ id: 'wf-1', mergeMode: 'automatic', onFinish: 'merge' }]);
     const submitter = { submit: vi.fn(() => 42) };
 
-    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+    await createAutoApproveTick({ store, submitter, logger, enabled: true, authorGate: allowOwnPr })({
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
@@ -224,6 +234,7 @@ describe('autoapprove worker', () => {
       submitter,
       logger,
       enabled: true,
+      authorGate: allowOwnPr,
       drainWakeupHints: () => [wakeup(), wakeup()],
     })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1,
       signal: new AbortController().signal });
@@ -249,7 +260,7 @@ describe('autoapprove worker', () => {
     const { store, writes } = makeStore([task()]);
     const submitter = { submit: vi.fn(() => 42) };
 
-    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+    await createAutoApproveTick({ store, submitter, logger, enabled: true, authorGate: allowOwnPr })({
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
@@ -282,5 +293,47 @@ describe('autoapprove worker', () => {
 
     expect(store.listWorkflows).not.toHaveBeenCalled();
     expect(submitter.submit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit when the author allowlist file is missing', async () => {
+    const { store, writes } = makeStore([task()]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+      signal: new AbortController().signal,
+    });
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+    expect(writes[0]).toMatchObject({
+      status: 'skipped',
+      summary: 'Skipped AI fix approval: allowlist-missing',
+    });
+  });
+
+  it('does not submit a mapped PR from a non-allowlisted author', async () => {
+    const { store, writes } = makeStore([task()]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({
+      store,
+      submitter,
+      logger,
+      enabled: true,
+      authorGate: async () => ({ allowed: false, reason: 'author-not-allowlisted' }),
+    })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+      signal: new AbortController().signal,
+    });
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+    expect(writes[0]).toMatchObject({
+      status: 'skipped',
+      summary: 'Skipped AI fix approval: author-not-allowlisted',
+    });
   });
 });

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -67,6 +67,7 @@ export * from './pr-stack-detection.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/infra-repair-worker.js';
 export * from './workers/auto-approve-worker.js';
+export * from './workers/auto-approve-author-allowlist.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/claude-oauth-refresh-worker.js';
 export * from './claude-oauth-refresh.js';

--- a/packages/execution-engine/src/workers/auto-approve-author-allowlist.ts
+++ b/packages/execution-engine/src/workers/auto-approve-author-allowlist.ts
@@ -1,0 +1,187 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { PrMaintenanceCommandRunner } from './pr-maintenance-command.js';
+
+export const AUTO_APPROVE_AUTHORS_CONFIG_KEY = 'autoApproveAuthors';
+
+export type AutoApproveAllowlistRead =
+  | { ok: true; authors: ReadonlySet<string> }
+  | { ok: false; reason: 'missing' | 'empty' | 'unreadable' };
+
+export type AutoApproveAuthorGateReason =
+  | 'allowlist-missing'
+  | 'allowlist-empty'
+  | 'allowlist-unreadable'
+  | 'no-mapped-pr'
+  | 'pr-author-unresolved'
+  | 'author-not-allowlisted';
+
+export type AutoApproveAuthorGateResult =
+  | { allowed: true; author: string; prNumber: string; repo: string }
+  | { allowed: false; reason: AutoApproveAuthorGateReason };
+
+export interface ParsedGithubPrRef {
+  number: string;
+  repo?: string;
+}
+
+/** Deduplicate GitHub logins case-insensitively, keeping first-seen spelling. */
+export function normalizeAutoApproveAuthors(logins: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const authors: string[] = [];
+  for (const raw of logins) {
+    const login = raw.trim();
+    if (!login) continue;
+    const key = login.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    authors.push(login);
+  }
+  return authors;
+}
+
+/** Read `autoApproveAuthors` from a config.json value. Missing/empty = nobody. */
+export function authorsFromConfigValue(value: unknown): AutoApproveAllowlistRead {
+  if (value === undefined) return { ok: false, reason: 'missing' };
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    return { ok: false, reason: 'unreadable' };
+  }
+  const authors = normalizeAutoApproveAuthors(value);
+  if (authors.length === 0) return { ok: false, reason: 'empty' };
+  return { ok: true, authors: new Set(authors.map((login) => login.toLowerCase())) };
+}
+
+export function isAllowlistedGithubLogin(
+  login: string,
+  authors: ReadonlySet<string>,
+): boolean {
+  const key = login.trim().toLowerCase();
+  return key.length > 0 && authors.has(key);
+}
+
+export function parseGithubPrRef(
+  reviewId?: string | null,
+  reviewUrl?: string | null,
+): ParsedGithubPrRef | null {
+  const fromUrl = parsePrUrl(reviewUrl);
+  if (fromUrl) return fromUrl;
+  return parsePrId(reviewId);
+}
+
+function parsePrUrl(value?: string | null): ParsedGithubPrRef | null {
+  if (!value) return null;
+  const match = value.match(/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/i);
+  if (!match) return null;
+  return { repo: match[1], number: match[2] };
+}
+
+function parsePrId(value?: string | null): ParsedGithubPrRef | null {
+  if (!value) return null;
+  const fromUrl = parsePrUrl(value);
+  if (fromUrl) return fromUrl;
+  const bare = value.trim().replace(/^#/, '');
+  return /^\d+$/.test(bare) ? { number: bare } : null;
+}
+
+/** Merge-node review id/url, including review-gate artifact fallbacks. */
+export function mappedPrFromWorkflowTasks(
+  tasks: readonly TaskState[],
+): { reviewId?: string; reviewUrl?: string } | null {
+  const merge = tasks.find((task) => task.config.isMergeNode === true);
+  if (!merge) return null;
+  const artifacts = merge.execution.reviewGate?.artifacts ?? [];
+  const reviewId = firstNonEmpty(
+    merge.execution.reviewId,
+    artifacts.find((artifact) => typeof artifact.providerId === 'string')?.providerId,
+  );
+  const reviewUrl = firstNonEmpty(
+    merge.execution.reviewUrl,
+    artifacts.find((artifact) => typeof artifact.url === 'string')?.url,
+  );
+  if (!reviewId && !reviewUrl) return null;
+  return { reviewId, reviewUrl };
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function evaluateAutoApproveAuthorGate(input: {
+  allowlist: AutoApproveAllowlistRead;
+  mappedPr: { reviewId?: string; reviewUrl?: string } | null;
+  prAuthor: string | null;
+  defaultRepo: string;
+}): AutoApproveAuthorGateResult {
+  if (!input.allowlist.ok) {
+    return {
+      allowed: false,
+      reason: input.allowlist.reason === 'missing'
+        ? 'allowlist-missing'
+        : input.allowlist.reason === 'empty'
+          ? 'allowlist-empty'
+          : 'allowlist-unreadable',
+    };
+  }
+  const parsed = parseGithubPrRef(input.mappedPr?.reviewId, input.mappedPr?.reviewUrl);
+  if (!parsed) return { allowed: false, reason: 'no-mapped-pr' };
+  const author = input.prAuthor?.trim() ?? '';
+  if (!author) return { allowed: false, reason: 'pr-author-unresolved' };
+  if (!isAllowlistedGithubLogin(author, input.allowlist.authors)) {
+    return { allowed: false, reason: 'author-not-allowlisted' };
+  }
+  return {
+    allowed: true,
+    author,
+    prNumber: parsed.number,
+    repo: parsed.repo ?? input.defaultRepo,
+  };
+}
+
+export function createGithubPrAuthorLookup(options: {
+  run: PrMaintenanceCommandRunner;
+  defaultRepo: string;
+}): (ref: ParsedGithubPrRef) => Promise<string | null> {
+  return async (ref) => {
+    const repo = ref.repo?.trim() || options.defaultRepo;
+    const result = await options.run({
+      command: 'gh',
+      args: ['pr', 'view', ref.number, '--repo', repo, '--json', 'author'],
+    });
+    if (result.spawnError || result.code !== 0) return null;
+    try {
+      const parsed: unknown = JSON.parse(result.stdout);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+      const author = (parsed as { author?: { login?: unknown } }).author?.login;
+      return typeof author === 'string' && author.trim() ? author.trim() : null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+export function createPersistedAutoApproveAuthorGate(options: {
+  readAllowlist: () => AutoApproveAllowlistRead;
+  loadTasks: (workflowId: string) => readonly TaskState[];
+  loadTask?: (taskId: string) => TaskState | undefined;
+  lookupPrAuthor: (ref: ParsedGithubPrRef) => Promise<string | null>;
+  defaultRepo: string;
+}): (taskId: string) => Promise<AutoApproveAuthorGateResult> {
+  return async (taskId: string): Promise<AutoApproveAuthorGateResult> => {
+    const allowlist = options.readAllowlist();
+    const task = options.loadTask?.(taskId);
+    const workflowId = task?.config.workflowId ?? taskId.split('/')[0];
+    if (!workflowId) return { allowed: false, reason: 'no-mapped-pr' };
+    const mappedPr = mappedPrFromWorkflowTasks(options.loadTasks(workflowId));
+    const parsed = parseGithubPrRef(mappedPr?.reviewId, mappedPr?.reviewUrl);
+    const prAuthor = parsed ? await options.lookupPrAuthor(parsed) : null;
+    return evaluateAutoApproveAuthorGate({
+      allowlist,
+      mappedPr,
+      prAuthor,
+      defaultRepo: options.defaultRepo,
+    });
+  };
+}

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -14,6 +14,7 @@ import type { RecoveryWorkerWakeupHint, WorkflowLifecycleEvent } from '../lifecy
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+import type { AutoApproveAuthorGateResult } from './auto-approve-author-allowlist.js';
 
 export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
 export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
@@ -48,6 +49,8 @@ export interface AutoApproveWorkerSubmitter {
 
 export interface AutoApproveWorkerConfig {
   enabled?: boolean;
+  /** Fail-closed PR-author gate. Missing/denied means this worker must not approve. */
+  authorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export interface AutoApproveWorkerPolicyOptions {
@@ -56,6 +59,7 @@ export interface AutoApproveWorkerPolicyOptions {
   logger: Logger;
   enabled?: boolean;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+  authorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export interface AutoApproveWorkerOptions {
@@ -109,6 +113,7 @@ export function registerAutoApproveWorker(
           store: deps.store,
           submitter: deps.submitter,
           enabled: deps.autoApprove?.enabled,
+          authorGate: deps.autoApprove?.authorGate,
         },
       }),
   });
@@ -426,6 +431,15 @@ export function createAutoApproveTick(options: AutoApproveWorkerPolicyOptions): 
     for (const candidate of collectValidatedAutoApproveCandidates(options, candidates)) {
       if (submittedThisTick.has(candidate.taskId)) {
         skipAutoApproveCandidate(options, candidate, 'duplicate-candidate');
+        continue;
+      }
+      const authorGate = options.authorGate
+        ? await options.authorGate(candidate.taskId)
+        : { allowed: false as const, reason: 'allowlist-missing' as const };
+      if (!authorGate.allowed) {
+        skipAutoApproveCandidate(options, candidate, authorGate.reason, {
+          author: 'author' in authorGate ? authorGate.author : null,
+        });
         continue;
       }
       const intentId = options.submitter.submit(


### PR DESCRIPTION
## Summary

The auto-approve worker could approve a task even when it had no way to check who authored the mapped GitHub PR. That is a silent bypass of the allowlist.

This change adds an author gate the worker calls before every auto-approve. If the gate is missing, unreadable, or the author can't be resolved, it does not get approved.

The gate re-reads `autoApproveAuthors` from `config.json` on each call and resolves the mapped PR's author over `gh pr view`, so a config edit takes effect without restarting Invoker.

## Review Claim

Approve wiring a fail-closed PR-author gate into the auto-approve worker: any candidate without a resolved, allowlisted PR author is never approved.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The gate is additive and fails closed: `createAutoApproveTick` treats a missing `authorGate` the same as an explicit `allowed: false` denial, so a wiring or config gap leaves a candidate unapproved instead of approved. Every new branch in `evaluateAutoApproveAuthorGate` is covered by `auto-approve-author-allowlist.test.ts`, and the worker-level wiring is covered by `auto-approve-worker.test.ts`.

## Slice Rationale

This is the only slice: the allowlist-evaluation helpers, the worker wiring, and the app-level gate builder are one cohesive fail-closed change with no independent value split apart.

## Non-goals

Does not change how `autoApproveAuthors` is configured or read in `config.json` — that format is unchanged.

Does not add a UI affordance for editing the allowlist.

Does not change auto-approve behavior for candidates that already pass the gate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/auto-approve-author-allowlist.test.ts src/__tests__/auto-approve-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
