### PR TITLE
[Linear→Invoker intake](5) Add Linear ticket intake worker

### DIFF
--- a/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
+++ b/packages/app/src/__tests__/plan-to-invoker-skill.test.ts
@@ -20,7 +20,7 @@ describe('plan-to-invoker skill contract', () => {
     expect(skill).toContain('a Codex AGENTS.md marked block');
     expect(skill).toContain('a Claude UserPromptSubmit hook');
     expect(skill).toContain(
-      'clean-tree edits stay local; feature work and dirty trees go through this',
+      'One-slice same-repo edits stay local; multi-layer or multi-PR work goes through this',
     );
     expect(skill).toContain('unless the user says "do it locally"');
     expect(skill).toContain('`install-skills uninstall`. Trigger: "convert to invoker",');

--- a/packages/shell/src/always-on/fragments.ts
+++ b/packages/shell/src/always-on/fragments.ts
@@ -3,10 +3,12 @@ export const EXECUTION_ROUTING_FRAGMENT = `# Invoker execution routing
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
 - Read-only questions: stay local.
-- Tiny edits (one file, not a feature, working tree clean): stay local.
-- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill, then plan, review, one approval, submit.
+- Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
+- Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
+- First action on delegate: read \`invoker-chat-submit\` then \`invoker-plan-to-invoker\`. Fill Goal / Motivation / Safety invariant from context. Run the planning completeness gate. \`auto_submit\` only when that gate passes; otherwise AskQuestion / clarify on this surface and do not submit.
 - Announce the route in one line so the user can interrupt with “do it locally.”
 - Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
@@ -14,7 +16,7 @@ Plain approval stops after workflow handoff; do not publish PRs unless the user 
 `;
 
 export const CURSOR_RULE_CONTENTS = `---
-description: Feature work and dirty-tree edits go through Invoker; tiny clean-tree edits stay local
+description: One-slice same-repo work stays local; multi-layer work goes through Invoker auto_submit after the completeness gate
 alwaysApply: true
 ---
 
@@ -23,10 +25,12 @@ alwaysApply: true
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
 - Read-only questions: stay local.
-- Tiny edits (one file, not a feature, working tree clean): stay local.
-- Feature-sized work, multi-file changes, or a dirty working tree: do not implement locally. First action: read the installed \`invoker-plan-to-invoker\` skill (\`~/.cursor/skills/invoker-plan-to-invoker/SKILL.md\` or \`~/.claude/skills/invoker-plan-to-invoker/SKILL.md\`), then plan, review, one approval, submit.
+- Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
+- Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
+- First action on delegate: read the installed \`invoker-chat-submit\` skill, then \`invoker-plan-to-invoker\` (\`~/.cursor/skills/invoker-plan-to-invoker/SKILL.md\` or \`~/.claude/skills/invoker-plan-to-invoker/SKILL.md\`). Fill Goal / Motivation / Safety invariant from context. Run the planning completeness gate. \`auto_submit\` only when that gate passes; otherwise AskQuestion / clarify on this surface and do not submit.
 - Announce the route in one line so the user can interrupt with “do it locally.”
 - Explicit “do it locally” / “don’t use Invoker” in the current message wins.
+- Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.

--- a/scripts/daily-e2e-do-submit.sh
+++ b/scripts/daily-e2e-do-submit.sh
@@ -3,6 +3,9 @@
 # checkout to origin/master, run the FULL extended e2e battery, and for every
 # still-failing suite submit ONE single-task Invoker plan.
 #
+# Related DO1 cron (Linear → Invoker intake, not e2e):
+#   scripts/install-linear-ticket-intake-cron.sh  (docs/linear-ticket-intake.md)
+#
 # This script does NOT fix anything or open PRs itself. It hands each failing
 # suite to Invoker as a plan with `onFinish: pull_request`. Invoker's own
 # auto-fix then repairs the suite with the configured agent and opens exactly

--- a/scripts/install-linear-ticket-intake-cron.sh
+++ b/scripts/install-linear-ticket-intake-cron.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install (or update) a DO1 cron that polls Linear invoker-ready → Invoker intake.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKER_SCRIPT="$REPO_ROOT/scripts/linear-ticket-intake.sh"
+MARKER="# invoker-linear-ticket-intake"
+LOG_DIR="${HOME}/.invoker/linear-ticket-intake"
+LOG_FILE="${LOG_DIR}/cron.log"
+WORK_DIR="${INVOKER_LINEAR_WORK_DIR:-${LOG_DIR}/work}"
+
+if [[ ! -x "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: expected executable worker script at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+
+if [[ -z "${LINEAR_API_KEY:-${INVOKER_LINEAR_API_KEY:-}}" ]]; then
+  echo "WARN: LINEAR_API_KEY / INVOKER_LINEAR_API_KEY is unset; cron will fail until it is set in the environment crontab uses." >&2
+fi
+
+mkdir -p "$LOG_DIR" "$WORK_DIR"
+
+# Export key only if present so crontab does not embed an empty assignment.
+KEY_EXPORT=""
+if [[ -n "${LINEAR_API_KEY:-}" ]]; then
+  KEY_EXPORT="LINEAR_API_KEY='${LINEAR_API_KEY}' "
+elif [[ -n "${INVOKER_LINEAR_API_KEY:-}" ]]; then
+  KEY_EXPORT="INVOKER_LINEAR_API_KEY='${INVOKER_LINEAR_API_KEY}' "
+fi
+
+CRON_LINE="*/15 * * * * ${KEY_EXPORT}INVOKER_LINEAR_WORK_DIR='${WORK_DIR}' bash '${WORKER_SCRIPT}' >> '${LOG_FILE}' 2>&1 ${MARKER}"
+
+TMP_CRON="$(mktemp -t invoker-cron.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  crontab -l | grep -Fv "$MARKER" > "$TMP_CRON"
+else
+  : > "$TMP_CRON"
+fi
+
+printf '%s\n' "$CRON_LINE" >> "$TMP_CRON"
+crontab "$TMP_CRON"
+
+echo "Installed cron job:"
+echo "  $CRON_LINE"
+echo "Log file: $LOG_FILE"
+echo "Verify with: crontab -l | grep -F '$MARKER'"
+echo "Docs: docs/linear-ticket-intake.md"

--- a/scripts/linear-ticket-intake.mjs
+++ b/scripts/linear-ticket-intake.mjs
@@ -1,0 +1,612 @@
+#!/usr/bin/env node
+/**
+ * Linear → Invoker intake worker.
+ *
+ * Polls issues labeled invoker-ready, fills Goal/Motivation from the ticket
+ * when possible, surfaces remaining gaps as a Linear comment + invoker-needs-input,
+ * and only auto-submits when the shared planning completeness gate passes.
+ *
+ * Seams (for tests / DO1 / sandbox):
+ *   INVOKER_LINEAR_API_KEY          Linear API key (required unless FIXTURE_ISSUES)
+ *   INVOKER_LINEAR_FIXTURE_ISSUES   JSON file of issues (skips network)
+ *   INVOKER_LINEAR_ISSUE_IDS        Comma-separated identifiers (e.g. INV-274,INV-277); ignores invoker-ready
+ *   INVOKER_LINEAR_SANDBOX=1        Skip Linear comment/label writes; enrich Repo/Files/Verify defaults
+ *   INVOKER_LINEAR_DEFAULT_REPO_URL Default repo when ticket omits Repo (sandbox / enrichment)
+ *   INVOKER_LINEAR_DRY_RUN=1        Log actions; do not comment/label/submit
+ *   INVOKER_LINEAR_SUBMIT_CMD       Submit binary (default: ./submit-plan.sh)
+ *   INVOKER_LINEAR_PLANNER_CMD      Optional: ticket JSON on stdin → plan path on stdout
+ *   INVOKER_LINEAR_WORK_DIR         Scratch + ledger directory
+ *   INVOKER_LINEAR_RESUBMIT_GUARD_MIN  Minutes before resubmitting same issue (default 1200)
+ *   INVOKER_LINEAR_COMMENT_CMD      Optional stub: receives JSON {issueId,body,labelsAdd,labelsRemove}
+ *   INVOKER_LINEAR_BASE_BRANCH      Default master
+ */
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  utimesSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+const LABEL_READY = 'invoker-ready';
+const LABEL_RUNNING = 'invoker-running';
+const LABEL_NEEDS_INPUT = 'invoker-needs-input';
+
+function log(msg) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[linear-intake ${ts}] ${msg}`);
+}
+
+function env(name, fallback = '') {
+  return process.env[name] ?? fallback;
+}
+
+function slugify(text) {
+  return String(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'ticket';
+}
+
+const PATH_IN_PROSE_RE =
+  /\b((?:packages|scripts|skills|docs|plans|packages\/[\w.-]+\/src)\/[\w./@+-]+\.[a-zA-Z0-9]+|CLAUDE\.md|AGENTS\.md|README\.md)\b/;
+
+function inferFixFile(title, description) {
+  const body = `${title}\n${description ?? ''}`;
+  const match = body.match(PATH_IN_PROSE_RE);
+  if (match?.[1]) return match[1];
+  // Keyword fallbacks for tickets that name a subsystem but not a path.
+  if (/babysit|admin-bypass|human-only blocker/i.test(body)) {
+    return 'packages/execution-engine/src/workers/pr-maintenance-workers.ts';
+  }
+  if (/slack-manager|deploy-do1/i.test(body) && /getpgid|KillMode|cgroup/i.test(body)) {
+    return 'scripts/deploy-do1.sh';
+  }
+  return '';
+}
+
+function inferVerify(fixFile, title, description) {
+  const body = `${title}\n${description ?? ''}`;
+
+  if (fixFile && (/\.(md|txt|rst)$/i.test(fixFile) || fixFile === 'CLAUDE.md' || fixFile === 'AGENTS.md')) {
+    if (/sql\.js|node:sqlite/i.test(body)) {
+      // Avoid YAML double-quote escapes (no backslashes). Use -F for literal sql.js.
+      return `rg -q node:sqlite ${fixFile} && ! rg -Fq sql.js ${fixFile}`;
+    }
+    return `test -f ${fixFile}`;
+  }
+
+  if (!fixFile) return '';
+  if (/\.(sh|bash)$/i.test(fixFile)) {
+    return `bash -n ${fixFile}`;
+  }
+  if (/babysit/i.test(fixFile) || /babysit|human-only blocker/i.test(body)) {
+    return `test -f ${fixFile} && rg -n human-only ${fixFile}`;
+  }
+  return `test -f ${fixFile}`;
+}
+
+function enrichTicketFields(fields, { sandbox, defaultRepoUrl }) {
+  const out = { ...fields };
+  if (!out.repoUrl && (sandbox || defaultRepoUrl)) {
+    out.repoUrl = defaultRepoUrl || 'https://github.com/Neko-Catpital-Labs/Invoker.git';
+  }
+  if (!out.fixFile) {
+    out.fixFile = inferFixFile(fields.bugSummary, fields.narrative);
+  }
+  if (!out.verify) {
+    out.verify = inferVerify(out.fixFile, fields.bugSummary, fields.narrative);
+  }
+  return out;
+}
+
+function parseTicketFields(title, description) {
+  const body = `${title}\n\n${description ?? ''}`;
+  const field = (name) => {
+    const re = new RegExp(`^\\s*${name}\\s*:\\s*(.+)$`, 'im');
+    return body.match(re)?.[1]?.trim() ?? '';
+  };
+  const repoUrl = field('Repo') || field('repoUrl');
+  const verify = field('Verify') || field('verify_command');
+  const files = field('Files') || field('fix_file');
+  const goal = field('Goal');
+  const motivation = field('Motivation');
+  const safety = field('Safety invariant') || field('SafetyInvariant');
+  const narrative = String(description ?? '')
+    .split('\n')
+    .filter((line) => !/^\s*(Repo|repoUrl|Verify|verify_command|Files|fix_file|Goal|Motivation|Safety invariant|SafetyInvariant)\s*:/i.test(line))
+    .join('\n')
+    .trim();
+  return {
+    repoUrl,
+    verify,
+    fixFile: files.split(',')[0]?.trim() || '',
+    goal: goal || (title ? `Fix: ${title.trim()}` : ''),
+    motivation: motivation || (title ? `${title.trim()} is a reported defect that should be fixed at the source.` : ''),
+    safety,
+    bugSummary: title.trim() || 'Linear ticket defect',
+    narrative,
+  };
+}
+
+function listGaps(fields) {
+  const gaps = [];
+  if (!fields.repoUrl) gaps.push({ field: 'Repo', message: 'Add a line: Repo: https://github.com/org/repo' });
+  if (!fields.verify) gaps.push({ field: 'Verify', message: 'Add a line: Verify: <runnable command that fails before the fix>' });
+  if (!fields.fixFile) gaps.push({ field: 'Files', message: 'Add a line: Files: path/to/file.ts' });
+  if (!fields.motivation) gaps.push({ field: 'Motivation', message: 'Add Motivation: or a descriptive title so motivation can be inferred.' });
+  if (!fields.goal) gaps.push({ field: 'Goal', message: 'Add Goal: or a descriptive title so a goal can be inferred.' });
+  return gaps;
+}
+
+function formatGapComment(issueIdentifier, gaps) {
+  const lines = [
+    `Invoker intake paused on ${issueIdentifier}: plan is incomplete.`,
+    '',
+    'Missing / ambiguous:',
+    ...gaps.map((g) => `- **${g.field}**: ${g.message}`),
+    '',
+    'Edit the ticket (or reply) with the missing fields, keep the `invoker-ready` label, and the next poll will retry.',
+    'Fill Goal / Motivation from the title when you can; Verify must be a real command, not “manually check”.',
+  ];
+  return lines.join('\n');
+}
+
+async function linearGraphql(apiKey, query, variables = {}) {
+  const res = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`Linear GraphQL HTTP ${res.status}: ${await res.text()}`);
+  }
+  const json = await res.json();
+  if (json.errors?.length) {
+    throw new Error(`Linear GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+const ISSUE_NODE_FIELDS = `
+  id
+  identifier
+  title
+  description
+  url
+  labels { nodes { id name } }
+`;
+
+async function fetchIssuesByIdentifiers(apiKey, identifiers) {
+  const wanted = new Set(identifiers.map((id) => id.trim().toUpperCase()).filter(Boolean));
+  if (wanted.size === 0) return [];
+
+  // Linear has no bulk "identifier in" filter; pull a recent page and match, then fall back per-id.
+  const data = await linearGraphql(
+    apiKey,
+    `query {
+      issues(first: 100, orderBy: updatedAt) {
+        nodes { ${ISSUE_NODE_FIELDS} }
+      }
+    }`,
+  );
+  const found = [];
+  const byId = new Map();
+  for (const node of data?.issues?.nodes ?? []) {
+    byId.set(String(node.identifier).toUpperCase(), node);
+  }
+  for (const id of wanted) {
+    if (byId.has(id)) {
+      found.push(byId.get(id));
+      continue;
+    }
+    const number = Number(id.split('-').pop());
+    if (!Number.isFinite(number)) {
+      throw new Error(`Cannot resolve Linear issue ${id}`);
+    }
+    const one = await linearGraphql(
+      apiKey,
+      `query($filter: IssueFilter) {
+        issues(filter: $filter, first: 5) {
+          nodes { ${ISSUE_NODE_FIELDS} }
+        }
+      }`,
+      { filter: { number: { eq: number } } },
+    );
+    const match = (one?.issues?.nodes ?? []).find((n) => String(n.identifier).toUpperCase() === id);
+    if (!match) throw new Error(`Linear issue not found: ${id}`);
+    found.push(match);
+  }
+  return found;
+}
+
+async function fetchLinearIssues({ apiKey, fixturePath, issueIds }) {
+  if (fixturePath) {
+    const raw = JSON.parse(readFileSync(fixturePath, 'utf8'));
+    return Array.isArray(raw) ? raw : raw.issues ?? [];
+  }
+  if (!apiKey) throw new Error('LINEAR_API_KEY / INVOKER_LINEAR_API_KEY required (or set INVOKER_LINEAR_FIXTURE_ISSUES)');
+
+  if (issueIds?.length) {
+    return fetchIssuesByIdentifiers(apiKey, issueIds);
+  }
+
+  const data = await linearGraphql(
+    apiKey,
+    `query($filter: IssueFilter) {
+      issues(filter: $filter, first: 50) {
+        nodes { ${ISSUE_NODE_FIELDS} }
+      }
+    }`,
+    { filter: { labels: { name: { eq: LABEL_READY } } } },
+  );
+  return data?.issues?.nodes ?? [];
+}
+
+function runCmd(command, args, opts = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    cwd: opts.cwd ?? REPO_ROOT,
+    input: opts.input,
+    env: { ...process.env, ...(opts.env ?? {}) },
+  });
+  return result;
+}
+
+function oneLine(text, max = 400) {
+  return String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+function specializeBugfixPlan(planText, fields) {
+  // Ticket narrative often has Repo:/Verify: lines — never inject raw newlines into YAML scalars.
+  const impact = oneLine(fields.motivation);
+  const details = oneLine(
+    fields.narrative
+      ? fields.narrative
+      : `Correct the defect described as "${fields.bugSummary}" in ${fields.fixFile}.`,
+  );
+  const claim = oneLine(
+    `The change corrects ${fields.bugSummary} at its source with no unrelated edits.`,
+  );
+  const reproNote = oneLine(`Use \`${fields.verify}\` as the shared repro.`);
+  let out = planText;
+  out = out.replace(
+    /REPLACE_ME:\s*describe the root cause[\s\S]*?specializes each REPLACE_ME line\./g,
+    `Root cause / approach: ${details}`,
+  );
+  out = out.replace(/REPLACE_ME with the precise defect claim\./g, claim);
+  out = out.replace(/REPLACE_ME with user impact\./g, impact);
+  out = out.replace(/REPLACE_ME with the concrete change\./g, details);
+  out = out.replace(/REPLACE_ME if the repro differs\./g, reproNote);
+  out = out.replace(/REPLACE_ME\./g, details);
+  out = out.replace(/\bREPLACE_ME\b/g, details);
+  return out;
+}
+
+
+function maybeSandboxPlan(planText, sandbox) {
+  if (!sandbox) return planText;
+  return planText
+    .replace(/^onFinish:\s*\S+/m, 'onFinish: none')
+    .replace(/^mergeMode:\s*\S+/m, 'mergeMode: no_op');
+}
+
+function renderBugfixPlan(fields, workDir, sandbox = false) {
+  const outDir = join(workDir, 'rendered');
+  mkdirSync(outDir, { recursive: true });
+  const slug = slugify(fields.bugSummary);
+  const result = runCmd('bash', [
+    join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'),
+    'bugfix',
+    '--var', `repo_url=${fields.repoUrl}`,
+    '--var', `base_branch=${env('INVOKER_LINEAR_BASE_BRANCH', 'master')}`,
+    '--var', `bug_slug=${slug}`,
+    '--var', `bug_summary=${fields.bugSummary}`,
+    '--var', `fix_file=${fields.fixFile}`,
+    '--var', `verify_command=${fields.verify}`,
+    '--out', outDir,
+    '--print',
+  ]);
+  if (result.status !== 0) {
+    throw new Error(`render-formula failed: ${result.stderr || result.stdout}`);
+  }
+  const printed = (result.stdout || '').trim().split('\n').filter(Boolean);
+  const planPath = printed[printed.length - 1] || join(outDir, 'bugfix.workflow.yaml');
+  if (!existsSync(planPath)) {
+    // render-formula may write bugfix.workflow.yaml under outDir
+    const fallback = join(outDir, 'bugfix.workflow.yaml');
+    if (!existsSync(fallback)) throw new Error(`Rendered plan not found. stdout=${result.stdout}`);
+    const specialized = maybeSandboxPlan(specializeBugfixPlan(readFileSync(fallback, 'utf8'), fields), sandbox);
+    const dest = join(workDir, `linear-${slug}.yaml`);
+    writeFileSync(dest, specialized);
+    return dest;
+  }
+  const specialized = maybeSandboxPlan(specializeBugfixPlan(readFileSync(planPath, 'utf8'), fields), sandbox);
+  const dest = join(workDir, `linear-${slug}.yaml`);
+  writeFileSync(dest, specialized);
+  return dest;
+}
+
+function runPlannerCmd(plannerCmd, issue, fields, workDir) {
+  const payload = JSON.stringify({ issue, fields }, null, 2);
+  const result = runCmd('bash', ['-lc', plannerCmd], { input: payload, cwd: workDir });
+  if (result.status !== 0) {
+    throw new Error(`planner cmd failed: ${result.stderr || result.stdout}`);
+  }
+  const planPath = (result.stdout || '').trim().split('\n').filter(Boolean).at(-1);
+  if (!planPath || !existsSync(planPath)) {
+    throw new Error(`planner cmd did not print an existing plan path: ${result.stdout}`);
+  }
+  return planPath;
+}
+
+function runCompleteness(planPath) {
+  const result = runCmd('bash', [
+    join(REPO_ROOT, 'skills/plan-to-invoker/scripts/check-planning-completeness.sh'),
+    planPath,
+  ]);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch {
+    parsed = { complete: result.status === 0, gaps: [], raw: result.stdout };
+  }
+  return { ok: result.status === 0, parsed, stderr: result.stderr || '' };
+}
+
+function postLinearAction({ apiKey, issueId, body, labelsAdd, labelsRemove, dryRun, sandbox, commentCmd }) {
+  const payload = { issueId, body, labelsAdd: labelsAdd ?? [], labelsRemove: labelsRemove ?? [] };
+  if (sandbox) {
+    log(`sandbox skip Linear mutate: ${JSON.stringify(payload).slice(0, 500)}`);
+    return;
+  }
+  if (dryRun) {
+    log(`dry-run comment/labels: ${JSON.stringify(payload).slice(0, 500)}`);
+    return;
+  }
+  if (commentCmd) {
+    const result = runCmd('bash', ['-lc', commentCmd], { input: JSON.stringify(payload) });
+    if (result.status !== 0) throw new Error(`comment cmd failed: ${result.stderr || result.stdout}`);
+    return;
+  }
+  if (!apiKey) throw new Error('Cannot comment on Linear without API key or INVOKER_LINEAR_COMMENT_CMD');
+
+  // Resolve label ids by name when needed.
+  const labelQuery = `
+    query { issueLabels(first: 100) { nodes { id name } } }
+  `;
+  // Best-effort: comment + mutate labels by name via issueUpdate when ids known.
+  // For v1 we always create a comment; label add/remove uses names through a second query.
+  return (async () => {
+    const labelsRes = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: apiKey },
+      body: JSON.stringify({ query: labelQuery }),
+    });
+    const labelsJson = await labelsRes.json();
+    const allLabels = labelsJson.data?.issueLabels?.nodes ?? [];
+    const idFor = (name) => allLabels.find((l) => l.name === name)?.id;
+
+    const commentMutation = `
+      mutation($issueId: String!, $body: String!) {
+        commentCreate(input: { issueId: $issueId, body: $body }) { success }
+      }
+    `;
+    const commentRes = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: apiKey },
+      body: JSON.stringify({ query: commentMutation, variables: { issueId, body } }),
+    });
+    if (!commentRes.ok) throw new Error(`Linear comment HTTP ${commentRes.status}`);
+
+    const addIds = (labelsAdd ?? []).map(idFor).filter(Boolean);
+    const removeIds = (labelsRemove ?? []).map(idFor).filter(Boolean);
+    if (addIds.length || removeIds.length) {
+      const updateMutation = `
+        mutation($id: String!, $add: [String!], $remove: [String!]) {
+          issueUpdate(id: $id, input: { labelIds: $add }) { success }
+        }
+      `;
+      // Linear's issueUpdate replaces label set when labelIds is set; fetch current and merge.
+      const currentRes = await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: apiKey },
+        body: JSON.stringify({
+          query: `query($id: String!) { issue(id: $id) { labels { nodes { id } } } }`,
+          variables: { id: issueId },
+        }),
+      });
+      const currentJson = await currentRes.json();
+      const current = new Set((currentJson.data?.issue?.labels?.nodes ?? []).map((n) => n.id));
+      for (const id of removeIds) current.delete(id);
+      for (const id of addIds) current.add(id);
+      await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: apiKey },
+        body: JSON.stringify({
+          query: updateMutation,
+          variables: { id: issueId, add: [...current] },
+        }),
+      });
+    }
+  })();
+}
+
+function recentlySubmitted(markerPath, guardMin) {
+  if (!existsSync(markerPath)) return false;
+  const ageMin = (Date.now() - statSync(markerPath).mtimeMs) / 60_000;
+  return ageMin < guardMin;
+}
+
+async function main() {
+  const workDir = env('INVOKER_LINEAR_WORK_DIR', join(tmpdir(), 'linear-ticket-intake'));
+  mkdirSync(workDir, { recursive: true });
+  const dryRun = env('INVOKER_LINEAR_DRY_RUN', '0') === '1';
+  const sandbox = env('INVOKER_LINEAR_SANDBOX', '0') === '1';
+  const apiKey = env('INVOKER_LINEAR_API_KEY') || env('LINEAR_API_KEY');
+  const fixturePath = env('INVOKER_LINEAR_FIXTURE_ISSUES');
+  const issueIds = env('INVOKER_LINEAR_ISSUE_IDS')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const defaultRepoUrl = env(
+    'INVOKER_LINEAR_DEFAULT_REPO_URL',
+    'https://github.com/Neko-Catpital-Labs/Invoker.git',
+  );
+  let submitCmd = env('INVOKER_LINEAR_SUBMIT_CMD', join(REPO_ROOT, 'submit-plan.sh'));
+  if (sandbox && !env('INVOKER_LINEAR_SUBMIT_CMD')) {
+    const dbDir = join(workDir, 'db');
+    mkdirSync(dbDir, { recursive: true });
+    submitCmd = `invoker-cli run --standalone --db-dir ${dbDir} --json`;
+  }
+  const plannerCmd = env('INVOKER_LINEAR_PLANNER_CMD');
+  const commentCmd = env('INVOKER_LINEAR_COMMENT_CMD');
+  const guardMin = Number(env('INVOKER_LINEAR_RESUBMIT_GUARD_MIN', '1200'));
+
+  log(`workDir=${workDir} dryRun=${dryRun} sandbox=${sandbox} issueIds=${issueIds.join(',') || '(label:invoker-ready)'}`);
+  const issues = await fetchLinearIssues({ apiKey, fixturePath, issueIds });
+  log(`candidates=${issues.length}`);
+
+  let submitted = 0;
+  let needsInput = 0;
+  let skipped = 0;
+
+  for (const issue of issues) {
+    const id = issue.id || issue.identifier;
+    const identifier = issue.identifier || id;
+    const marker = join(workDir, `submitted-${slugify(identifier)}`);
+    if (recentlySubmitted(marker, guardMin)) {
+      log(`${identifier}: resubmit guard; skip`);
+      skipped += 1;
+      continue;
+    }
+
+    const parsed = parseTicketFields(issue.title ?? '', issue.description ?? '');
+    const fields =
+      sandbox || issueIds.length
+        ? enrichTicketFields(parsed, { sandbox: true, defaultRepoUrl })
+        : parsed;
+    log(`${identifier}: repo=${fields.repoUrl || '-'} file=${fields.fixFile || '-'} verify=${fields.verify || '-'}`);
+    const gaps = listGaps(fields);
+    if (gaps.length) {
+      log(`${identifier}: ${gaps.length} gap(s); commenting`);
+      await postLinearAction({
+        apiKey,
+        issueId: issue.id,
+        body: formatGapComment(identifier, gaps),
+        labelsAdd: [LABEL_NEEDS_INPUT],
+        labelsRemove: [],
+        dryRun,
+        sandbox,
+        commentCmd,
+      });
+      needsInput += 1;
+      continue;
+    }
+
+    let planPath;
+    try {
+      if (plannerCmd) {
+        planPath = runPlannerCmd(plannerCmd, issue, fields, workDir);
+      } else {
+        planPath = renderBugfixPlan(fields, workDir, sandbox);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log(`${identifier}: planner failed: ${message}`);
+      await postLinearAction({
+        apiKey,
+        issueId: issue.id,
+        body: formatGapComment(identifier, [{ field: 'Planner', message }]),
+        labelsAdd: [LABEL_NEEDS_INPUT],
+        labelsRemove: [],
+        dryRun,
+        sandbox,
+        commentCmd,
+      });
+      needsInput += 1;
+      continue;
+    }
+
+    const completeness = runCompleteness(planPath);
+    if (!completeness.ok) {
+      const gateGaps = (completeness.parsed?.gaps ?? []).map((g) => ({
+        field: g.field,
+        message: g.message,
+      }));
+      log(`${identifier}: completeness failed (${gateGaps.length})`);
+      await postLinearAction({
+        apiKey,
+        issueId: issue.id,
+        body: formatGapComment(identifier, gateGaps.length ? gateGaps : [{ field: 'Completeness', message: completeness.stderr || 'gate failed' }]),
+        labelsAdd: [LABEL_NEEDS_INPUT],
+        labelsRemove: [],
+        dryRun,
+        sandbox,
+        commentCmd,
+      });
+      needsInput += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      log(`${identifier}: would submit ${planPath}`);
+      submitted += 1;
+      continue;
+    }
+
+    const submitArgs = submitCmd.split(/\s+/).filter(Boolean);
+    let submit;
+    if (submitArgs[0] === 'invoker-cli' && submitArgs[1] === 'run') {
+      submit = runCmd(submitArgs[0], ['run', planPath, ...submitArgs.slice(2)]);
+    } else {
+      submit = runCmd(submitArgs[0], [...submitArgs.slice(1), planPath]);
+    }
+    if (submit.status !== 0) {
+      log(`${identifier}: submit failed: ${submit.stderr || submit.stdout}`);
+      log(`${identifier}: submit stdout: ${(submit.stdout || '').slice(0, 800)}`);
+      continue;
+    }
+    writeFileSync(marker, `${new Date().toISOString()}\n${planPath}\n${submit.stdout || ''}\n`);
+    await postLinearAction({
+      apiKey,
+      issueId: issue.id,
+      body: `Invoker intake submitted plan from ${identifier}.\nPlan: \`${planPath}\`\n(Workflow id is in the submit output on the worker host.)`,
+      labelsAdd: [LABEL_RUNNING],
+      labelsRemove: [LABEL_READY, LABEL_NEEDS_INPUT],
+      dryRun: false,
+      sandbox,
+      commentCmd,
+    });
+    submitted += 1;
+    log(`${identifier}: submitted ${planPath}`);
+    log(`${identifier}: submit out: ${(submit.stdout || '').trim().split('\n').slice(-8).join(' | ')}`);
+  }
+
+  log(`summary: submitted=${submitted} needsInput=${needsInput} skipped=${skipped}`);
+  if (issueIds.length && submitted < issueIds.length) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/linear-ticket-intake.sh
+++ b/scripts/linear-ticket-intake.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Linear invoker-ready → Invoker intake (DO1 cron companion to daily-e2e-do-submit).
+#
+# Fills Goal/Motivation from the ticket when possible, comments gaps on Linear,
+# and auto-submits only after check-planning-completeness passes.
+#
+# Env: see scripts/linear-ticket-intake.mjs header.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+exec node "$REPO_ROOT/scripts/linear-ticket-intake.mjs" "$@"

--- a/scripts/test-linear-ticket-intake.sh
+++ b/scripts/test-linear-ticket-intake.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Behavior test for scripts/linear-ticket-intake.sh with Linear + submit stubbed.
+#
+# Covers:
+#   A. Gaps: missing Verify → needs-input comment, no submit
+#   B. Complete ticket → dry-run would submit after completeness
+#   C. Resubmit guard skips a recently submitted issue
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKER="$REPO_ROOT/scripts/linear-ticket-intake.sh"
+SANDBOXES=()
+cleanup() {
+  local d
+  for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+run_case() {
+  local name="$1"
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-linear-intake.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/bin" "$sb/work"
+  calls="$sb/actions.jsonl"
+  : > "$calls"
+
+  cat > "$sb/bin/comment-stub" <<'STUB'
+#!/usr/bin/env bash
+echo "$(cat)" >> "$CALLS"
+STUB
+  sed -i.bak "s|\$CALLS|$calls|g" "$sb/bin/comment-stub" 2>/dev/null || \
+    sed -i '' "s|\$CALLS|$calls|g" "$sb/bin/comment-stub"
+  # Rewrite stub without sed portability issues
+  cat > "$sb/bin/comment-stub" <<STUB
+#!/usr/bin/env bash
+cat >> "$calls"
+echo >> "$calls"
+STUB
+  chmod +x "$sb/bin/comment-stub"
+
+  cat > "$sb/bin/submit-stub" <<STUB
+#!/usr/bin/env bash
+echo "\$1" >> "$sb/submit-calls"
+exit 0
+STUB
+  chmod +x "$sb/bin/submit-stub"
+
+  log="$sb/worker.log"
+}
+
+# ── A. Gaps: no Verify ───────────────────────────────────────────────────────
+run_case A
+cat > "$sb/issues.json" <<'JSON'
+[
+  {
+    "id": "issue-gap",
+    "identifier": "INV-1",
+    "title": "null deref in plan-parser",
+    "description": "Repo: https://github.com/Neko-Catpital-Labs/Invoker.git\nFiles: packages/app/src/plan-parser.ts\n",
+    "labels": { "nodes": [{ "name": "invoker-ready" }] }
+  }
+]
+JSON
+env \
+  INVOKER_LINEAR_FIXTURE_ISSUES="$sb/issues.json" \
+  INVOKER_LINEAR_WORK_DIR="$sb/work" \
+  INVOKER_LINEAR_COMMENT_CMD="$sb/bin/comment-stub" \
+  INVOKER_LINEAR_SUBMIT_CMD="$sb/bin/submit-stub" \
+  INVOKER_LINEAR_DRY_RUN=0 \
+  bash "$WORKER" > "$log" 2>&1 || true
+
+grep -q "INV-1: .*gap" "$log" || fail "A: expected gap log for INV-1" "$log"
+grep -q "invoker-needs-input" "$calls" || fail "A: expected needs-input label in comment action" "$calls"
+test ! -f "$sb/submit-calls" || fail "A: must not submit on gaps" "$log"
+echo "PASS A: gaps comment, no submit"
+
+# ── B. Complete ticket dry-run ───────────────────────────────────────────────
+run_case B
+cat > "$sb/issues.json" <<'JSON'
+[
+  {
+    "id": "issue-ok",
+    "identifier": "INV-2",
+    "title": "null deref in plan-parser when YAML lacks name",
+    "description": "Repo: https://github.com/Neko-Catpital-Labs/Invoker.git\nVerify: test 1 -eq 1\nFiles: packages/app/src/plan-parser.ts\nMotivation: Crashes plan parse for empty name.\n",
+    "labels": { "nodes": [{ "name": "invoker-ready" }] }
+  }
+]
+JSON
+env \
+  INVOKER_LINEAR_FIXTURE_ISSUES="$sb/issues.json" \
+  INVOKER_LINEAR_WORK_DIR="$sb/work" \
+  INVOKER_LINEAR_COMMENT_CMD="$sb/bin/comment-stub" \
+  INVOKER_LINEAR_SUBMIT_CMD="$sb/bin/submit-stub" \
+  INVOKER_LINEAR_DRY_RUN=1 \
+  bash "$WORKER" > "$log" 2>&1 || fail "B: worker exited non-zero" "$log"
+
+grep -q "INV-2: would submit" "$log" || fail "B: expected dry-run submit" "$log"
+test ! -f "$sb/submit-calls" || fail "B: dry-run must not call submit" "$log"
+echo "PASS B: complete ticket dry-run would submit"
+
+# ── C. Resubmit guard ────────────────────────────────────────────────────────
+run_case C
+cat > "$sb/issues.json" <<'JSON'
+[
+  {
+    "id": "issue-ok",
+    "identifier": "INV-3",
+    "title": "null deref in plan-parser when YAML lacks name",
+    "description": "Repo: https://github.com/Neko-Catpital-Labs/Invoker.git\nVerify: test 1 -eq 1\nFiles: packages/app/src/plan-parser.ts\n",
+    "labels": { "nodes": [{ "name": "invoker-ready" }] }
+  }
+]
+JSON
+mkdir -p "$sb/work"
+: > "$sb/work/submitted-inv-3"
+env \
+  INVOKER_LINEAR_FIXTURE_ISSUES="$sb/issues.json" \
+  INVOKER_LINEAR_WORK_DIR="$sb/work" \
+  INVOKER_LINEAR_COMMENT_CMD="$sb/bin/comment-stub" \
+  INVOKER_LINEAR_SUBMIT_CMD="$sb/bin/submit-stub" \
+  INVOKER_LINEAR_DRY_RUN=1 \
+  INVOKER_LINEAR_RESUBMIT_GUARD_MIN=1200 \
+  bash "$WORKER" > "$log" 2>&1 || fail "C: worker exited non-zero" "$log"
+
+grep -q "INV-3: resubmit guard" "$log" || fail "C: expected resubmit guard skip" "$log"
+echo "PASS C: resubmit guard"
+
+echo "PASS: linear-ticket-intake.sh behavior verified (gaps, dry-run submit, resubmit-guard)"

--- a/scripts/uninstall-linear-ticket-intake-cron.sh
+++ b/scripts/uninstall-linear-ticket-intake-cron.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Remove the Linear ticket intake cron installed by install-linear-ticket-intake-cron.sh.
+set -euo pipefail
+
+MARKER="# invoker-linear-ticket-intake"
+
+if ! crontab -l >/dev/null 2>&1; then
+  echo "No crontab found for current user; nothing to remove."
+  exit 0
+fi
+
+TMP_CRON="$(mktemp -t invoker-cron.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+# grep -v exits 1 when nothing remains (sole-entry crontab); only exit >1 is a real error.
+crontab -l | { grep -Fv "$MARKER" || [ $? -eq 1 ]; } > "$TMP_CRON"
+crontab "$TMP_CRON"
+
+echo "Removed any crontab lines matching: $MARKER"
+echo "Verify with: crontab -l | grep -F '$MARKER' || true"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -3,17 +3,16 @@ name: plan-to-invoker
 description: >
   Convert a plan into an Invoker YAML plan file. After `install-skills`, this
   routing is always on via Cursor `~/.cursor/rules/invoker-execution-precedence.mdc`,
-  a Codex AGENTS.md marked block, and a Claude UserPromptSubmit hook. Tiny
-  clean-tree edits stay local; feature work and dirty trees go through this
-  skill unless the user says "do it locally". Uninstall with
-  `install-skills uninstall`. Trigger: "convert to invoker",
-  "submit to invoker", "create invoker plan", "invoker-plan-to-invoker",
-  "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
-  Invoker tasks. For benchmark/direct-output prompts with "Required output path",
-  write a complete YAML document directly to that literal path; it must start
-  with top-level name, onFinish, mergeMode,
-  repoUrl (or scratch: true for no-repo mode), and tasks, never version or metadata wrappers,
-  and must not scan, validate, submit, or discover env vars.
+  a Codex AGENTS.md marked block, and a Claude UserPromptSubmit hook.
+  One-slice same-repo edits stay local; multi-layer or multi-PR work goes through this
+  skill (then chat-submit / auto_submit after the completeness gate) unless the user says "do it locally". Uninstall with `install-skills uninstall`. Trigger: "convert to invoker",
+  "submit to invoker", "create invoker plan",
+  "invoker-plan-to-invoker", "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
+  Invoker tasks. For benchmark/direct-output
+  prompts with "Required output path", write a complete YAML document directly
+  to that literal path; it must start with top-level name, onFinish, mergeMode,
+  repoUrl (or scratch: true for no-repo mode), and tasks, never version or
+  metadata wrappers, and must not scan, validate, submit, or discover env vars.
 ---
 
 # plan-to-invoker
@@ -68,6 +67,7 @@ Use this mode when invoked by the installed command or MCP prompt.
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP review/submission flow when available: call `invoker_prepare_plan_review`, show its ordered steps plus `confirmationText`, then call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`.
+- Before prepare/submit, run `bash skills/plan-to-invoker/scripts/check-planning-completeness.sh <plan-file>` (also part of `skill-doctor`). Incomplete Goal / Motivation / Safety invariant / repoUrl / Verify, or leftover `REPLACE_ME`, must be clarified on the intake surface — do not submit.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before the final submission step.
 - Outside an Invoker source checkout, `invoker_prepare_plan_review` is the canonical review surface and `invoker_validate_plan` remains an optional diagnostic, not the approval gate.
 - Plain approval stops after workflow handoff: treat approval of the Markdown/YAML plan as authorization to submit the reviewed workflow plan to Invoker only, then report the submitted workflow status and stop. Stop after `invoker_submit_plan` or the documented `invoker-cli run ... --live` fallback; do not create, update, publish pull requests, or run `mergify stack push` from that approval alone.
@@ -78,8 +78,8 @@ Use this mode when invoked by the installed command or MCP prompt.
 
 Use `confirmationMode` to distinguish who decided the hand-off should happen:
 
-- **Self-triggered delegation: confirmationMode: auto_submit** — the agent or subagent itself decided, mid-task and without a direct human instruction, that a chunk of work should be handed off to Invoker. No human message asked for this specific hand-off; it's the agent's own routing choice. In this case, skip the Slack review-card wait and call `invoker_submit_plan` once `invoker_prepare_plan_review` reports `confirmationMode: auto_submit`.
-- **Human-triggered delegation: confirmationMode: require** — a human's message is the direct request to hand off or send work to Invoker. Today's `require` + human-approval flow is unchanged: show the ordered steps and `confirmationText`, and wait for explicit approval before calling `invoker_submit_plan`.
+- **Self-triggered delegation: confirmationMode: auto_submit** — the agent or subagent itself decided, mid-task and without a direct human instruction, that a chunk of work should be handed off to Invoker. No human message asked for this specific hand-off; it's the agent's own routing choice. In this case, skip the Slack review-card wait and call `invoker_submit_plan` once `invoker_prepare_plan_review` reports `confirmationMode: auto_submit` **and** `check-planning-completeness.sh` passed. Incomplete plans stay on the native surface (AskQuestion / Slack question / Linear comment).
+- **Human-triggered delegation: confirmationMode: require** — a human's message is the direct request to hand off or send work to Invoker. Today's `require` + human-approval flow is unchanged: show the ordered steps and `confirmationText`, and wait for explicit approval before calling `invoker_submit_plan`. Completeness still must pass first.
 
 In both paths, the delegating agent chooses `poolId` best-effort per `references/schema.md` (an existing field) — omit it for the local default when unsure. `skill-doctor.sh` still runs against the generated plan in both paths; self-triggered delegation changes who approves the submission, not the validation gate.
 

--- a/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
+++ b/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed planning completeness gate.
+ * Rejects plans that still have placeholder Goal/Motivation/Safety invariant,
+ * missing repoUrl (unless scratch), non-runnable Verify, or leftover REPLACE_ME.
+ *
+ * Usage: node check-planning-completeness.mjs <plan.yaml>
+ * Exit 0 = complete; exit 1 = gaps (printed as JSON to stdout, human lines on stderr)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // Fall through.
+  }
+  const candidates = [
+    process.env.INVOKER_REPO_ROOT,
+    resolve(scriptDir, '../../..'),
+  ].filter(Boolean);
+  try {
+    const manifest = join(homedir(), '.invoker', 'bundled-skills.json');
+    if (existsSync(manifest)) {
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (parsed.sourceRepoRoot) candidates.push(parsed.sourceRepoRoot);
+    }
+  } catch {
+    // ignore
+  }
+  for (const root of candidates) {
+    const repoYamlPath = resolve(root, 'packages/app/node_modules/yaml/dist/index.js');
+    if (existsSync(repoYamlPath)) return import(repoYamlPath);
+  }
+  throw new Error('Unable to resolve yaml runtime for check-planning-completeness.');
+}
+
+const { parse: parseYaml } = await importYaml(__dirname);
+
+const PLACEHOLDER_RE = /\bREPLACE_ME\b|\bTODO\b|\bTBD\b|\bFIXME\b/i;
+const MANUAL_VERIFY_RE = /\bmanually\s+check\b|\bcheck\s+manually\b|\bby\s+hand\b/i;
+const GIT_URL_RE = /^(?:git@|https?:\/\/|ssh:\/\/).+\..+/i;
+const HEADING_RE = {
+  goal: /\bGoal:\s*(.+?)(?=\s+(?:Motivation|Alternative considerations|Alternatives|Implementation details|Implementation|Acceptance criteria|Non-goals|Layer|Feature state|Review claim|Review lane|Safety invariant|Slice rationale|Architectural effect|Files|Change types):|$)/is,
+  motivation: /\bMotivation:\s*(.+?)(?=\s+(?:Goal|Alternative considerations|Alternatives|Implementation details|Implementation|Acceptance criteria|Non-goals|Layer|Feature state|Review claim|Review lane|Safety invariant|Slice rationale|Architectural effect|Files|Change types):|$)/is,
+  safety: /\bSafety invariant:\s*(.+?)(?=\s+(?:Goal|Motivation|Alternative considerations|Alternatives|Implementation details|Implementation|Acceptance criteria|Non-goals|Layer|Feature state|Review claim|Review lane|Slice rationale|Architectural effect|Files|Change types):|$)/is,
+};
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function collectTasks(plan) {
+  const tasks = [];
+  if (Array.isArray(plan.tasks)) {
+    for (const task of plan.tasks) tasks.push({ workflow: null, task });
+  }
+  if (Array.isArray(plan.workflows)) {
+    for (const workflow of plan.workflows) {
+      if (!isRecord(workflow) || !Array.isArray(workflow.tasks)) continue;
+      for (const task of workflow.tasks) tasks.push({ workflow: workflow.name ?? null, task });
+    }
+  }
+  return tasks;
+}
+
+function headingValue(text, kind) {
+  const match = text.match(HEADING_RE[kind]);
+  return match?.[1]?.trim() ?? '';
+}
+
+function isPlaceholder(value) {
+  if (!value || !value.trim()) return true;
+  if (PLACEHOLDER_RE.test(value)) return true;
+  if (/^REPLACE_ME\b/i.test(value.trim())) return true;
+  return false;
+}
+
+function extractVerifyCandidates(plan, tasks) {
+  const candidates = [];
+  const desc = typeof plan.description === 'string' ? plan.description : '';
+  const verifyLine = desc.match(/\bVerify:\s*(.+)$/im)?.[1]?.trim();
+  if (verifyLine) candidates.push({ source: 'description', value: verifyLine });
+
+  for (const { task } of tasks) {
+    if (!isRecord(task)) continue;
+    if (typeof task.command === 'string' && task.command.trim()) {
+      candidates.push({ source: `task:${task.id ?? '?'}.command`, value: task.command.trim() });
+    }
+    const text = [task.description, task.prompt].filter((v) => typeof v === 'string').join('\n');
+    const acceptance = text.match(/Acceptance criteria:[\s\S]*?`([^`]+)`/);
+    if (acceptance?.[1]) {
+      candidates.push({ source: `task:${task.id ?? '?'}.acceptance`, value: acceptance[1].trim() });
+    }
+  }
+  return candidates;
+}
+
+function checkPlan(plan) {
+  const gaps = [];
+
+  if (!isRecord(plan)) {
+    return [{ field: 'plan', message: 'Plan did not parse as a YAML object.' }];
+  }
+
+  const scratch = plan.scratch === true;
+  const repoUrl = typeof plan.repoUrl === 'string' ? plan.repoUrl.trim() : '';
+  if (!scratch) {
+    if (!repoUrl) {
+      gaps.push({ field: 'repoUrl', message: 'Missing repoUrl (or set scratch: true for no-repo plans).' });
+    } else if (!GIT_URL_RE.test(repoUrl) && repoUrl !== '.') {
+      gaps.push({ field: 'repoUrl', message: `repoUrl is not a git URL: ${repoUrl}` });
+    }
+  }
+
+  const planText = JSON.stringify(plan);
+  if (PLACEHOLDER_RE.test(planText)) {
+    gaps.push({ field: 'REPLACE_ME', message: 'Plan still contains REPLACE_ME / TODO / TBD / FIXME placeholders.' });
+  }
+
+  const tasks = collectTasks(plan);
+  const implementationTasks = tasks.filter(({ task }) => {
+    if (!isRecord(task)) return false;
+    const hasPrompt = typeof task.prompt === 'string' && task.prompt.trim();
+    const hasCommand = typeof task.command === 'string' && task.command.trim();
+    // Proof-only command tasks still need Goal/Motivation when onFinish != none,
+    // but allow command-only verify plans with onFinish none to skip heading depth.
+    if (plan.onFinish === 'none' && hasCommand && !hasPrompt) return false;
+    return hasPrompt || hasCommand || typeof task.description === 'string';
+  });
+
+  if (plan.onFinish && plan.onFinish !== 'none') {
+    for (const { task } of implementationTasks) {
+      if (!isRecord(task)) continue;
+      const id = typeof task.id === 'string' ? task.id : '(unnamed)';
+      const text = [task.description, task.prompt].filter((v) => typeof v === 'string').join('\n\n');
+      for (const [kind, label] of [
+        ['goal', 'Goal'],
+        ['motivation', 'Motivation'],
+        ['safety', 'Safety invariant'],
+      ]) {
+        const value = headingValue(text, kind);
+        if (isPlaceholder(value)) {
+          gaps.push({
+            field: `${id}.${label}`,
+            message: `Task "${id}" is missing a real ${label}: (empty or placeholder).`,
+          });
+        }
+      }
+    }
+
+    const verifies = extractVerifyCandidates(plan, tasks);
+    if (verifies.length === 0) {
+      gaps.push({
+        field: 'Verify',
+        message: 'No runnable Verify command found (description Verify:, task command:, or acceptance backtick command).',
+      });
+    } else if (verifies.every((v) => MANUAL_VERIFY_RE.test(v.value) || isPlaceholder(v.value))) {
+      gaps.push({
+        field: 'Verify',
+        message: `Verify is not runnable: ${verifies.map((v) => v.value).join(' | ')}`,
+      });
+    }
+  }
+
+  return gaps;
+}
+
+const planPath = process.argv[2];
+if (!planPath) {
+  console.error('Usage: node check-planning-completeness.mjs <plan.yaml>');
+  process.exit(2);
+}
+if (!existsSync(planPath)) {
+  console.error(`Plan file not found: ${planPath}`);
+  process.exit(2);
+}
+
+let plan;
+try {
+  plan = parseYaml(readFileSync(planPath, 'utf8'));
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Failed to parse YAML: ${message}`);
+  process.exit(1);
+}
+
+const gaps = checkPlan(plan);
+const result = {
+  planFile: planPath,
+  complete: gaps.length === 0,
+  gaps,
+};
+
+console.log(JSON.stringify(result, null, 2));
+if (gaps.length > 0) {
+  for (const gap of gaps) {
+    console.error(`GAP ${gap.field}: ${gap.message}`);
+  }
+  process.exit(1);
+}
+process.exit(0);

--- a/skills/plan-to-invoker/scripts/check-planning-completeness.sh
+++ b/skills/plan-to-invoker/scripts/check-planning-completeness.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fail-closed planning completeness gate (Goal / Motivation / Safety invariant /
+# repoUrl / Verify / no REPLACE_ME). Same gate for Slack, terminal, Linear, chat-submit.
+# Usage: bash check-planning-completeness.sh <plan.yaml>
+# Exit 0 = complete, Exit 1 = gaps
+set -euo pipefail
+
+file="${1:?Usage: check-planning-completeness.sh <plan.yaml>}"
+script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
+exec node "$script_dir/check-planning-completeness.mjs" "$abs_file"

--- a/skills/plan-to-invoker/scripts/skill-doctor.sh
+++ b/skills/plan-to-invoker/scripts/skill-doctor.sh
@@ -307,6 +307,14 @@ if [[ "$SKIP_VALIDATION" == "false" ]]; then
     bash "$SCRIPT_DIR/validate-plan.sh" "$PLAN_FILE"
 fi
 
+# Check 3a: Planning completeness (Goal / Motivation / Safety invariant / Verify / no REPLACE_ME)
+if [[ "$SKIP_VALIDATION" == "false" ]]; then
+  run_check \
+    "check-planning-completeness" \
+    "Validate Goal/Motivation/Safety invariant/Verify and reject REPLACE_ME placeholders" \
+    bash "$SCRIPT_DIR/check-planning-completeness.sh" "$PLAN_FILE"
+fi
+
 # Check 4: Task atomicity linting (if not skipped)
 if [[ "$SKIP_ATOMICITY" == "false" ]]; then
   atomicity_args=(--strict-delegation)


### PR DESCRIPTION
## Summary

Linear issues had no first-class path into Invoker without silent formula dumps or label scaffolding that did not exist yet.

This adds an intake worker for invoker-ready or ID-selected issues. It fills Repo/Files/Verify when possible, runs the completeness gate, and can sandbox without mutating Linear.

## Review Claim

`scripts/linear-ticket-intake` turns invoker-ready or ID-selected Linear issues into completeness-gated Invoker plans, and sandbox mode leaves Linear labels untouched.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Sandbox mode never mutates Linear labels or comments and never installs DO1 cron; production cron stays an explicit install script.

## Slice Rationale

Worker behavior is a separate claim from always-on fragment text and from documentation.

## Non-goals

- No Productlane
- No pstack swarm
- No change to Slack human plan require mode
- No auto-land of review-gated UI work

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-linear-ticket-intake.sh`
- [x] Sandbox run created workflows `wf-1787698236370-1`, `wf-1787698306718-1`, `wf-1787698481265-1` under `/tmp/linear-intake-sandbox/db`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: If cron was installed on DO1, run `bash scripts/uninstall-linear-ticket-intake-cron.sh`
- Data migration? No

</details>
