### PR TITLE
[Bugfix: CLAUDE.md SQLite runtime](1) Document node:sqlite persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Concrete incidents that motivate the class-search rule above — each is a case 
 
 ## Testing Architecture
 
-All packages use standard `vitest run` via `pnpm test`. The persistence layer uses `sql.js` (WASM-based SQLite), so tests run under system Node with no native SQLite addon or Electron test runtime.
+All packages use standard `vitest run` via `pnpm test`. The persistence layer uses Node's built-in `node:sqlite`, so tests run under system Node with no native SQLite addon or Electron test runtime.
 
 ### How it works
 


### PR DESCRIPTION
## Summary

CLAUDE.md's Testing Architecture section said the persistence layer uses `sql.js`.

The actual persistence code in `packages/data-store/src/sqlite-adapter.ts` imports Node's built-in `node:sqlite`, not `sql.js`.

This updates the doc to match the real runtime dependency.

## Review Claim

Approve a one-line CLAUDE.md correction: persistence runs on `node:sqlite`, not `sql.js`.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This only edits a doc sentence; it changes no code paths, so there is no runtime behavior to break.

## Slice Rationale

A one-line factual correction to CLAUDE.md stands alone and should not be bundled with any behavior or policy change.

## Non-goals

Does not touch `packages/persistence`'s still-present `sql.js` dependency or any test/runtime code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `grep -n "node:sqlite" packages/data-store/src/sqlite-adapter.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 432de5489ee259e4e178dcd8fff1fccb2fa2b56a`
- Post-revert steps: None
- Data migration? No

</details>