### PR TITLE
[Claude session usage](1) Parse message.usage from Claude Code JSONL

### DIFF
--- a/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
@@ -154,6 +154,31 @@ describe('ClaudeSessionDriver', () => {
     });
   });
 
+  it('extractUsage reads message.usage and message.model (Claude Code JSONL shape)', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          model: 'claude-opus-5',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input_tokens: 12, output_tokens: 34, cache_read_input_tokens: 5600 },
+        },
+        timestamp: '2026-08-23T00:00:00Z',
+      }),
+    ].join('\n');
+
+    const events = driver.extractUsage(jsonl);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      model: 'claude-opus-5',
+      inputTokens: 12,
+      outputTokens: 34,
+      cachedTokens: 5600,
+      totalTokens: 46,
+      confidence: 'exact',
+    });
+  });
+
   it('extractUsage returns empty array when no usage metadata', () => {
     // The standard sample fixture has no usage fields
     expect(driver.extractUsage(sampleClaudeJsonl)).toEqual([]);

--- a/packages/execution-engine/src/claude-session-driver.ts
+++ b/packages/execution-engine/src/claude-session-driver.ts
@@ -118,10 +118,11 @@ export class ClaudeSessionDriver implements SessionDriver {
   /**
    * Extract usage events from Claude session JSONL.
    *
-   * Claude CLI assistant entries may carry a top-level `usage` object with
-   * input_tokens / output_tokens / cache_read_input_tokens. When usage
-   * metadata is absent the entry is skipped (callers may synthesize an
-   * unknown-confidence placeholder upstream).
+   * Claude Code assistant entries historically put usage on the entry root;
+   * current Claude Code JSONL nests it under `message.usage` (and model under
+   * `message.model`). Accept either shape. When usage metadata is absent the
+   * entry is skipped (callers may synthesize an unknown-confidence placeholder
+   * upstream).
    */
   extractUsage(raw: string): SessionUsageEvent[] {
     const events: SessionUsageEvent[] = [];
@@ -132,26 +133,35 @@ export class ClaudeSessionDriver implements SessionDriver {
       lineIndex++;
       try {
         const entry = JSON.parse(line);
+        if (entry.type !== 'assistant') continue;
 
-        // Claude JSONL assistant entries may include usage metadata
-        if (entry.type === 'assistant' && entry.usage) {
-          const u = entry.usage;
-          const input = typeof u.input_tokens === 'number' ? u.input_tokens : 0;
-          const output = typeof u.output_tokens === 'number' ? u.output_tokens : 0;
-          const cached = typeof u.cache_read_input_tokens === 'number'
-            ? u.cache_read_input_tokens
-            : 0;
-          events.push({
-            eventId: `claude-assistant-${lineIndex}`,
-            timestamp: entry.timestamp ?? '',
-            model: typeof entry.model === 'string' ? entry.model : '',
-            inputTokens: input,
-            outputTokens: output,
-            cachedTokens: cached,
-            totalTokens: input + output,
-            confidence: 'exact',
-          });
-        }
+        const message = entry.message && typeof entry.message === 'object'
+          ? entry.message as Record<string, unknown>
+          : null;
+        const usageRaw = entry.usage ?? message?.usage;
+        if (!usageRaw || typeof usageRaw !== 'object') continue;
+        const u = usageRaw as Record<string, unknown>;
+
+        const input = typeof u.input_tokens === 'number' ? u.input_tokens : 0;
+        const output = typeof u.output_tokens === 'number' ? u.output_tokens : 0;
+        const cached = typeof u.cache_read_input_tokens === 'number'
+          ? u.cache_read_input_tokens
+          : 0;
+        const modelFromMessage = typeof message?.model === 'string' ? message.model : '';
+        const model = typeof entry.model === 'string' && entry.model
+          ? entry.model
+          : modelFromMessage;
+
+        events.push({
+          eventId: `claude-assistant-${lineIndex}`,
+          timestamp: entry.timestamp ?? '',
+          model,
+          inputTokens: input,
+          outputTokens: output,
+          cachedTokens: cached,
+          totalTokens: input + output,
+          confidence: 'exact',
+        });
       } catch {
         // Skip malformed lines
       }


### PR DESCRIPTION
## Summary

Fixes Claude session cost extraction so Claude Code JSONL `message.usage` is counted.

Without this, query-time cost rollups reported zero Claude tokens even when sessions had full usage metadata.

## Review Claim

Approve reading `message.usage` / `message.model` in `ClaudeSessionDriver.extractUsage` while keeping top-level usage support.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Parser-only change over existing session JSONL; does not alter task execution, writes, or agent prompts.

## Slice Rationale

First of two telemetry parser slices; cache_creation lands in the next stack PR.

## Non-goals

- No cache_creation field yet (next slice)
- No report artifact changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Claude session driver unit tests covering nested message.usage

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
