### PR TITLE
[Desktop release packaging](1) Build surfaces before the app

### DIFF
--- a/scripts/package-desktop.sh
+++ b/scripts/package-desktop.sh
@@ -36,6 +36,7 @@ fi
 
 pnpm --filter @invoker/ui build
 pnpm --filter @invoker/cli build
+pnpm --filter @invoker/surfaces build
 rm -rf release/embedded-cli
 mkdir -p release/embedded-cli
 TARGET_ARCH="${MAC_ARCH:-$(node -p "process.arch")}"

--- a/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+++ b/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# Guardrail: the shared app-build-dist CI artifact must package packages/surfaces/dist.
+# Guardrail: every path that builds the Electron app must compile
+# packages/surfaces/dist first. @invoker/surfaces stays external in
+# packages/app/tsup.config.ts (not bundled), so a missing dist makes
+# packages/app's verify-workspace-imports.cjs throw
+# "Unresolvable workspace dependency @invoker/surfaces".
 #
-# Regression: build-artifacts only tarred packages/ui/dist and packages/app/dist. The
-# built Electron app requires @invoker/surfaces at runtime (it stays external in
-# packages/app/tsup.config.ts's noExternal list), so every required-fast/ssh/e2e-proof/
-# playwright job that downloaded the artifact crashed with
-# "Cannot find module '.../@invoker/surfaces/dist/index.js'" and hung until CI timeout.
+# Siblings:
+# - CI build-artifacts "Build UI and app" step (app-build-dist.tgz)
+# - scripts/package-desktop.sh (tagged + daily GitHub Release cuts)
+#
+# Regression: build-artifacts only tarred packages/ui/dist and packages/app/dist.
+# required-fast/ssh/e2e-proof/playwright jobs then crashed with
+# "Cannot find module '.../@invoker/surfaces/dist/index.js'" and hung until
+# CI timeout (#5845). package-desktop.sh was not updated, so tagged/daily
+# desktop jobs hit the same class later.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -29,4 +37,17 @@ if ! grep -q 'tar -czf app-build-dist.tgz.*packages/surfaces/dist' <<<"$STEP"; t
   exit 1
 fi
 
-echo "PASS: app-build-dist.tgz packages packages/surfaces/dist"
+PACKAGE_DESKTOP="$ROOT/scripts/package-desktop.sh"
+if ! grep -q 'pnpm --filter @invoker/surfaces build' "$PACKAGE_DESKTOP"; then
+  echo "FAIL: package-desktop.sh must build @invoker/surfaces before @invoker/app (tagged/daily desktop cuts)" >&2
+  exit 1
+fi
+
+surfaces_line="$(grep -n 'pnpm --filter @invoker/surfaces build' "$PACKAGE_DESKTOP" | head -n1 | cut -d: -f1)"
+app_line="$(grep -n 'pnpm --filter @invoker/app build' "$PACKAGE_DESKTOP" | head -n1 | cut -d: -f1)"
+if [[ -z "$surfaces_line" || -z "$app_line" || "$surfaces_line" -ge "$app_line" ]]; then
+  echo "FAIL: package-desktop.sh must run @invoker/surfaces build before @invoker/app build" >&2
+  exit 1
+fi
+
+echo "PASS: app-build-dist.tgz and package-desktop.sh both build packages/surfaces/dist"


### PR DESCRIPTION
## Summary

Desktop GitHub Release jobs failed because `package-desktop.sh` never compiled `@invoker/surfaces`.

The app leaves that package external, so a missing `dist` makes the app build throw Unresolvable workspace dependency.

CI's artifact step already compiles surfaces first. This adds the same step into the desktop packager used by tagged and daily cuts.

The existing surfaces guard now also requires that line in `package-desktop.sh`, so the sibling cannot drift again.

## Review Claim

Approve adding `pnpm --filter @invoker/surfaces build` to `package-desktop.sh` before the app build, and extending the existing surfaces guard to cover that script.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `scripts/package-desktop.sh` and `scripts/test-suites/required/08-build-artifact-surfaces-guard.sh` change. No product runtime code. The new packager step matches the CI artifact step that already ships on master.

## Slice Rationale

One claim: the desktop packager must compile surfaces before the app, and the existing guard must cover that sibling.

## Non-goals

Does not change app bundling, tsup `noExternal`, or the CI artifact tarball contents. Does not retag or re-run the GitHub Release in this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Hide `packages/surfaces/dist`, run `node packages/app/scripts/verify-workspace-imports.cjs` -- throws `Unresolvable workspace dependency @invoker/surfaces` (exit 1)
- [x] Restore dist; `bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh` -- `PASS: app-build-dist.tgz and package-desktop.sh both build packages/surfaces/dist`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
