### PR TITLE
[Release watcher version sync](2) Include watcher in version-sync scripts

### DIFF
--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -5,10 +5,10 @@
 //   node scripts/bump-version.mjs 0.0.7
 //
 // Covers the root + publishable package.json files (app, cli, slack-manager,
-// npm-cli, npm-ui, npm-slack), the VERSION constants baked into the CLI and
-// Slack manager sources, and CHANGELOG.md (renames "## Unreleased" to the
-// new version and starts a fresh "## Unreleased"). After this, commit and tag
-// (vX.Y.Z) to trigger the release workflow.
+// watcher, npm-cli, npm-ui, npm-slack, npm-watcher), the VERSION constants
+// baked into the CLI and Slack manager sources, and CHANGELOG.md (renames
+// "## Unreleased" to the new version and starts a fresh "## Unreleased").
+// After this, commit and tag (vX.Y.Z) to trigger the release workflow.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -44,9 +44,11 @@ function main() {
     'packages/app/package.json',
     'packages/cli/package.json',
     'packages/slack-manager/package.json',
+    'packages/watcher/package.json',
     'packages/npm-cli/package.json',
     'packages/npm-ui/package.json',
     'packages/npm-slack/package.json',
+    'packages/npm-watcher/package.json',
   ];
 
   for (const relPath of packageJsonPaths) {

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -14,9 +14,11 @@ const sources = [
   ['packages/app/package.json', JSON.parse(readFileSync(join(root, 'packages/app/package.json'), 'utf8')).version],
   ['packages/cli/package.json', JSON.parse(readFileSync(join(root, 'packages/cli/package.json'), 'utf8')).version],
   ['packages/slack-manager/package.json', JSON.parse(readFileSync(join(root, 'packages/slack-manager/package.json'), 'utf8')).version],
+  ['packages/watcher/package.json', JSON.parse(readFileSync(join(root, 'packages/watcher/package.json'), 'utf8')).version],
   ['packages/npm-cli/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-cli/package.json'), 'utf8')).version],
   ['packages/npm-ui/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-ui/package.json'), 'utf8')).version],
   ['packages/npm-slack/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-slack/package.json'), 'utf8')).version],
+  ['packages/npm-watcher/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-watcher/package.json'), 'utf8')).version],
   [
     'packages/cli/src/index.ts (const VERSION)',
     readFileSync(join(root, 'packages/cli/src/index.ts'), 'utf8').match(/^const VERSION = '([^']+)';$/m)?.[1],


### PR DESCRIPTION
## Summary

The v0.0.13 bump omitted watcher, so a later cut can drift the same way.

This adds `packages/watcher` and `packages/npm-watcher` to bump-version.mjs and check-version-sync.mjs.

The paired PR already set those package.json version fields to 0.0.13, so the sync check stays green.

## Review Claim

Approve listing the two watcher package.json paths in bump-version.mjs and check-version-sync.mjs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the two version-sync scripts change. No package.json edits in this slice. `node scripts/check-version-sync.mjs` prints `ok all release versions are 0.0.13` once the paired version bump is underneath.

## Slice Rationale

Keep the script edits in their own PR. Version-field edits in packages/ are a different review lane.

## Non-goals

Does not change watcher package.json in this slice. Does not change watcher behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/check-version-sync.mjs` prints `ok all release versions are 0.0.13`
- [x] `node scripts/test-bump-version-changelog.mjs` prints `ok bump-version changelog roll`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
