### PR TITLE
[cross-repo-research](2) Forward Linear API keys from secretsFile onto task hosts

### DIFF
--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -20,7 +20,7 @@ import {
   type PersistedTaskMeta,
   type TerminalSpec,
 } from '@invoker/execution-engine';
-import { loadConfig } from './config.js';
+import { loadConfig, resolveSecretsFilePath } from './config.js';
 import {
   buildLinuxXTerminalBashScript,
   buildMacOSOsascriptArgs,
@@ -249,6 +249,7 @@ export function resolveTaskTerminalSpec(
         cacheDir: path.resolve(invokerHome, 'repos'),
         maxWorktrees,
         agentRegistry: opts.executionAgentRegistry,
+        secretsFile: resolveSecretsFilePath(loadConfig()),
       });
       executorRegistry.register('worktree', worktree);
       executor = worktree;

--- a/packages/execution-engine/src/__tests__/remote-agent-env.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-agent-env.test.ts
@@ -1,0 +1,82 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildRemoteAgentEnvExports,
+  loadLinearEnv,
+  loadRemoteAgentEnv,
+} from '../remote-agent-env.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeSecrets(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'remote-agent-env-'));
+  dirs.push(dir);
+  const path = join(dir, 'secrets.env');
+  writeFileSync(path, body, { mode: 0o600 });
+  chmodSync(path, 0o600);
+  return path;
+}
+
+describe('loadLinearEnv', () => {
+  it('returns empty when secretsFile is unset', () => {
+    expect(loadLinearEnv(undefined)).toEqual({});
+  });
+
+  it('loads LINEAR keys without useApiKey', () => {
+    const path = writeSecrets([
+      'LINEAR_API_KEY=lin_secret',
+      'INVOKER_LINEAR_API_KEY=lin_alt',
+      'ANTHROPIC_API_KEY=should-not-appear',
+      'OTHER_TOKEN=nope',
+    ].join('\n'));
+    expect(loadLinearEnv(path)).toEqual({
+      LINEAR_API_KEY: 'lin_secret',
+      INVOKER_LINEAR_API_KEY: 'lin_alt',
+    });
+  });
+});
+
+describe('loadRemoteAgentEnv', () => {
+  it('always includes Linear keys even when useApiKey is false', () => {
+    const path = writeSecrets([
+      'LINEAR_API_KEY=lin_secret',
+      'ANTHROPIC_API_KEY=agent-key',
+      'OTHER_TOKEN=nope',
+    ].join('\n'));
+    expect(loadRemoteAgentEnv(path, false)).toEqual({
+      LINEAR_API_KEY: 'lin_secret',
+    });
+  });
+
+  it('includes agent keys only when useApiKey is true', () => {
+    const path = writeSecrets([
+      'LINEAR_API_KEY=lin_secret',
+      'ANTHROPIC_API_KEY=agent-key',
+      'OTHER_TOKEN=nope',
+    ].join('\n'));
+    expect(loadRemoteAgentEnv(path, true)).toEqual({
+      LINEAR_API_KEY: 'lin_secret',
+      ANTHROPIC_API_KEY: 'agent-key',
+    });
+  });
+
+  it('never leaks non-allowlisted secrets into exports', () => {
+    const path = writeSecrets([
+      'LINEAR_API_KEY=lin_secret',
+      'IGNORED_TOKEN=nope',
+    ].join('\n'));
+    const exports = buildRemoteAgentEnvExports(path, true);
+    expect(exports).toContain("export LINEAR_API_KEY='lin_secret'");
+    expect(exports).not.toContain('IGNORED_TOKEN');
+    expect(exports).not.toContain('nope');
+  });
+});

--- a/packages/execution-engine/src/remote-agent-env.ts
+++ b/packages/execution-engine/src/remote-agent-env.ts
@@ -15,20 +15,46 @@ const AGENT_ENV_KEYS = new Set([
   'KIMI_API_KEY',
 ]);
 
+/** Linear keys always forwarded from secretsFile when present (independent of useApiKey). */
+export const LINEAR_ENV_KEYS = new Set([
+  'LINEAR_API_KEY',
+  'INVOKER_LINEAR_API_KEY',
+]);
+
 function shellQuote(value: string): string {
   return "'" + value.replace(/'/g, "'\\''") + "'";
 }
 
-export function loadRemoteAgentEnv(secretsFile: string | undefined, useApiKey: boolean): Record<string, string> {
-  if (!useApiKey) return {};
-
-  const env: Record<string, string> = {};
+function entriesFromSecretsFile(secretsFile: string | undefined): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
   for (const entry of loadSecretsFile(secretsFile)) {
     const eq = entry.indexOf('=');
     if (eq <= 0) continue;
-    const key = entry.slice(0, eq);
+    out.push([entry.slice(0, eq), entry.slice(eq + 1)]);
+  }
+  return out;
+}
+
+/**
+ * Load Linear API keys from secretsFile whenever the file is set.
+ * Independent of useApiKey so file-linear command tasks can run on any host.
+ */
+export function loadLinearEnv(secretsFile: string | undefined): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of entriesFromSecretsFile(secretsFile)) {
+    if (!LINEAR_ENV_KEYS.has(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+export function loadRemoteAgentEnv(secretsFile: string | undefined, useApiKey: boolean): Record<string, string> {
+  const env: Record<string, string> = { ...loadLinearEnv(secretsFile) };
+  if (!useApiKey) return env;
+
+  for (const [key, value] of entriesFromSecretsFile(secretsFile)) {
     if (!AGENT_ENV_KEYS.has(key)) continue;
-    env[key] = entry.slice(eq + 1);
+    env[key] = value;
   }
 
   return env;

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -722,6 +722,7 @@ export function selectExecutor(
         ...(selectedWorktreeTarget ?? {}),
         provisionCommand: selectedWorktreeTarget?.provisionCommand?.trim() || '',
         repoProvisionCommands,
+        secretsFile: host.dockerConfig.secretsFile ?? '',
         worktreeBaseDir: resolve(invokerHome, 'worktrees'),
         cacheDir: resolve(invokerHome, 'repos'),
       });
@@ -739,6 +740,7 @@ export function selectExecutor(
         provisionCommand: selectedWorktreeTarget?.provisionCommand,
         repoProvisionCommands,
         leasePersistence: host.persistence,
+        secretsFile: host.dockerConfig.secretsFile,
       });
       host.executorRegistry.register('worktree', worktree);
       host.worktreeExecutorCache.set(configFingerprint, worktree);

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -23,6 +23,7 @@ import {
 import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { sanitizeBranchForPath } from './git-utils.js';
+import { loadLinearEnv } from './remote-agent-env.js';
 
 // Re-export for backward compatibility
 export { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
@@ -54,6 +55,11 @@ export interface WorktreeExecutorConfig {
   maxDurationMs?: number;
   /** Optional DB-backed lease authority for worktree slots (see RepoPoolConfig). */
   leasePersistence?: RepoPoolLeasePersistence;
+  /**
+   * Optional secrets file. LINEAR_API_KEY / INVOKER_LINEAR_API_KEY are merged
+   * into local task env whenever set (independent of agent API-key export).
+   */
+  secretsFile?: string;
 }
 
 
@@ -87,11 +93,16 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   private readonly worktreeBaseDir: string;
   private readonly claudeCommand: string;
   private readonly agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  private readonly secretsFile: string | undefined;
   private pool: RepoPool;
   constructor(config: WorktreeExecutorConfig) {
     super(config.heartbeatIntervalMs, config.maxDurationMs);
     this.claudeCommand = config.claudeCommand ?? 'claude';
     this.agentRegistry = config.agentRegistry;
+    this.secretsFile = config.secretsFile
+      ?? (existsSync(join(homedir(), '.config', 'invoker', 'secrets.env'))
+        ? join(homedir(), '.config', 'invoker', 'secrets.env')
+        : undefined);
     this.setProvisionCommand(config.provisionCommand, DEFAULT_WORKTREE_PROVISION_COMMAND);
     this.setRepoProvisionCommands(config.repoProvisionCommands);
     this.worktreeBaseDir =
@@ -501,7 +512,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       stdio: [stdinMode, 'pipe', 'pipe'],
       cwd: acquired.worktreePath,
       detached: true,
-      env: cleanElectronEnv(),
+      env: {
+        ...cleanElectronEnv(),
+        ...loadLinearEnv(this.secretsFile),
+      },
     });
     bench('WorktreeExecutor.spawn.after');
 


### PR DESCRIPTION
## Summary

Forwards `LINEAR_API_KEY` and `INVOKER_LINEAR_API_KEY` from `secretsFile` onto local, SSH, and Docker task env.

This path is independent of `useApiKey`, so filing tasks can call Linear without agent API keys.

Values stay in process env only. Nothing here logs or prints secret material.

## Review Claim

Approve allowlisting Linear keys from secretsFile onto task hosts without tying them to `useApiKey`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Linear keys are read only from the secrets allowlist. This slice never logs secret values and does not write keys into git, tickets, or workflow YAML.

## Slice Rationale

Secret plumbing is a separate host-env claim from mining scripts and worker registration.

## Non-goals

Does not add mining scripts, register the worker, change Linear ticket labels, or document the feature.

## Architecture

### Before

```mermaid
graph TD
    A["secretsFile"] --> B["loadRemoteAgentEnv when useApiKey"]
    B --> C["agent API keys only"]
```

### After

```mermaid
graph TD
    A["secretsFile"] --> B["loadLinearEnv always"]
    A --> C["loadRemoteAgentEnv when useApiKey"]
    B --> D["LINEAR keys on local SSH docker"]
    C --> E["agent API keys"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/remote-agent-env.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
