### PR TITLE
[Quick install](5) Document npx invoker-cli install as the default packaged install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,27 @@ PR maintenance uses the same owner-host worker path. Enable `prMaintenance` to l
 
 ## Install
 
+Requires Node.js 26.x. One command installs CLI + UI, runs doctor, wires skills/MCP, and turns on `pr-status` / `autofix` / `auto-approve` (skips Slack and remote machines):
+
+```bash
+npx @neko-catpital-labs/invoker-cli@latest install
+```
+
+Sample output: [docs/install-transcript.txt](docs/install-transcript.txt) (`invoker-cli install --demo`).
+
+Default Invoker owner is **local**. In chat, name a host or IP to use a remote Invoker (the agent probes SSH and retargets MCP). Slack and remote machines stay optional (`invoker-cli setup slack` / `setup machines`).
+
+Manual equivalent:
+
 ```bash
 npm install -g @neko-catpital-labs/invoker-ui
 npm install -g @neko-catpital-labs/invoker-cli
-npm install -g @neko-catpital-labs/invoker-slack
-invoker-cli setup
+invoker-cli install
 ```
 
-Or grab desktop builds and standalone binaries from [GitHub Releases](https://github.com/Neko-Catpital-Labs/Invoker/releases/latest). Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
+If you need Node installed first, optional wrapper: `curl -fsSL …/scripts/bootstrap.sh | bash` (ensures Node 26, then runs the same `npx … install`). Desktop packages only: `curl …/scripts/install.sh | bash`. Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
 
-`invoker-cli setup` installs the first-party Invoker AI helper skills, registers the Invoker MCP server with Codex, Claude, Cursor, and OMP, and walks through the rest of onboarding (Slack integration, GitHub auth, a smoke-test plan run).
+`invoker-cli install` (and interactive `invoker-cli setup`) installs the first-party Invoker AI helper skills and registers the Invoker MCP server with Codex, Claude, Cursor, and OMP. Interactive `setup` still walks Slack and machines when you want them.
 
 Then, in Codex, Claude, Cursor, or OMP, ask in normal chat to plan and run durable work through Invoker. Setup already installs the `invoker-chat-submit` skill and MCP tools, so the agent can prepare a review, wait for one approval, submit, and watch status without a slash command.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm install -g @neko-catpital-labs/invoker-cli
 invoker-cli install
 ```
 
-If you need Node installed first, optional wrapper: `curl -fsSL …/scripts/bootstrap.sh | bash` (ensures Node 26, then runs the same `npx … install`). Desktop packages only: `curl …/scripts/install.sh | bash`. Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
+If you need Node installed first, optional wrapper: `curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/bootstrap.sh | bash` (ensures Node 26, then runs the same `npx @neko-catpital-labs/invoker-cli@latest install`). Desktop packages only: `curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/install.sh | bash`. Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
 
 `invoker-cli install` (and interactive `invoker-cli setup`) installs the first-party Invoker AI helper skills and registers the Invoker MCP server with Codex, Claude, Cursor, and OMP. Interactive `setup` still walks Slack and machines when you want them.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,24 @@ Install, configure, and run Invoker. For the product overview, see the [README](
 
 ## Installation
 
+**Recommended (packaged):** Node.js 26.x required. One command installs `invoker-cli` + `invoker-ui`, runs `doctor --fix`, installs skills + local MCP, and enables `pr-status` / `autofix` / `auto-approve`. It does not write Slack tokens or remote machines.
+
+```bash
+npx @neko-catpital-labs/invoker-cli@latest install
+```
+
+Expected output shape: [install-transcript.txt](install-transcript.txt) (from `invoker-cli install --demo`).
+
+Default Invoker owner is local (`invoker-cli mcp`). In Claude / Cursor / Codex / OMP chat, name a host or IP to use a remote Invoker — the agent probes SSH and retargets MCP only after a successful probe.
+
+**Need Node first?** Optional wrapper installs Node 26 when missing, then runs the same CLI install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/bootstrap.sh | bash
+```
+
+**Source checkout** (contributors):
+
 ```bash
 git clone https://github.com/Neko-Catpital-Labs/Invoker.git invoker && cd invoker
 pnpm install
@@ -27,17 +45,16 @@ For packaged installs, the repo includes npm launchers, direct GitHub Release do
 
 The downloaded standalone CLI binary does not require Node after installation. It can run plans directly, or delegate to a running Invoker desktop owner when one is available. The npm package is a launcher that installs and runs that bundled binary as `invoker-cli`.
 
-Install with npm:
+Prefer the [npx install one-liner](#installation) above. Manual npm path:
 
 ```bash
 npm install -g @neko-catpital-labs/invoker-cli
 invoker-cli --version
-invoker-cli doctor
-invoker-cli setup
+invoker-cli install
 invoker-cli run plans/fixtures/hello-world.yaml --standalone
 ```
 
-`invoker-cli setup` installs the first-party Invoker AI helper skills, registers the Invoker MCP server with Codex, Claude, Cursor, and OMP, and walks through the rest of onboarding (Slack integration, GitHub auth, a smoke-test plan run) — one command for the full standalone install.
+`invoker-cli install` installs the first-party Invoker AI helper skills, registers the Invoker MCP server with Codex, Claude, Cursor, and OMP, and enables default workers (`pr-status`, `autofix`, `auto-approve`). It skips Slack/machines. Interactive `invoker-cli setup` still walks those when you want them.
 
 Or download the platform binary from GitHub Releases:
 
@@ -88,11 +105,13 @@ The macOS npm launcher uses the `.zip` app bundle asset so it does not need to m
 
 For a local maintainer build from the latest `master` commit, including Apple Silicon `.dmg` generation, the standalone `invoker-slack` binary, and unsigned-build quarantine removal, see [local-macos-release-build.md](local-macos-release-build.md) (`bash scripts/local-macos-release-build.sh`).
 
-For source-based packaged installs, the repo includes an installer script:
+For desktop binary packages only (no npm/skills), the repo includes an installer script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/install.sh | bash
 ```
+
+For CLI + UI + skills/MCP in one step, use `npx @neko-catpital-labs/invoker-cli@latest install` (or the optional Node wrapper [`scripts/bootstrap.sh`](../scripts/bootstrap.sh)).
 
 Tagged releases are configured to publish:
 - standalone CLI binaries and `.tar.gz` archives for macOS and Linux on x64 and arm64

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,9 +118,9 @@ Tagged releases are configured to publish:
 - desktop `.dmg`, `.zip`, `.deb`, and `.AppImage`
 - `SHA256SUMS` covering release assets
 
-Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers by running `invoker-cli setup` (or System Setup in the desktop app).
+Packaged installs bundle the first-party Invoker AI helpers inside the app. `invoker-cli install` already installs the helper skills and MCP server; run `invoker-cli setup` (or System Setup in the desktop app) only if you also want optional Slack and remote machine configuration.
 
-Then, in Codex, Claude, Cursor, or OMP, ask in normal chat to plan and run durable work through Invoker. Setup already installs `invoker-chat-submit` plus MCP review/submit/status tools, so the agent can prepare a review, wait for one approval, submit, and watch without a slash command.
+Then, in Codex, Claude, Cursor, or OMP, ask in normal chat to plan and run durable work through Invoker. Install already installs `invoker-chat-submit` plus MCP review/submit/status tools, so the agent can prepare a review, wait for one approval, submit, and watch without a slash command.
 
 Explicit fallback:
 

--- a/docs/install-transcript.txt
+++ b/docs/install-transcript.txt
@@ -1,0 +1,33 @@
+==> Invoker quick-install
+
+==> Checking Node.js...
+    OK: Node.js v26.x
+
+==> Installing npm packages...
+    OK: @neko-catpital-labs/invoker-cli @neko-catpital-labs/invoker-ui
+
+==> Running doctor --fix...
+    Doctor finished (optional tools may still be missing).
+
+==> Installing skills + local MCP...
+    Skills/MCP: installed for detected harnesses.
+    Slack: skipped (optional: invoker-cli setup slack)
+    Remote machines: skipped (optional: invoker-cli setup machines)
+
+==> Enabling default workers...
+    Workers on: pr-status, autofix, auto-approve
+
+==> GitHub auth + smoke (report only)...
+    Report-only checks finished (install continues even if red).
+
+============================================
+  Quick-install complete.
+
+  Default Invoker owner: local (invoker-cli mcp).
+
+  Optional next:
+    invoker-cli auto-approve-authors --add-current-github-user
+    invoker-cli setup slack
+    invoker-cli setup machines
+    invoker-ui
+============================================


### PR DESCRIPTION
## Summary

README and getting-started now lead with the public npx install one-liner for packaged installs.

The golden install --demo transcript is checked in so reviewers can see the expected output shape.

## Review Claim

Public install guides point new users at the packaged install one-liner and show sample output.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Guide text only. Runtime installer behavior is unchanged in this slice; the install entry itself lands earlier in the stack.

## Slice Rationale

Review-unit checks forbid shipping install guides with tooling-policy files, so guides follow those slices.

## Non-goals

No application source changes. No Slack setup guide rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n 'npx @neko-catpital-labs/invoker-cli@latest install' README.md docs/getting-started.md`
- [x] `bash scripts/test-install-transcript.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

## Sample install output

From `docs/install-transcript.txt` (`install --demo`):

```text
==> Invoker quick-install

==> Checking Node.js...
    OK: Node.js v26.x

==> Installing npm packages...
    OK: @neko-catpital-labs/invoker-cli @neko-catpital-labs/invoker-ui

==> Running doctor --fix...
    Doctor finished (optional tools may still be missing).

==> Installing skills + local MCP...
    Skills/MCP: installed for detected harnesses.
    Slack: skipped (optional: invoker-cli setup slack)
    Remote machines: skipped (optional: invoker-cli setup machines)

==> Enabling default workers...
    Workers on: pr-status, autofix, auto-approve

==> GitHub auth + smoke (report only)...
    Report-only checks finished (install continues even if red).

============================================
  Quick-install complete.

  Default Invoker owner: local (invoker-cli mcp).

  Optional next:
    invoker-cli auto-approve-authors --add-current-github-user
    invoker-cli setup slack
    invoker-cli setup machines
    invoker-ui
============================================
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation guidance to require Node.js 26.x.
  - Added a recommended one-command installer for the CLI, UI, skills, MCP setup, health checks, and default workers.
  - Clarified manual, desktop-only, Slack, and remote-machine installation options.
  - Added a complete quick-install transcript with verification, authentication, and smoke-check steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->