### PR TITLE
[Linear→Invoker intake](3) Assert one-slice routing in skill contract test

### DIFF
--- a/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
+++ b/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
@@ -20,7 +20,7 @@ describe('plan-to-invoker skill contract', () => {
     expect(skill).toContain('a Codex AGENTS.md marked block');
     expect(skill).toContain('a Claude UserPromptSubmit hook');
     expect(skill).toContain(
-      'clean-tree edits stay local; feature work and dirty trees go through this',
+      'One-slice same-repo edits stay local; multi-layer or multi-PR work goes through this',
     );
     expect(skill).toContain('unless the user says "do it locally"');
     expect(skill).toContain('`install-skills uninstall`. Trigger: "convert to invoker",');


### PR DESCRIPTION
Lock the always-on stay-local wording so the discriminator cannot drift.


Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #10483