### PR TITLE
[Bootstrap onboarding](3) Ship always-on harness fragments for local/remote Invoker MCP routing

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -684,8 +684,11 @@ describe('bundled-skills', () => {
       expect(existsSync(join(fakeHome, '.cursor', 'skills', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(true);
       expect(existsSync(cursorRule)).toBe(true);
       expect(readFileSync(cursorRule, 'utf-8')).toContain('alwaysApply: true');
+      expect(readFileSync(cursorRule, 'utf-8')).toContain('Local vs remote Invoker');
+      expect(readFileSync(cursorRule, 'utf-8')).toContain('BatchMode=yes');
       expect(agents).toContain('# Personal rules');
       expect(agents).toContain('<!-- invoker-execution -->');
+      expect(agents).toContain('Local vs remote Invoker');
       expect(settings.hooks.UserPromptSubmit).toHaveLength(2);
       expect(settings.hooks.UserPromptSubmit[0].hooks[0].command).toBe('python3 other.py');
       expect(settings.hooks.UserPromptSubmit[1].hooks[0].command).toContain('invoker-execution/claude_prompt_submit');
@@ -698,6 +701,8 @@ describe('bundled-skills', () => {
       });
       expect(hookResult.status).toBe(0);
       expect(JSON.parse(hookResult.stdout).hookSpecificOutput.additionalContext).toContain('Invoker execution routing');
+      expect(JSON.parse(hookResult.stdout).hookSpecificOutput.additionalContext).toContain('Local vs remote Invoker');
+      expect(JSON.parse(hookResult.stdout).hookSpecificOutput.additionalContext).toContain('BatchMode=yes');
 
       installBundledSkills({
         isPackaged: true,

--- a/packages/shell/src/always-on/fragments.ts
+++ b/packages/shell/src/always-on/fragments.ts
@@ -2,6 +2,7 @@ export const EXECUTION_ROUTING_FRAGMENT = `# Invoker execution routing
 
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
+- Default Invoker owner is **local** (\`invoker-cli mcp\` stdio). Prefer delegating durable work to Invoker over inventing local multi-agent orchestration.
 - Read-only questions: stay local.
 - Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
 - Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
@@ -11,12 +12,21 @@ When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or 
 - Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
 
+## Local vs remote Invoker (conversational)
+
+- Default: leave harness MCP pointed at local \`invoker-cli mcp\`.
+- If the **current turn** names a host, IP, or SSH alias for Invoker (e.g. “use 1.2.3.4”, “on do1”, “ssh my-box”), best-effort retarget before submit:
+  1. Probe: \`ssh -o BatchMode=yes -o ConnectTimeout=5 <spec> 'command -v invoker-cli'\` (exit 0 required).
+  2. On success only: set the harness \`invoker\` MCP server to \`command: ssh\`, \`args: ["-o","BatchMode=yes","<spec>","invoker-cli","mcp"]\` (Claude/Cursor/OMP JSON or Codex TOML). Do not invent HTTP/SSE MCP.
+  3. On probe failure: leave the local MCP entry unchanged and tell the user; do not clobber local.
+- “Local” / “this machine” in the current turn restores local \`invoker-cli mcp\`.
+
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
 Plain approval stops after workflow handoff; do not publish PRs unless the user asks.
 `;
 
 export const CURSOR_RULE_CONTENTS = `---
-description: One-slice same-repo work stays local; multi-layer work goes through Invoker auto_submit after the completeness gate
+description: One-slice same-repo work stays local; multi-layer work goes through Invoker (local MCP by default; host/IP retargets after SSH probe)
 alwaysApply: true
 ---
 
@@ -24,6 +34,7 @@ alwaysApply: true
 
 When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or \`invoker-cli\` is available:
 
+- Default Invoker owner is **local** (\`invoker-cli mcp\` stdio). Prefer delegating durable work to Invoker over inventing local multi-agent orchestration.
 - Read-only questions: stay local.
 - Stay in this chat when **all** hold: current repo only; one review slice / one layer; feature iteration on existing files or a one-file bug with a local repro.
 - Delegate to Invoker when **any** hold: more than one layer, review slice, package boundary, or PR-worthy commit; cross-repo; overnight / user stepping away; agent self-routes mid-task.
@@ -32,6 +43,15 @@ When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or 
 - Explicit “do it locally” / “don’t use Invoker” in the current message wins.
 - Dirty working tree alone does **not** force Invoker.
 - If MCP and CLI are both missing: stay local.
+
+## Local vs remote Invoker (conversational)
+
+- Default: leave harness MCP pointed at local \`invoker-cli mcp\`.
+- If the **current turn** names a host, IP, or SSH alias for Invoker (e.g. “use 1.2.3.4”, “on do1”, “ssh my-box”), best-effort retarget before submit:
+  1. Probe: \`ssh -o BatchMode=yes -o ConnectTimeout=5 <spec> 'command -v invoker-cli'\` (exit 0 required).
+  2. On success only: set the harness \`invoker\` MCP server to \`command: ssh\`, \`args: ["-o","BatchMode=yes","<spec>","invoker-cli","mcp"]\` (Claude/Cursor/OMP JSON or Codex TOML). Do not invent HTTP/SSE MCP.
+  3. On probe failure: leave the local MCP entry unchanged and tell the user; do not clobber local.
+- “Local” / “this machine” in the current turn restores local \`invoker-cli mcp\`.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
 Plain approval stops after workflow handoff; do not publish PRs unless the user asks.


### PR DESCRIPTION
## Summary

Always-on harness instructions now state that Invoker MCP defaults to local stdio and may retarget over SSH after a successful probe.

Cursor rules, Codex AGENTS blocks, and Claude prompt hooks pick up the same wording on the next skills install.

## Review Claim

Shipped always-on harness fragments document local MCP default plus conversational remote SSH retarget.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Fragment text only. Default MCP remains local stdio. Remote retarget still requires a successful SSH probe and does not invent HTTP MCP.

## Slice Rationale

packages/shell is product-scoped, so this fragment update cannot share a policy lane with the bootstrap script.

## Non-goals

No bootstrap script changes. No skill markdown changes. No HTTP MCP listener.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/bundled-skills.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
