### PR TITLE
[admin-bypass-repair-bot-thread-pr-10541-2eb9914](2) Verify Node major version after install in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -85,6 +85,17 @@ if [ "$NEED_NODE" = true ]; then
     echo "    ERROR: Node.js installation failed." >&2
     exit 1
   fi
+  INSTALLED_NODE_MAJOR="$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")"
+  if [ "$INSTALLED_NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]; then
+    echo "    ERROR: Node.js $REQUIRED_NODE_MAJOR.x was installed, but 'node' on PATH is still v$(node --version | tr -d v)." >&2
+    if [ "$OS" = "Darwin" ]; then
+      echo "    Homebrew likely failed to link node@$REQUIRED_NODE_MAJOR ahead of another Node on PATH." >&2
+      echo "    Run: brew link --overwrite node@$REQUIRED_NODE_MAJOR" >&2
+    else
+      echo "    Another Node.js install earlier on PATH is shadowing the new one; fix PATH and re-run." >&2
+    fi
+    exit 1
+  fi
   echo "    Installed: Node.js $(node --version)"
 fi
 echo ""

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -37,8 +37,58 @@ must_not_contain() {
 must_not_contain 'invoker-cli doctor --fix' 'bootstrap must not reimplement doctor'
 must_not_contain 'invoker-cli setup --yes' 'bootstrap must not reimplement setup'
 
+must_contain 'INSTALLED_NODE_MAJOR' 'bootstrap must re-check the Node major version after installing'
+must_contain '$REQUIRED_NODE_MAJOR.x was installed, but' 'bootstrap must fail loudly on a post-install Node major mismatch'
+
 help_out="$("$BOOTSTRAP" --help)"
 printf '%s\n' "$help_out" | grep -qF 'npx @neko-catpital-labs/invoker-cli@latest install' \
   || fail '--help must mention npx install one-liner'
+
+MOCK_BIN="$(mktemp -d)"
+trap 'rm -rf "$MOCK_BIN"' EXIT
+
+cat > "$MOCK_BIN/node" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "v18.0.0"
+  exit 0
+fi
+if [ "$1" = "-e" ]; then
+  echo "18"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_BIN/node"
+
+cat > "$MOCK_BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/apt-get"
+
+cat > "$MOCK_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/curl"
+
+cat > "$MOCK_BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/sudo"
+
+set +e
+mismatch_out="$(PATH="$MOCK_BIN:$PATH" "$BOOTSTRAP" 2>&1)"
+mismatch_rc=$?
+set -e
+
+[[ $mismatch_rc -ne 0 ]] || fail 'bootstrap must exit non-zero on a post-install Node major mismatch'
+printf '%s\n' "$mismatch_out" | grep -qF 'was installed, but' \
+  || fail 'bootstrap must report the post-install Node major mismatch'
+
+rm -rf "$MOCK_BIN"
+trap - EXIT
 
 echo "OK: bootstrap contract"


### PR DESCRIPTION
## Summary

Hardens `scripts/bootstrap.sh`'s post-install check for Node.

Before this change, the script only checked that some `node` binary existed on PATH after installing.

A stale or shadowed Node left over from an earlier install could still be first on PATH. The script would then report success while the wrong major version stayed active.

Now it re-reads the installed major version and compares it against `REQUIRED_NODE_MAJOR`. It fails with concrete repair guidance instead of silently continuing.

## Review Claim

Approve re-checking the installed Node major version after install in `scripts/bootstrap.sh`, instead of only checking that a `node` binary exists.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only adds a stricter post-install check and an early `exit 1` with guidance; it does not change the install commands themselves, so the worst case is the script now fails loudly in a situation where it previously silently proceeded.

## Slice Rationale

Split from `(1)` because it is a distinct local claim: `(1)` adds the wrapper, this slice fixes a specific correctness gap in that wrapper's verification step found after the fact. Keeping it separate lets a reviewer approve the foundational script and the hardening fix independently.

## Non-goals

Does not change how Node is installed on any platform. Does not touch `scripts/capture-install-transcript.sh` or the review-unit classifier entries from `(1)`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-bootstrap.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
