### PR TITLE
[Repair cost miner](4) Add workerSessionMineIntervalMs config field

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -283,6 +283,8 @@ export interface InvokerConfig {
    * Cadence stays in the flat `e2eAutoFixIntervalMs` above.
    */
   e2eAutoFix?: E2eAutoFixConfig;
+  /** Cadence for the worker-session-mine worker in milliseconds. Default: 3_600_000 (1h). */
+  workerSessionMineIntervalMs?: number;
   stallRequeueRetries?: number;
   stallRequeueBackoffMs?: number;
   /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -428,7 +428,7 @@ function buildRegisteredOwnerWorkerDeps(
       ),
     },
     e2eAutoFix: resolveE2eAutoFixWorkerConfig(invokerConfig),
-    workerSessionMine: { intervalMs: invokerConfig.workerSessionMineIntervalMs },
+    workerSessionMine: {},
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),
       authorGate: buildPersistedAutoApproveAuthorGate(persistence),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -428,7 +428,7 @@ function buildRegisteredOwnerWorkerDeps(
       ),
     },
     e2eAutoFix: resolveE2eAutoFixWorkerConfig(invokerConfig),
-    workerSessionMine: {},
+    workerSessionMine: { intervalMs: invokerConfig.workerSessionMineIntervalMs },
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),
       authorGate: buildPersistedAutoApproveAuthorGate(persistence),


### PR DESCRIPTION
## Summary

The session mine worker needs a configurable poll interval on owner config.

This adds `workerSessionMineIntervalMs` so enablement policy can tune cadence without hardcoding.

## Review Claim

Owner config gains `workerSessionMineIntervalMs` for the session mine worker poll cadence.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Additive config field only. Default leaves the worker off until desired-state enables it.

## Slice Rationale

Config policy stays separate from executor behavior and from script tooling.

## Non-goals

- No mine script changes
- No Workers UI label changes beyond prior registration

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Confirm `workerSessionMineIntervalMs` parses in app config

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10515
