### PR TITLE
[Repair cost miner](3) Skip agent autofix for command tasks

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -40,7 +40,9 @@ import {
   StaleLineageError,
   captureTaskLineage,
   assertLineageCurrent,
+  shouldSkipAgentAutoFixForTask
 } from '../workflow-actions.js';
+// patched import below
 
 vi.mock('../delete-all-snapshot.js', () => ({
   createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
@@ -2695,5 +2697,30 @@ describe('fixWithAgentAction review-gate CI context', () => {
       savedError: 'ci failed',
       fixError: 'agent exploded',
     });
+  });
+});
+
+describe('shouldSkipAgentAutoFixForTask', () => {
+  it('shouldSkipAgentAutoFixForTask is true when task has a command', () => {
+    expect(shouldSkipAgentAutoFixForTask({ config: { command: 'echo hi' } })).toBe(true);
+    expect(shouldSkipAgentAutoFixForTask({ config: {} })).toBe(false);
+    expect(shouldSkipAgentAutoFixForTask({})).toBe(false);
+  });
+
+  it('skips fixWithAgent for command tasks in autoFixOnFailure', async () => {
+    const fixWithAgent = vi.fn();
+    const getTask = vi.fn().mockReturnValue({
+      id: 'normalize',
+      status: 'failed',
+      config: { command: 'echo fail' },
+      execution: { error: 'boom', generation: 0 },
+    });
+    await autoFixOnFailure('normalize', {
+      orchestrator: { getTask } as any,
+      persistence: { logEvent: vi.fn(), appendTaskOutput: vi.fn(), getTaskOutput: () => '' } as any,
+      commandService: {} as any,
+      taskExecutor: { fixWithAgent, executeTasks: vi.fn() } as any,
+    });
+    expect(fixWithAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -1212,6 +1212,12 @@ async function recordFixedIntegrationAnchor(
  * Automatically fix a failed task with an AI agent and restart it.
  * Worker retry limits are enforced before this action is queued.
  */
+
+/** Command tasks (normalize/safe-push) must not spawn Claude autofix sessions. */
+export function shouldSkipAgentAutoFixForTask(task: { config?: { command?: string } }): boolean {
+  return Boolean(task.config?.command);
+}
+
 export async function autoFixOnFailure(
   taskId: string,
   deps: {
@@ -1232,6 +1238,14 @@ export async function autoFixOnFailure(
 
   const task = orchestrator.getTask(taskId);
   if (!task || task.status !== 'failed') return;
+
+  if (shouldSkipAgentAutoFixForTask(task)) {
+    console.log(`[auto-fix] "${taskId}" skipping agent autofix for command task`);
+    persistence.logEvent?.(taskId, 'debug.auto-fix', {
+      phase: 'auto-fix-skip-command-task',
+    });
+    return;
+  }
 
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, deps.signal);


### PR DESCRIPTION
## Summary

Agent autofix was still spending tokens on pure shell tasks that never need an agent rewrite.

This gates autofix so shell-only tasks leave the agent path unused.

## Review Claim

Workflow actions keep agent autofix off for shell-only tasks while prompt and repair tasks still reach the agent path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Shell-only tasks no longer enter agent autofix. Prompt and repair tasks keep the prior autofix path.

## Slice Rationale

Autofix gating is a separate activation claim from turn-budget enforcement and mine scripts.

## Non-goals

- No turn-budget changes
- No miner scripts
- No Workers UI changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/workflow-actions.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10514
