### PR TITLE
[CI regression: 3c1487a-playwright-9-of-9](1) Read chip and task status in one evaluate() call

### DIFF
--- a/packages/app/e2e/rebase-recreate-ui-drift-repro.spec.ts
+++ b/packages/app/e2e/rebase-recreate-ui-drift-repro.spec.ts
@@ -96,19 +96,23 @@ test.describe('rebase-recreate UI drift repro', () => {
       tick += 1;
       const elapsed = Date.now() - startedAt;
 
-      const polled = await page.evaluate(async () => {
+      // invoker query and the chip DOM text both live in the renderer — read
+      // both in one page.evaluate() instead of two separate Playwright
+      // round-trips, so a status transition can't land between them and
+      // produce a false disagreement.
+      const { polledTaskA, polledChip } = await page.evaluate(async () => {
         const result = await window.invoker.getTasks();
-        return Array.isArray(result) ? result : result.tasks;
+        const tasks = Array.isArray(result) ? result : result.tasks;
+        const task = tasks.find((t: { id: string }) => t.id.endsWith('/a'));
+        const chipEl = document.querySelector('[data-testid="queue-chip-running"]');
+        return { polledTaskA: task, polledChip: chipEl ? chipEl.textContent : null };
       });
-      const polledTaskA = polled.find((t: { id: string }) => t.id.endsWith('/a'));
 
       const db2 = new DatabaseSync(dbPath, { readOnly: true });
       const polledRow = db2.prepare('SELECT status FROM tasks WHERE id = ?').get(polledTaskA.id) as
         | { status: string }
         | undefined;
       db2.close();
-
-      const polledChip = await page.getByTestId('queue-chip-running').textContent();
 
       if (polledTaskA.status === 'running' && backendFlippedAtMs === null) backendFlippedAtMs = elapsed;
       const chipShowsRunning = polledChip === 'Executing (1/1)';


### PR DESCRIPTION
## Summary

This spec measures how quickly the UI chip catches up after a task's status
flips to running.

It read the backend status and the chip text in two separate browser round
trips. A status change could land between those two reads.

That produced a false mismatch and an intermittent failure in CI job
`playwright / 9-of-9`.

The fix reads both values from one browser evaluation instead. Both values
now come from the same JavaScript tick, so no chip transition can land in
between the two reads.

## Review Claim

Approve reading the backend task status and the UI chip text from a single
browser evaluation call, instead of two separate calls that could straddle a
status change.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The change only touches how one existing spec collects two values it already
read elsewhere in the same spec. No product runtime file changed, no new
assertions were added, and the pass/fail condition compares the exact same
fields as before.

## Slice Rationale

This is the one spec file responsible for CI job `playwright / 9-of-9`'s
intermittent failure. No other file needed a change to make the job pass
locally.

## Non-goals

No other Playwright spec in this job's file list was touched. No product
runtime file changed. No new coverage was added beyond fixing the existing
two-step collection into one.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — exited 0 on the finalized branch (recorded by the paired `verify-ci-3c1487a-playwright-9-of-9` task)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
