### PR TITLE
[Owner unclean-exit guards](1) Leader-check process-group kills and redact merge-gate logs

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { GitHubMergeGateProvider, resolveMergeGatePrLifecycle } from '../github-merge-gate-provider.js';
+import {
+  GitHubMergeGateProvider,
+  formatMergeGatePrLog,
+  resolveMergeGatePrLifecycle,
+  utf8ByteLength,
+} from '../github-merge-gate-provider.js';
 
 vi.mock('node:child_process');
 
@@ -19,6 +24,24 @@ function mockSpawnResult(stdoutData: string, exitCode: number, stderrData = '') 
 
   return child;
 }
+
+describe('merge-gate PR log redaction helpers', () => {
+  it('formats number/html_url/byte lengths without a body blob', () => {
+    const body = `## Summary\n\n${'x'.repeat(8_000)}`;
+    const line = formatMergeGatePrLog({
+      number: 42,
+      htmlUrl: 'https://github.com/owner/repo/pull/42',
+      bodyBytes: utf8ByteLength(body),
+      responseBytes: 12_345,
+    });
+    expect(line).toContain('number=42');
+    expect(line).toContain('html_url=https://github.com/owner/repo/pull/42');
+    expect(line).toContain(`body_bytes=${utf8ByteLength(body)}`);
+    expect(line).toContain('response_bytes=12345');
+    expect(line).not.toContain('"body":');
+    expect(line).not.toContain(body.slice(0, 40));
+  });
+});
 
 describe('GitHubMergeGateProvider', () => {
   let provider: GitHubMergeGateProvider;
@@ -65,6 +88,125 @@ describe('GitHubMergeGateProvider', () => {
   });
 
   describe('createReview', () => {
+    it('logs createReview without dumping PR body or create stdout JSON', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+      const logs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        logs.push(args.map(String).join(' '));
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const hugeBody = `## Summary\n\n${'PR_BODY_MARKER_'.repeat(400)}`;
+      const createStdout = JSON.stringify({
+        html_url: 'https://github.com/owner/repo/pull/99',
+        number: 99,
+        body: hugeBody,
+        title: 'Test PR',
+      });
+
+      spawnMock.mockImplementation(((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+          return mockSpawnResult('https://github.com/owner/repo.git', 0);
+        }
+        if (cmd === 'git') return mockSpawnResult('', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) {
+          return mockSpawnResult('[]', 0);
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('POST')) {
+          return mockSpawnResult(createStdout, 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      try {
+        const result = await provider.createReview({
+          baseBranch: 'main',
+          featureBranch: 'feature/test',
+          title: 'Test PR',
+          cwd: '/tmp/repo',
+          body: hugeBody,
+        });
+
+        expect(result.url).toBe('https://github.com/owner/repo/pull/99');
+        expect(result.identifier).toBe('99');
+
+        const joined = logs.join('\n');
+        expect(joined).toContain('number=99');
+        expect(joined).toContain('html_url=https://github.com/owner/repo/pull/99');
+        expect(joined).toContain(`body_bytes=${utf8ByteLength(hugeBody)}`);
+        expect(joined).not.toContain('PR_BODY_MARKER_');
+        expect(joined).not.toContain('"body":');
+        expect(joined).not.toContain(`stdout=${createStdout}`);
+        expect(joined).not.toContain(`gh_result=`);
+        expect(joined).not.toContain(createStdout);
+      } finally {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('logs existing-PR update without dumping gh_result JSON body blobs', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+      const logs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        logs.push(args.map(String).join(' '));
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const hugeBody = `## Summary\n\n${'UPDATE_BODY_MARKER_'.repeat(400)}`;
+      const patchStdout = JSON.stringify({
+        html_url: 'https://github.com/owner/repo/pull/10',
+        number: 10,
+        body: hugeBody,
+      });
+
+      spawnMock.mockImplementation(((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+          return mockSpawnResult('https://github.com/owner/repo.git', 0);
+        }
+        if (cmd === 'git') return mockSpawnResult('', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) {
+          return mockSpawnResult(
+            JSON.stringify([{ html_url: 'https://github.com/owner/repo/pull/10', number: 10, body: hugeBody }]),
+            0,
+          );
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls/10') {
+          return mockSpawnResult(patchStdout, 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      try {
+        await provider.createReview({
+          baseBranch: 'main',
+          featureBranch: 'feature/test',
+          title: 'Updated PR',
+          cwd: '/tmp/repo',
+          body: hugeBody,
+        });
+
+        const joined = logs.join('\n');
+        expect(joined).toContain('number=10');
+        expect(joined).toContain('html_url=https://github.com/owner/repo/pull/10');
+        expect(joined).not.toContain('UPDATE_BODY_MARKER_');
+        expect(joined).not.toContain('"body":');
+        expect(joined).not.toContain(`gh_result=${patchStdout}`);
+        expect(joined).not.toContain(patchStdout);
+      } finally {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
     it('targets origin repository when creating merge-gate PRs', async () => {
       const { spawn } = await import('node:child_process');
       const spawnMock = vi.mocked(spawn);

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -5,9 +5,13 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
-}));
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
 
 function createMockProcess(): ChildProcess & EventEmitter {
   const proc = new EventEmitter() as ChildProcess & EventEmitter;
@@ -268,6 +272,85 @@ describe('terminateChildProcessGroup', () => {
     expect(child.kill).toHaveBeenCalledWith('SIGKILL');
     child.emit('close', null, 'SIGKILL');
     await expect(killed).resolves.toBeUndefined();
+  });
+});
+
+describe('killProcessGroup leader guard', () => {
+  // Production killProcessGroup must match e2e killOwnedProcessGroup: only
+  // process.kill(-pid) when the child leads its own group. A recycled or
+  // non-leader pid must not SIGTERM a foreign group (including the owner).
+
+  const liveChildren: ChildProcess[] = [];
+
+  async function spawnSleeper(opts: { detached: boolean }): Promise<ChildProcess> {
+    const { spawn: realSpawn } = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    const child = realSpawn('sleep', ['30'], { detached: opts.detached, stdio: 'ignore' });
+    liveChildren.push(child);
+    return await new Promise((resolve, reject) => {
+      child.once('spawn', () => resolve(child));
+      child.once('error', reject);
+    });
+  }
+
+  afterEach(() => {
+    for (const child of liveChildren.splice(0)) {
+      try {
+        if (child.pid) {
+          try { process.kill(-child.pid, 'SIGKILL'); } catch { /* not a leader */ }
+          child.kill('SIGKILL');
+        }
+      } catch { /* already gone */ }
+    }
+  });
+
+  it('reads the real pgid: detached child leads its own group, non-detached child does not', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const leader = await spawnSleeper({ detached: true });
+    const follower = await spawnSleeper({ detached: false });
+    expect(processUtils.readProcessGroupId(leader.pid!)).toBe(leader.pid);
+    expect(processUtils.readProcessGroupId(follower.pid!)).not.toBe(follower.pid);
+  });
+
+  it('group-kills a verified leader via negative pid', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const leader = await spawnSleeper({ detached: true });
+    const exited = new Promise<NodeJS.Signals | number | null>((resolve) => {
+      leader.once('exit', (code, signal) => resolve(signal ?? code));
+    });
+    const killSpy = vi.spyOn(process, 'kill');
+    expect(processUtils.killProcessGroup(leader, 'SIGTERM')).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(-leader.pid!, 'SIGTERM');
+    expect(await exited).toBe('SIGTERM');
+    killSpy.mockRestore();
+  });
+
+  it('refuses group-kill for a non-leader and only signals the child', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const victim = await spawnSleeper({ detached: true });
+    const nonLeader = await spawnSleeper({ detached: false });
+    const killSpy = vi.spyOn(process, 'kill');
+
+    expect(processUtils.killProcessGroup(nonLeader, 'SIGTERM')).toBe(true);
+
+    expect(killSpy).not.toHaveBeenCalledWith(-nonLeader.pid!, 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(-victim.pid!, 'SIGTERM');
+    expect(nonLeader.killed || nonLeader.signalCode === 'SIGTERM' || nonLeader.exitCode != null).toBe(true);
+    expect(victim.exitCode).toBeNull();
+    expect(victim.signalCode).toBeNull();
+    killSpy.mockRestore();
+  });
+
+  it('falls back to child.kill when pgid cannot be read', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+    const pgidSpy = vi.spyOn(processUtils, 'readProcessGroupId').mockReturnValue(null);
+    const killSpy = vi.spyOn(process, 'kill');
+
+    expect(processUtils.killProcessGroup(child, 'SIGTERM')).toBe(true);
+    expect(killSpy).not.toHaveBeenCalledWith(-child.pid!, 'SIGTERM');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    killSpy.mockRestore();
+    pgidSpy.mockRestore();
   });
 });
 

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -19,6 +19,68 @@ type ExistingPullRequest = { url: string; number: number };
 const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
 const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
 
+/** Byte length of a UTF-8 string without allocating a Buffer when possible. */
+export function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+/**
+ * Compact PR / gh API log fields. Never include full `body`, create `stdout`,
+ * or `gh_result` JSON — those blobs inflate owner logs toward OOM.
+ */
+export function formatMergeGatePrLog(fields: {
+  number?: number | string | null;
+  htmlUrl?: string | null;
+  bodyBytes?: number | null;
+  responseBytes?: number | null;
+  count?: number | null;
+}): string {
+  const parts: string[] = [];
+  if (fields.number != null && fields.number !== '') {
+    parts.push(`number=${fields.number}`);
+  }
+  if (fields.htmlUrl) {
+    parts.push(`html_url=${fields.htmlUrl}`);
+  }
+  if (fields.bodyBytes != null) {
+    parts.push(`body_bytes=${fields.bodyBytes}`);
+  }
+  if (fields.responseBytes != null) {
+    parts.push(`response_bytes=${fields.responseBytes}`);
+  }
+  if (fields.count != null) {
+    parts.push(`count=${fields.count}`);
+  }
+  return parts.join(' ');
+}
+
+function summarizeGhJsonPayload(raw: string): string {
+  const responseBytes = utf8ByteLength(raw);
+  try {
+    const parsed = JSON.parse(raw) as {
+      number?: number;
+      html_url?: string;
+      url?: string;
+    } | Array<{ number?: number; html_url?: string; url?: string }>;
+    if (Array.isArray(parsed)) {
+      const first = parsed[0];
+      return formatMergeGatePrLog({
+        number: first?.number,
+        htmlUrl: first?.html_url ?? first?.url,
+        responseBytes,
+        count: parsed.length,
+      });
+    }
+    return formatMergeGatePrLog({
+      number: parsed.number,
+      htmlUrl: parsed.html_url ?? parsed.url,
+      responseBytes,
+    });
+  } catch {
+    return formatMergeGatePrLog({ responseBytes });
+  }
+}
+
 export function resolveMergeGatePrLifecycle(state: string): MergeGatePrLifecycle {
   return state === 'MERGED' ? 'merged' : state === 'CLOSED' ? 'closed' : 'open';
 }
@@ -60,9 +122,11 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     body?: string;
   }): Promise<MergeGateProviderResult> {
     const { baseBranch, featureBranch, title, cwd, body } = opts;
+    const bodyBytes = utf8ByteLength(body ?? '');
     console.log(
       `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview ` +
-      `baseBranch=${baseBranch} featureBranch=${featureBranch} title=${title} cwd=${cwd} body=${body}`,
+      `baseBranch=${baseBranch} featureBranch=${featureBranch} title=${title} cwd=${cwd} ` +
+      formatMergeGatePrLog({ bodyBytes }),
     );
     const remoteNames = await listRemoteNamesForGithubCli(this.exec.bind(this), cwd);
     const ghBase = normalizeBranchForGithubCli(baseBranch, remoteNames);
@@ -73,7 +137,14 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     await this.pushFeatureBranch(cwd, featureBranch);
 
     const existing = await this.findExistingOpenPullRequest(cwd, targetRepo, ghHead);
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview existing=${existing}`);
+    console.log(
+      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview existing=` +
+      formatMergeGatePrLog({
+        number: existing[0]?.number,
+        htmlUrl: existing[0]?.url,
+        count: existing.length,
+      }),
+    );
 
     if (existing.length > 0) {
       const apiArgs = [
@@ -84,7 +155,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       ];
       if (body) apiArgs.push('-f', `body=${body}`);
       const ghResult = await retryTransientGitHubCli(() => this.exec('gh', apiArgs, cwd));
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview update existing gh_result=${ghResult}`);
+      console.log(
+        `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview update existing ` +
+        summarizeGhJsonPayload(ghResult),
+      );
 
       return { url: existing[0].url, identifier: String(existing[0].number) };
     }
@@ -98,7 +172,14 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const stdout = await this.exec('gh', createArgs, cwd);
     const pr = JSON.parse(stdout) as { html_url: string; number: number };
 
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview creating stdout=${stdout}`);
+    console.log(
+      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview creating ` +
+      formatMergeGatePrLog({
+        number: pr.number,
+        htmlUrl: pr.html_url,
+        responseBytes: utf8ByteLength(stdout),
+      }),
+    );
     return { url: pr.html_url, identifier: String(pr.number) };
   }
 
@@ -253,8 +334,17 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
         '--json', 'url,number',
         '--limit', '1',
       ], cwd);
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview listOutput=${listOutput}`);
-      return JSON.parse(listOutput) as ExistingPullRequest[];
+      const pulls = JSON.parse(listOutput) as ExistingPullRequest[];
+      console.log(
+        `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview listOutput ` +
+        formatMergeGatePrLog({
+          number: pulls[0]?.number,
+          htmlUrl: pulls[0]?.url,
+          responseBytes: utf8ByteLength(listOutput),
+          count: pulls.length,
+        }),
+      );
+      return pulls;
     } catch (err) {
       console.warn(
         `[merge-gate] gh pr list failed; falling back to REST pulls lookup: ` +
@@ -278,14 +368,23 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '-f', `head=${owner}:${ghHead}`,
       '-f', 'per_page=1',
     ], cwd));
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview restListOutput=${output}`);
     const pulls = JSON.parse(output) as Array<{ html_url?: string; url?: string; number: number }>;
-    return pulls
+    const existing = pulls
       .map((pull) => ({
         url: pull.html_url ?? pull.url ?? '',
         number: pull.number,
       }))
       .filter((pull): pull is ExistingPullRequest => Boolean(pull.url) && Number.isFinite(pull.number));
+    console.log(
+      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview restListOutput ` +
+      formatMergeGatePrLog({
+        number: existing[0]?.number,
+        htmlUrl: existing[0]?.url,
+        responseBytes: utf8ByteLength(output),
+        count: existing.length,
+      }),
+    );
+    return existing;
   }
 
   private parseGitHubRepoNwo(url: string): string | undefined {

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -1,5 +1,5 @@
-import { spawn, type ChildProcess } from 'node:child_process';
-import { accessSync, constants } from 'node:fs';
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
+import { accessSync, constants, readFileSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 
 export const SIGKILL_TIMEOUT_MS = 5_000;
@@ -34,17 +34,50 @@ let initializationPromise: Promise<ShellEnvironmentInitResult> | null = null;
 let initializationResult: ShellEnvironmentInitResult | null = null;
 
 /**
- * Sends a signal to the entire process group.
- * Uses negative PID to target the group when the process was spawned with detached: true.
+ * Read the process group id for `pid`. A group kill aimed at `-pid` only
+ * reaches that process's own tree when the process leads its group
+ * (`pgid === pid`). When it does not — or when a recycled pid matches a
+ * foreign group — the same call signals whichever group happens to carry
+ * that id (including the Invoker owner). Matches the e2e
+ * `killOwnedProcessGroup` leader check.
+ */
+export function readProcessGroupId(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const afterComm = stat.slice(stat.lastIndexOf(')') + 2);
+    const fields = afterComm.split(' ');
+    const pgid = Number.parseInt(fields[2] ?? '', 10);
+    return Number.isFinite(pgid) ? pgid : null;
+  } catch {
+    // /proc unavailable (non-linux) — fall through to ps.
+  }
+  try {
+    const out = execFileSync('ps', ['-o', 'pgid=', '-p', String(pid)], { encoding: 'utf8' });
+    const pgid = Number.parseInt(out.trim(), 10);
+    return Number.isFinite(pgid) ? pgid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sends a signal to the entire process group only when the child verifiably
+ * leads it (`pgid === pid`). Otherwise falls back to signaling the child
+ * alone — never `kill(-pid)` against an unverified / recycled group id.
  */
 export function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): boolean {
   if (child.pid == null) return false;
-  try {
-    process.kill(-child.pid, signal);
-    return true;
-  } catch {
-    return child.kill(signal);
+  const pid = child.pid;
+  const pgid = readProcessGroupId(pid);
+  if (pgid === pid) {
+    try {
+      process.kill(-pid, signal);
+      return true;
+    } catch {
+      return child.kill(signal);
+    }
   }
+  return child.kill(signal);
 }
 
 export function childProcessHasExited(child: ChildProcess): boolean {


### PR DESCRIPTION
## Summary

Production process teardown could `kill(-pid)` without checking that the child leads that group.

A recycled or non-leader pid can SIGTERM a foreign group, including the Invoker owner, which matches the unclean owner-exit class.

Merge-gate create/update also logged full GitHub PR JSON, including large `body` fields, into owner console output.

This slice adds the same leader check the e2e fixture uses, and logs only `number` / `html_url` / byte lengths.

## Review Claim

Approve leader-checked process-group kills and compact merge-gate PR logging so owner teardown cannot self-signal a foreign group and cannot OOM from PR JSON dumps.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Assumptions: unconfirmed — this slice only changes how child groups are signaled and how merge-gate traces are printed; it does not alter PR create/update API args or merge semantics.

## Slice Rationale

Kept separate from autofix merge recreate, setMaxListeners bumps, and skill prose so this unclean-exit / OOM class can land on its own.

## Non-goals

- Autofix merge recreate behavior
- setMaxListeners changes
- Skill instruction edits

## Architecture

### Before

```mermaid
graph TD
    A["killProcessGroup(child)"] --> B["process.kill(-pid)"]
    B --> C["may signal foreign group"]
    D["createReview logs"] --> E["full body / gh_result / stdout JSON"]
```

### After

```mermaid
graph TD
    A["killProcessGroup(child)"] --> B{"pgid equals pid?"}
    B -->|yes| C["process.kill(-pid)"]
    B -->|no| D["child.kill only"]
    E["createReview logs"] --> F["number / html_url / byte lengths"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/process-utils.test.ts src/__tests__/github-merge-gate-provider.test.ts`
- [x] Confirm 50 passed across both files

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a498c226c3`
- Post-revert steps: None
- Data migration? No

</details>
