### PR TITLE
[Autofix Merge Recreate](1) Route invalid merge workspaces to recreate-task

### DIFF
--- a/packages/app/src/workflow-mutation-handlers.ts
+++ b/packages/app/src/workflow-mutation-handlers.ts
@@ -2,6 +2,7 @@ import {
   AUTO_APPROVE_COMMAND_CHANNEL,
   AUTO_FIX_BARE_RETRY_CHANNEL,
   AUTO_FIX_COMMAND_CHANNEL,
+  AUTO_FIX_RECREATE_CHANNEL,
   buildHeadlessFixArgs,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
@@ -75,6 +76,10 @@ export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Ma
 
   handlers.set(AUTO_FIX_BARE_RETRY_CHANNEL, async (...retryArgs: unknown[]) => {
     return runHeadlessCommand(['retry-task', String(retryArgs[0])]);
+  });
+
+  handlers.set(AUTO_FIX_RECREATE_CHANNEL, async (...recreateArgs: unknown[]) => {
+    return runHeadlessCommand(['recreate-task', String(recreateArgs[0])]);
   });
 
   handlers.set(REQUEUE_COMMAND_CHANNEL, async (...requeueArgs: unknown[]) => {

--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import type { TaskState } from '@invoker/workflow-core';
 
-import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
-import { collectValidatedAutoFixRecoveryCandidates } from '../auto-fix-recovery.js';
+import { createAutoFixAttemptLedger, autoFixAttemptLedgerKeyFromTask } from '../auto-fix-attempt-ledger.js';
+import {
+  AUTO_FIX_RECREATE_CHANNEL,
+  AUTO_FIX_WORKER_KIND,
+  collectValidatedAutoFixRecoveryCandidates,
+  createAutoFixRecoveryTick,
+  shouldRecreateMergeGateInsteadOfAutoFix,
+} from '../auto-fix-recovery.js';
+import { autoFixBareRetryExternalKey } from '../auto-fix-retry-cap.js';
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
 
 const logger = {
   info: vi.fn(),
@@ -38,6 +53,40 @@ function makeFailedTask(overrides: Partial<TaskState> = {}): TaskState {
     taskStateVersion: 7,
     ...rest,
   } as TaskState;
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeHarness(task = makeFailedTask()) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 99);
+  const store = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn(() => []),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) =>
+      actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const key = `${write.workerKind}:${write.externalKey}`;
+      const existing = actions.get(key);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(key, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  const attemptLedger = createAutoFixAttemptLedger();
+  return { tasks, actions, store, submit, attemptLedger };
 }
 
 describe('collectValidatedAutoFixRecoveryCandidates', () => {
@@ -95,5 +144,129 @@ describe('collectValidatedAutoFixRecoveryCandidates', () => {
       const validated = collectValidatedAutoFixRecoveryCandidates(options, scanned);
       expect(validated, failureClass).toEqual([]);
     }
+  });
+});
+
+describe('shouldRecreateMergeGateInsteadOfAutoFix', () => {
+  it('is false for non-merge tasks even with a missing workspace', () => {
+    expect(shouldRecreateMergeGateInsteadOfAutoFix(makeFailedTask({
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        error: 'build failed',
+      },
+    }))).toBe(false);
+  });
+
+  it('is true when the merge-gate error already says to recreate the gate', () => {
+    expect(shouldRecreateMergeGateInsteadOfAutoFix(makeFailedTask({
+      id: '__merge__wf-1',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        workspacePath: '/tmp/does-not-matter',
+        error: "Cannot apply a fix because this merge gate's saved workspace is missing or is not a git repository. Recreate this merge-gate task from a fresh base, then rerun the gate.",
+      },
+    }))).toBe(true);
+  });
+
+  it('is true when the merge-gate workspace path is missing', () => {
+    expect(shouldRecreateMergeGateInsteadOfAutoFix(makeFailedTask({
+      id: '__merge__wf-1',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        error: 'merge failed',
+      },
+    }))).toBe(true);
+  });
+
+  it('is true when the merge-gate workspace exists but is not a git repo', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'autofix-merge-nongit-'));
+    try {
+      expect(shouldRecreateMergeGateInsteadOfAutoFix(makeFailedTask({
+        id: '__merge__wf-1',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          generation: 2,
+          selectedAttemptId: 'attempt-1',
+          workspacePath: dir,
+          error: 'merge failed',
+        },
+      }))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is false when the merge-gate workspace is a git worktree', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'autofix-merge-git-'));
+    try {
+      mkdirSync(join(dir, '.git'));
+      writeFileSync(join(dir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+      expect(shouldRecreateMergeGateInsteadOfAutoFix(makeFailedTask({
+        id: '__merge__wf-1',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          generation: 2,
+          selectedAttemptId: 'attempt-1',
+          workspacePath: dir,
+          error: 'merge conflict in packages/app/src/foo.ts',
+        },
+      }))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('auto-fix recovery merge-gate recreate routing', () => {
+  it('submits invoker:recreate-task instead of fix-with-agent for invalid merge workspaces', async () => {
+    const mergeTask = makeFailedTask({
+      id: '__merge__wf-1',
+      description: 'Merge gate',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        workspacePath: '/tmp/invoker-empty-launch-placeholder',
+        error: 'Unable to resolve merge worktree ref "plan/old-base"',
+        failureClass: undefined,
+      },
+    });
+    const harness = makeHarness(mergeTask);
+    harness.actions.set(`${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(mergeTask.id)}`, toRecord({
+      id: `${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(mergeTask.id)}`,
+      workerKind: AUTO_FIX_WORKER_KIND,
+      externalKey: autoFixBareRetryExternalKey(mergeTask.id),
+      actionType: 'auto-retry',
+      subjectType: 'task',
+      subjectId: mergeTask.id,
+      status: 'queued',
+      attemptCount: 1,
+      workflowId: 'wf-1',
+      taskId: mergeTask.id,
+    }));
+
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    const [workflowId, priority, channel, args] = harness.submit.mock.calls[0]!;
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('normal');
+    expect(channel).toBe(AUTO_FIX_RECREATE_CHANNEL);
+    expect(args).toEqual([mergeTask.id]);
+    expect(harness.attemptLedger.get(autoFixAttemptLedgerKeyFromTask(mergeTask))).toBe(0);
   });
 });

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -36,6 +36,30 @@ export function hasOpenFixIntentForTask(
   return intents.some((intent) => isFixIntentForTask(intent, taskId));
 }
 
+export function isRecreateIntentForTask(intent: WorkflowMutationIntent, taskId: string): boolean {
+  if (intent.channel === 'invoker:recreate-task') {
+    return typeof intent.args[0] === 'string' && intent.args[0] === taskId;
+  }
+  if (intent.channel === 'invoker:infra-repair-recreate-task') {
+    const first = intent.args[0];
+    if (first && typeof first === 'object' && !Array.isArray(first)) {
+      const candidate = first as { taskId?: unknown };
+      return typeof candidate.taskId === 'string' && candidate.taskId === taskId;
+    }
+    return typeof first === 'string' && first === taskId;
+  }
+
+  const args = getHeadlessExecArgs(intent);
+  return args[0] === 'recreate-task' && typeof args[1] === 'string' && args[1] === taskId;
+}
+
+export function listOpenRecreateIntentsForTask(
+  intents: WorkflowMutationIntent[],
+  taskId: string,
+): WorkflowMutationIntent[] {
+  return intents.filter((intent) => isRecreateIntentForTask(intent, taskId));
+}
+
 export interface ReviewGateCiContext {
   reviewId: string;
   generation: number;

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { Logger } from '@invoker/contracts';
 import type {
   WorkerActionRecord,
@@ -19,6 +22,7 @@ import {
 import {
   buildFixWithAgentMutationArgs,
   listOpenFixIntentsForTask,
+  listOpenRecreateIntentsForTask,
 } from './auto-fix-intents.js';
 import {
   autoFixAttemptLedgerKeyFromTask,
@@ -52,8 +56,15 @@ const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 export const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
 /** Owner-worker mutation channel the recovery worker submits its free bare retry through. Must have a registered `workflowMutationDispatcher` handler in `packages/app/src/main.ts`. */
 export const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:retry-task';
+/**
+ * Owner-worker mutation channel used when a merge gate cannot be fixed in-place
+ * because its saved workspace is missing or is not a git repository.
+ * Must have a registered `workflowMutationDispatcher` handler in `packages/app/src/main.ts`.
+ */
+export const AUTO_FIX_RECREATE_CHANNEL = 'invoker:recreate-task';
 const AUTO_FIX_ACTION_TYPE = 'auto-fix';
 const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
+const AUTO_FIX_RECREATE_ACTION_TYPE = 'auto-recreate';
 /**
  * A failed task's auto-fix attempt is a real, capacity-limited agent
  * dispatch, not a free retry. If the provider itself is out of quota, every
@@ -64,9 +75,16 @@ const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
  */
 export const DEFAULT_CIRCUIT_BREAKER_PAUSE_MS = 6 * 60 * 60 * 1000;
 
+/** Substrings that indicate a prior fix attempt already diagnosed an invalid merge workspace. */
+export const INVALID_MERGE_WORKSPACE_ERROR_MARKERS = [
+  "Cannot apply a fix because this merge gate's saved workspace",
+  'Recreate this merge-gate task from a fresh base',
+] as const;
+
 const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
   'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
   'worker-autofix-bare-retry-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
+  'worker-autofix-recreate-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
   'worker-autofix-skip': { eventType: 'recovery.worker.skip', action: 'skip' },
 };
 
@@ -83,11 +101,16 @@ export interface AutoFixRecoveryStore {
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
 }
 
+export type AutoFixRecoverySubmitChannel =
+  | typeof AUTO_FIX_COMMAND_CHANNEL
+  | typeof AUTO_FIX_BARE_RETRY_CHANNEL
+  | typeof AUTO_FIX_RECREATE_CHANNEL;
+
 export interface AutoFixRecoverySubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof AUTO_FIX_COMMAND_CHANNEL | typeof AUTO_FIX_BARE_RETRY_CHANNEL,
+    channel: AutoFixRecoverySubmitChannel,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
@@ -234,6 +257,27 @@ function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryP
   const max = retryBudgetForTask(task, options);
   if (max <= 0) return false;
   return true;
+}
+
+export function isInvalidMergeWorkspaceErrorText(error: string | undefined): boolean {
+  if (!error) return false;
+  return INVALID_MERGE_WORKSPACE_ERROR_MARKERS.some((marker) => error.includes(marker));
+}
+
+/**
+ * True when a merge-gate task cannot be fixed in-place because its saved
+ * workspace is missing / not a git repo, or a prior attempt already reported that.
+ */
+export function shouldRecreateMergeGateInsteadOfAutoFix(task: TaskState): boolean {
+  if (!task.config.isMergeNode) return false;
+  if (isInvalidMergeWorkspaceErrorText(task.execution.error)) return true;
+
+  const workspacePath = task.execution.workspacePath?.trim();
+  if (!workspacePath) return true;
+  if (!existsSync(workspacePath)) return true;
+  // Linked worktrees store `.git` as a file; bare/missing trees have neither.
+  if (!existsSync(join(workspacePath, '.git'))) return true;
+  return false;
 }
 
 function loadLatestTask(
@@ -474,6 +518,14 @@ function validateAutoFixCandidate(
     return undefined;
   }
 
+  const openTaskRecreateIntents = listOpenRecreateIntentsForTask(openIntents, candidate.taskId);
+  if (openTaskRecreateIntents.length > 0) {
+    skipAutoFixCandidate(options, candidate, 'already-queued-recreate-intent', {
+      existingIntentIds: openTaskRecreateIntents.map((intent) => intent.id),
+    });
+    return undefined;
+  }
+
   return { ...latestRef, source: candidate.source, task: latest };
 }
 
@@ -566,6 +618,44 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
           intentId,
           extraPayload: {
             channel: AUTO_FIX_BARE_RETRY_CHANNEL,
+          },
+        });
+        recordAutoFixRetryConsumed(options.store, candidate.taskId, {
+          workflowId: candidate.workflowId,
+        });
+        continue;
+      }
+
+      // Merge gates with a missing/non-git workspace cannot be fixed in-place.
+      // Recreate the gate instead of burning fix-with-agent retry budget.
+      if (shouldRecreateMergeGateInsteadOfAutoFix(candidate.task)) {
+        const intentId = options.submitter.submit(
+          candidate.workflowId,
+          'normal',
+          AUTO_FIX_RECREATE_CHANNEL,
+          [candidate.taskId],
+        );
+        submittedThisTick.add(candidate.taskId);
+        logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-recreate-submitted', {
+          workflowId: candidate.workflowId,
+          intentId,
+          channel: AUTO_FIX_RECREATE_CHANNEL,
+          generation: candidate.generation,
+          taskStateVersion: candidate.taskStateVersion,
+          attemptId: candidate.attemptId ?? null,
+          reason: 'invalid-merge-workspace',
+          workspacePath: candidate.task.execution.workspacePath ?? null,
+        });
+        recordAutoFixDecisionRow(options, candidate, {
+          status: 'queued',
+          summary: 'Queued recreate-task for invalid merge-gate workspace',
+          reason: 'invalid-merge-workspace',
+          intentId,
+          incrementAttempt: true,
+          extraPayload: {
+            channel: AUTO_FIX_RECREATE_CHANNEL,
+            actionType: AUTO_FIX_RECREATE_ACTION_TYPE,
+            workspacePath: candidate.task.execution.workspacePath ?? null,
           },
         });
         recordAutoFixRetryConsumed(options.store, candidate.taskId, {

--- a/packages/execution-engine/src/worker-mutation-channels.ts
+++ b/packages/execution-engine/src/worker-mutation-channels.ts
@@ -1,4 +1,4 @@
-import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL } from './auto-fix-recovery.js';
+import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL, AUTO_FIX_RECREATE_CHANNEL } from './auto-fix-recovery.js';
 import { AUTO_APPROVE_COMMAND_CHANNEL } from './workers/auto-approve-worker.js';
 import { INFRA_REPAIR_RECREATE_TASK_CHANNEL, INFRA_REPAIR_RETRY_TASK_CHANNEL } from './workers/infra-repair-worker.js';
 import { REQUEUE_COMMAND_CHANNEL, REQUEUE_ESCALATE_CHANNEL } from './workers/requeue-worker.js';
@@ -24,6 +24,7 @@ import { WORKFLOW_RESUME_COMMAND_CHANNEL } from './workers/workflow-resume-worke
 export const WORKER_SUBMITTED_MUTATION_CHANNELS: readonly string[] = [
   AUTO_FIX_COMMAND_CHANNEL,
   AUTO_FIX_BARE_RETRY_CHANNEL,
+  AUTO_FIX_RECREATE_CHANNEL,
   AUTO_APPROVE_COMMAND_CHANNEL,
   REQUEUE_COMMAND_CHANNEL,
   REQUEUE_ESCALATE_CHANNEL,


### PR DESCRIPTION
## Summary

When a merge gate has a missing or non-git saved workspace, autofix recovery now asks for recreate-task instead of an agent fix attempt.

That keeps the worker from consuming agent-fix budget on an unrecoverable merge-launches path.

## Review Claim

Approve that autofix recovery chooses recreate-task for invalid merge-gate workspaces rather than an agent fix attempt.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Assumptions: unconfirmed — only merge nodes with missing or non-git workspaces (or that error text already) take the recreate-task path; other failed tasks keep the prior recovery sequence.

## Slice Rationale

This is the worker-side durable recovery for the stuck merge-gate case. The interactive fix path is unchanged and can land later if needed.

## Non-goals

- No change to the interactive fix path for invalid merge workspaces.
- No changes to merge-gate clone creation or workspace provisioning.
- No broader autofix budget policy rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/auto-fix-bare-retry.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/workflow-mutation-handlers.test.ts src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0ccddeb460`
- Post-revert steps: None
- Data migration? No

</details>
