### PR TITLE
[Linear→Invoker intake](4) Document Linear intake and chat-submit routing

### DIFF
--- a/docs/linear-ticket-intake.md
+++ b/docs/linear-ticket-intake.md
@@ -1,0 +1,80 @@
+# Linear → Invoker ticket intake
+
+Worker: [`scripts/linear-ticket-intake.sh`](../scripts/linear-ticket-intake.sh) (DO1 cron companion to `daily-e2e-do-submit`).
+
+## Labels
+
+| Label | Meaning |
+| --- | --- |
+| `invoker-ready` | Poll this issue; attempt plan + submit |
+| `invoker-needs-input` | Completeness gaps; edit ticket and keep/re-add `invoker-ready` |
+| `invoker-running` | Plan submitted; Invoker owns execution / PR |
+
+UI / interaction tickets stay unlabeled. You keep those.
+
+## Ticket body contract
+
+Optional structured lines (inferred from the title when missing Goal/Motivation):
+
+```
+Repo: https://github.com/org/repo
+Verify: bash scripts/repro-foo.sh
+Files: path/to/file.ts
+Goal: Make the shared repro exit 0
+Motivation: Users hit a null deref when YAML omits name
+Safety invariant: Other behavior in path/to/file.ts stays identical
+```
+
+`Verify` must be a runnable command, not “manually check”.
+
+## Completeness (same as Slack / terminal / chat-submit)
+
+Before submit the worker runs:
+
+```bash
+bash skills/plan-to-invoker/scripts/check-planning-completeness.sh <plan.yaml>
+```
+
+Rejects leftover `REPLACE_ME` / `TODO`, missing Goal / Motivation / Safety invariant, missing `repoUrl`, or non-runnable Verify. Gaps are commented on the Linear issue; nothing is submitted.
+
+## Planner
+
+Default (one-file + one Verify): render the `bugfix` formula and specialize placeholders from the ticket title/description — fill Goal/Motivation from the title when present; never leave `REPLACE_ME`.
+
+Multi-layer / stack tickets: set `INVOKER_LINEAR_PLANNER_CMD` to a PlanConversation-backed planner (same shape as Slack bug-scan: ticket JSON on stdin, plan path on stdout). Completeness gate still runs before submit.
+
+## Env
+
+| Variable | Purpose |
+| --- | --- |
+| `LINEAR_API_KEY` / `INVOKER_LINEAR_API_KEY` | Linear GraphQL |
+| `INVOKER_LINEAR_FIXTURE_ISSUES` | JSON issues file (tests; skips network) |
+| `INVOKER_LINEAR_DRY_RUN=1` | Log only |
+| `INVOKER_LINEAR_SUBMIT_CMD` | Default `./submit-plan.sh` |
+| `INVOKER_LINEAR_COMMENT_CMD` | Stub for comment/label mutations in tests |
+| `INVOKER_LINEAR_WORK_DIR` | Ledger + rendered plans |
+| `INVOKER_LINEAR_RESUBMIT_GUARD_MIN` | Default 1200 |
+| `INVOKER_LINEAR_PLANNER_CMD` | Optional external planner |
+| `INVOKER_LINEAR_BASE_BRANCH` | Default `master` |
+
+## Cron (DO1)
+
+Companion to `scripts/daily-e2e-do-submit.sh` (same host, separate cadence).
+
+Install / update:
+
+```bash
+LINEAR_API_KEY=lin_api_... bash scripts/install-linear-ticket-intake-cron.sh
+```
+
+Uninstall:
+
+```bash
+bash scripts/uninstall-linear-ticket-intake-cron.sh
+```
+
+Manual equivalent (every 15 minutes):
+
+```cron
+*/15 * * * * cd /path/to/Invoker && LINEAR_API_KEY=... INVOKER_LINEAR_WORK_DIR=$HOME/.invoker/linear-ticket-intake/work bash scripts/linear-ticket-intake.sh >>$HOME/.invoker/linear-ticket-intake/cron.log 2>&1
+```

--- a/skills/chat-submit/SKILL.md
+++ b/skills/chat-submit/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Automatically route approved plans and durable/parallel execution work from
   normal chat into Invoker. Trigger when the user has a plan ready to run,
   asks to submit/run/execute via Invoker, wants durable parallel agent work,
-  or says "submit to invoker" / "run this on invoker" without using a slash
-  command. Prefer this over inventing local multi-agent orchestration when
-  Invoker MCP tools are available.
+  multi-layer or multi-PR work that should not stay in this chat, or says
+  "submit to invoker" / "run this on invoker" without using a slash command.
+  Prefer this over inventing local multi-agent orchestration when Invoker MCP
+  tools are available.
 ---
 
 # chat-submit
@@ -19,29 +20,35 @@ Operator actions against existing workflows live in `invoker-ops`.
 Use this skill when **all** of the following are true:
 
 1. Invoker MCP tools are available (`invoker_prepare_plan_review`, `invoker_submit_plan`).
-2. The request is an approved plan, durable multi-step work, or parallel execution that benefits from Invoker's persisted workflow graph.
+2. The request is multi-layer / multi-PR / overnight / durable parallel work, an approved plan, or the user asked to run it on Invoker.
 3. The user did not already start `/invoker-plan-to-invoker` (that command remains a valid explicit entrypoint).
 
-Do **not** use this skill for small local edits, one-file fixes, or read-only questions. Keep those in the current chat.
+Do **not** use this skill for one-slice same-repo feature iteration, one-file fixes with a local repro, or read-only questions. Keep those in the current chat.
 
 ## Flow
 
-1. If there is no Invoker YAML yet, follow `skill://plan-to-invoker/SKILL.md` (or the installed `invoker-plan-to-invoker` skill) to produce `plans/invoker-handoff.yaml` from a Markdown plan. Stop after YAML exists if the user has not asked to submit.
-2. Call `invoker_prepare_plan_review` with **exactly one** of:
+1. If there is no Invoker YAML yet, follow `skill://plan-to-invoker/SKILL.md` (or the installed `invoker-plan-to-invoker` skill) to produce `plans/invoker-handoff.yaml` from a Markdown plan. Fill `Goal:`, `Motivation:`, and `Safety invariant:` from the conversation. Stop after YAML exists if the user has not asked to submit and the work is human-triggered `require`.
+2. Run the planning completeness gate before review:
+   `bash skills/plan-to-invoker/scripts/check-planning-completeness.sh <plan-file>`
+   (also runs inside `skill-doctor`). If it fails, AskQuestion / clarify the missing fields on this surface and do **not** submit.
+3. Call `invoker_prepare_plan_review` with **exactly one** of:
    - `planPath` pointing at the YAML file, or
    - `sessionId` for an in-app planning session
-3. Show the ordered steps and confirmation text. Keep the returned `reviewToken`. Never paste the full YAML into chat.
-4. Default gate: wait for one explicit user approval unless the review result has `confirmationMode: "auto_submit"`.
-5. Call `invoker_submit_plan` with the same source (`planPath` or `sessionId`) plus `reviewToken` and `mode: "live"`.
-6. Watch results with read-only MCP tools:
+4. Show the ordered steps and confirmation text. Keep the returned `reviewToken`. Never paste the full YAML into chat.
+5. Confirmation:
+   - Self-triggered multi-layer delegation: use `confirmationMode: "auto_submit"` and call `invoker_submit_plan` once prepare reports that mode **and** completeness passed.
+   - Human-triggered handoff: wait for one explicit user approval unless prepare already returned `auto_submit`.
+6. Call `invoker_submit_plan` with the same source (`planPath` or `sessionId`) plus `reviewToken` and `mode: "live"`.
+7. Watch results with read-only MCP tools:
    - `invoker_get_workflow`
    - `invoker_list_tasks`
    - bounded `invoker_wait_for_workflow`
-7. Report completion, a blocker, or an approval gate. For retries/cancels/approvals against the running workflow, switch to `skill://invoker-ops/SKILL.md`.
+8. Report completion, a blocker, or an approval gate. For retries/cancels/approvals against the running workflow, switch to `skill://invoker-ops/SKILL.md`.
 
 ## Hard rules
 
-- One approval before submit by default.
+- Completeness gate before submit. Missing Goal / Motivation / Safety invariant / repoUrl / Verify, or leftover `REPLACE_ME`, blocks submit.
+- One approval before submit for human-triggered work; self-triggered large work may `auto_submit` after completeness.
 - Never invent SQLite reads or recovery paths — Invoker owns persistence.
 - Never submit without the review token from the matching prepare call.
 - If plan content changed after review, prepare again and re-approve.


### PR DESCRIPTION
## Summary

Operators need the ticket field guide, and agents need the chat handoff skill prose to match the new stay-local vs Invoker path.

This documents Linear intake labels, env, and cron install, and updates that skill so multi-layer work runs completeness before auto handoff.

## Review Claim

Docs and the chat handoff skill prose match completeness-gated Linear intake and the stay-local vs multi-layer Invoker path.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Markdown and skill prose only; no executable worker or always-on fragment changes in this slice.

## Slice Rationale

Documentation and chat handoff guidance are a docs unit and must stay apart from tooling-policy worker files.

## Non-goals

- No worker logic changes
- No always-on fragment edits

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n 'check-planning-completeness|auto_submit' skills/chat-submit/SKILL.md docs/linear-ticket-intake.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
