### PR TITLE
[Release watcher version sync](1) Bump watcher package versions to 0.0.13

### DIFF
--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

The v0.0.13 GitHub Release built every platform, then stopped before publish.

Watcher tarballs used 0.0.11 from `packages/watcher`, while the required tarball names use the root 0.0.13 version.

This sets `packages/watcher` and `packages/npm-watcher` to 0.0.13 so the archive names match.

## Review Claim

Approve the literal 0.0.11 to 0.0.13 version-field change in the two watcher package.json files, with no other edits.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every changed line is a version string in package.json. No watcher runtime logic. The next slice adds these files to the sync scripts.

## Slice Rationale

Keep the version-field edits in their own PR. The sync-script edits are a separate review lane and would mix product files with policy files.

## Non-goals

Does not change bump-version.mjs or check-version-sync.mjs. Does not change watcher behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -p "require('./packages/watcher/package.json').version"` prints `0.0.13`
- [x] `node -p "require('./packages/npm-watcher/package.json').version"` prints `0.0.13`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
