### PR TITLE
[admin-bypass-repair-bot-thread-pr-10541-2eb9914](1) Add Node bootstrap wrapper that delegates to invoker-cli install

### DIFF
--- a/plans/close-superseded-pr-10549.md
+++ b/plans/close-superseded-pr-10549.md
@@ -1,0 +1,55 @@
+# Close superseded repair-bot PR #10549
+
+## Goal
+
+Close GitHub PR #10549 without merging, because its content is fully
+superseded by already-merged PR #10541 (commit `49b7394ff`).
+
+## Motivation
+
+PR #10549 was asked to be rebased onto `master`. The rebase fails with
+add/add conflicts on `scripts/bootstrap.sh`,
+`scripts/capture-install-transcript.sh`, `scripts/test-bootstrap.sh`, and
+`scripts/test-install-transcript.sh`, because PR #10541 already merged an
+independently-written version of the exact same feature ("Add Node
+bootstrap wrapper that delegates to invoker-cli install") to `master`.
+
+Diffing PR #10549's head (`0aa1f8f26201651f918ec5cc59c1bdaaf944109e`)
+against `master`'s merged version confirms PR #10549 has no unique content:
+
+- The two non-conflicting files it also touched
+  (`scripts/review-unit-rules.mjs`, `scripts/test-review-unit-classification.mjs`)
+  are byte-identical to `master`.
+- Its four conflicting files are a strict subset of `master`'s: `master`
+  additionally has a `run_nodesource_setup` helper (downloads the NodeSource
+  setup script to a file and validates it before running, instead of piping
+  `curl` straight into a privileged `sudo bash`) and a post-install Node
+  major-version mismatch check, plus the tests for both. PR #10549 lacks
+  both hardenings.
+
+There is nothing to cherry-pick and no restructuring that keeps any of
+PR #10549's own code — the correct fix is to close it as superseded, not
+force a resolution that reintroduces a weaker, already-superseded
+implementation.
+
+## Safety invariant
+
+Closing PR #10549 does not touch `master` or any other open PR, does not
+merge or delete its branch, and does not modify code. It is a metadata-only,
+reversible GitHub action (the PR can be reopened).
+
+## Verify
+
+`gh pr view 10549 --json state -q .state` returns `CLOSED` after the task
+runs, and the two non-conflicting files remain byte-identical to `master`
+at close time (re-checked immediately before closing, in case `master`
+moved).
+
+## Plan
+
+Single command-only workflow, `onFinish: none` (no code change), that:
+
+1. Re-verifies PR #10549 has no unique content vs. current `master`.
+2. Closes PR #10549 with an explanatory comment citing #10541 /
+   `49b7394ff`, gated on manual approval since it's a visible action on
+   shared GitHub state.

--- a/plans/close-superseded-pr-10549.yaml
+++ b/plans/close-superseded-pr-10549.yaml
@@ -1,0 +1,44 @@
+name: close-superseded-repair-pr-10549
+description: >
+  PR #10549 is a repair-bot branch that duplicates already-merged PR #10541
+  (commit 49b7394ff), which independently implements the same Node bootstrap
+  wrapper feature. Diffing confirms PR #10549 has no content beyond what
+  master already has, and master's version is strictly better (it keeps a
+  NodeSource-script validation step and a post-install Node major-version
+  mismatch check that PR #10549's version drops), so this plan closes
+  PR #10549 without merging instead of forcing a rebase that would
+  reintroduce a weaker, superseded implementation.
+onFinish: none
+mergeMode: manual
+repoUrl: "https://github.com/Neko-Catpital-Labs/Invoker.git"
+
+tasks:
+  - id: verify-pr-10549-superseded
+    description: >
+      Re-confirm PR #10549 (head 0aa1f8f26201651f918ec5cc59c1bdaaf944109e)
+      has no content that master lacks, immediately before closing it.
+      Checks that master's scripts/bootstrap.sh still has the
+      run_nodesource_setup safety wrapper and the INSTALLED_NODE_MAJOR
+      mismatch check (both absent from PR #10549's version), and that the
+      two files PR #10549 touched outside the conflict set
+      (scripts/review-unit-rules.mjs, scripts/test-review-unit-classification.mjs)
+      are still byte-identical to master.
+    command: >
+      git fetch origin master &&
+      git show origin/master:scripts/bootstrap.sh | grep -q 'run_nodesource_setup' &&
+      git show origin/master:scripts/bootstrap.sh | grep -q 'INSTALLED_NODE_MAJOR' &&
+      git diff --exit-code origin/master:scripts/review-unit-rules.mjs 0aa1f8f26201651f918ec5cc59c1bdaaf944109e:scripts/review-unit-rules.mjs &&
+      git diff --exit-code origin/master:scripts/test-review-unit-classification.mjs 0aa1f8f26201651f918ec5cc59c1bdaaf944109e:scripts/test-review-unit-classification.mjs &&
+      echo "OK: master supersedes PR #10549, no unique content found"
+    dependencies: []
+
+  - id: close-pr-10549
+    description: >
+      Close PR #10549 without merging, with a comment explaining it is
+      superseded by #10541 (49b7394ff). Gated on manual approval since this
+      is a visible, external action on shared GitHub state.
+    command: >
+      gh pr close 10549 --comment "Closing: superseded by #10541 (merged as 49b7394ff), which independently implements this same Node bootstrap wrapper feature with additional safety hardening (NodeSource setup-script validation before privileged execution, and a post-install Node major-version mismatch check) that this branch's version lacks. Diffed against current master: no unique content remains here to rebase or cherry-pick."
+    dependencies:
+      - verify-pr-10549-superseded
+    requiresManualApproval: true

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Optional Node bootstrap for Invoker. Ensures Node 26, then runs the
+# public invoker-cli quick-install one-liner. Prefer:
+#   npx @neko-catpital-labs/invoker-cli@latest install
+# when Node is already installed.
+# Does NOT write Slack tokens or remote machines.
+set -euo pipefail
+
+REQUIRED_NODE_MAJOR=26
+
+usage() {
+  cat <<'EOF'
+Usage: curl -fsSL https://raw.githubusercontent.com/Neko-Catpital-Labs/Invoker/master/scripts/bootstrap.sh | bash
+
+Optional wrapper: installs Node.js 26.x if needed, then runs:
+  npx @neko-catpital-labs/invoker-cli@latest install
+
+Prefer that npx one-liner directly when Node 26 is already available.
+Does not configure Slack or remote machines.
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+has() { command -v "$1" >/dev/null 2>&1; }
+
+# Child CLIs must not read from the curl|bash stdin pipe.
+run_cli() {
+  "$@" </dev/null
+}
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin|Linux) ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Invoker bootstrap (Node ensure → invoker-cli install)"
+echo ""
+
+echo "==> Checking Node.js..."
+NEED_NODE=false
+if has node; then
+  NODE_MAJOR="$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")"
+  if [ "$NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]; then
+    echo "    Found Node.js v$(node --version | tr -d v), but Node $REQUIRED_NODE_MAJOR.x is required."
+    NEED_NODE=true
+  else
+    echo "    OK: Node.js $(node --version)"
+  fi
+else
+  echo "    Node.js not found."
+  NEED_NODE=true
+fi
+
+if [ "$NEED_NODE" = true ]; then
+  echo "    Installing Node.js $REQUIRED_NODE_MAJOR.x..."
+  if [ "$OS" = "Darwin" ]; then
+    if ! has brew; then
+      echo "    ERROR: Homebrew is required to install Node.js on macOS." >&2
+      echo "    Install it from https://brew.sh and re-run this script." >&2
+      exit 1
+    fi
+    brew install "node@$REQUIRED_NODE_MAJOR"
+    brew link --overwrite "node@$REQUIRED_NODE_MAJOR" 2>/dev/null || true
+  else
+    if has apt-get; then
+      curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo -E bash -
+      sudo apt-get install -y nodejs
+    elif has dnf; then
+      curl -fsSL "https://rpm.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sudo bash -
+      sudo dnf install -y nodejs
+    else
+      echo "    ERROR: Could not detect apt or dnf. Install Node.js $REQUIRED_NODE_MAJOR.x manually." >&2
+      exit 1
+    fi
+  fi
+  if ! has node; then
+    echo "    ERROR: Node.js installation failed." >&2
+    exit 1
+  fi
+  echo "    Installed: Node.js $(node --version)"
+fi
+echo ""
+
+if ! has npm; then
+  echo "ERROR: npm not found after Node install." >&2
+  exit 1
+fi
+
+echo "==> Running npx @neko-catpital-labs/invoker-cli@latest install..."
+run_cli npx --yes @neko-catpital-labs/invoker-cli@latest install

--- a/scripts/capture-install-transcript.sh
+++ b/scripts/capture-install-transcript.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Regenerate docs/install-transcript.txt from invoker-cli install --demo.
+# Prefer the built package binary when available; otherwise tsx/source via vitest-free node.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$REPO_ROOT/docs/install-transcript.txt"
+CLI_DIST="$REPO_ROOT/packages/cli/dist/index.js"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$(dirname "$OUT")"
+
+if [[ -f "$CLI_DIST" ]]; then
+  node "$CLI_DIST" install --demo >"$OUT"
+elif command -v invoker-cli >/dev/null 2>&1; then
+  invoker-cli install --demo >"$OUT"
+else
+  # Build cli first so dist exists, then capture.
+  pnpm --filter @invoker/cli run build
+  [[ -f "$CLI_DIST" ]] || fail "missing $CLI_DIST after build"
+  node "$CLI_DIST" install --demo >"$OUT"
+fi
+
+grep -qF 'Slack: skipped' "$OUT" || fail "transcript missing Slack skip"
+grep -qF 'Remote machines: skipped' "$OUT" || fail "transcript missing machines skip"
+grep -qF 'Workers on: pr-status, autofix, auto-approve' "$OUT" || fail "transcript missing workers"
+grep -qF 'Quick-install complete' "$OUT" || fail "transcript missing completion banner"
+
+echo "Wrote $OUT"

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -279,7 +279,8 @@ export function classifyReviewUnitsForPath(filePath) {
   if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
   if (
     path === 'skills/make-pr/SKILL.md'
-    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path.startsWith('skills/chat-submit/')
+    || path.startsWith('skills/plan-to-invoker/')
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Contract checks for scripts/bootstrap.sh (Node ensure → CLI install).
+# Run from repo root.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/scripts/bootstrap.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$BOOTSTRAP" ]] || fail "missing $BOOTSTRAP"
+[[ -x "$BOOTSTRAP" ]] || fail "bootstrap.sh must be executable"
+
+bash -n "$BOOTSTRAP" || fail "bash -n failed"
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  if ! grep -qF -- "$needle" "$BOOTSTRAP"; then
+    fail "$hint — missing: $needle"
+  fi
+}
+
+must_contain '</dev/null' 'curl|bash-safe CLI calls must redirect stdin from /dev/null'
+must_contain 'npx --yes @neko-catpital-labs/invoker-cli@latest install' 'bootstrap must delegate to invoker-cli install'
+must_not_contain() {
+  local needle="$1"
+  local hint="$2"
+  if grep -qF -- "$needle" "$BOOTSTRAP"; then
+    fail "$hint — unexpected: $needle"
+  fi
+}
+
+must_not_contain 'invoker-cli doctor --fix' 'bootstrap must not reimplement doctor'
+must_not_contain 'invoker-cli setup --yes' 'bootstrap must not reimplement setup'
+
+help_out="$("$BOOTSTRAP" --help)"
+printf '%s\n' "$help_out" | grep -qF 'npx @neko-catpital-labs/invoker-cli@latest install' \
+  || fail '--help must mention npx install one-liner'
+
+echo "OK: bootstrap contract"

--- a/scripts/test-install-transcript.sh
+++ b/scripts/test-install-transcript.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Contract: docs/install-transcript.txt matches install --demo and required banners.
+# When the golden is not in this checkout yet (earlier stack slices), only syntax-check.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GOLDEN="$REPO_ROOT/docs/install-transcript.txt"
+CLI_DIST="$REPO_ROOT/packages/cli/dist/index.js"
+CAPTURE="$REPO_ROOT/scripts/capture-install-transcript.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$CAPTURE" ]] || fail "missing $CAPTURE"
+[[ -x "$CAPTURE" ]] || fail "capture-install-transcript.sh must be executable"
+bash -n "$CAPTURE" || fail "bash -n capture failed"
+bash -n "$0" || fail "bash -n self failed"
+
+if [[ ! -f "$GOLDEN" ]]; then
+  echo "OK: install transcript scripts (golden docs/install-transcript.txt lands in docs slice)"
+  exit 0
+fi
+
+must_contain() {
+  grep -qF -- "$1" "$GOLDEN" || fail "golden missing: $1"
+}
+
+must_contain '==> Invoker quick-install'
+must_contain 'Slack: skipped'
+must_contain 'Remote machines: skipped'
+must_contain 'Workers on: pr-status, autofix, auto-approve'
+must_contain 'Quick-install complete'
+must_contain 'auto-approve-authors --add-current-github-user'
+
+if [[ -f "$CLI_DIST" ]]; then
+  actual="$(mktemp)"
+  node "$CLI_DIST" install --demo >"$actual"
+  if ! diff -u "$GOLDEN" "$actual"; then
+    rm -f "$actual"
+    fail "golden transcript drift — re-run bash scripts/capture-install-transcript.sh"
+  fi
+  rm -f "$actual"
+fi
+
+echo "OK: install transcript contract"

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -36,10 +36,15 @@ const stillToolingPolicy = [
   'scripts/review-unit-rules.mjs',
   '.github/workflows/ci.yml',
   'skills/make-pr/SKILL.md',
+  'skills/chat-submit/SKILL.md',
+  'skills/chat-submit/scripts/check-contract.sh',
   'skills/plan-to-invoker/SKILL.md',
+  'skills/plan-to-invoker/references/local-vs-remote-mcp.md',
   'skills/land-stack/SKILL.md',
   'skills/visual-proof/SKILL.md',
   'skills/prove-it/SKILL.md',
+  'scripts/bootstrap.sh',
+  'scripts/test-bootstrap.sh',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Adds `scripts/bootstrap.sh`, an optional curl|bash wrapper for machines that don't have Node yet.

It installs Node 26 via Homebrew or apt/dnf, then delegates to the real product install path: `npx @neko-catpital-labs/invoker-cli@latest install`.

Machines that already have Node 26 should keep using the npx one-liner directly; this script only exists for the "no Node yet" case.

A companion script, `scripts/capture-install-transcript.sh`, regenerates the recorded demo install transcript reference file from the built package.

Both new scripts are registered in the tooling-policy classifier so CI review-unit checks recognize them correctly.

## Review Claim

Approve adding the optional Node-bootstrap wrapper and install-transcript capture script, plus their tooling-policy classification entries.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The script only runs when a maintainer or user explicitly pipes it into bash; it never runs in CI or as part of any automated Invoker workflow, and it makes no product-code changes.

## Slice Rationale

This slice lands the wrapper and its classifier registration as one unit, separate from the follow-up hardening in `(2)` that fixes a specific post-install verification gap discovered afterward. Splitting keeps the foundational addition reviewable on its own before the correctness fix lands on top of it.

## Non-goals

Does not configure Slack tokens or remote machines. Does not change the `npx @neko-catpital-labs/invoker-cli@latest install` product path itself. Does not add the post-install major-version re-check (see `(2)`).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-bootstrap.sh`
- [ ] `bash scripts/test-install-transcript.sh`
- [ ] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
