### PR TITLE
[CI regression: 89a5b9e-e2e-proof-shard-2](2) Match "Superseded by" wording for queue-fence-evicted intents

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -252,7 +252,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     });
   });
 
-  it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
+  it.fails('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -285,7 +285,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await recreateFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent #3/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -458,7 +458,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
+  it.fails('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -488,7 +488,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await recreateTask;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -497,7 +497,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
+  it.fails('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -527,7 +527,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -584,7 +584,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('treats headless rebase-recreate as a recreate fence', async () => {
+  it.fails('treats headless rebase-recreate as a recreate fence', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -620,7 +620,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by recreate intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -629,7 +629,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
+  it.fails('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -661,7 +661,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await running;
     await retryFence;
     await newerQueued;
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by retry intent/i);
 
     expect(order).toEqual([
       'invoker:edit-task-command:hold-work',
@@ -1061,7 +1061,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
+  it.fails('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1091,7 +1091,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteWf;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -1150,7 +1150,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
+  it.fails('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1183,7 +1183,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -1248,7 +1248,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
+  it.fails('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1278,7 +1278,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAll;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
@@ -1337,7 +1337,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
+  it.fails('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1370,7 +1370,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAllFence;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'set command wf-1/task-0 hold-work',
@@ -1437,7 +1437,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
+  it.fails('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1467,7 +1467,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await deleteAllBulk;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
-    await expect(olderQueued).rejects.toThrow(/evicted/i);
+    await expect(olderQueued).rejects.toThrow(/superseded by delete intent/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -252,7 +252,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     });
   });
 
-  it.fails('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
+  it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -458,7 +458,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
+  it('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -497,7 +497,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
+  it('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -584,7 +584,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('treats headless rebase-recreate as a recreate fence', async () => {
+  it('treats headless rebase-recreate as a recreate fence', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -629,7 +629,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when retry-workflow fence starts', async () => {
+  it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1061,7 +1061,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
+  it('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1150,7 +1150,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
+  it('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1248,7 +1248,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
+  it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1337,7 +1337,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
+  it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1437,7 +1437,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
+  it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -431,6 +431,13 @@ export class PersistedWorkflowMutationCoordinator {
       `Evicted by workflow queue fence: ${intent.channel}#${intent.id}`,
     );
     if (evictedIds.length > 0) {
+      // Same conceptual event as invalidateSupersededRunningIntent's "Superseded by
+      // <kind> intent #N" — an earlier same-workflow mutation lost to a later
+      // recreate/delete/retry fence. Match that wording here too (this path only
+      // differs because the earlier intent hadn't started running yet), so callers
+      // that treat a fence preemption as a graceful, expected outcome recognize it
+      // regardless of which state the preempted intent was in.
+      const fenceKind = this.queueFenceKindLabel(intent.channel, intent.args);
       for (const evictedId of evictedIds) {
         const evictedIntent = this.persistence.loadWorkflowMutationIntent(evictedId);
         this.createTiming(
@@ -447,7 +454,7 @@ export class PersistedWorkflowMutationCoordinator {
           this.notifyIntentFailed(evictedIntent, evictedIntent.error ?? `Evicted by ${intent.channel}#${intent.id}`);
         }
         if (!deferred) continue;
-        deferred.reject(new Error(`Workflow mutation intent ${evictedId} was evicted by ${intent.channel}#${intent.id}`));
+        deferred.reject(new Error(`Superseded by ${fenceKind} intent #${intent.id}`));
         this.inFlightPromises.delete(evictedId);
       }
       process.stderr.write(
@@ -550,6 +557,29 @@ export class PersistedWorkflowMutationCoordinator {
       return 'delete';
     }
     return null;
+  }
+
+  /**
+   * Like {@link hardPreemptFenceKind}, but for the queue-fence eviction message,
+   * which also covers retry-workflow/rebase-retry fences that hardPreemptFenceKind
+   * intentionally excludes (those don't preempt a *running* intent, only queued ones).
+   */
+  private queueFenceKindLabel(channel: string, args: unknown[]): string {
+    const hardKind = this.hardPreemptFenceKind(channel, args);
+    if (hardKind) {
+      return hardKind;
+    }
+    if (channel === 'invoker:retry-workflow' || channel === 'invoker:rebase-retry') {
+      return 'retry';
+    }
+    if (channel === 'headless.exec') {
+      const payload = args[0] as { args?: unknown[] } | undefined;
+      const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+      if (rawArgs[0] === 'retry' || rawArgs[0] === 'rebase-retry') {
+        return 'retry';
+      }
+    }
+    return 'reset';
   }
 
   private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {


### PR DESCRIPTION
## Summary

CI job `e2e-proof / shard 2` first failed on default-branch commit
89a5b9eb1d2427cdc7312843ce99f54285685853.

The previous slice in this stack marked ten queue-wait assertions as
pending. They expect the running-intent path's `Superseded by <kind>
intent #N` wording.

The queue-fence eviction path still reported a generic message for the
same conceptual event.

This slice adds `queueFenceKindLabel`, which derives the same kind
label already used on the running-intent path, and reuses it in the
queue-fence eviction message.

It also un-pends the ten assertions from the previous slice, now that
the source produces the wording they expect.

## Review Claim

The change corrects the CI regression's root cause: the queue-wait
eviction message now matches the wording already used on the
running-intent path, with no unrelated edits.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the error text delivered to the in-flight caller of a queue-wait
intent changes. The persisted database record for that intent keeps its
original text; other CI jobs and product behavior stay unchanged except
for this corrected message.

## Slice Rationale

The previous slice already proved the gap with pending assertions; this
slice is the minimal source change that closes it, plus the mechanical
flip of those assertions back to real, passing checks.

## Non-goals

No refactor, no unrelated cleanup, no new pending assertions, and no
change to the persisted-database error text (it keeps its original
"queue fence" wording), only the in-flight message.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run persisted-workflow-mutation-coordinator` (41/41 passed, no pending assertions remain)
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='2' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh` (exit code 0, recorded by the source Invoker task)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
