### PR TITLE
[Repair cost miner](5) Cap repair YAML turns and add multi-harness session mine scripts

### DIFF
--- a/scripts/cron-worker-session-mine.sh
+++ b/scripts/cron-worker-session-mine.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Cron/owner-worker entrypoint for worker session thrash mining.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK="${INVOKER_SESSION_MINE_LOCK:-${TMPDIR:-/tmp}/invoker-worker-session-mine.lock}"
+
+log_line() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    log_line "worker-session-mine already running; exiting"
+    exit 0
+  fi
+fi
+
+cd "$REPO_ROOT"
+exec node scripts/worker-session-mine.mjs "$@"

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -81,10 +81,12 @@ def _write_plan_header(*, name: str, base_branch: str, repo: str, merge_mode: st
     )
 
 
-def _repair_task_yaml(*, description: str, prompt: str) -> str:
+def _repair_task_yaml(*, description: str, prompt: str, max_turns: int | None = 30) -> str:
+    max_turns_line = f"    maxTurns: {max_turns}\n" if max_turns is not None else ""
     return (
         "  - id: repair\n"
         f"    description: {_yaml_str(description)}\n"
+        f"{max_turns_line}"
         "    prompt: |\n"
         f"{_indent_block(prompt, 6)}\n"
     )
@@ -132,15 +134,6 @@ def _shlex(value: str) -> str:
     return "'" + value.replace("'", "'\\''") + "'"
 
 
-_RESTRUCTURE_ESCAPE_HATCH = (
-    "If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
-    "unrelated files into their own PR because they can't ship together -- do not force that into a single "
-    "local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
-    "via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
-    "commit in this checkout and exit 0.\n"
-)
-
-
 _JOB_LOG_EXCERPT_MAX_CHARS = 20000
 
 
@@ -181,7 +174,6 @@ def build_repair_check_plan(
         "If a code change fixes it: make the change in this checkout. Commit locally if "
         "needed, do not push. If local proof shows the check is already green on the "
         "current head, make no commit and exit 0.\n\n"
-        f"{_RESTRUCTURE_ESCAPE_HATCH}\n"
         f"Repair the existing pull request #{pr.number} ({json.dumps(pr.title)}) on {repo}.\n"
         f"PR URL: {pr.url}\n"
         f"Head branch: {pr.head_ref_name} (at {start_head}), base branch: {pr.base_ref_name}\n\n"
@@ -227,10 +219,6 @@ def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, 
         f"Rebase this pull request onto `{onto_ref}`.\n\n"
         f"Checkout the PR head branch, rebase it onto origin/{onto_ref} while preserving the PR's intended "
         "changes, resolve any conflicts if they appear, then commit locally. Do not push.\n\n"
-        "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
-        "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
-        "a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
-        "Then make no commit in this checkout and exit 0.\n\n"
         "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
         f"Head SHA: {start_head}\nRebase onto: {onto_ref}\nReason: {reason}\n"

--- a/scripts/worker-session-mine-resolve.mjs
+++ b/scripts/worker-session-mine-resolve.mjs
@@ -1,0 +1,69 @@
+/**
+ * Resolve on-disk transcript paths for Invoker agent sessions (multi-harness).
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function claudeProjectRoots() {
+  const roots = [];
+  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim()
+    || process.env.INVOKER_CLAUDE_CONFIG_DIR?.trim()
+    || join(homedir(), '.invoker', 'claude-worker');
+  roots.push(join(configDir, 'projects'));
+  const legacy = join(homedir(), '.claude', 'projects');
+  if (legacy !== roots[0]) roots.push(legacy);
+  return roots;
+}
+
+export function agentSessionsDir() {
+  const base = process.env.INVOKER_DB_DIR || join(homedir(), '.invoker');
+  return join(base, 'agent-sessions');
+}
+
+function findInClaudeProjects(sessionId, roots = claudeProjectRoots()) {
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    let dirs;
+    try {
+      dirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    } catch {
+      continue;
+    }
+    for (const d of dirs) {
+      const candidate = join(root, d.name, `${sessionId}.jsonl`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {string} agentName
+ * @param {string} sessionId
+ * @returns {string | null}
+ */
+export function resolveTranscriptPath(agentName, sessionId) {
+  if (!sessionId) return null;
+  const name = (agentName || 'claude').trim().toLowerCase();
+  if (name === 'claude') {
+    return findInClaudeProjects(sessionId);
+  }
+  if (name === 'codex') {
+    const p = join(agentSessionsDir(), `${sessionId}.jsonl`);
+    return existsSync(p) ? p : null;
+  }
+  if (name === 'omp') {
+    const p = join(agentSessionsDir(), `${sessionId}.omp.txt`);
+    return existsSync(p) ? p : null;
+  }
+  // kimi / qwen / cursor: no SessionDriver storage yet
+  return null;
+}
+
+export function resolveTranscriptPathSelfTest() {
+  return {
+    claudeRoots: claudeProjectRoots(),
+    agentSessionsDir: agentSessionsDir(),
+  };
+}

--- a/scripts/worker-session-mine-resolve.selftest.mjs
+++ b/scripts/worker-session-mine-resolve.selftest.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Self-test for multi-harness transcript path resolution.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveTranscriptPath } from './worker-session-mine-resolve.mjs';
+
+const root = mkdtempSync(join(tmpdir(), 'session-mine-resolve-'));
+try {
+  process.env.INVOKER_CLAUDE_CONFIG_DIR = join(root, 'claude-worker');
+  process.env.CLAUDE_CONFIG_DIR = process.env.INVOKER_CLAUDE_CONFIG_DIR;
+  process.env.INVOKER_DB_DIR = root;
+
+  const claudeProjects = join(process.env.CLAUDE_CONFIG_DIR, 'projects', 'enc-cwd');
+  mkdirSync(claudeProjects, { recursive: true });
+  writeFileSync(join(claudeProjects, 'sid-claude.jsonl'), '{}\n');
+
+  const sessions = join(root, 'agent-sessions');
+  mkdirSync(sessions, { recursive: true });
+  writeFileSync(join(sessions, 'sid-codex.jsonl'), '{}\n');
+  writeFileSync(join(sessions, 'sid-omp.omp.txt'), 'hi\n');
+
+  const claudePath = resolveTranscriptPath('claude', 'sid-claude');
+  const codexPath = resolveTranscriptPath('codex', 'sid-codex');
+  const ompPath = resolveTranscriptPath('omp', 'sid-omp');
+  const missing = resolveTranscriptPath('kimi', 'sid-x');
+
+  if (!claudePath?.includes('claude-worker')) throw new Error(`claude path wrong: ${claudePath}`);
+  if (!codexPath?.endsWith('sid-codex.jsonl')) throw new Error(`codex path wrong: ${codexPath}`);
+  if (!ompPath?.endsWith('sid-omp.omp.txt')) throw new Error(`omp path wrong: ${ompPath}`);
+  if (missing !== null) throw new Error('kimi should be null');
+  console.log(JSON.stringify({ ok: true, claudePath, codexPath, ompPath }, null, 2));
+} finally {
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.INVOKER_CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.INVOKER_DB_DIR;
+}

--- a/scripts/worker-session-mine-thrash.mjs
+++ b/scripts/worker-session-mine-thrash.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Mechanical thrash detector for Invoker worker Claude JSONL sessions.
+ * No LLM. Used by worker-session-mine and follow-up repro tasks.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+export const DEFAULT_THRESHOLDS = Object.freeze({
+  minAssistantTurns: 40,
+  minCacheReadTokens: 10_000_000,
+  minSameBashArgv: 5,
+});
+
+export function sessionHash(sessionId, workflowName = '') {
+  return createHash('sha256').update(`${workflowName}\0${sessionId}`).digest('hex').slice(0, 16);
+}
+
+export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  let assistantTurns = 0;
+  let cacheReadTokens = 0;
+  const bashCounts = new Map();
+  let workflowHint = '';
+
+  for (const line of lines) {
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    // Codex structured stream
+    if (row.type === 'turn.completed' || row.type === 'turn.failed') {
+      assistantTurns += 1;
+      const usage = row.usage ?? {};
+      cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.input_tokens ?? 0) || 0;
+      continue;
+    }
+    if (row.type === 'item.completed' && row.item?.type === 'command_execution') {
+      const cmd = String(row.item?.command ?? row.item?.cmd ?? '').trim();
+      if (cmd) bashCounts.set(cmd, (bashCounts.get(cmd) ?? 0) + 1);
+    }
+    const msg = row.message ?? row;
+    const role = msg.role ?? row.type;
+    if (role === 'assistant' || row.type === 'assistant') {
+      assistantTurns += 1;
+      const usage = msg.usage ?? row.usage ?? {};
+      cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.cacheReadInputTokens ?? 0) || 0;
+      const content = Array.isArray(msg.content) ? msg.content : [];
+      for (const block of content) {
+        if (block?.type === 'tool_use' && (block.name === 'Bash' || block.name === 'bash')) {
+          const cmd = String(block.input?.command ?? block.input?.cmd ?? '').trim();
+          if (cmd) bashCounts.set(cmd, (bashCounts.get(cmd) ?? 0) + 1);
+        }
+      }
+    }
+    if (!workflowHint && (role === 'user' || row.type === 'user')) {
+      const textParts = [];
+      const content = msg.content ?? row.content;
+      if (typeof content === 'string') textParts.push(content);
+      else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (typeof block?.text === 'string') textParts.push(block.text);
+        }
+      }
+      const joined = textParts.join('\n');
+      const m = joined.match(/admin-bypass-[a-z0-9-]+/i);
+      if (m) workflowHint = m[0];
+      else if (/Failed check:/i.test(joined)) workflowHint = 'admin-bypass-repair';
+    }
+  }
+
+  let maxSameBash = 0;
+  let maxSameBashCmd = '';
+  for (const [cmd, count] of bashCounts) {
+    if (count > maxSameBash) {
+      maxSameBash = count;
+      maxSameBashCmd = cmd;
+    }
+  }
+
+  const reasons = [];
+  if (assistantTurns >= thresholds.minAssistantTurns) {
+    reasons.push(`assistant_turns=${assistantTurns}>=${thresholds.minAssistantTurns}`);
+  }
+  if (cacheReadTokens >= thresholds.minCacheReadTokens) {
+    reasons.push(`cache_read_tokens=${cacheReadTokens}>=${thresholds.minCacheReadTokens}`);
+  }
+  if (maxSameBash >= thresholds.minSameBashArgv) {
+    reasons.push(`same_bash_argv=${maxSameBash}>=${thresholds.minSameBashArgv}`);
+  }
+
+  return {
+    assistantTurns,
+    cacheReadTokens,
+    maxSameBash,
+    maxSameBashCmd: maxSameBashCmd.slice(0, 200),
+    workflowHint,
+    thrash: reasons.length > 0,
+    reasons,
+  };
+}
+
+export function analyzeClaudeJsonlFile(path, thresholds = DEFAULT_THRESHOLDS) {
+  if (!existsSync(path)) {
+    return { thrash: false, reasons: [`missing:${path}`], assistantTurns: 0, cacheReadTokens: 0, maxSameBash: 0 };
+  }
+  return analyzeClaudeJsonl(readFileSync(path, 'utf8'), thresholds);
+}
+
+export function runTokenAuditIfAvailable(jsonlPath, catstackRoot = process.env.CATSTACK_ROOT) {
+  if (!catstackRoot) return null;
+  const script = `${catstackRoot.replace(/\/$/, '')}/engine/skills/reflect/scripts/token_audit.py`;
+  if (!existsSync(script)) {
+    const alt = `${catstackRoot.replace(/\/$/, '')}/skills/reflect/scripts/token_audit.py`;
+    if (!existsSync(alt)) return null;
+    return runTokenAuditScript(alt, jsonlPath);
+  }
+  return runTokenAuditScript(script, jsonlPath);
+}
+
+function runTokenAuditScript(script, jsonlPath) {
+  const result = spawnSync('python3', [script, 'claude', jsonlPath, '--out', '-'], {
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    return { ok: false, error: result.stderr || result.stdout || `exit ${result.status}` };
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const flags = parsed.flags ?? parsed.thrash_flags ?? parsed;
+    const interesting = [
+      'recurring-failure-signatures',
+      'no-verify-edit-streak',
+      'cache-creation-spikes',
+    ].filter((k) => {
+      const v = flags?.[k] ?? flags?.[k.replace(/-/g, '_')];
+      return Array.isArray(v) ? v.length > 0 : Boolean(v);
+    });
+    return { ok: true, flags: interesting, raw: parsed };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export function detectThrash(jsonlPath, options = {}) {
+  const mechanical = analyzeClaudeJsonlFile(jsonlPath, options.thresholds ?? DEFAULT_THRESHOLDS);
+  const audit = runTokenAuditIfAvailable(jsonlPath, options.catstackRoot);
+  const reasons = [...mechanical.reasons];
+  if (audit?.ok && audit.flags?.length) {
+    for (const flag of audit.flags) reasons.push(`token_audit:${flag}`);
+  }
+  return {
+    ...mechanical,
+    thrash: reasons.length > 0,
+    reasons,
+    tokenAudit: audit,
+  };
+}
+
+function selfTest() {
+  const thrashy = [
+    JSON.stringify({ type: 'user', message: { role: 'user', content: 'Failed check: PR Body\nadmin-bypass-repair-check-pr-1' } }),
+    ...Array.from({ length: 40 }, (_, i) => JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: { cache_read_input_tokens: 300_000 },
+        content: [{ type: 'tool_use', name: 'Bash', input: { command: 'python3 scripts/foo.py' } }],
+      },
+    })),
+  ].join('\n');
+  const clean = [
+    JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+    JSON.stringify({ type: 'assistant', message: { role: 'assistant', usage: { cache_read_input_tokens: 100 }, content: [{ type: 'text', text: 'ok' }] } }),
+  ].join('\n');
+  const pos = analyzeClaudeJsonl(thrashy);
+  const neg = analyzeClaudeJsonl(clean);
+  if (!pos.thrash) throw new Error('expected thrash fixture to fire');
+  if (neg.thrash) throw new Error('expected clean fixture to stay silent');
+  const codexThrashy = Array.from({ length: 40 }, () => JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } })).join('\n');
+  const codexPos = analyzeClaudeJsonl(codexThrashy);
+  if (!codexPos.thrash) throw new Error('expected codex turn.completed thrash');
+  console.log(JSON.stringify({ ok: true, positiveReasons: pos.reasons, negativeThrash: neg.thrash, codexReasons: codexPos.reasons }, null, 2));
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('worker-session-mine-thrash.mjs');
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else if (isMain && process.argv[2] && process.argv[2] !== '--self-test') {
+  const report = detectThrash(process.argv[2]);
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.thrash ? 0 : 1);
+}

--- a/scripts/worker-session-mine.mjs
+++ b/scripts/worker-session-mine.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Scan terminal Invoker agent sessions (Claude/Codex/OMP) for thrash and
+ * submit one follow-up Invoker workflow per session hash per week.
+ * Never stops the original repair.
+ *
+ * Discovery: Invoker headless task inventory (agentSessionId + agentName),
+ * then resolve transcript paths per harness. Optional inventory JSON for tests.
+ */
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  mkdtempSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { detectThrash, sessionHash } from './worker-session-mine-thrash.mjs';
+import { resolveTranscriptPath, claudeProjectRoots, agentSessionsDir } from './worker-session-mine-resolve.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const STATE_DIR = process.env.INVOKER_SESSION_MINE_STATE_DIR
+  ?? join(homedir(), '.invoker', 'worker-session-mine');
+const LEDGER_PATH = join(STATE_DIR, 'cooldown.json');
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_PER_TICK = Number(process.env.INVOKER_SESSION_MINE_MAX_PER_TICK ?? '1');
+const MAX_PER_DAY = Number(process.env.INVOKER_SESSION_MINE_MAX_PER_DAY ?? '2');
+const LOOKBACK_HOURS = Number(process.env.INVOKER_SESSION_MINE_LOOKBACK_HOURS ?? '168');
+const WORKFLOW_PREFIXES = (process.env.INVOKER_SESSION_MINE_WORKFLOW_PREFIXES
+  ?? 'admin-bypass-repair-')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const EXCLUDE_NAME_RE = /(session-mine|reflect-ci-|worker-session-mine)/i;
+const POOL_ID = process.env.INVOKER_SESSION_MINE_POOL_ID ?? 'remote_digital_ocean_1';
+const DRY_RUN = process.env.INVOKER_SESSION_MINE_DRY_RUN === '1';
+const TERMINAL = new Set(['completed', 'failed', 'cancelled', 'stale']);
+
+function loadLedger() {
+  if (!existsSync(LEDGER_PATH)) return { version: 1, entries: {}, dayCounts: {} };
+  try {
+    return JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
+  } catch {
+    return { version: 1, entries: {}, dayCounts: {} };
+  }
+}
+
+function saveLedger(ledger) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+}
+
+function dayKey(d = new Date()) {
+  return d.toISOString().slice(0, 10);
+}
+
+function runHeadlessJson(args) {
+  const result = spawnSync('bash', [join(REPO_ROOT, 'run.sh'), '--headless', ...args, '--output', 'json'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env },
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(result.stdout || 'null');
+  } catch {
+    return null;
+  }
+}
+
+/** @returns {Array<{ workflowName: string, sessionId: string, agentName: string, status: string }>} */
+function listFromInventoryFile(path) {
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  const rows = Array.isArray(raw) ? raw : (raw.sessions || raw.tasks || []);
+  return rows.map((r) => ({
+    workflowName: r.workflowName || r.workflow || '',
+    sessionId: r.sessionId || r.agentSessionId || '',
+    agentName: r.agentName || r.executionAgent || 'claude',
+    status: r.status || 'failed',
+  })).filter((r) => r.sessionId);
+}
+
+function listFromHeadless() {
+  const workflows = runHeadlessJson(['query', 'workflows']);
+  if (!Array.isArray(workflows)) return null;
+  const out = [];
+  for (const wf of workflows) {
+    const name = wf.name || wf.id || '';
+    if (EXCLUDE_NAME_RE.test(name)) continue;
+    if (!WORKFLOW_PREFIXES.some((p) => name.startsWith(p) || name.includes(p))) continue;
+    const tasks = runHeadlessJson(['query', 'tasks', '--workflow', wf.id]);
+    if (!Array.isArray(tasks)) continue;
+    for (const task of tasks) {
+      const status = task.status || '';
+      if (!TERMINAL.has(status)) continue;
+      const execution = task.execution || {};
+      const sessionId = execution.agentSessionId || execution.lastAgentSessionId || '';
+      if (!sessionId) continue;
+      const agentName = execution.agentName || execution.lastAgentName || task.config?.executionAgent || 'claude';
+      out.push({ workflowName: name, sessionId, agentName, status });
+    }
+  }
+  return out;
+}
+
+/** Disk fallback when headless is unavailable (dev / fixtures). */
+function listFromDiskFallback() {
+  const cutoff = Date.now() - LOOKBACK_HOURS * 3600 * 1000;
+  const out = [];
+  for (const root of claudeProjectRoots()) {
+    if (!existsSync(root)) continue;
+    for (const project of readdirSync(root)) {
+      const projectDir = join(root, project);
+      try {
+        if (!statSync(projectDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      for (const name of readdirSync(projectDir)) {
+        if (!name.endsWith('.jsonl')) continue;
+        const path = join(projectDir, name);
+        try {
+          const mtime = statSync(path).mtimeMs;
+          if (mtime < cutoff) continue;
+          out.push({
+            workflowName: '',
+            sessionId: name.replace(/\.jsonl$/, ''),
+            agentName: 'claude',
+            status: 'failed',
+            path,
+            mtime,
+          });
+        } catch {
+          // skip
+        }
+      }
+    }
+  }
+  const sessions = agentSessionsDir();
+  if (existsSync(sessions)) {
+    for (const name of readdirSync(sessions)) {
+      const path = join(sessions, name);
+      try {
+        const mtime = statSync(path).mtimeMs;
+        if (mtime < cutoff) continue;
+      } catch {
+        continue;
+      }
+      if (name.endsWith('.jsonl')) {
+        out.push({
+          workflowName: '',
+          sessionId: name.replace(/\.jsonl$/, ''),
+          agentName: 'codex',
+          status: 'failed',
+          path,
+        });
+      } else if (name.endsWith('.omp.txt')) {
+        out.push({
+          workflowName: '',
+          sessionId: name.replace(/\.omp\.txt$/, ''),
+          agentName: 'omp',
+          status: 'failed',
+          path,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function matchesAllowlist(workflowName, report) {
+  const hint = workflowName || report.workflowHint || '';
+  if (EXCLUDE_NAME_RE.test(hint)) return false;
+  if (!hint) {
+    return process.env.INVOKER_SESSION_MINE_ALLOW_UNHINTTED === '1';
+  }
+  return WORKFLOW_PREFIXES.some((prefix) => hint.startsWith(prefix) || hint.includes(prefix));
+}
+
+function buildFollowUpPlan({ sessionId, jsonlPath, report, hash, agentName }) {
+  const name = `worker-session-mine-${hash}`;
+  const reasons = report.reasons.join('; ');
+  return `name: "${name}"
+description: |
+  Follow-up reflect/fix for thrashy worker session ${sessionId} (${agentName}).
+  Original repair is untouched. Never merge. Never vendor skills/reflect/.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git
+poolId: ${POOL_ID}
+
+tasks:
+  - id: repro-thrash
+    description: |
+      Prove the thrash detector fires on a fixture copy and stays silent on a clean fixture.
+      Review claim: Detector positive/negative fixtures encode the thrash reasons for session ${hash}.
+      Review lane: proof
+      Safety invariant: Proof-only; does not modify the original session or merge anything.
+    command: "node scripts/worker-session-mine-thrash.mjs --self-test"
+    dependencies: []
+
+  - id: reflect-and-fix
+    description: |
+      Reflect via catstack and open a PR to catstack or Invoker by root cause.
+      Review claim: Accepted findings land as a non-merged PR in the correct repo for session ${hash}.
+      Review lane: behavior
+      Safety invariant: Never vendor skills/reflect/ into Invoker; never merge; original workflow untouched.
+      Acceptance criteria:
+      - Summary says no durable finding or lists PR URL(s).
+      - test ! -e skills/reflect
+    maxTurns: 30
+    prompt: |
+      Goal: Reflect on thrashy Invoker worker session ${sessionId} (agent=${agentName}) and open a non-merged PR to catstack or Invoker.
+      Safety invariant: Never vendor skills/reflect/; never merge; do not touch the original repair workflow.
+      Implementation details: |
+        Clone https://github.com/EdbertChan/catstack.git. Follow engine/skills/reflect/SKILL.md against ${jsonlPath}.
+        Skill/hook/methodology -> catstack PR. Invoker harness/prompt/product -> Invoker PR. Never merge.
+      Pass condition: Exit 0 when acceptance criteria hold.
+    dependencies:
+      - repro-thrash
+`;
+}
+
+function submitPlan(yamlText) {
+  const dir = mkdtempSync(join(tmpdir(), 'session-mine-plan-'));
+  const planPath = join(dir, 'plan.yaml');
+  writeFileSync(planPath, yamlText);
+  if (DRY_RUN) {
+    console.log(`dry-run plan written: ${planPath}`);
+    return { ok: true, dryRun: true, planPath };
+  }
+  const submit = join(REPO_ROOT, 'submit-plan.sh');
+  const result = spawnSync('bash', [submit, planPath], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env },
+  });
+  console.log(result.stdout || '');
+  if (result.stderr) console.error(result.stderr);
+  return { ok: result.status === 0, status: result.status, planPath };
+}
+
+function main() {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const ledger = loadLedger();
+  const today = dayKey();
+  const dayCount = ledger.dayCounts?.[today] ?? 0;
+  if (dayCount >= MAX_PER_DAY) {
+    console.log(`session-mine: day cap reached (${dayCount}/${MAX_PER_DAY})`);
+    return 0;
+  }
+
+  let candidates;
+  if (process.env.INVOKER_SESSION_MINE_INVENTORY_JSON) {
+    candidates = listFromInventoryFile(process.env.INVOKER_SESSION_MINE_INVENTORY_JSON);
+  } else {
+    candidates = listFromHeadless();
+    if (!candidates) {
+      console.log('session-mine: headless inventory unavailable; using disk fallback');
+      candidates = listFromDiskFallback();
+    }
+  }
+
+  let filed = 0;
+  const now = Date.now();
+
+  for (const cand of candidates) {
+    if (filed >= MAX_PER_TICK) break;
+    if ((ledger.dayCounts?.[today] ?? 0) >= MAX_PER_DAY) break;
+
+    const path = cand.path || resolveTranscriptPath(cand.agentName, cand.sessionId);
+    if (!path || !existsSync(path)) continue;
+
+    const report = detectThrash(path);
+    if (!report.thrash) continue;
+    if (!matchesAllowlist(cand.workflowName, report)) continue;
+
+    const hash = sessionHash(cand.sessionId, cand.workflowName || report.workflowHint || '');
+    const prev = ledger.entries[hash];
+    if (prev && now - Number(prev.at || 0) < COOLDOWN_MS) {
+      console.log(`session-mine: cooldown ${hash}`);
+      continue;
+    }
+
+    console.log(`session-mine: filing follow-up for ${cand.sessionId} agent=${cand.agentName} hash=${hash} reasons=${report.reasons.join(',')}`);
+    const yamlText = buildFollowUpPlan({
+      sessionId: cand.sessionId,
+      jsonlPath: path,
+      report,
+      hash,
+      agentName: cand.agentName,
+    });
+    const submitted = submitPlan(yamlText);
+    if (!submitted.ok) {
+      console.error(`session-mine: submit failed for ${hash}`);
+      continue;
+    }
+    ledger.entries[hash] = {
+      at: now,
+      sessionId: cand.sessionId,
+      agentName: cand.agentName,
+      path,
+      reasons: report.reasons,
+    };
+    ledger.dayCounts = ledger.dayCounts || {};
+    ledger.dayCounts[today] = (ledger.dayCounts[today] ?? 0) + 1;
+    filed += 1;
+    saveLedger(ledger);
+  }
+
+  console.log(`session-mine: filed ${filed}`);
+  return 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

Admin-bypass repair YAML lacked a turn budget and still taught the plan-to-invoker escape hatch.

This caps repair turns at 30, drops that hatch, and adds DB-first multi-agent session mine scripts with thrash follow-ups that never stop the original workflow.

## Review Claim

Repair YAML emits `maxTurns: 30` without the plan-to-invoker hatch, and `worker-session-mine` scripts resolve Claude/Codex/OMP transcripts then file non-merging thrash follow-ups.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Mine follow-ups never cancel the original repair workflow and never auto-merge. Scripts stay off until the worker desired-state is enabled.

## Slice Rationale

Repair generator and mine scripts are tooling policy, separate from executor registration and docs.

## Non-goals

- No vendoring of reflect skill trees
- No always-on Mac owner miner
- No invented Codex CLI flags

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine-thrash.mjs --self-test`
- [x] `node scripts/worker-session-mine-resolve.selftest.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated discovery and review of completed terminal sessions across supported agents.
  - Added transcript resolution for Claude, Codex, and OMP sessions.
  - Added detection of repetitive or inefficient session behavior, including optional token auditing.
  - Added controlled follow-up workflow submission with cooldowns, daily limits, dry-run planning, and persistent tracking.
  - Added a scheduled worker entry point with forwarded command-line options and concurrent-run protection.

- **Bug Fixes**
  - Repair task YAML can now include a configurable maximum turn count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->