### PR TITLE
[Bootstrap onboarding](2) Teach Invoker skills local MCP default and conversational remote retarget

### DIFF
--- a/skills/chat-submit/SKILL.md
+++ b/skills/chat-submit/SKILL.md
@@ -19,11 +19,17 @@ Operator actions against existing workflows live in `invoker-ops`.
 
 Use this skill when **all** of the following are true:
 
-1. Invoker MCP tools are available (`invoker_prepare_plan_review`, `invoker_submit_plan`).
+1. Invoker MCP tools are available (`invoker_prepare_plan_review`, `invoker_submit_plan`), or can be made available via local/`invoker-cli setup` or a probed remote SSH MCP retarget.
 2. The request is multi-layer / multi-PR / overnight / durable parallel work, an approved plan, or the user asked to run it on Invoker.
 3. The user did not already start `/invoker-plan-to-invoker` (that command remains a valid explicit entrypoint).
 
 Do **not** use this skill for one-slice same-repo feature iteration, one-file fixes with a local repro, or read-only questions. Keep those in the current chat.
+
+## Local vs remote owner
+
+- Default MCP target is **local** `invoker-cli mcp`.
+- If the current turn names a host, IP, or SSH alias for Invoker, follow `skill://plan-to-invoker/references/local-vs-remote-mcp.md` (probe SSH first; rewrite harness MCP only on success; never clobber local on failure).
+- “Local” / “this machine” restores local MCP.
 
 ## Flow
 
@@ -48,8 +54,9 @@ Do **not** use this skill for one-slice same-repo feature iteration, one-file fi
 ## Hard rules
 
 - Completeness gate before submit. Missing Goal / Motivation / Safety invariant / repoUrl / Verify, or leftover `REPLACE_ME`, blocks submit.
-- One approval before submit for human-triggered work; self-triggered large work may `auto_submit` after completeness.
+- One approval before submit by default for human-triggered work; self-triggered large work may `auto_submit` after completeness.
 - Never invent SQLite reads or recovery paths — Invoker owns persistence.
 - Never submit without the review token from the matching prepare call.
 - If plan content changed after review, prepare again and re-approve.
-- If MCP tools are missing, tell the user to run `invoker-cli setup` (or use `/invoker-plan-to-invoker`) instead of falling back to raw database access.
+- If MCP tools are missing, tell the user to run `invoker-cli setup` / the bootstrap one-liner (or use `/invoker-plan-to-invoker`) instead of falling back to raw database access.
+- Never invent HTTP/SSE MCP; remote means SSH stdio to `invoker-cli mcp` after a successful probe.

--- a/skills/chat-submit/scripts/check-contract.sh
+++ b/skills/chat-submit/scripts/check-contract.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Contract checks for skills/chat-submit/SKILL.md.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$SKILL_DIR/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$SKILL" ]] || fail "missing $SKILL"
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  if ! grep -qF -- "$needle" "$SKILL"; then
+    fail "$hint — missing: $needle"
+  fi
+}
+
+must_contain 'invoker_prepare_plan_review' 'chat-submit must prepare a review'
+must_contain 'reviewToken' 'chat-submit must require a review token'
+must_contain 'One approval before submit by default' 'chat-submit must keep the default approval gate'
+must_contain 'invoker_submit_plan' 'chat-submit must submit via MCP'
+must_contain 'mode: "live"' 'chat-submit must submit live'
+must_contain 'invoker_wait_for_workflow' 'chat-submit must wait on workflow status'
+must_contain '## Local vs remote owner' 'chat-submit must document local vs remote owner'
+must_contain 'invoker-cli mcp' 'chat-submit must default to local invoker-cli mcp'
+must_contain 'references/local-vs-remote-mcp.md' 'chat-submit must point at the remote MCP reference'
+must_contain 'Never invent HTTP/SSE MCP' 'chat-submit must forbid inventing HTTP/SSE MCP'
+
+echo "OK: chat-submit skill contract"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -64,6 +64,10 @@ Use this mode when invoked by the installed command or MCP prompt.
 
 > **Not this mode:** Slack `plan:` and agent threads use a separate, orchestrator-owned Slack plan submission path. Do not invoke the CLI or MCP handoff tools from those threads.
 
+### Local vs remote Invoker
+
+Default owner is local (`invoker-cli mcp`). If the current turn names a host, IP, or SSH alias, follow [references/local-vs-remote-mcp.md](references/local-vs-remote-mcp.md) before prepare/submit: probe SSH, rewrite harness MCP only on success, never clobber local on failure. “Local” / “this machine” restores local MCP. Do not invent HTTP/SSE MCP.
+
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP review/submission flow when available: call `invoker_prepare_plan_review`, show its ordered steps plus `confirmationText`, then call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`.

--- a/skills/plan-to-invoker/references/local-vs-remote-mcp.md
+++ b/skills/plan-to-invoker/references/local-vs-remote-mcp.md
@@ -1,0 +1,44 @@
+# Local vs remote Invoker MCP
+
+Harnesses talk to Invoker over **stdio MCP** (`invoker-cli mcp`). There is no HTTP MCP listener in this flow.
+
+## Default
+
+Leave the harness `invoker` MCP server as local:
+
+```json
+{ "type": "stdio", "command": "invoker-cli", "args": ["mcp"] }
+```
+
+(Codex uses the equivalent TOML `mcp_servers.invoker` entry.)
+
+## Conversational remote
+
+When the **current user turn** names a host, IP, or SSH alias as the Invoker owner:
+
+1. Probe (must exit 0):
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=5 <spec> 'command -v invoker-cli'
+```
+
+2. On success only, rewrite the harness `invoker` MCP entry to:
+
+```json
+{
+  "command": "ssh",
+  "args": ["-o", "BatchMode=yes", "<spec>", "invoker-cli", "mcp"]
+}
+```
+
+Paths: `~/.cursor/mcp.json`, `~/.claude.json` (`mcpServers`), `~/.omp/agent/mcp.json`, or `~/.codex/config.toml`.
+
+3. On probe failure: **do not** change the local entry; report the SSH error and continue with local MCP or ask for another host.
+
+4. “Local” / “this machine” restores the default local `invoker-cli mcp` entry.
+
+## Hard rules
+
+- Never invent HTTP/SSE MCP URLs for this path.
+- Never clobber a working local MCP entry after a failed probe.
+- Retarget only from an explicit host/IP/alias in the current turn — not from ambient config alone.


### PR DESCRIPTION
## Summary

chat-submit and plan-to-invoker now default to local Invoker stdio MCP and retarget over SSH only after a successful probe.

A focused skill check locks the local-vs-remote instructions in place.

## Review Claim

Invoker skills keep local MCP unless a named host passes an SSH probe, and never invent HTTP MCP.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Failed SSH probes leave the local MCP entry unchanged. No harness MCP entry is replaced without a successful probe in the current turn.

## Slice Rationale

Skill instruction text is tooling-policy. Always-on package fragments stay in the next product slice.

## Non-goals

No bootstrap script changes. No packages/shell fragment source changes. No HTTP MCP listener.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/chat-submit/scripts/check-contract.sh`
- [x] `test -f skills/plan-to-invoker/references/local-vs-remote-mcp.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
