### PR TITLE
[cross-repo-research](1) Add crossRepoResearch config schema and validation

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -662,3 +662,67 @@ describe('prMaintenance.targetRepos', () => {
     })).toThrow(/owner\/repo/);
   });
 });
+
+describe('crossRepoResearch config', () => {
+  it('accepts omitted crossRepoResearch block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts empty maps without linearTeamId', () => {
+    expect(validateInvokerConfig({
+      crossRepoResearch: { maps: {} },
+    }).crossRepoResearch?.maps).toEqual({});
+  });
+
+  it('requires linearTeamId when maps are non-empty', () => {
+    expect(() => validateInvokerConfig({
+      crossRepoResearch: {
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/stablyai/orca',
+          ],
+        },
+      },
+    })).toThrow(/linearTeamId is required/);
+  });
+
+  it('rejects lookbackDays of 0', () => {
+    expect(() => validateInvokerConfig({
+      crossRepoResearch: {
+        linearTeamId: 'team-1',
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            { repoUrl: 'https://github.com/stablyai/orca', lookbackDays: 0 },
+          ],
+        },
+      },
+    })).toThrow(/lookbackDays must be an integer > 0/);
+  });
+
+  it('accepts string sources and object sources with lookbackDays', () => {
+    const config = validateInvokerConfig({
+      crossRepoResearch: {
+        intervalDays: 14,
+        linearTeamId: 'team-1',
+        maxCandidatesPerSource: 5,
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/stablyai/orca',
+            { repoUrl: 'https://github.com/example/other', lookbackDays: 7 },
+          ],
+        },
+      },
+    });
+    expect(config.crossRepoResearch?.linearTeamId).toBe('team-1');
+    expect(config.crossRepoResearch?.maps?.['https://github.com/Neko-Catpital-Labs/Invoker.git']).toHaveLength(2);
+  });
+
+  it('rejects non-git map keys', () => {
+    expect(() => validateInvokerConfig({
+      crossRepoResearch: {
+        linearTeamId: 'team-1',
+        maps: { 'not-a-url': ['https://github.com/stablyai/orca'] },
+      },
+    })).toThrow(/maps key must be a git URL/);
+  });
+});

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -725,4 +725,32 @@ describe('crossRepoResearch config', () => {
       },
     })).toThrow(/maps key must be a git URL/);
   });
+
+  it.each([
+    'https://github.com/owner',
+    'git@example.com',
+    'ssh://example.com',
+  ])('rejects map keys with no repository path (%s)', (targetUrl) => {
+    expect(() => validateInvokerConfig({
+      crossRepoResearch: {
+        linearTeamId: 'team-1',
+        maps: { [targetUrl]: ['https://github.com/stablyai/orca'] },
+      },
+    })).toThrow(/maps key must be a git URL/);
+  });
+
+  it.each([
+    'https://github.com/owner',
+    'git@example.com',
+    'ssh://example.com',
+  ])('rejects string sources with no repository path (%s)', (sourceUrl) => {
+    expect(() => validateInvokerConfig({
+      crossRepoResearch: {
+        linearTeamId: 'team-1',
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [sourceUrl],
+        },
+      },
+    })).toThrow(/must be a git URL string/);
+  });
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,5 +1,11 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
-import { normalizeGithubOwnerRepo, type InvokerConfig } from './config.js';
+import {
+  normalizeGithubOwnerRepo,
+  type CrossRepoResearchConfig,
+  type CrossRepoResearchSource,
+  type InvokerConfig,
+  DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS,
+} from './config.js';
 
 const builtinAgents = registerBuiltinAgents();
 
@@ -25,6 +31,91 @@ function validatePrMaintenanceTargetRepos(config: InvokerConfig): void {
       );
     }
   }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isGitUrl(value: string): boolean {
+  return /^(?:git@|https?:\/\/|ssh:\/\/).+\..+/i.test(value.trim());
+}
+
+function validateCrossRepoResearchSource(entry: unknown, path: string): void {
+  if (typeof entry === 'string') {
+    if (!isGitUrl(entry)) {
+      throw new Error(`${path} must be a git URL string; got ${JSON.stringify(entry)}`);
+    }
+    return;
+  }
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error(`${path} must be a git URL string or { repoUrl, lookbackDays? }`);
+  }
+  const source = entry as CrossRepoResearchSource;
+  if (!isNonEmptyString(source.repoUrl) || !isGitUrl(source.repoUrl)) {
+    throw new Error(`${path}.repoUrl must be a git URL string`);
+  }
+  if (source.lookbackDays !== undefined) {
+    if (typeof source.lookbackDays !== 'number' || !Number.isInteger(source.lookbackDays) || source.lookbackDays <= 0) {
+      throw new Error(`${path}.lookbackDays must be an integer > 0`);
+    }
+  }
+}
+
+function validateCrossRepoResearchConfig(config: InvokerConfig): void {
+  const crossRepoResearch = config.crossRepoResearch;
+  if (crossRepoResearch === undefined) return;
+  if (typeof crossRepoResearch !== 'object' || crossRepoResearch === null || Array.isArray(crossRepoResearch)) {
+    throw new Error('crossRepoResearch must be an object');
+  }
+  const typed = crossRepoResearch as CrossRepoResearchConfig;
+  if (typed.intervalDays !== undefined) {
+    if (typeof typed.intervalDays !== 'number' || !Number.isInteger(typed.intervalDays) || typed.intervalDays <= 0) {
+      throw new Error('crossRepoResearch.intervalDays must be an integer > 0');
+    }
+  }
+  if (typed.maxCandidatesPerSource !== undefined) {
+    if (
+      typeof typed.maxCandidatesPerSource !== 'number'
+      || !Number.isInteger(typed.maxCandidatesPerSource)
+      || typed.maxCandidatesPerSource <= 0
+    ) {
+      throw new Error('crossRepoResearch.maxCandidatesPerSource must be an integer > 0');
+    }
+  }
+  if (typed.linearTeamId !== undefined && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('crossRepoResearch.linearTeamId must be a non-empty string when set');
+  }
+  if (typed.maps === undefined) return;
+  if (typeof typed.maps !== 'object' || typed.maps === null || Array.isArray(typed.maps)) {
+    throw new Error('crossRepoResearch.maps must be an object keyed by target repo URL');
+  }
+  const entries = Object.entries(typed.maps);
+  if (entries.length > 0 && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('crossRepoResearch.linearTeamId is required when crossRepoResearch.maps is non-empty');
+  }
+  for (const [targetUrl, sources] of entries) {
+    if (!isGitUrl(targetUrl)) {
+      throw new Error(`crossRepoResearch.maps key must be a git URL; got ${JSON.stringify(targetUrl)}`);
+    }
+    if (!Array.isArray(sources)) {
+      throw new Error(`crossRepoResearch.maps[${JSON.stringify(targetUrl)}] must be an array`);
+    }
+    sources.forEach((source, index) => {
+      validateCrossRepoResearchSource(source, `crossRepoResearch.maps[${JSON.stringify(targetUrl)}][${index}]`);
+    });
+  }
+}
+
+/** Normalize a source entry to `{ repoUrl, lookbackDays }` with defaults applied. */
+export function normalizeCrossRepoResearchSource(entry: string | CrossRepoResearchSource): Required<CrossRepoResearchSource> {
+  if (typeof entry === 'string') {
+    return { repoUrl: entry.trim(), lookbackDays: DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS };
+  }
+  return {
+    repoUrl: entry.repoUrl.trim(),
+    lookbackDays: entry.lookbackDays ?? DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS,
+  };
 }
 
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
@@ -54,5 +145,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   validatePrMaintenanceTargetRepos(config);
+  validateCrossRepoResearchConfig(config);
   return config;
 }

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -37,8 +37,13 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+const HTTP_GIT_URL_RE = /^https?:\/\/[^\s/]+\.[^\s/]+\/[^\s/]+\/[^\s/]+/i;
+const SSH_GIT_URL_RE = /^ssh:\/\/(?:[^\s@/]+@)?[^\s/]+\.[^\s/]+\/[^\s/]+\/[^\s/]+/i;
+const SCP_GIT_URL_RE = /^git@[^\s:]+\.[^\s:]+:[^\s/]+\/[^\s/]+/i;
+
 function isGitUrl(value: string): boolean {
-  return /^(?:git@|https?:\/\/|ssh:\/\/).+\..+/i.test(value.trim());
+  const trimmed = value.trim();
+  return HTTP_GIT_URL_RE.test(trimmed) || SSH_GIT_URL_RE.test(trimmed) || SCP_GIT_URL_RE.test(trimmed);
 }
 
 function validateCrossRepoResearchSource(entry: unknown, path: string): void {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -103,6 +103,42 @@ export interface SlackBugScanConfig {
   maxAutoSubmissionsPerTick?: number;
 }
 
+/** One source repo to mine for stealable ideas. */
+export interface CrossRepoResearchSource {
+  /** GitHub repo URL (https or git@). */
+  repoUrl: string;
+  /** Days of source activity to consider. Must be > 0. Default: 30. */
+  lookbackDays?: number;
+}
+
+/**
+ * Opt-in cross-repo-research worker settings. Process on/off is SQLite
+ * `worker_desired_states`, not a config boolean.
+ */
+export interface CrossRepoResearchConfig {
+  /** Poll cadence in days. Default: 14. */
+  intervalDays?: number;
+  /** Linear team id required when maps are non-empty. */
+  linearTeamId?: string;
+  /** Cap candidate ideas per source per tick. Default: 5. */
+  maxCandidatesPerSource?: number;
+  /**
+   * Target repo URL → list of sources to mine.
+   * Source entries may be a URL string (lookbackDays defaults to 30) or
+   * `{ repoUrl, lookbackDays }`.
+   */
+  maps?: Record<string, Array<string | CrossRepoResearchSource>>;
+}
+
+/** Default lookback when a source omits lookbackDays. */
+export const DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS = 30;
+
+/** Default worker poll cadence when intervalDays is unset. */
+export const DEFAULT_CROSS_REPO_RESEARCH_INTERVAL_DAYS = 14;
+
+/** Default max candidates mined per source per tick. */
+export const DEFAULT_CROSS_REPO_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -435,6 +471,11 @@ export interface InvokerConfig {
     cleanupEnabled?: boolean;
   };
   slackBugScan?: SlackBugScanConfig;
+  /**
+   * Cross-repo research worker: maps target repos to source repos to mine.
+   * Process on/off is SQLite `worker_desired_states`, not a config boolean.
+   */
+  crossRepoResearch?: CrossRepoResearchConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },


### PR DESCRIPTION
## Summary

Adds an optional `crossRepoResearch` config block for target→source mining maps.

Per-source lookback defaults to 30 days. Worker interval defaults to 14 days.

Missing the block leaves boot and config load unchanged.

Invalid maps fail validation only when present and malformed.

## Review Claim

Approve the `crossRepoResearch` fields and validation rules without enabling any worker process.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Omitting `crossRepoResearch` does not change boot, defaults, or existing config acceptance. Only explicit invalid maps fail validation.

## Slice Rationale

Config shape is foundation for later scripts and worker wiring and must review alone.

## Non-goals

Does not register a worker, spawn scripts, forward Linear secrets, or file Linear issues.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
