### PR TITLE
[Quick install](1) Add Node bootstrap wrapper that delegates to invoker-cli install

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,6 +32,22 @@ run_cli() {
   "$@" </dev/null
 }
 
+# Download a NodeSource setup script to a local file and inspect it before
+# executing, instead of piping curl output directly into a privileged shell.
+run_nodesource_setup() {
+  local url="$1"
+  shift
+  local tmp
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' RETURN
+  curl -fsSL "$url" -o "$tmp"
+  if [ ! -s "$tmp" ] || ! head -c 2 "$tmp" | grep -q '^#!'; then
+    echo "    ERROR: Downloaded NodeSource setup script failed validation." >&2
+    exit 1
+  fi
+  sudo "$@" bash "$tmp"
+}
+
 OS="$(uname -s)"
 case "$OS" in
   Darwin|Linux) ;;
@@ -71,10 +87,10 @@ if [ "$NEED_NODE" = true ]; then
     brew link --overwrite "node@$REQUIRED_NODE_MAJOR" 2>/dev/null || true
   else
     if has apt-get; then
-      curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo -E bash -
+      run_nodesource_setup "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" -E
       sudo apt-get install -y nodejs
     elif has dnf; then
-      curl -fsSL "https://rpm.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo bash -
+      run_nodesource_setup "https://rpm.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x"
       sudo dnf install -y nodejs
     else
       echo "    ERROR: Could not detect apt or dnf. Install Node.js $REQUIRED_NODE_MAJOR.x manually." >&2

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Optional Node bootstrap for Invoker. Ensures Node 26, then runs the
+# public invoker-cli quick-install one-liner. Prefer:
+#   npx @neko-catpital-labs/invoker-cli@latest install
+# when Node is already installed.
+# Does NOT write Slack tokens or remote machines.
+set -euo pipefail
+
+REQUIRED_NODE_MAJOR=26
+
+usage() {
+  cat <<'EOF'
+Usage: curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/bootstrap.sh | bash
+
+Optional wrapper: installs Node.js 26.x if needed, then runs:
+  npx @neko-catpital-labs/invoker-cli@latest install
+
+Prefer that npx one-liner directly when Node 26 is already available.
+Does not configure Slack or remote machines.
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+has() { command -v "$1" >/dev/null 2>&1; }
+
+# Child CLIs must not read from the curl|bash stdin pipe.
+run_cli() {
+  "$@" </dev/null
+}
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin|Linux) ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Invoker bootstrap (Node ensure → invoker-cli install)"
+echo ""
+
+echo "==> Checking Node.js..."
+NEED_NODE=false
+if has node; then
+  NODE_MAJOR="$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")"
+  if [ "$NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]; then
+    echo "    Found Node.js v$(node --version | tr -d v), but Node $REQUIRED_NODE_MAJOR.x is required."
+    NEED_NODE=true
+  else
+    echo "    OK: Node.js $(node --version)"
+  fi
+else
+  echo "    Node.js not found."
+  NEED_NODE=true
+fi
+
+if [ "$NEED_NODE" = true ]; then
+  echo "    Installing Node.js $REQUIRED_NODE_MAJOR.x..."
+  if [ "$OS" = "Darwin" ]; then
+    if ! has brew; then
+      echo "    ERROR: Homebrew is required to install Node.js on macOS." >&2
+      echo "    Install it from https://brew.sh and re-run this script." >&2
+      exit 1
+    fi
+    brew install "node@$REQUIRED_NODE_MAJOR"
+    brew link --overwrite "node@$REQUIRED_NODE_MAJOR" 2>/dev/null || true
+  else
+    if has apt-get; then
+      curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo -E bash -
+      sudo apt-get install -y nodejs
+    elif has dnf; then
+      curl -fsSL "https://rpm.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo bash -
+      sudo dnf install -y nodejs
+    else
+      echo "    ERROR: Could not detect apt or dnf. Install Node.js $REQUIRED_NODE_MAJOR.x manually." >&2
+      exit 1
+    fi
+  fi
+  if ! has node; then
+    echo "    ERROR: Node.js installation failed." >&2
+    exit 1
+  fi
+  echo "    Installed: Node.js $(node --version)"
+fi
+echo ""
+
+if ! has npm; then
+  echo "ERROR: npm not found after Node install." >&2
+  exit 1
+fi
+
+echo "==> Running npx @neko-catpital-labs/invoker-cli@latest install..."
+run_cli npx --yes @neko-catpital-labs/invoker-cli@latest install

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -85,6 +85,17 @@ if [ "$NEED_NODE" = true ]; then
     echo "    ERROR: Node.js installation failed." >&2
     exit 1
   fi
+  INSTALLED_NODE_MAJOR="$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")"
+  if [ "$INSTALLED_NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]; then
+    echo "    ERROR: Node.js $REQUIRED_NODE_MAJOR.x was installed, but 'node' on PATH is still v$(node --version | tr -d v)." >&2
+    if [ "$OS" = "Darwin" ]; then
+      echo "    Homebrew likely failed to link node@$REQUIRED_NODE_MAJOR ahead of another Node on PATH." >&2
+      echo "    Run: brew link --overwrite node@$REQUIRED_NODE_MAJOR" >&2
+    else
+      echo "    Another Node.js install earlier on PATH is shadowing the new one; fix PATH and re-run." >&2
+    fi
+    exit 1
+  fi
   echo "    Installed: Node.js $(node --version)"
 fi
 echo ""

--- a/scripts/capture-install-transcript.sh
+++ b/scripts/capture-install-transcript.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Regenerate docs/install-transcript.txt from invoker-cli install --demo.
+# Prefer the built package binary when available; otherwise tsx/source via vitest-free node.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$REPO_ROOT/docs/install-transcript.txt"
+CLI_DIST="$REPO_ROOT/packages/cli/dist/index.js"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$(dirname "$OUT")"
+
+if [[ -f "$CLI_DIST" ]]; then
+  node "$CLI_DIST" install --demo >"$OUT"
+elif command -v invoker-cli >/dev/null 2>&1; then
+  invoker-cli install --demo >"$OUT"
+else
+  # Build cli first so dist exists, then capture.
+  pnpm --filter @invoker/cli run build
+  [[ -f "$CLI_DIST" ]] || fail "missing $CLI_DIST after build"
+  node "$CLI_DIST" install --demo >"$OUT"
+fi
+
+grep -qF 'Slack: skipped' "$OUT" || fail "transcript missing Slack skip"
+grep -qF 'Remote machines: skipped' "$OUT" || fail "transcript missing machines skip"
+grep -qF 'Workers on: pr-status, autofix, auto-approve' "$OUT" || fail "transcript missing workers"
+grep -qF 'Quick-install complete' "$OUT" || fail "transcript missing completion banner"
+
+echo "Wrote $OUT"

--- a/scripts/capture-install-transcript.sh
+++ b/scripts/capture-install-transcript.sh
@@ -20,9 +20,11 @@ if [[ ! -f "$CLI_DIST" ]]; then
 fi
 node "$CLI_DIST" install --demo >"$OUT"
 
+grep -qF '==> Invoker quick-install' "$OUT" || fail "transcript missing banner"
 grep -qF 'Slack: skipped' "$OUT" || fail "transcript missing Slack skip"
 grep -qF 'Remote machines: skipped' "$OUT" || fail "transcript missing machines skip"
 grep -qF 'Workers on: pr-status, autofix, auto-approve' "$OUT" || fail "transcript missing workers"
 grep -qF 'Quick-install complete' "$OUT" || fail "transcript missing completion banner"
+grep -qF 'auto-approve-authors --add-current-github-user' "$OUT" || fail "transcript missing auto-approve-authors marker"
 
 echo "Wrote $OUT"

--- a/scripts/capture-install-transcript.sh
+++ b/scripts/capture-install-transcript.sh
@@ -14,16 +14,11 @@ fail() {
 
 mkdir -p "$(dirname "$OUT")"
 
-if [[ -f "$CLI_DIST" ]]; then
-  node "$CLI_DIST" install --demo >"$OUT"
-elif command -v invoker-cli >/dev/null 2>&1; then
-  invoker-cli install --demo >"$OUT"
-else
-  # Build cli first so dist exists, then capture.
+if [[ ! -f "$CLI_DIST" ]]; then
   pnpm --filter @invoker/cli run build
   [[ -f "$CLI_DIST" ]] || fail "missing $CLI_DIST after build"
-  node "$CLI_DIST" install --demo >"$OUT"
 fi
+node "$CLI_DIST" install --demo >"$OUT"
 
 grep -qF 'Slack: skipped' "$OUT" || fail "transcript missing Slack skip"
 grep -qF 'Remote machines: skipped' "$OUT" || fail "transcript missing machines skip"

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -279,7 +279,8 @@ export function classifyReviewUnitsForPath(filePath) {
   if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
   if (
     path === 'skills/make-pr/SKILL.md'
-    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path.startsWith('skills/chat-submit/')
+    || path.startsWith('skills/plan-to-invoker/')
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -37,8 +37,58 @@ must_not_contain() {
 must_not_contain 'invoker-cli doctor --fix' 'bootstrap must not reimplement doctor'
 must_not_contain 'invoker-cli setup --yes' 'bootstrap must not reimplement setup'
 
+must_contain 'INSTALLED_NODE_MAJOR' 'bootstrap must re-check the Node major version after installing'
+must_contain '$REQUIRED_NODE_MAJOR.x was installed, but' 'bootstrap must fail loudly on a post-install Node major mismatch'
+
 help_out="$("$BOOTSTRAP" --help)"
 printf '%s\n' "$help_out" | grep -qF 'npx @neko-catpital-labs/invoker-cli@latest install' \
   || fail '--help must mention npx install one-liner'
+
+MOCK_BIN="$(mktemp -d)"
+trap 'rm -rf "$MOCK_BIN"' EXIT
+
+cat > "$MOCK_BIN/node" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "v18.0.0"
+  exit 0
+fi
+if [ "$1" = "-e" ]; then
+  echo "18"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_BIN/node"
+
+cat > "$MOCK_BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/apt-get"
+
+cat > "$MOCK_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/curl"
+
+cat > "$MOCK_BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/sudo"
+
+set +e
+mismatch_out="$(PATH="$MOCK_BIN:$PATH" "$BOOTSTRAP" 2>&1)"
+mismatch_rc=$?
+set -e
+
+[[ $mismatch_rc -ne 0 ]] || fail 'bootstrap must exit non-zero on a post-install Node major mismatch'
+printf '%s\n' "$mismatch_out" | grep -qF 'was installed, but' \
+  || fail 'bootstrap must report the post-install Node major mismatch'
+
+rm -rf "$MOCK_BIN"
+trap - EXIT
 
 echo "OK: bootstrap contract"

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Contract checks for scripts/bootstrap.sh (Node ensure → CLI install).
+# Run from repo root.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/scripts/bootstrap.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$BOOTSTRAP" ]] || fail "missing $BOOTSTRAP"
+[[ -x "$BOOTSTRAP" ]] || fail "bootstrap.sh must be executable"
+
+bash -n "$BOOTSTRAP" || fail "bash -n failed"
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  if ! grep -qF -- "$needle" "$BOOTSTRAP"; then
+    fail "$hint — missing: $needle"
+  fi
+}
+
+must_contain '</dev/null' 'curl|bash-safe CLI calls must redirect stdin from /dev/null'
+must_contain 'npx --yes @neko-catpital-labs/invoker-cli@latest install' 'bootstrap must delegate to invoker-cli install'
+must_not_contain() {
+  local needle="$1"
+  local hint="$2"
+  if grep -qF -- "$needle" "$BOOTSTRAP"; then
+    fail "$hint — unexpected: $needle"
+  fi
+}
+
+must_not_contain 'invoker-cli doctor --fix' 'bootstrap must not reimplement doctor'
+must_not_contain 'invoker-cli setup --yes' 'bootstrap must not reimplement setup'
+
+help_out="$("$BOOTSTRAP" --help)"
+printf '%s\n' "$help_out" | grep -qF 'npx @neko-catpital-labs/invoker-cli@latest install' \
+  || fail '--help must mention npx install one-liner'
+
+echo "OK: bootstrap contract"

--- a/scripts/test-install-transcript.sh
+++ b/scripts/test-install-transcript.sh
@@ -34,14 +34,17 @@ must_contain 'Workers on: pr-status, autofix, auto-approve'
 must_contain 'Quick-install complete'
 must_contain 'auto-approve-authors --add-current-github-user'
 
-if [[ -f "$CLI_DIST" ]]; then
-  actual="$(mktemp)"
-  node "$CLI_DIST" install --demo >"$actual"
-  if ! diff -u "$GOLDEN" "$actual"; then
-    rm -f "$actual"
-    fail "golden transcript drift — re-run bash scripts/capture-install-transcript.sh"
-  fi
-  rm -f "$actual"
+if [[ ! -f "$CLI_DIST" ]]; then
+  pnpm --filter @invoker/cli run build
+  [[ -f "$CLI_DIST" ]] || fail "missing $CLI_DIST after build"
 fi
+
+actual="$(mktemp)"
+node "$CLI_DIST" install --demo >"$actual"
+if ! diff -u "$GOLDEN" "$actual"; then
+  rm -f "$actual"
+  fail "golden transcript drift — re-run bash scripts/capture-install-transcript.sh"
+fi
+rm -f "$actual"
 
 echo "OK: install transcript contract"

--- a/scripts/test-install-transcript.sh
+++ b/scripts/test-install-transcript.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Contract: docs/install-transcript.txt matches install --demo and required banners.
+# When the golden is not in this checkout yet (earlier stack slices), only syntax-check.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GOLDEN="$REPO_ROOT/docs/install-transcript.txt"
+CLI_DIST="$REPO_ROOT/packages/cli/dist/index.js"
+CAPTURE="$REPO_ROOT/scripts/capture-install-transcript.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$CAPTURE" ]] || fail "missing $CAPTURE"
+[[ -x "$CAPTURE" ]] || fail "capture-install-transcript.sh must be executable"
+bash -n "$CAPTURE" || fail "bash -n capture failed"
+bash -n "$0" || fail "bash -n self failed"
+
+if [[ ! -f "$GOLDEN" ]]; then
+  echo "OK: install transcript scripts (golden docs/install-transcript.txt lands in docs slice)"
+  exit 0
+fi
+
+must_contain() {
+  grep -qF -- "$1" "$GOLDEN" || fail "golden missing: $1"
+}
+
+must_contain '==> Invoker quick-install'
+must_contain 'Slack: skipped'
+must_contain 'Remote machines: skipped'
+must_contain 'Workers on: pr-status, autofix, auto-approve'
+must_contain 'Quick-install complete'
+must_contain 'auto-approve-authors --add-current-github-user'
+
+if [[ -f "$CLI_DIST" ]]; then
+  actual="$(mktemp)"
+  node "$CLI_DIST" install --demo >"$actual"
+  if ! diff -u "$GOLDEN" "$actual"; then
+    rm -f "$actual"
+    fail "golden transcript drift — re-run bash scripts/capture-install-transcript.sh"
+  fi
+  rm -f "$actual"
+fi
+
+echo "OK: install transcript contract"

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -36,10 +36,15 @@ const stillToolingPolicy = [
   'scripts/review-unit-rules.mjs',
   '.github/workflows/ci.yml',
   'skills/make-pr/SKILL.md',
+  'skills/chat-submit/SKILL.md',
+  'skills/chat-submit/scripts/check-contract.sh',
   'skills/plan-to-invoker/SKILL.md',
+  'skills/plan-to-invoker/references/local-vs-remote-mcp.md',
   'skills/land-stack/SKILL.md',
   'skills/visual-proof/SKILL.md',
   'skills/prove-it/SKILL.md',
+  'scripts/bootstrap.sh',
+  'scripts/test-bootstrap.sh',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Optional curl bootstrap now only ensures Node 26, then runs the public npx install one-liner.

Capture and check scripts lock the install demo transcript banners for reviewers.

## Review Claim

Bootstrap no longer reimplements doctor or setup; it delegates to the packaged install entry after Node is present.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Bootstrap never writes Slack credentials or remote machines. It does not replace desktop install.sh. Failed optional tools stay soft.

## Slice Rationale

Script and classification changes are tooling-policy and must land before skills and later product slices.

## Non-goals

No packages/cli install implementation in this slice. No README install guide rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-bootstrap.sh`
- [x] `bash scripts/test-install-transcript.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
