### PR TITLE
[Babysit conflict waiting](1) Re-file when waiting is not a real queue

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -180,6 +180,7 @@ def run_cycle(
     # closed (ledger/owner unreachable) would silently drop the action from
     # the printed plan instead.
     dry_run_claim_repair_filing = None if args.dry_run else claim_repair_filing
+    dry_run_release_repair_filing = None if args.dry_run else release_repair_filing
     for stack in stacks:
         plan = plan_stack_execution(
             stack,
@@ -193,6 +194,7 @@ def run_cycle(
             trunk,
             stale_base_by_pr,
             dry_run_claim_repair_filing,
+            dry_run_release_repair_filing,
         )
         queue_only_noop_check = plan.queue_only_noop_check
         logger.stack("admin-bypass-stack", plan.summary)

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -388,6 +388,30 @@ def payload_rule(payload: Mapping[str, object], body: str) -> str:
     return match.group(1).strip() if match else ""
 
 
+def payload_head_sha(payload: Mapping[str, object], body: str) -> str:
+    """Prefer Mergify payload SHA fields; fall back to Left-the-queue prose.
+
+    Waiting comments never contain the Left-the-queue SHA markup, so without
+    payload SHA the planner cannot detect HEAD movement against a waiting event.
+    """
+    for key in ("head_sha", "sha", "pull_request_head_sha", "current_sha"):
+        value = payload.get(key)
+        if isinstance(value, str) and re.fullmatch(r"[0-9a-fA-F]{40}", value):
+            return value
+    pull_request = payload.get("pull_request")
+    if isinstance(pull_request, Mapping):
+        head = pull_request.get("head")
+        if isinstance(head, Mapping):
+            value = head.get("sha")
+            if isinstance(value, str) and re.fullmatch(r"[0-9a-fA-F]{40}", value):
+                return value
+        value = pull_request.get("sha")
+        if isinstance(value, str) and re.fullmatch(r"[0-9a-fA-F]{40}", value):
+            return value
+    sha_match = re.search(r"Left the queue.*?`([0-9a-fA-F]{40})`", body, re.I | re.S)
+    return sha_match.group(1) if sha_match else ""
+
+
 def clean_markdown(text: str) -> str:
     clean = re.sub(r"<[^>]+>", "", text)
     clean = re.sub(r"[*_]", "", clean)

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -241,7 +241,17 @@ def has_active_queue_event(pr: PrSnapshot, now: int) -> bool:
     # A pending `queue` command reports state "waiting" with a null queue
     # rule while Mergify evaluates its conditions; requeueing on top of it is
     # a duplicate Mergify ignores but the retry-cap ledger still counts.
+    # Exception: Mergify also reports "waiting" when the PR is blocked on a
+    # conflict queue requirement (DIRTY / CONFLICTING / dequeued / waiting_for
+    # conflict). That is not a productive in-flight queue — treat it as idle
+    # so conflict repair can file (PR #10278).
     if latest.state == "waiting":
+        if pr.merge_state_status == "DIRTY" or pr.mergeable == "CONFLICTING":
+            return False
+        if "dequeued" in pr.labels:
+            return False
+        if any("conflict" in item.lower() for item in latest.waiting_for):
+            return False
         if latest.head_sha and latest.head_sha != pr.head_ref_oid:
             return "queued" in pr.labels
         return True
@@ -1016,6 +1026,7 @@ def plan_mergify_queue_repairs(
     now: int,
     pr_numbers: Collection[int] | None = None,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
@@ -1053,6 +1064,7 @@ def plan_mergify_queue_repairs(
                 now,
                 "Mergify dequeued with no named required-check failure while behind master",
                 claim_repair_filing,
+                release_repair_filing,
             )
             if action is not None:
                 return action
@@ -1066,6 +1078,7 @@ def plan_direct_repairs(
     now: int,
     pr_numbers: Collection[int] | None = None,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
@@ -1080,6 +1093,7 @@ def plan_direct_repairs(
                     continue
                 action = plan_invoker_rebase_onto_master(
                     pr, ledger, max_repair_attempts, now, blocker.detail, claim_repair_filing,
+                    release_repair_filing,
                 )
                 if action is not None:
                     return action
@@ -1241,6 +1255,7 @@ def plan_invoker_rebase_onto_master(
     now: int,
     reason: str,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> Action | None:
     """File an Invoker prompt job to rebase the PR onto master (no local force-push)."""
     key = f"rebase-onto-master:{pr.number}"
@@ -1264,11 +1279,56 @@ def plan_invoker_rebase_onto_master(
         ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now,
     ):
         return None
+    legacy_key = f"conflict:{pr.number}"
+    if not decision["crashed_on_infra"] and repair_in_flight(
+        ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now,
+    ):
+        return None
     if claim_repair_filing is not None and claim_repair_filing(
         REBASE_ONTO_MASTER_FILING_KIND, str(pr.number), pr.head_ref_oid,
     ):
-        return None
+        if not _release_stale_rebase_filing_claim(
+            ledger, pr, key, legacy_key, now, claim_repair_filing, release_repair_filing,
+        ):
+            return None
     return Action("rebase_onto_master", pr.number, key, reason)
+
+
+def _release_stale_rebase_filing_claim(
+    ledger: Ledger,
+    pr: PrSnapshot,
+    key: str,
+    legacy_key: str,
+    now: int,
+    claim_repair_filing: ClaimRepairFiling,
+    release_repair_filing: ReleaseRepairFiling | None,
+) -> bool:
+    """Release a held filing claim when a prior attempt already settled.
+
+    Returns True when the caller may proceed (claim re-acquired). Returns False
+    when the claim is still held for a live attempt or release is unavailable.
+    """
+    if release_repair_filing is None:
+        return False
+    if repair_in_flight(ledger, pr.number, pr.head_ref_oid, REBASE_ONTO_MASTER_LEDGER_KIND, key, now):
+        return False
+    if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+        return False
+    settled = ledger.latest(
+        f"{REBASE_ONTO_MASTER_LEDGER_KIND}-settled", pr.number, pr.head_ref_oid, key,
+    )
+    if settled is None:
+        settled = ledger.latest("conflict-repair-settled", pr.number, pr.head_ref_oid, legacy_key)
+    if settled is None:
+        settled = ledger.latest_by_unit(
+            f"{REBASE_ONTO_MASTER_LEDGER_KIND}-settled", pr.number, key,
+        )
+    if settled is None:
+        settled = ledger.latest_by_unit("conflict-repair-settled", pr.number, legacy_key)
+    if settled is None:
+        return False
+    release_repair_filing(REBASE_ONTO_MASTER_FILING_KIND, str(pr.number), pr.head_ref_oid)
+    return not claim_repair_filing(REBASE_ONTO_MASTER_FILING_KIND, str(pr.number), pr.head_ref_oid)
 
 
 def plan_rebase_onto_base(
@@ -1394,13 +1454,18 @@ def plan_actions_from_facts(
     max_repair_attempts: int,
     now: int,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> tuple[Action, ...]:
     if facts.bottom:
         bottom_pr_numbers = (facts.bottom.number,)
-        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers, claim_repair_filing)
+        action = plan_mergify_queue_repairs(
+            facts, ledger, max_repair_attempts, now, bottom_pr_numbers, claim_repair_filing, release_repair_filing,
+        )
         if action is not None:
             return (action,)
-        action = plan_direct_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers, claim_repair_filing)
+        action = plan_direct_repairs(
+            facts, ledger, max_repair_attempts, now, bottom_pr_numbers, claim_repair_filing, release_repair_filing,
+        )
         if action is not None:
             return (action,)
         action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
@@ -1416,10 +1481,16 @@ def plan_actions_from_facts(
         action = plan_bottom_progress(facts, ledger, max_requeue_attempts, now, claim_repair_filing)
         if action is not None:
             return (action,)
-    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now, claim_repair_filing=claim_repair_filing)
+    action = plan_mergify_queue_repairs(
+        facts, ledger, max_repair_attempts, now,
+        claim_repair_filing=claim_repair_filing, release_repair_filing=release_repair_filing,
+    )
     if action is not None:
         return (action,)
-    action = plan_direct_repairs(facts, ledger, max_repair_attempts, now, claim_repair_filing=claim_repair_filing)
+    action = plan_direct_repairs(
+        facts, ledger, max_repair_attempts, now,
+        claim_repair_filing=claim_repair_filing, release_repair_filing=release_repair_filing,
+    )
     if action is not None:
         return (action,)
     action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now)
@@ -1452,6 +1523,7 @@ def plan_stack_actions(
     suppressed_failed_checks_by_pr: Mapping[int, Collection[str]] | None = None,
     open_pr_numbers_by_head: Mapping[str, Collection[int]] | None = None,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> tuple[Action, ...]:
     del suppressed_failed_checks_by_pr
     facts = build_stack_facts(
@@ -1462,7 +1534,10 @@ def plan_stack_actions(
         open_pr_numbers_by_head=open_pr_numbers_by_head or {},
         trunk=TRUNK,
     )
-    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch, claim_repair_filing)
+    return plan_actions_from_facts(
+        facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch,
+        claim_repair_filing, release_repair_filing,
+    )
 
 
 def plan_stack_execution(
@@ -1477,6 +1552,7 @@ def plan_stack_execution(
     trunk: str = TRUNK,
     stale_base_by_pr: Mapping[int, bool] | None = None,
     claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
 ) -> StackExecutionPlan:
     facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk, stale_base_by_pr=stale_base_by_pr)
     summary = summarize_stack(facts)
@@ -1488,7 +1564,10 @@ def plan_stack_execution(
             prereq_status=facts.prereq_status,
             queue_only_noop_check=facts.queue_only_noop_check,
         )
-    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch, claim_repair_filing)
+    actions = plan_actions_from_facts(
+        facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch,
+        claim_repair_filing, release_repair_filing,
+    )
     if actions:
         return StackExecutionPlan(
             summary=summary,

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -53,6 +53,7 @@ try:
         extract_first_json_object,
         failing_check_urls,
         latest_contexts_by_required_check,
+        payload_head_sha,
         payload_rule,
         payload_state,
         reason_failed_checks,
@@ -70,6 +71,7 @@ except ImportError:
         extract_first_json_object,
         failing_check_urls,
         latest_contexts_by_required_check,
+        payload_head_sha,
         payload_rule,
         payload_state,
         reason_failed_checks,
@@ -281,8 +283,7 @@ def parse_mergify_queue_event(comment: Mapping[str, object]) -> MergifyQueueEven
     if "-*- Mergify Payload -*-" not in body:
         return None
     payload = extract_first_json_object(body[body.find("-*- Mergify Payload -*-"):]) or {}
-    sha_match = re.search(r"Left the queue.*?`([0-9a-fA-F]{40})`", body, re.I | re.S)
-    head_sha = sha_match.group(1) if sha_match else ""
+    head_sha = payload_head_sha(payload, body)
     queue_pr_match = re.search(r"on draft #(\d+)", body, re.I)
     queue_pr_number = int(queue_pr_match.group(1)) if queue_pr_match else 0
     failing_checks = section_items(body, "Failing checks")

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -135,16 +135,16 @@ def classify_repair_outcome(workflow_id: str, status: str) -> str:
 
     `infra` and `superseded` must not spend the code-repair attempt budget.
     Unknown/code failures still count so thrash cannot loop forever.
+    Inspect tasks before treating `completed` as success — a merge-gate
+    workflow can complete while safe-push failed with stale-head (PR #10278).
     """
-    if status == "completed":
-        return "success"
     tasks = list_workflow_tasks(workflow_id) or []
     for task in tasks:
         execution = task.get("execution") if isinstance(task.get("execution"), dict) else {}
         failure_class = execution.get("failureClass")
         if isinstance(failure_class, str) and failure_class in _SSH_INFRA_FAILURE_CLASSES:
             return "infra"
-        error = str(execution.get("error") or "")
+        error = str(execution.get("error") or execution.get("pendingFixError") or "")
         if "stale-head" in error:
             return "superseded"
         if "fatal: not a git repository" in error and "/.git/worktrees/" in error:
@@ -155,6 +155,8 @@ def classify_repair_outcome(workflow_id: str, status: str) -> str:
             return "infra"
         if "/Users/" in error and ("PermissionError" in error or "Permission denied" in error):
             return "infra"
+    if status == "completed":
+        return "success"
     if status in _TERMINAL_WORKFLOW_STATUSES:
         return "code"
     return "unknown"

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -41,6 +41,7 @@ def event(
     conditions=(),
     queue_rule_name="admin-bypass",
     queued_at="2026-07-07T05:00:00Z",
+    waiting_for=(),
 ):
     return m.MergifyQueueEvent(
         comment_id=comment_id,
@@ -48,7 +49,7 @@ def event(
         queue_rule_name=queue_rule_name,
         queued_at=queued_at,
         head_sha=head,
-        waiting_for=(),
+        waiting_for=waiting_for,
         failing_checks=failing,
         comment_url="u",
         condition_states=conditions,
@@ -647,6 +648,70 @@ class PlanStackActions(PlannerTestCase):
         )
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_master", 77))
         self.assertEqual(actions[0].key, "rebase-onto-master:77")
+
+    def test_dirty_conflict_waiting_dequeued_plans_rebase_despite_waiting(self):
+        # PR #10278 shape: Mergify state=waiting with empty SHA and conflict
+        # waiting_for must not be treated as productively queued.
+        snapshot = pr(
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            latest_mergify=event(
+                state="waiting",
+                head="",
+                queue_rule_name="",
+                waiting_for=("-conflict` [queue requirement]",),
+            ),
+        )
+        self.assertFalse(p.has_active_queue_event(snapshot, NOW))
+        actions = self._plan(snapshot)
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+
+    def test_held_claim_after_terminal_settle_reclaims_conflict_rebase(self):
+        ledger = self._ledger()
+        key = "rebase-onto-master:1"
+        ledger.record("rebase-onto-master", 1, HEAD, key, NOW - 120)
+        ledger.record(
+            "rebase-onto-master-settled",
+            1,
+            HEAD,
+            key,
+            NOW - 60,
+            meta={"outcomeClass": "success", "workflowStatus": "completed"},
+        )
+        claimed = {"held": True}
+        released = {"n": 0}
+
+        def claim(_kind, _subject, _sha):
+            return claimed["held"]
+
+        def release(_kind, _subject, _sha):
+            released["n"] += 1
+            claimed["held"] = False
+
+        snapshot = pr(
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            latest_mergify=event(
+                state="waiting",
+                head="",
+                queue_rule_name="",
+                waiting_for=("-conflict` [queue requirement]",),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=NOW,
+            open_pr_numbers={snapshot.number},
+            open_pr_numbers_by_head={},
+            claim_repair_filing=claim,
+            release_repair_filing=release,
+        )
+        self.assertEqual(plan.actions[0].kind, "rebase_onto_master")
+        self.assertGreaterEqual(released["n"], 1)
 
     def test_conflict_and_dequeue_share_rebase_onto_master_retry_budget(self):
         ledger = self._ledger()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -126,6 +126,30 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.queue_rule_name, "")
         self.assertEqual(event.head_sha, "")
 
+    def test_parses_waiting_payload_head_sha_without_left_the_queue_prose(self):
+        comment = {
+            "user": {"login": "mergify[bot]"},
+            "id": "c-payload-sha",
+            "created_at": "2026-08-25T06:09:00Z",
+            "updated_at": "2026-08-25T06:09:00Z",
+            "html_url": "https://github.com/o/r/pull/10278#issuecomment-1",
+            "body": (
+                "<!---\n"
+                "DO NOT EDIT\n"
+                "-*- Mergify Payload -*-\n"
+                '{"version": 1, "state": "waiting", "queue_rule_name": null,'
+                f' "head_sha": "{HEAD}"}}\n'
+                "-*- Mergify Payload End -*-\n"
+                "-->\n\n"
+                "# Merge Queue Status\n\n"
+                "- Waiting for queue conditions\n"
+            ),
+        }
+        event = s.parse_mergify_queue_event(comment)
+        assert event is not None
+        self.assertEqual(event.state, "waiting")
+        self.assertEqual(event.head_sha, HEAD)
+
     def test_edited_stale_dequeue_comment_does_not_outrank_newer_waiting_comment(self):
         # Incident 2026-08-04 (PR #7420): Mergify edited the old "dequeued"
         # status comment one second after posting the new "waiting" comment,

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -108,10 +108,6 @@ class SubmitClosePr(unittest.TestCase):
         self.assertIn('headless_mutation run "$2"', script)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class FastpathSettleObserver(unittest.TestCase):
     def _ledger(self, tmpdir):
         from mergify_admin_requeue_model import Ledger
@@ -276,3 +272,30 @@ class RepairerPlanSettleObserver(unittest.TestCase):
             with mock.patch.object(f, "list_workflows", return_value=[]):
                 self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
             self.assertIsNone(ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1"))
+
+
+class ClassifyRepairOutcome(unittest.TestCase):
+    def test_completed_with_stale_head_is_superseded_not_success(self):
+        tasks = [
+            {
+                "id": "wf/safe-push",
+                "status": "completed",
+                "execution": {
+                    "pendingFixError": (
+                        "pr-worker-safe-push: stale-head: refs/heads/stack/x "
+                        "is b7a44e5d; expected 1cc00e13\n"
+                        "[worktree] Process exited: exitCode=20"
+                    ),
+                },
+            }
+        ]
+        with mock.patch.object(f, "list_workflow_tasks", return_value=tasks):
+            self.assertEqual(f.classify_repair_outcome("wf-1", "completed"), "superseded")
+
+    def test_completed_without_task_failures_is_success(self):
+        with mock.patch.object(f, "list_workflow_tasks", return_value=[{"id": "wf/repair", "status": "completed", "execution": {}}]):
+            self.assertEqual(f.classify_repair_outcome("wf-1", "completed"), "success")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The land bot stopped fixing conflicts on PRs that only looked queued.

Mergify said "waiting" with no commit id, while GitHub still showed a conflict and `dequeued`. The bot treated that as "already in line" and never tried again.

Also, any finished repair workflow was scored a success without checking tasks. A bad repair could lock the filing claim and leave the conflict stuck.

Fix: dirty/conflict/`dequeued`/conflict-waiting count as not queued; read Mergify's SHA when present; unlock the claim after settle if no repair is running; judge success from tasks. Clean waiting still waits.


## Review Claim

Conflict waiting that is not a real queue position must re-file repair instead of waiting forever.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Planner only re-files when GitHub still shows DIRTY/CONFLICTING, or `dequeued`, or waiting-for-conflict.

Held claims release only after a terminal settle with `repair_in_flight` false.

Clean Mergify waiting without conflict still suppresses requeue.

## Slice Rationale

This is the land-worker policy fix for the #10278 hang.

The hermetic bash repro under `scripts/repro/` is a separate proof unit and is not in this PR.

## Non-goals

Does not change Mergify queue rules, admin-bypass labeling, or land-stack merge guards.

Does not wipe DO1 ledgers or change repair attempt caps.

Does not ship the bash repro script in this slice.

## Architecture

### Before

```mermaid
graph TD
    A["DIRTY + dequeued + waiting"] --> B["has_active_queue_event true"]
    B --> C["wait bottom-already-queued"]
    D["workflow completed"] --> E["classify success"]
    E --> F["claim stays held"]
```

### After

```mermaid
graph TD
    A["DIRTY + dequeued + waiting"] --> B["has_active_queue_event false"]
    B --> C["release held claim"]
    C --> D["plan rebase_onto_master"]
    E["workflow completed"] --> F["inspect tasks and stale-head"]
    F --> G["outcome may be failure"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd /Users/edbertchan/Documents/GitHub/Invoker && python3 -m unittest scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_snapshot scripts.test_mergify_admin_requeue_workflow_fastpath -v`
- [ ] `git diff --name-only origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
