### PR TITLE
[Auto-approve authors](2) Expose config.json autoApproveAuthors on CLI, MCP, and owner mutation surfaces

### DIFF
--- a/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
+++ b/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
@@ -31,6 +31,7 @@ function makeDeps(executionOverrides: Record<string, unknown> = {}, configOverri
     execution: { error: 'boom', ...executionOverrides },
     taskStateVersion: 1,
   };
+  const autoApproveAuthorGate = vi.fn(async () => ({ allowed: false, reason: 'allowlist-missing' as const }));
   const deps = {
     orchestrator: {
       getTask: vi.fn(() => task),
@@ -49,8 +50,9 @@ function makeDeps(executionOverrides: Record<string, unknown> = {}, configOverri
     invokerConfig: { autoApproveAIFixes: false, launchOutboxMode: 'active', ...configOverrides },
     ownerTaskRunnerProvider: () => ({ fixWithAgent: vi.fn(), resolveConflict: vi.fn() }),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    autoApproveAuthorGate,
   } as any;
-  return { deps, updateTask };
+  return { deps, updateTask, autoApproveAuthorGate };
 }
 
 describe('headless fix auto-fix context', () => {
@@ -117,5 +119,18 @@ describe('headless fix auto-fix context', () => {
 
     expect(fixWithAgentActionMock).toHaveBeenCalledTimes(1);
     expect(fixWithAgentActionMock.mock.calls[0][2]).toMatchObject({ reviewGateContext });
+  });
+
+  it('passes the on-disk PR-author gate into fix-with-agent', async () => {
+    const { runHeadless } = await import('../headless.js');
+    const { deps, autoApproveAuthorGate } = makeDeps();
+
+    await runHeadless(['fix', 'wf-1/task-1', 'claude'], deps);
+
+    expect(fixWithAgentActionMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        autoApproveAuthorGate,
+      }),
+    );
   });
 });

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -127,6 +127,12 @@ describe('resolveConflictAction', () => {
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutorWithApprove as unknown as TaskRunner,
       autoApproveAIFixes: true,
+      autoApproveAuthorGate: async () => ({
+        allowed: true,
+        author: 'EdbertChan',
+        prNumber: '1',
+        repo: 'Neko-Catpital-Labs/Invoker',
+      }),
     });
 
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -527,6 +527,12 @@ describe('finalizeAppliedFix', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: true,
+      autoApproveAuthorGate: async () => ({
+        allowed: true,
+        author: 'EdbertChan',
+        prNumber: '1',
+        repo: 'Neko-Catpital-Labs/Invoker',
+      }),
     });
 
     expect(result).toEqual({ autoApproved: true, started });
@@ -563,6 +569,12 @@ describe('finalizeAppliedFix', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: true,
+      autoApproveAuthorGate: async () => ({
+        allowed: true,
+        author: 'EdbertChan',
+        prNumber: '1',
+        repo: 'Neko-Catpital-Labs/Invoker',
+      }),
     });
 
     expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
@@ -570,6 +582,29 @@ describe('finalizeAppliedFix', () => {
     );
     expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
+  });
+
+  it('leaves the fix awaiting approval when the PR author is not allowlisted', async () => {
+    const orchestrator = {
+      setFixAwaitingApproval: vi.fn(),
+      approve: vi.fn(),
+    };
+    const taskExecutor = {
+      commitApprovedFix: vi.fn(),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    const result = await finalizeAppliedFix('task-a', 'saved-error', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      autoApproveAIFixes: true,
+      autoApproveAuthorGate: async () => ({ allowed: false, reason: 'author-not-allowlisted' }),
+    });
+
+    expect(result).toEqual({ autoApproved: false, started: [] });
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
+    expect(orchestrator.approve).not.toHaveBeenCalled();
   });
 });
 
@@ -909,6 +944,12 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
       commandService: makeCommandService(),
       getAutoApproveAIFixes: () => true,
+      autoApproveAuthorGate: async () => ({
+        allowed: true,
+        author: 'EdbertChan',
+        prNumber: '1',
+        repo: 'Neko-Catpital-Labs/Invoker',
+      }),
     });
 
     expect(taskExecutor.execGitIn).toHaveBeenCalledWith(['rev-parse', 'HEAD'], '/tmp/merge-a');
@@ -1003,6 +1044,12 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
       commandService: makeCommandService(),
       getAutoApproveAIFixes: () => true,
+      autoApproveAuthorGate: async () => ({
+        allowed: true,
+        author: 'EdbertChan',
+        prNumber: '1',
+        repo: 'Neko-Catpital-Labs/Invoker',
+      }),
     });
 
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(2);

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -35,6 +35,7 @@ import {
   forkWorkflow as sharedForkWorkflow,
 } from './workflow-actions.js';
 import { parseHeadlessFixArgs } from './auto-fix-intents.js';
+import { buildPersistedAutoApproveAuthorGate } from './auto-approve-author-gate.js';
 import { resolveDefaultExecutionAgent, resolveConflictResolutionSettings } from './config.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -641,6 +642,8 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       taskExecutor: te,
       mutationTiming: deps.mutationTiming,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+      autoApproveAuthorGate: deps.autoApproveAuthorGate
+        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
     }, {
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
@@ -700,6 +703,8 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
       ...deps,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+      autoApproveAuthorGate: deps.autoApproveAuthorGate
+        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
     }, agentArg?.toLowerCase(), deps.signal, {
       pathDefaultAgent: resolveDefaultExecutionAgent(deps.invokerConfig),
     });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -26,6 +26,10 @@ import {
 } from '@invoker/execution-engine';
 import { loadConfig, resolveAutoFixExecutionModel, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { resolveAutoFixRetries } from './autofix-defaults.js';
+import {
+  buildPersistedAutoApproveAuthorGate,
+  type AutoApproveAuthorGateResult,
+} from './auto-approve-author-gate.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { trackWorkflow } from './headless-watch.js';
 import {
@@ -98,6 +102,8 @@ export interface HeadlessDeps {
    * only delegated here to run one command and exit).
    */
   getWorkerRuntimeController?: () => WorkerRuntimeController | null;
+  /** Fail-closed PR-author gate for auto-approve. Reads config.json autoApproveAuthors. */
+  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export const RESET = '\x1b[0m';
@@ -126,6 +132,8 @@ export function buildHeadlessApiServerDeps(
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
+      autoApproveAuthorGate: deps.autoApproveAuthorGate
+        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
       allowGraphMutation: deps.invokerConfig?.allowGraphMutation,
       defaultAutoFixRetries: deps.invokerConfig ? resolveAutoFixRetries(deps.invokerConfig) : undefined,
       getAutoFixAgent: () => deps.invokerConfig?.autoFixAgent,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -49,6 +49,7 @@ import {
   type InvokerConfig,
 } from '../config.js';
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
+import { buildPersistedAutoApproveAuthorGate } from '../auto-approve-author-gate.js';
 import { backupPlan } from '../plan-backup.js';
 import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
@@ -529,6 +530,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
         autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
+        autoApproveAuthorGate: buildPersistedAutoApproveAuthorGate(persistence),
       },
       {
         agentName,
@@ -2438,6 +2440,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         persistence,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
+        autoApproveAuthorGate: buildPersistedAutoApproveAuthorGate(persistence),
       }, agentName, activeMutationContext?.signal);
       await finalizeMutationWithGlobalTopup({
         orchestrator,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,7 +22,7 @@ import {
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, formatAgentFailureForTask } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, type AutoApproveAuthorGateResult, formatAgentFailureForTask } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
@@ -144,6 +144,8 @@ export interface ActionDeps {
   mutationTiming?: WorkflowMutationTiming;
   /** When true, successful AI-applied fixes are approved immediately. */
   autoApproveAIFixes?: boolean;
+  /** Fail-closed PR-author allowlist. Missing/denied means do not auto-approve. */
+  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export interface CommandActionDeps extends ActionDeps {
@@ -838,7 +840,7 @@ export async function setTaskFixContext(
 
 export async function resolveConflictAction(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'autoApproveAuthorGate'> & { taskExecutor: TaskRunner },
   agentName?: string,
   signal?: AbortSignal,
   options?: { pathDefaultAgent?: string },
@@ -882,7 +884,7 @@ function resolveTaskRunnerDefaultExecutionAgent(taskExecutor: TaskRunner): strin
 
 export async function fixWithAgentAction(
   taskId: string,
-  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
+  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'autoApproveAuthorGate' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
   options: {
     agentName?: string;
     recoveryRoute?: FailureRecoveryRoute;
@@ -990,7 +992,7 @@ export async function fixWithAgentAction(
 export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes' | 'autoApproveAuthorGate'> & { taskExecutor: TaskRunner },
   signal?: AbortSignal,
   lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -1002,6 +1004,12 @@ export async function finalizeAppliedFix(
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
   if (!deps.autoApproveAIFixes) {
+    return { autoApproved: false, started: [] };
+  }
+  const authorGate = deps.autoApproveAuthorGate
+    ? await deps.autoApproveAuthorGate(taskId)
+    : { allowed: false as const, reason: 'allowlist-missing' as const };
+  if (!authorGate.allowed) {
     return { autoApproved: false, started: [] };
   }
 
@@ -1215,6 +1223,7 @@ export async function autoFixOnFailure(
     mutationTiming?: WorkflowMutationTiming;
     getAutoFixAgent?: () => string | undefined;
     getAutoApproveAIFixes?: () => boolean | undefined;
+    autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
     signal?: AbortSignal;
   },
   inlineRetryDepth = 0,
@@ -1344,6 +1353,7 @@ export async function autoFixOnFailure(
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
+        autoApproveAuthorGate: deps.autoApproveAuthorGate,
       }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -20,7 +20,8 @@ import { makeEnvelope } from '@invoker/contracts';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { TaskRunner } from '@invoker/execution-engine';
+import type { AutoApproveAuthorGateResult, TaskRunner } from '@invoker/execution-engine';
+import { buildPersistedAutoApproveAuthorGate } from './auto-approve-author-gate.js';
 import {
   parseSpawnRepairWorkflowMutationArgs,
   submitRepairWorkflowFromCiFailure,
@@ -121,6 +122,7 @@ export interface WorkflowMutationFacadeDeps {
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
   autoApproveAIFixes?: boolean;
+  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
   allowGraphMutation?: boolean;
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
@@ -136,7 +138,15 @@ export interface WorkflowMutationFacadeDeps {
  * lifecycle shared by all entrypoints.
  */
 export class WorkflowMutationFacade {
-  constructor(private readonly deps: WorkflowMutationFacadeDeps) {}
+  private readonly deps: WorkflowMutationFacadeDeps;
+
+  constructor(deps: WorkflowMutationFacadeDeps) {
+    this.deps = {
+      ...deps,
+      autoApproveAuthorGate: deps.autoApproveAuthorGate
+        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
+    };
+  }
 
   // ── Task-scoped mutations ────────────────────────────────
 
@@ -479,6 +489,7 @@ export class WorkflowMutationFacade {
         persistence: this.deps.persistence,
         taskExecutor: this.deps.taskExecutor,
         autoApproveAIFixes: this.deps.autoApproveAIFixes,
+        autoApproveAuthorGate: this.deps.autoApproveAuthorGate,
       },
       agentName,
     );
@@ -513,6 +524,7 @@ export class WorkflowMutationFacade {
         commandService: this.deps.commandService,
         taskExecutor: this.deps.taskExecutor,
         autoApproveAIFixes: this.deps.autoApproveAIFixes,
+        autoApproveAuthorGate: this.deps.autoApproveAuthorGate,
       },
       options,
     );
@@ -540,6 +552,7 @@ export class WorkflowMutationFacade {
       commandService: this.deps.commandService,
       taskExecutor: this.deps.taskExecutor,
       autoApproveAIFixes: this.deps.autoApproveAIFixes,
+      autoApproveAuthorGate: this.deps.autoApproveAuthorGate,
     };
   }
 

--- a/packages/cli/src/__tests__/auto-approve-authors-config.test.ts
+++ b/packages/cli/src/__tests__/auto-approve-authors-config.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  addAutoApproveAuthor,
+  applyAutoApproveAuthorsAction,
+  readAutoApproveAuthors,
+  writeAutoApproveAuthors,
+} from '../auto-approve-authors-config.js';
+import { readInvokerConfigFile, writeInvokerConfigFile } from '@invoker/contracts';
+
+const tempRoots: string[] = [];
+
+function makeConfigPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'auto-approve-authors-config-'));
+  tempRoots.push(root);
+  return join(root, 'config.json');
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('auto-approve authors config', () => {
+  it('treats a missing key as nobody', () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, { autoApproveAIFixes: false });
+    expect(readAutoApproveAuthors(readInvokerConfigFile(configPath))).toEqual({
+      authors: [],
+      allowlistOk: false,
+      reason: 'missing',
+    });
+  });
+
+  it('adds the current GitHub login without enabling the toggle', async () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, { autoApproveAIFixes: false, maxConcurrency: 2 });
+    const result = await applyAutoApproveAuthorsAction({
+      configPath,
+      action: 'add_current_github_user',
+      lookupGithubLogin: async () => 'EdbertChan',
+    });
+    expect(result).toEqual({ authors: ['EdbertChan'], allowlistOk: true });
+    const saved = readInvokerConfigFile(configPath);
+    expect(saved.autoApproveAuthors).toEqual(['EdbertChan']);
+    expect(saved.autoApproveAIFixes).toBe(false);
+    expect(saved.maxConcurrency).toBe(2);
+  });
+
+  it('replaces and clears the list', async () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, {});
+    await applyAutoApproveAuthorsAction({
+      configPath,
+      action: 'set',
+      authors: ['Alice', 'Bob'],
+    });
+    expect(readInvokerConfigFile(configPath).autoApproveAuthors).toEqual(['Alice', 'Bob']);
+    await applyAutoApproveAuthorsAction({ configPath, action: 'clear' });
+    expect(readInvokerConfigFile(configPath).autoApproveAuthors).toEqual([]);
+  });
+
+  it('fails closed when gh cannot resolve the current user', async () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, {});
+    await expect(applyAutoApproveAuthorsAction({
+      configPath,
+      action: 'add_current_github_user',
+      lookupGithubLogin: async () => null,
+    })).rejects.toThrow(/Could not read the current GitHub login/);
+    expect(readInvokerConfigFile(configPath).autoApproveAuthors).toBeUndefined();
+  });
+
+  it('dedupes on add', () => {
+    const config = {};
+    writeAutoApproveAuthors(config, ['EdbertChan']);
+    expect(addAutoApproveAuthor(config, 'edbertchan')).toEqual(['EdbertChan']);
+  });
+});

--- a/packages/cli/src/__tests__/mcp-auto-approve-authors.test.ts
+++ b/packages/cli/src/__tests__/mcp-auto-approve-authors.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { createMcpServer } from '../mcp-server.js';
+import { readInvokerConfigFile, writeInvokerConfigFile } from '@invoker/contracts';
+
+const tempRoots: string[] = [];
+
+function makeConfigPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-auto-approve-authors-'));
+  tempRoots.push(root);
+  return join(root, 'config.json');
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('invoker_auto_approve_authors MCP tool', () => {
+  it('adds the current GitHub user to config.json and leaves the toggle off', async () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, { autoApproveAIFixes: false });
+    const server = createMcpServer({
+      configPath,
+      lookupGithubLogin: async () => 'EdbertChan',
+      createMessageBus: async () => {
+        throw new Error('live owner should not be required to write autoApproveAuthors');
+      },
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'invoker-cli-test-client', version: '0.0.0' });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+    try {
+      const result = await client.callTool({
+        name: 'invoker_auto_approve_authors',
+        arguments: { action: 'add_current_github_user' },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as Array<{ text: string }>)[0]!.text);
+      expect(parsed).toMatchObject({
+        ok: true,
+        autoApproveAuthors: ['EdbertChan'],
+        allowlistOk: true,
+        autoApproveToggleUnchanged: true,
+      });
+      const saved = readInvokerConfigFile(configPath);
+      expect(saved.autoApproveAuthors).toEqual(['EdbertChan']);
+      expect(saved.autoApproveAIFixes).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -46,6 +46,11 @@ describe('applyWorkerToggle / readWorkerToggleValue', () => {
     expect(readWorkerToggleValue({}, spec)).toBeUndefined();
   });
 
+  it('auto-approve toggle names config.json autoApproveAuthors', () => {
+    const spec = findWorkerToggle('auto-approve')!;
+    expect(spec.description).toContain('autoApproveAuthors');
+  });
+
   it('does not mutate the input config object', () => {
     const spec = findWorkerToggle('e2e-autofix')!;
     const original = { defaultBranch: 'main' };

--- a/packages/cli/src/auto-approve-authors-config.ts
+++ b/packages/cli/src/auto-approve-authors-config.ts
@@ -1,0 +1,175 @@
+import { spawnSync } from 'node:child_process';
+import {
+  readInvokerConfigFile,
+  updateInvokerConfigFile,
+  type InvokerConfigRecord,
+} from '@invoker/contracts';
+
+export const AUTO_APPROVE_AUTHORS_CONFIG_KEY = 'autoApproveAuthors';
+
+export type AutoApproveAuthorsSnapshot = {
+  authors: string[];
+  allowlistOk: boolean;
+  reason?: 'missing' | 'empty' | 'unreadable';
+};
+
+export type GithubLoginLookup = () => Promise<string | null>;
+
+function normalizeAutoApproveAuthors(logins: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const authors: string[] = [];
+  for (const raw of logins) {
+    const login = raw.trim();
+    if (!login) continue;
+    const key = login.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    authors.push(login);
+  }
+  return authors;
+}
+
+function authorsFromConfigValue(value: unknown): AutoApproveAuthorsSnapshot {
+  if (value === undefined) return { authors: [], allowlistOk: false, reason: 'missing' };
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    return { authors: [], allowlistOk: false, reason: 'unreadable' };
+  }
+  const authors = normalizeAutoApproveAuthors(value);
+  if (authors.length === 0) return { authors: [], allowlistOk: false, reason: 'empty' };
+  return { authors, allowlistOk: true };
+}
+
+export function readAutoApproveAuthors(config: InvokerConfigRecord): AutoApproveAuthorsSnapshot {
+  return authorsFromConfigValue(config[AUTO_APPROVE_AUTHORS_CONFIG_KEY]);
+}
+
+export function writeAutoApproveAuthors(
+  config: InvokerConfigRecord,
+  authors: readonly string[],
+): string[] {
+  const next = normalizeAutoApproveAuthors(authors);
+  config[AUTO_APPROVE_AUTHORS_CONFIG_KEY] = next;
+  return next;
+}
+
+export function addAutoApproveAuthor(
+  config: InvokerConfigRecord,
+  login: string,
+): string[] {
+  const current = readAutoApproveAuthors(config).authors;
+  return writeAutoApproveAuthors(config, [...current, login]);
+}
+
+export function lookupCurrentGithubLoginWithGh(): string | null {
+  const result = spawnSync('gh', ['api', 'user', '--jq', '.login'], {
+    encoding: 'utf8',
+  });
+  if (result.error || result.status !== 0) return null;
+  const login = (result.stdout ?? '').trim();
+  return login.length > 0 ? login : null;
+}
+
+export async function applyAutoApproveAuthorsAction(options: {
+  configPath: string;
+  action: 'get' | 'set' | 'add' | 'add_current_github_user' | 'clear';
+  authors?: string[];
+  login?: string;
+  lookupGithubLogin?: GithubLoginLookup;
+}): Promise<AutoApproveAuthorsSnapshot> {
+  const lookup = options.lookupGithubLogin ?? (async () => lookupCurrentGithubLoginWithGh());
+
+  if (options.action === 'get') {
+    return readAutoApproveAuthors(readInvokerConfigFile(options.configPath));
+  }
+
+  if (options.action === 'clear') {
+    updateInvokerConfigFile(options.configPath, (config) => {
+      writeAutoApproveAuthors(config, []);
+    });
+    return readAutoApproveAuthors(readInvokerConfigFile(options.configPath));
+  }
+
+  if (options.action === 'set') {
+    if (!options.authors) {
+      throw new Error('authors is required for set');
+    }
+    updateInvokerConfigFile(options.configPath, (config) => {
+      writeAutoApproveAuthors(config, options.authors ?? []);
+    });
+    return readAutoApproveAuthors(readInvokerConfigFile(options.configPath));
+  }
+
+  if (options.action === 'add') {
+    const login = options.login?.trim();
+    if (!login) throw new Error('login is required for add');
+    updateInvokerConfigFile(options.configPath, (config) => {
+      addAutoApproveAuthor(config, login);
+    });
+    return readAutoApproveAuthors(readInvokerConfigFile(options.configPath));
+  }
+
+  const login = (await lookup())?.trim();
+  if (!login) {
+    throw new Error('Could not read the current GitHub login. Run `gh auth login`, then retry.');
+  }
+  updateInvokerConfigFile(options.configPath, (config) => {
+    addAutoApproveAuthor(config, login);
+  });
+  return readAutoApproveAuthors(readInvokerConfigFile(options.configPath));
+}
+
+export async function runAutoApproveAuthorsCommand(
+  args: string[],
+  options: {
+    configPath: string;
+    lookupGithubLogin?: GithubLoginLookup;
+    stdout?: (text: string) => void;
+  },
+): Promise<number> {
+  const write = options.stdout ?? ((text: string) => {
+    process.stdout.write(text);
+  });
+  let action: 'get' | 'set' | 'add' | 'add_current_github_user' | 'clear' = 'get';
+  let json = false;
+  const setAuthors: string[] = [];
+  let addLogin: string | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--clear') {
+      action = 'clear';
+    } else if (arg === '--add-current-github-user') {
+      action = 'add_current_github_user';
+    } else if (arg === '--set') {
+      action = 'set';
+      while (args[i + 1] && !args[i + 1]!.startsWith('--')) {
+        setAuthors.push(args[++i]!);
+      }
+    } else if (arg === '--add') {
+      action = 'add';
+      addLogin = args[++i];
+      if (!addLogin) throw new Error('Missing value for --add');
+    } else {
+      throw new Error(`Unknown option for auto-approve-authors: "${arg}"`);
+    }
+  }
+
+  const result = await applyAutoApproveAuthorsAction({
+    configPath: options.configPath,
+    action,
+    authors: action === 'set' ? setAuthors : undefined,
+    login: addLogin,
+    lookupGithubLogin: options.lookupGithubLogin,
+  });
+
+  if (json) {
+    write(`${JSON.stringify({ autoApproveAuthors: result.authors, allowlistOk: result.allowlistOk, reason: result.reason ?? null })}\n`);
+  } else if (result.authors.length === 0) {
+    write('autoApproveAuthors: (empty — auto-approve will not act on anyone)\n');
+  } else {
+    write(`autoApproveAuthors:\n${result.authors.map((login) => `  ${login}\n`).join('')}`);
+  }
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,12 +51,8 @@ import {
 } from './live-owner-bus.js';
 import { runMcpServer } from './mcp-server.js';
 import { defaultConfigPath, runDoctor, runSetup } from './onboarding.js';
-import {
-  applyWorkerToggle,
-  findWorkerToggle,
-  ONBOARDING_WORKER_TOGGLES,
-  readWorkerToggleValue,
-} from './worker-toggles.js';
+import { applyWorkerToggle, findWorkerToggle, ONBOARDING_WORKER_TOGGLES, readWorkerToggleValue } from './worker-toggles.js';
+import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
 const VERSION = '0.0.12';
 
@@ -185,6 +181,7 @@ function usage(): string {
     '  invoker-cli mcp',
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli worker toggles [--enable <id>|--disable <id> ...]',
+    '  invoker-cli auto-approve-authors [--json] [--set <login...>|--add <login>|--add-current-github-user|--clear]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -202,6 +199,7 @@ function usage(): string {
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
     '  worker toggles      Show or set the on/off state of optional owner workers (PR maintenance, e2e auto-fix, auto-approve, disk-headroom cleanup).',
+    '  auto-approve-authors  Show or set GitHub logins in config.json that auto-approve may act on. Does not enable the auto-approve toggle.',
     '',
     'Options:',
     '  --planner-url <url>   Planner service URL for `setup planner`.',
@@ -1070,6 +1068,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'mcp') {
       await (deps.runMcpServer ?? runMcpServer)();
       return 0;
+    }
+    if (argv[0] === 'auto-approve-authors') {
+      return await runAutoApproveAuthorsCommand(argv.slice(1), { configPath: defaultConfigPath() });
     }
     if (argv[0] === 'owner') {
       if (argv[1] !== 'serve') {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,10 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { InAppPlanningSubmitResponse } from '@invoker/contracts';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import type { MessageBus } from '@invoker/transport';
 import type { PlanningConfirmationMode, PlanningReviewDraft } from '../../planning-core/src/planning-review.js';
 import { buildPlanningHandoffInstructions } from '../../planning-core/src/planning-handoff-prompt.js';
@@ -13,6 +15,10 @@ import type { PlanSummary } from '../../planning-core/src/plan-summary.js';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { z } from 'zod';
 import { createDefaultMessageBus, discoverLiveOwner } from './live-owner-bus.js';
+import {
+  applyAutoApproveAuthorsAction,
+  type GithubLoginLookup,
+} from './auto-approve-authors-config.js';
 import {
   assertPlanUnchanged,
   createReviewTokenStore,
@@ -339,6 +345,8 @@ export interface McpServerOptions {
   createMessageBus?: () => Promise<MessageBus>;
   reviewTokens?: ReviewTokenStore;
   sleep?: (ms: number) => Promise<void>;
+  configPath?: string;
+  lookupGithubLogin?: GithubLoginLookup;
 }
 
 export function createMcpServer(options: McpServerOptions = {}): McpServer {
@@ -346,6 +354,8 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
   const createBus = options.createMessageBus ?? createDefaultMessageBus;
   const reviewTokens = options.reviewTokens ?? createReviewTokenStore();
   const sleep = options.sleep;
+  const configPath = options.configPath ?? resolveInvokerConfigPath(process.env, homedir());
+  const lookupGithubLogin = options.lookupGithubLogin;
   const server = new McpServer({ name: 'invoker', version: '0.0.6' });
 
   server.registerTool(
@@ -558,6 +568,38 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
           loadTasks: () => loadWorkflowTasks(workflowId, createBus),
         });
         return mcpJson({ ok: true, ...result });
+      } catch (err) {
+        return mcpError(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.registerTool(
+    'invoker_auto_approve_authors',
+    {
+      description: 'Read or write GitHub logins in ~/.invoker/config.json autoApproveAuthors. Auto-approve only acts on PRs by those logins. Missing/empty means nobody. Does not enable the auto-approve toggle. Use add_current_github_user when setting this up for the person whose gh is logged in on this machine.',
+      inputSchema: {
+        action: z.enum(['get', 'set', 'add', 'add_current_github_user', 'clear']),
+        authors: z.array(z.string()).optional(),
+        login: z.string().optional(),
+      },
+    },
+    async ({ action, authors, login }) => {
+      try {
+        const result = await applyAutoApproveAuthorsAction({
+          configPath,
+          action,
+          authors,
+          login,
+          lookupGithubLogin,
+        });
+        return mcpJson({
+          ok: true,
+          autoApproveAuthors: result.authors,
+          allowlistOk: result.allowlistOk,
+          reason: result.reason ?? null,
+          autoApproveToggleUnchanged: true,
+        });
       } catch (err) {
         return mcpError(err instanceof Error ? err.message : String(err));
       }

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -37,7 +37,7 @@ export const ONBOARDING_WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
   {
     id: 'auto-approve',
     label: 'Auto-approve AI fixes',
-    description: 'Skips the manual "Approve Fix" step for fix-with-agent and resolve-conflict flows. The worker itself always runs; this only controls whether it acts automatically.',
+    description: 'Skips the manual "Approve Fix" step for fix-with-agent and resolve-conflict flows, but only for GitHub PRs whose author is listed in config.json autoApproveAuthors (missing/empty means nobody). The worker itself always runs; this only controls whether it acts automatically.',
     configPath: 'autoApproveAIFixes',
   },
   {


### PR DESCRIPTION
## Summary

PR #10422 added a fail-closed `autoApproveAuthorGate` but nothing called it yet.

This slice wires that gate into every owner-mutation call site that can auto-approve a fix.

It also exposes the underlying `autoApproveAuthors` config.json list through a new CLI subcommand and a new MCP tool, so an owner can read or edit the allowlist without hand-editing JSON.

## Review Claim

Approve wiring `buildPersistedAutoApproveAuthorGate` into the owner-mutation auto-approve paths, plus a CLI subcommand and MCP tool that read/write `autoApproveAuthors` in config.json.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The gate defaults closed: `finalizeAppliedFix` treats a missing `autoApproveAuthorGate` dependency as `{ allowed: false, reason: 'allowlist-missing' }`, so auto-approve still refuses to act unless a caller explicitly wires the gate and the PR author is allowlisted. The new CLI/MCP surfaces only read and write the `autoApproveAuthors` array; they never flip the separate auto-approve enable/disable toggle.

## Slice Rationale

PR #10422 built the gate function on its own so a reviewer could focus on its fail-closed behavior alone. This slice is the next one up: it threads that same gate through the real call sites and gives owners a way to populate the allowlist, kept separate so each piece stays small to review.

## Non-goals

Does not change the auto-approve enable/disable toggle. Does not change which fixes are eligible for auto-approve beyond the author check. Does not add a GUI settings panel for the allowlist — CLI and MCP only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/app test -- resolve-conflict-action.test.ts`
- [x] `pnpm --filter @invoker/app test -- headless-fix-autofix-context.test.ts`
- [x] `pnpm --filter @invoker/cli test -- auto-approve-authors-config.test.ts`
- [x] `pnpm --filter @invoker/cli test -- mcp-auto-approve-authors.test.ts`
- [x] `pnpm --filter @invoker/cli test -- worker-toggles.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10422
