### PR TITLE
[Linear→Invoker intake](2) Retarget always-on routing discriminator

### DIFF
--- a/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
+++ b/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
@@ -20,7 +20,7 @@ describe('plan-to-invoker skill contract', () => {
     expect(skill).toContain('a Codex AGENTS.md marked block');
     expect(skill).toContain('a Claude UserPromptSubmit hook');
     expect(skill).toContain(
-      'clean-tree edits stay local; feature work and dirty trees go through this',
+      'One-slice same-repo edits stay local; multi-layer or multi-PR work goes through this',
     );
     expect(skill).toContain('unless the user says "do it locally"');
     expect(skill).toContain('`install-skills uninstall`. Trigger: "convert to invoker",');

--- a/packages/shell/src/always-on/fragments.ts
+++ b/packages/shell/src/always-on/fragments.ts
@@ -3,10 +3,12 @@ export const EXECUTION_ROUTING_FRAGMENT = `# Invoker execution routing
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
 - Read-only questions: stay local.
-- Tiny edits (one file, not a feature, working tree clean): stay local.
-- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill, then plan, review, one approval, submit.
+- Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
+- Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
+- First action on delegate: read \`invoker-chat-submit\` then \`invoker-plan-to-invoker\`. Fill Goal / Motivation / Safety invariant from context. Run the planning completeness gate. \`auto_submit\` only when that gate passes; otherwise AskQuestion / clarify on this surface and do not submit.
 - Announce the route in one line so the user can interrupt with “do it locally.”
 - Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
@@ -14,7 +16,7 @@ Plain approval stops after workflow handoff; do not publish PRs unless the user 
 `;
 
 export const CURSOR_RULE_CONTENTS = `---
-description: Feature work and dirty-tree edits go through Invoker; tiny clean-tree edits stay local
+description: One-slice same-repo work stays local; multi-layer work goes through Invoker auto_submit after the completeness gate
 alwaysApply: true
 ---
 
@@ -23,10 +25,12 @@ alwaysApply: true
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
 - Read-only questions: stay local.
-- Tiny edits (one file, not a feature, working tree clean): stay local.
-- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill (\`~/.cursor/skills/invoker-plan-to-invoker/SKILL.md\` or \`~/.claude/skills/invoker-plan-to-invoker/SKILL.md\`), then plan, review, one approval, submit.
+- Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
+- Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
+- First action on delegate: read the installed \`invoker-chat-submit\` skill, then \`invoker-plan-to-invoker\` (\`~/.cursor/skills/invoker-plan-to-invoker/SKILL.md\` or \`~/.claude/skills/invoker-plan-to-invoker/SKILL.md\`). Fill Goal / Motivation / Safety invariant from context. Run the planning completeness gate. \`auto_submit\` only when that gate passes; otherwise AskQuestion / clarify on this surface and do not submit.
 - Announce the route in one line so the user can interrupt with “do it locally.”
 - Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -3,17 +3,16 @@ name: plan-to-invoker
 description: >
   Convert a plan into an Invoker YAML plan file. After `install-skills`, this
   routing is always on via Cursor `~/.cursor/rules/invoker-execution-precedence.mdc`,
-  a Codex AGENTS.md marked block, and a Claude UserPromptSubmit hook. Tiny
-  clean-tree edits stay local; feature work and dirty trees go through this
-  skill unless the user says "do it locally". Uninstall with
-  `install-skills uninstall`. Trigger: "convert to invoker",
-  "submit to invoker", "create invoker plan", "invoker-plan-to-invoker",
-  "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
-  Invoker tasks. For benchmark/direct-output prompts with "Required output path",
-  write a complete YAML document directly to that literal path; it must start
-  with top-level name, onFinish, mergeMode,
-  repoUrl (or scratch: true for no-repo mode), and tasks, never version or metadata wrappers,
-  and must not scan, validate, submit, or discover env vars.
+  a Codex AGENTS.md marked block, and a Claude UserPromptSubmit hook.
+  One-slice same-repo edits stay local; multi-layer or multi-PR work goes through this
+  skill (then chat-submit / auto_submit after the completeness gate) unless the user says "do it locally". Uninstall with `install-skills uninstall`. Trigger: "convert to invoker",
+  "submit to invoker", "create invoker plan",
+  "invoker-plan-to-invoker", "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
+  Invoker tasks. For benchmark/direct-output
+  prompts with "Required output path", write a complete YAML document directly
+  to that literal path; it must start with top-level name, onFinish, mergeMode,
+  repoUrl (or scratch: true for no-repo mode), and tasks, never version or
+  metadata wrappers, and must not scan, validate, submit, or discover env vars.
 ---
 
 # plan-to-invoker
@@ -68,6 +67,7 @@ Use this mode when invoked by the installed command or MCP prompt.
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP review/submission flow when available: call `invoker_prepare_plan_review`, show its ordered steps plus `confirmationText`, then call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`.
+- Before prepare/submit, run `bash skills/plan-to-invoker/scripts/check-planning-completeness.sh <plan-file>` (also part of `skill-doctor`). Incomplete Goal / Motivation / Safety invariant / repoUrl / Verify, or leftover `REPLACE_ME`, must be clarified on the intake surface — do not submit.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before the final submission step.
 - Outside an Invoker source checkout, `invoker_prepare_plan_review` is the canonical review surface and `invoker_validate_plan` remains an optional diagnostic, not the approval gate.
 - Plain approval stops after workflow handoff: treat approval of the Markdown/YAML plan as authorization to submit the reviewed workflow plan to Invoker only, then report the submitted workflow status and stop. Stop after `invoker_submit_plan` or the documented `invoker-cli run ... --live` fallback; do not create, update, publish pull requests, or run `mergify stack push` from that approval alone.
@@ -78,8 +78,8 @@ Use this mode when invoked by the installed command or MCP prompt.
 
 Use `confirmationMode` to distinguish who decided the hand-off should happen:
 
-- **Self-triggered delegation: confirmationMode: auto_submit** — the agent or subagent itself decided, mid-task and without a direct human instruction, that a chunk of work should be handed off to Invoker. No human message asked for this specific hand-off; it's the agent's own routing choice. In this case, skip the Slack review-card wait and call `invoker_submit_plan` once `invoker_prepare_plan_review` reports `confirmationMode: auto_submit`.
-- **Human-triggered delegation: confirmationMode: require** — a human's message is the direct request to hand off or send work to Invoker. Today's `require` + human-approval flow is unchanged: show the ordered steps and `confirmationText`, and wait for explicit approval before calling `invoker_submit_plan`.
+- **Self-triggered delegation: confirmationMode: auto_submit** — the agent or subagent itself decided, mid-task and without a direct human instruction, that a chunk of work should be handed off to Invoker. No human message asked for this specific hand-off; it's the agent's own routing choice. In this case, skip the Slack review-card wait and call `invoker_submit_plan` once `invoker_prepare_plan_review` reports `confirmationMode: auto_submit` **and** `check-planning-completeness.sh` passed. Incomplete plans stay on the native surface (AskQuestion / Slack question / Linear comment).
+- **Human-triggered delegation: confirmationMode: require** — a human's message is the direct request to hand off or send work to Invoker. Today's `require` + human-approval flow is unchanged: show the ordered steps and `confirmationText`, and wait for explicit approval before calling `invoker_submit_plan`. Completeness still must pass first.
 
 In both paths, the delegating agent chooses `poolId` best-effort per `references/schema.md` (an existing field) — omit it for the local default when unsure. `skill-doctor.sh` still runs against the generated plan in both paths; self-triggered delegation changes who approves the submission, not the validation gate.
 


### PR DESCRIPTION
One-slice same-repo stays local; multi-layer goes auto_submit after
completeness. Dirty tree alone no longer forces Invoker.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #10478