### PR TITLE
CI regression: 89a5b9e-e2e-proof-shard-2 — Match "Superseded by" wording for queue-fence-evicted intents

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -285,7 +285,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await recreateFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent #3/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -298,6 +298,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(invalidatedIntent?.status).toBe('failed');
     expect(invalidatedIntent?.error).toContain('Superseded by recreate intent #3');
     expect(evictedIntent?.status).toBe('failed');
+    // Persisted DB reason still records the raw queue-fence boundary; the
+    // "Superseded by recreate intent #N" wording above is what the in-flight
+    // caller (e.g. a tracked CLI command) actually observes as its rejection.
     expect(evictedIntent?.error).toContain('queue fence');
     gate.resolve();
   });
@@ -488,7 +491,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await recreateTask;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -527,7 +530,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -620,7 +623,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -661,7 +664,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await running;
     await retryFence;
     await newerQueued;
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by retry intent/i);
 
     expect(order).toEqual([
       'invoker:edit-task-command:hold-work',
@@ -1091,7 +1094,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteWf;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -1183,7 +1186,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -1278,7 +1281,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAll;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -1370,7 +1373,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAllFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -1467,7 +1470,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAllBulk;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -431,6 +431,13 @@ export class PersistedWorkflowMutationCoordinator {
       `Evicted by workflow queue fence: ${intent.channel}#${intent.id}`,
     );
     if (evictedIds.length > 0) {
+      // Same conceptual event as invalidateSupersededRunningIntent's "Superseded by
+      // <kind> intent #N" — an earlier same-workflow mutation lost to a later
+      // recreate/delete/retry fence. Match that wording here too (this path only
+      // differs because the earlier intent hadn't started running yet), so callers
+      // that treat a fence preemption as a graceful, expected outcome recognize it
+      // regardless of which state the preempted intent was in.
+      const fenceKind = this.queueFenceKindLabel(intent.channel, intent.args);
       for (const evictedId of evictedIds) {
         const evictedIntent = this.persistence.loadWorkflowMutationIntent(evictedId);
         this.createTiming(
@@ -447,7 +454,7 @@ export class PersistedWorkflowMutationCoordinator {
           this.notifyIntentFailed(evictedIntent, evictedIntent.error ?? `Evicted by ${intent.channel}#${intent.id}`);
         }
         if (!deferred) continue;
-        deferred.reject(new Error(`Workflow mutation intent ${evictedId} was evicted by ${intent.channel}#${intent.id}`));
+        deferred.reject(new Error(`Superseded by ${fenceKind} intent #${intent.id}`));
         this.inFlightPromises.delete(evictedId);
       }
       process.stderr.write(
@@ -550,6 +557,29 @@ export class PersistedWorkflowMutationCoordinator {
       return 'delete';
     }
     return null;
+  }
+
+  /**
+   * Like {@link hardPreemptFenceKind}, but for the queue-fence eviction message,
+   * which also covers retry-workflow/rebase-retry fences that hardPreemptFenceKind
+   * intentionally excludes (those don't preempt a *running* intent, only queued ones).
+   */
+  private queueFenceKindLabel(channel: string, args: unknown[]): string {
+    const hardKind = this.hardPreemptFenceKind(channel, args);
+    if (hardKind) {
+      return hardKind;
+    }
+    if (channel === 'invoker:retry-workflow' || channel === 'invoker:rebase-retry') {
+      return 'retry';
+    }
+    if (channel === 'headless.exec') {
+      const payload = args[0] as { args?: unknown[] } | undefined;
+      const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+      if (rawArgs[0] === 'retry' || rawArgs[0] === 'rebase-retry') {
+        return 'retry';
+      }
+    }
+    return 'reset';
   }
 
   private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {


### PR DESCRIPTION
CI job e2e-proof / shard 2 first failed on default-branch commit
89a5b9eb1d2427cdc7312843ce99f54285685853.

PersistedWorkflowMutationCoordinator.evictQueuedIntents rejected a
queue-fence-evicted intent with a generic "was evicted by ..." message,
while the sibling hard-preempt path already rejected running intents
with "Superseded by <kind> intent #N". Callers matching on the
"Superseded by" wording did not recognize the queue-fence eviction as
the same graceful, expected outcome.

Add queueFenceKindLabel to derive the same kind label (recreate,
delete, retry, or reset) for the queue-fence eviction path, and reuse
it in the rejection message so both eviction paths report a consistent
"Superseded by <kind> intent #N" message.