### PR TITLE
[Repair cost miner](1) Add maxTurns to task and work-request contracts

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -65,6 +65,8 @@ export interface WorkRequestInputs {
   executionAgent?: string;
   /** Agent-specific model selector. The selected CLI owns validation. */
   executionModel?: string;
+  /** Finite agent turn budget (Claude `--max-turns`) when set. */
+  maxTurns?: number;
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -47,6 +47,8 @@ export interface BaseTaskConfig {
   readonly executionAgent?: string;
   /** Agent-specific model selector passed through without central validation. */
   readonly executionModel?: string;
+  /** Finite agent turn budget (Claude `--max-turns`) when set. */
+  readonly maxTurns?: number;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Repair agent tasks need an optional turn budget on the shared task shape.

This slice only adds `maxTurns` on the task and work-request shapes so later slices can enforce it.

## Review Claim

Task and work-request shapes gain an optional `maxTurns` field with no runtime enforcement yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Additive optional field only. Existing tasks without `maxTurns` keep prior meaning.

## Slice Rationale

Foundation shapes land before any executor or worker behavior that consumes them.

## Non-goals

- No executor enforcement
- No worker registration
- No repair YAML edits

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Typecheck packages that consume the updated shapes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: none
