### PR TITLE
[Slack doctor stringify clash](2) Stage doctor-approved Slack plan bytes

### DIFF
--- a/packages/surfaces/src/__tests__/slack-doctor-draft-stringify-clash.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-doctor-draft-stringify-clash.e2e.test.ts
@@ -158,9 +158,7 @@ describe('Slack doctor-draft stringify clash (DO1 1787644363)', () => {
     nextReply = 'Draft ready.';
   });
 
-  // it.fails: asserts the desired behavior; stage+submit still drop the
-  // immutable doctor bytes today. A later fix slice removes `.fails`.
-  it.fails('stages and Approves the exact doctor-approved bytes when stringify would drop a blank line', async () => {
+  it('stages and Approves the exact doctor-approved bytes when stringify would drop a blank line', async () => {
     const onCommand = vi.fn(async () => ({ workflowIds: ['wf-doctor-1'] }));
     const { surface, slackPlanDraftRepo, conversationRepo } = await buildSurface(onCommand);
     const say = vi.fn().mockResolvedValue({ ts: 'card-ts' });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1362,19 +1362,22 @@ export class SlackSurface implements Surface {
       return { staged: false, reason: 'no_context' };
     }
     const approvedDraft = conversation.approvedPlanningDraft;
-    const reviewPlanText = approvedDraft?.planText ?? draftReview.planText;
-    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(reviewPlanText, context.repoUrl);
-    if (conversation.draftDoctorEnabled
-      && (!approvedDraft || approvedDraft.planText !== normalizedPlanText)) {
+    if (conversation.draftDoctorEnabled && !approvedDraft) {
       throw new Error('The review text does not exactly match the immutable doctor-approved draft.');
     }
-    const normalizedSummary = summarizePlanText(normalizedPlanText) ?? draftReview.summary;
+    const planTextForStage = approvedDraft && conversation.draftDoctorEnabled
+      ? approvedDraft.planText
+      : this.normalizeDraftedPlanRepoUrl(
+        approvedDraft?.planText ?? draftReview.planText,
+        context.repoUrl,
+      );
+    const planSummary = summarizePlanText(planTextForStage) ?? draftReview.summary;
     const draft = this.slackPlanDraftRepo.create({
       channelId: channel,
       threadTs,
       planningDraftId: approvedDraft?.id,
-      planText: normalizedPlanText,
-      summaryJson: JSON.stringify(normalizedSummary),
+      planText: planTextForStage,
+      summaryJson: JSON.stringify(planSummary),
       repoUrl: context.repoUrl,
       harnessPreset: context.presetKey,
       workingDir: context.workingDir,
@@ -1382,7 +1385,7 @@ export class SlackSurface implements Surface {
       confirmationMode: draftReview.confirmationMode,
     });
     try {
-      await this.postSlackPlanDraft(draft, normalizedSummary, say);
+      await this.postSlackPlanDraft(draft, planSummary, say);
       return { staged: true };
     } catch (error) {
       // The draft row already exists at this point and postSlackPlanDraft has
@@ -1600,11 +1603,9 @@ export class SlackSurface implements Surface {
     if (!approvedPlanText) {
       throw new Error('This plan review has no resolvable immutable draft.');
     }
-    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(approvedPlanText, draft.repoUrl);
-    if (draft.planningDraftId && normalizedPlanText !== approvedPlanText) {
-      throw new Error('This plan review would change during submission and cannot be approved.');
-    }
-    const planTextForSubmit = draft.planningDraftId ? approvedPlanText : normalizedPlanText;
+    const planTextForSubmit = draft.planningDraftId
+      ? approvedPlanText
+      : this.normalizeDraftedPlanRepoUrl(approvedPlanText, draft.repoUrl);
     const executionKey = this.slackPlanDraftRepo?.claim(draft);
     if (!executionKey) {
       throw new Error('This plan is already being submitted.');


### PR DESCRIPTION
## Summary

After a Slack plan doctor pass, the host must stage and run those exact YAML bytes.

Comparing them to a yaml stringify rewrite dropped blank lines and blocked the Approve card even when repoUrl was already correct.

This fix stages and starts the doctor-approved text. Non-doctor drafts still get channel-repo normalization.

## Review Claim

Approve staging and starting doctor-approved Slack plan YAML bytes without requiring them to equal normalizeDraftedPlanRepoUrl output.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Doctor-approved Slack plan YAML bytes are what get staged and started. RepoUrl pinning must not rewrite those bytes after the doctor passes. Silent DRAFT_STAGE posting stays unchanged.

## Slice Rationale

One behavior change after the locked repro: flip the expected-fail case by removing the post-doctor stringify exact-match gate.

## Non-goals

No in-thread DRAFT_STAGE error posting. No isExactPlanningSubmitCommand changes. No in-app planner changes. No pin-before-doctor rewrite.

## Architecture

### Before

```mermaid
flowchart LR
  doctorPass["Doctor candidate passes"]
  persist["Persist approvedPlanningDraft bytes"]
  normalize["normalizeDraftedPlanRepoUrl stringify"]
  throwGate["exact-match throw"]
  swallow["Catch logs only"]
  doctorPass --> persist --> normalize --> throwGate --> swallow
```

### After

```mermaid
flowchart LR
  doctorPass["Doctor candidate passes"]
  persist["Persist approvedPlanningDraft bytes"]
  stageBytes["Stage and start those bytes"]
  card["Approve card posts"]
  doctorPass --> persist --> stageBytes --> card
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-slack-doctor-draft-stringify-clash.sh`
- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-doctor-draft-stringify-clash.e2e.test.ts src/__tests__/slack-planning-session-happy-path.e2e.test.ts src/__tests__/slack-plan-draft-approve.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved doctor-approved plan text exactly during draft staging and submission.
  * Continued repository URL normalization for plans that have not been doctor-approved.
  * Removed an erroneous submission mismatch rejection for approved drafts.
* **Tests**
  * Enabled end-to-end coverage for Slack doctor-draft text preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->