### PR TITLE
[cross-repo-research](3) Add watch and Linear filing scripts

### DIFF
--- a/scripts/cross-repo-research-watch.mjs
+++ b/scripts/cross-repo-research-watch.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * Cross-repo research watch: for each configured target→sources map, mine source
+ * activity in the per-source lookback window and submit a 3-workflow Invoker
+ * chain (discover → research-swarm → file-linear). Does not classify in-process
+ * and never labels tickets invoker-ready.
+ *
+ * Env:
+ *   INVOKER_CROSS_REPO_RESEARCH_CONFIG_JSON   inline CrossRepoResearchConfig (tests)
+ *   INVOKER_CROSS_REPO_RESEARCH_ACTIVITY_FIXTURE  JSON activity by source repoUrl
+ *   INVOKER_CROSS_REPO_RESEARCH_DRY_RUN=1     generate chain only; do not submit
+ *   INVOKER_CROSS_REPO_RESEARCH_SUBMIT_CMD    override submit-workflow-chain.sh
+ *   INVOKER_CROSS_REPO_RESEARCH_WORK_DIR      ledger + generated plans (default ~/.invoker/cross-repo-research)
+ *   INVOKER_CROSS_REPO_RESEARCH_GENERATE_ONLY=1  write chain YAML and exit 0 (tests)
+ */
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+const DEFAULT_INTERVAL_DAYS = 14;
+const DEFAULT_MAX_CANDIDATES = 5;
+
+function env(name, fallback = '') {
+  return process.env[name] ?? fallback;
+}
+
+function log(msg) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[cross-repo-research ${ts}] ${msg}`);
+}
+
+function slugify(text) {
+  return String(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'idea';
+}
+
+function yamlQuote(value) {
+  return JSON.stringify(String(value ?? ''));
+}
+
+function loadOwnerConfig() {
+  const inline = env('INVOKER_CROSS_REPO_RESEARCH_CONFIG_JSON');
+  if (inline) return JSON.parse(inline);
+  const configPath = env('INVOKER_REPO_CONFIG_PATH')
+    || join(homedir(), '.invoker', 'config.json');
+  if (!existsSync(configPath)) return {};
+  return JSON.parse(readFileSync(configPath, 'utf8'));
+}
+
+function normalizeSource(entry) {
+  if (typeof entry === 'string') {
+    return { repoUrl: entry.trim(), lookbackDays: DEFAULT_LOOKBACK_DAYS };
+  }
+  return {
+    repoUrl: String(entry.repoUrl).trim(),
+    lookbackDays: entry.lookbackDays ?? DEFAULT_LOOKBACK_DAYS,
+  };
+}
+
+function normalizeMaps(crossRepoResearch) {
+  const maps = crossRepoResearch?.maps ?? {};
+  return Object.entries(maps).map(([targetRepoUrl, sources]) => ({
+    targetRepoUrl,
+    sources: (sources ?? []).map(normalizeSource),
+  }));
+}
+
+function fingerprint(text) {
+  return createHash('sha256').update(String(text).trim().toLowerCase()).digest('hex').slice(0, 16);
+}
+
+function sourceOwnerRepo(repoUrl) {
+  const m = repoUrl.match(/github\.com[/:]([^/]+)\/([^/.]+)(?:\.git)?/i);
+  if (!m) return null;
+  return `${m[1]}/${m[2]}`;
+}
+
+function readLedger(workDir) {
+  const path = join(workDir, 'ledger.json');
+  if (!existsSync(path)) return { fingerprints: {}, watermarks: {} };
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { fingerprints: {}, watermarks: {} };
+  }
+}
+
+function writeLedger(workDir, ledger) {
+  mkdirSync(workDir, { recursive: true });
+  writeFileSync(join(workDir, 'ledger.json'), `${JSON.stringify(ledger, null, 2)}\n`);
+}
+
+function loadActivityFixture() {
+  const path = env('INVOKER_CROSS_REPO_RESEARCH_ACTIVITY_FIXTURE');
+  if (!path) return null;
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function fetchSourceActivity(source, sinceIso) {
+  const fixture = loadActivityFixture();
+  if (fixture) {
+    const rows = fixture[source.repoUrl] ?? fixture[sourceOwnerRepo(source.repoUrl) ?? ''] ?? [];
+    return rows.filter((row) => !row.date || row.date >= sinceIso.slice(0, 10));
+  }
+
+  const ownerRepo = sourceOwnerRepo(source.repoUrl);
+  if (!ownerRepo) {
+    log(`skip unparseable source url: ${source.repoUrl}`);
+    return [];
+  }
+
+  const since = sinceIso;
+  const releases = spawnSync(
+    'gh',
+    ['api', `repos/${ownerRepo}/releases?per_page=30`, '--jq',
+      `[.[] | select(.published_at >= ${JSON.stringify(since)}) | {date: .published_at[0:10], kind: "release", title: (.name // .tag_name), url: .html_url, body: (.body // "")[0:1200]}]`],
+    { encoding: 'utf8' },
+  );
+  const commits = spawnSync(
+    'gh',
+    ['api', `repos/${ownerRepo}/commits?since=${encodeURIComponent(since)}&per_page=100`, '--jq',
+      `[.[] | select((.commit.message | split("\\n")[0] | test("^feat"; "i"))) | {date: .commit.author.date[0:10], kind: "feat", title: (.commit.message | split("\\n")[0]), url: .html_url, body: ""}]`],
+    { encoding: 'utf8' },
+  );
+
+  const out = [];
+  for (const result of [releases, commits]) {
+    if (result.status !== 0) {
+      log(`gh activity fetch warning: ${(result.stderr || result.stdout || '').slice(0, 200)}`);
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(result.stdout || '[]');
+      if (Array.isArray(parsed)) out.push(...parsed);
+    } catch {
+      // ignore parse errors; treat as empty
+    }
+  }
+  return out;
+}
+
+function selectCandidates(activity, { maxCandidates, ledger }) {
+  const selected = [];
+  for (const row of activity) {
+    const title = String(row.title ?? '').trim();
+    if (!title) continue;
+    const fp = fingerprint(`${row.kind ?? ''}:${title}`);
+    if (ledger.fingerprints[fp]) continue;
+    selected.push({
+      id: `c${selected.length + 1}`,
+      fingerprint: fp,
+      kind: row.kind ?? 'feat',
+      title,
+      url: row.url ?? '',
+      date: row.date ?? '',
+      body: row.body ?? '',
+    });
+    if (selected.length >= maxCandidates) break;
+  }
+  return selected;
+}
+
+function researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+  const candidate = slot.candidate;
+  const noop = !candidate;
+  return [
+    'You are researching whether a source-repo idea should be stolen into the target repo.',
+    'Do not implement product code. Do not open PRs. Do not label Linear tickets invoker-ready.',
+    noop
+      ? 'No candidate was assigned to this slot. Write a JSON artifact with verdict skip and title "noop-slot", then exit.'
+      : `Candidate: ${candidate.title}`,
+    `Source: ${sourceRepoUrl}`,
+    `Target checkout: ${targetRepoUrl}`,
+    candidate ? `Evidence URL: ${candidate.url}` : '',
+    candidate ? `Source snippet: ${String(candidate.body).slice(0, 800)}` : '',
+    `Write artifact JSON to ${artifactDir}/research-${slot.index}.json with fields:`,
+    'title, verdict (steal|skip), repo, goal, motivation, safetyInvariant, verify,',
+    'reviewClaim, reviewLane, sliceRationale, architecturalEffect, alternatives,',
+    'implementationDetails, nonGoals, files, changeTypes, acceptanceCriteria,',
+    'layer, featureState, evidence.',
+    'repo must be the target repo URL. verify must be a runnable command.',
+    'Justify good vs bad with target greps. Skip ideas the target already owns.',
+  ].filter(Boolean).join('\n');
+}
+
+function buildDiscoverWorkflow({ targetRepoUrl, sourceRepoUrl, candidatesPath, lookbackDays }) {
+  return `name: "cross-repo-research discover ${slugify(sourceOwnerRepo(sourceRepoUrl) ?? sourceRepoUrl)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+
+tasks:
+  - id: discover-candidates
+    description: |
+      Persist mined source candidates for the research swarm.
+      Goal: Write candidates.json for ${sourceRepoUrl} lookback ${lookbackDays}d.
+      Motivation: Downstream research tasks need a stable candidate list.
+      Safety invariant: This task only writes planning artifacts under ${candidatesPath}; no product code.
+    command: "test -f ${candidatesPath} && python3 -c \\"import json; d=json.load(open('${candidatesPath}')); assert isinstance(d.get('candidates'), list)\\""
+    dependencies: []
+`;
+}
+
+function buildResearchWorkflow({
+  targetRepoUrl,
+  sourceRepoUrl,
+  artifactDir,
+  slots,
+  upstreamToken,
+}) {
+  const tasks = slots.map((slot) => {
+    const deps = [];
+    return `  - id: research-${slot.index}
+    description: |
+      Research candidate slot ${slot.index} for steal vs skip.
+      Goal: Produce research-${slot.index}.json with plan-to-invoker fields.
+      Motivation: Human triage needs full Goal/Motivation/Safety/Verify before invoker-ready.
+      Safety invariant: No product commits; artifact write only under ${artifactDir}.
+      Review claim: The artifact records a justified steal or skip verdict for this candidate.
+      Review lane: docs
+      Slice rationale: One candidate per parallel research slot.
+      Architectural effect: None; research-only.
+      Alternative considerations: In-process classification was rejected; swarm research is required.
+      Implementation details: Grep the target checkout; write the artifact JSON.
+      Non-goals: No Linear create here; no product implementation.
+      Files: ${artifactDir}/research-${slot.index}.json
+      Change types: docs
+      Acceptance criteria:
+      - Artifact JSON exists with Goal, Motivation, Safety invariant, Verify, Verdict
+      Layer: docs
+      Feature state: active
+    prompt: |
+${researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir).split('\n').map((l) => `      ${l}`).join('\n')}
+    dependencies: ${JSON.stringify(deps)}
+`;
+  }).join('\n');
+
+  return `name: "cross-repo-research research ${slugify(sourceOwnerRepo(sourceRepoUrl) ?? sourceRepoUrl)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+externalDependencies:
+  - workflowId: "${upstreamToken}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: completed
+
+tasks:
+${tasks}
+`;
+}
+
+function buildFileLinearWorkflow({
+  targetRepoUrl,
+  artifactDir,
+  slotCount,
+  upstreamToken,
+}) {
+  const fileCommands = [];
+  for (let i = 1; i <= slotCount; i += 1) {
+    fileCommands.push(
+      `if [ -f ${artifactDir}/research-${i}.json ]; then `
+      + `node scripts/linear-issue-create.mjs --artifact ${artifactDir}/research-${i}.json; `
+      + 'fi',
+    );
+  }
+  const command = fileCommands.join(' && ');
+
+  return `name: "cross-repo-research file-linear ${slugify(artifactDir)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+externalDependencies:
+  - workflowId: "${upstreamToken}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: completed
+
+tasks:
+  - id: file-linear-tickets
+    description: |
+      Create Linear tickets from research artifacts.
+      Goal: File one Linear issue per research artifact (unlabeled steal, idea-skip for skip).
+      Motivation: Tickets must be triage-ready with plan-to-invoker fields.
+      Safety invariant: Never adds invoker-ready; Linear key stays in env/secrets only.
+    command: ${yamlQuote(command)}
+    dependencies: []
+`;
+}
+
+export function generateChainForPair({
+  targetRepoUrl,
+  source,
+  candidates,
+  workDir,
+  teamId,
+  maxCandidates,
+}) {
+  const ownerRepo = sourceOwnerRepo(source.repoUrl) ?? slugify(source.repoUrl);
+  const watermark = new Date().toISOString().replace(/[:.]/g, '-');
+  const runDir = join(workDir, 'runs', slugify(ownerRepo), watermark);
+  mkdirSync(runDir, { recursive: true });
+
+  const candidatesPath = join(runDir, 'candidates.json');
+  const capped = candidates.slice(0, maxCandidates);
+  writeFileSync(candidatesPath, `${JSON.stringify({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    lookbackDays: source.lookbackDays,
+    candidates: capped,
+  }, null, 2)}\n`);
+
+  const slots = [];
+  for (let i = 1; i <= maxCandidates; i += 1) {
+    slots.push({ index: i, candidate: capped[i - 1] ?? null });
+  }
+
+  const discoverPath = join(runDir, '01-discover.yaml');
+  const researchPath = join(runDir, '02-research.template.yaml');
+  const filePath = join(runDir, '03-file-linear.template.yaml');
+
+  writeFileSync(discoverPath, buildDiscoverWorkflow({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    candidatesPath,
+    lookbackDays: source.lookbackDays,
+  }));
+  writeFileSync(researchPath, buildResearchWorkflow({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    artifactDir: runDir,
+    slots,
+    upstreamToken: '__UPSTREAM_WORKFLOW_ID__',
+  }));
+  writeFileSync(filePath, buildFileLinearWorkflow({
+    targetRepoUrl,
+    artifactDir: runDir,
+    slotCount: maxCandidates,
+    upstreamToken: '__UPSTREAM_WORKFLOW_ID__',
+  }));
+
+  return {
+    runDir,
+    candidatesPath,
+    plans: [discoverPath, researchPath, filePath],
+    fingerprints: capped.map((c) => c.fingerprint),
+  };
+}
+
+function submitChain(plans, { dryRun, submitCmd }) {
+  if (dryRun || env('INVOKER_CROSS_REPO_RESEARCH_GENERATE_ONLY') === '1') {
+    log(`dry-run/generate-only chain: ${plans.join(' ')}`);
+    return { status: 0, stdout: plans.join('\n') };
+  }
+  const cmd = submitCmd || join(REPO_ROOT, 'scripts/submit-workflow-chain.sh');
+  const result = spawnSync('bash', [cmd, '--gate-policy', 'completed', ...plans], {
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error(`submit chain failed: ${result.stderr || result.stdout}`);
+  }
+  return result;
+}
+
+export function runCrossRepoResearchWatch(options = {}) {
+  const config = options.config ?? loadOwnerConfig();
+  const crossRepoResearch = config.crossRepoResearch ?? {};
+  const pairs = normalizeMaps(crossRepoResearch);
+  const workDir = options.workDir
+    ?? env('INVOKER_CROSS_REPO_RESEARCH_WORK_DIR')
+    ?? join(homedir(), '.invoker', 'cross-repo-research');
+  const dryRun = options.dryRun ?? env('INVOKER_CROSS_REPO_RESEARCH_DRY_RUN', '0') === '1';
+  const maxCandidates = crossRepoResearch.maxCandidatesPerSource ?? DEFAULT_MAX_CANDIDATES;
+  const teamId = crossRepoResearch.linearTeamId ?? env('INVOKER_LINEAR_TEAM_ID');
+  const ledger = readLedger(workDir);
+
+  if (pairs.length === 0) {
+    log('no crossRepoResearch.maps configured; no-op');
+    return { submitted: 0, pairs: 0 };
+  }
+  if (!teamId) {
+    throw new Error('crossRepoResearch.linearTeamId (or INVOKER_LINEAR_TEAM_ID) is required');
+  }
+
+  let submitted = 0;
+  for (const pair of pairs) {
+    for (const source of pair.sources) {
+      const since = new Date(Date.now() - source.lookbackDays * 86400000).toISOString();
+      const activity = fetchSourceActivity(source, since);
+      const candidates = selectCandidates(activity, { maxCandidates, ledger });
+      if (candidates.length === 0) {
+        log(`no new candidates for ${source.repoUrl} (lookback ${source.lookbackDays}d)`);
+        ledger.watermarks[source.repoUrl] = since;
+        continue;
+      }
+      log(`mining ${candidates.length} candidate(s) from ${source.repoUrl} → ${pair.targetRepoUrl}`);
+      const chain = generateChainForPair({
+        targetRepoUrl: pair.targetRepoUrl,
+        source,
+        candidates,
+        workDir,
+        teamId,
+        maxCandidates,
+      });
+      submitChain(chain.plans, {
+        dryRun,
+        submitCmd: options.submitCmd ?? env('INVOKER_CROSS_REPO_RESEARCH_SUBMIT_CMD'),
+      });
+      for (const fp of chain.fingerprints) {
+        ledger.fingerprints[fp] = {
+          at: new Date().toISOString(),
+          source: source.repoUrl,
+          target: pair.targetRepoUrl,
+        };
+      }
+      ledger.watermarks[source.repoUrl] = since;
+      submitted += 1;
+    }
+  }
+
+  writeLedger(workDir, ledger);
+  return { submitted, pairs: pairs.length };
+}
+
+function main() {
+  const result = runCrossRepoResearchWatch();
+  log(`done submitted=${result.submitted} pairs=${result.pairs}`);
+}
+
+const isDirect = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirect) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/cross-repo-research-watch.sh
+++ b/scripts/cross-repo-research-watch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Cron/worker entrypoint for cross-repo-research watch. Lock + log only;
+# logic lives in scripts/cross-repo-research-watch.mjs.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK="${INVOKER_CROSS_REPO_RESEARCH_LOCK:-${TMPDIR:-/tmp}/invoker-cross-repo-research-watch.lock}"
+
+log_line() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    log_line "cross-repo-research-watch already running; exiting"
+    exit 0
+  fi
+else
+  lockdir="${LOCK}.d"
+  if [ -d "$lockdir" ]; then
+    holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lockdir" 2>/dev/null || true
+    fi
+  fi
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    log_line "cross-repo-research-watch already running; exiting"
+    exit 0
+  fi
+  printf '%s\n' "$$" > "$lockdir/pid"
+  # shellcheck disable=SC2064
+  trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
+fi
+
+log_line "cross-repo-research-watch sweep starting"
+if node "$REPO_ROOT/scripts/cross-repo-research-watch.mjs"; then
+  log_line "cross-repo-research-watch sweep finished"
+else
+  status=$?
+  log_line "cross-repo-research-watch sweep failed (exit $status)"
+  exit "$status"
+fi

--- a/scripts/linear-issue-create.mjs
+++ b/scripts/linear-issue-create.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Create a Linear issue from a plan-to-invoker-shaped ticket body.
+ *
+ * Never adds invoker-ready. Steal tickets stay unlabeled; skip/bad tickets
+ * get the idea-skip label when requested.
+ *
+ * Env:
+ *   LINEAR_API_KEY / INVOKER_LINEAR_API_KEY  required unless dry-run/fixture
+ *   INVOKER_LINEAR_TEAM_ID                   Linear team id (required to create)
+ *   INVOKER_LINEAR_DRY_RUN=1                 print payload, no network
+ *   INVOKER_LINEAR_CREATE_CMD                stub: receives JSON on stdin
+ *   INVOKER_LINEAR_LABEL_NAMES               comma list (default empty; use idea-skip for skips)
+ *
+ * Usage:
+ *   node scripts/linear-issue-create.mjs --title "..." --body-file path.md
+ *   node scripts/linear-issue-create.mjs --artifact path.json
+ *
+ * Artifact JSON fields (preferred):
+ *   title, verdict (steal|skip), repo, goal, motivation, safetyInvariant,
+ *   verify, reviewClaim, reviewLane, sliceRationale, architecturalEffect,
+ *   alternatives, implementationDetails, nonGoals, files, changeTypes,
+ *   acceptanceCriteria, layer, featureState, evidence
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const LABEL_READY = 'invoker-ready';
+const LABEL_SKIP = 'idea-skip';
+
+function env(name, fallback = '') {
+  return process.env[name] ?? fallback;
+}
+
+function log(msg) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[linear-issue-create ${ts}] ${msg}`);
+}
+
+function parseArgs(argv) {
+  const out = { title: '', bodyFile: '', artifact: '', labelNames: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--title') out.title = argv[++i] ?? '';
+    else if (arg === '--body-file') out.bodyFile = argv[++i] ?? '';
+    else if (arg === '--artifact') out.artifact = argv[++i] ?? '';
+    else if (arg === '--label') out.labelNames.push(argv[++i] ?? '');
+    else if (arg === '--help' || arg === '-h') out.help = true;
+  }
+  const fromEnv = env('INVOKER_LINEAR_LABEL_NAMES')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  out.labelNames = [...out.labelNames, ...fromEnv];
+  return out;
+}
+
+function assertNoReadyLabel(labels) {
+  if (labels.some((name) => name === LABEL_READY)) {
+    throw new Error(`Refusing to create Linear issues with ${LABEL_READY}`);
+  }
+}
+
+function heading(name, value) {
+  const text = String(value ?? '').trim();
+  return text ? `${name}: ${text}` : '';
+}
+
+function buildBodyFromArtifact(artifact) {
+  const lines = [
+    heading('Repo', artifact.repo ?? artifact.repoUrl),
+    heading('Goal', artifact.goal),
+    heading('Motivation', artifact.motivation),
+    heading('Safety invariant', artifact.safetyInvariant ?? artifact.safety),
+    heading('Verify', artifact.verify),
+    heading('Review claim', artifact.reviewClaim),
+    heading('Review lane', artifact.reviewLane),
+    heading('Slice rationale', artifact.sliceRationale),
+    heading('Architectural effect', artifact.architecturalEffect),
+    heading('Alternative considerations', artifact.alternatives ?? artifact.alternativeConsiderations),
+    heading('Implementation details', artifact.implementationDetails ?? artifact.implementation),
+    heading('Non-goals', artifact.nonGoals),
+    heading('Files', Array.isArray(artifact.files) ? artifact.files.join(', ') : artifact.files),
+    heading('Change types', Array.isArray(artifact.changeTypes) ? artifact.changeTypes.join(', ') : artifact.changeTypes),
+    heading('Acceptance criteria', Array.isArray(artifact.acceptanceCriteria)
+      ? artifact.acceptanceCriteria.map((c) => `- ${c}`).join('\n')
+      : artifact.acceptanceCriteria),
+    heading('Layer', artifact.layer),
+    heading('Feature state', artifact.featureState),
+    heading('Verdict', artifact.verdict),
+    heading('Evidence', artifact.evidence),
+  ].filter(Boolean);
+  return `${lines.join('\n\n')}\n`;
+}
+
+function requireField(body, name) {
+  const re = new RegExp(`^\\s*${name}\\s*:\\s*.+`, 'im');
+  if (!re.test(body)) {
+    throw new Error(`Ticket body missing required field: ${name}`);
+  }
+}
+
+function validateBody(body) {
+  for (const field of ['Repo', 'Goal', 'Motivation', 'Safety invariant', 'Verify']) {
+    requireField(body, field);
+  }
+  if (/\binvoker-ready\b/i.test(body)) {
+    throw new Error('Ticket body must not mention invoker-ready');
+  }
+}
+
+async function linearGraphql(apiKey, query, variables = {}) {
+  const res = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (!res.ok || json.errors?.length) {
+    throw new Error(`Linear GraphQL failed: ${JSON.stringify(json.errors ?? json)}`);
+  }
+  return json.data;
+}
+
+async function resolveLabelIds(apiKey, names) {
+  if (names.length === 0) return [];
+  const data = await linearGraphql(apiKey, `query { issueLabels(first: 250) { nodes { id name } } }`);
+  const byName = new Map((data?.issueLabels?.nodes ?? []).map((n) => [n.name, n.id]));
+  const ids = [];
+  for (const name of names) {
+    const id = byName.get(name);
+    if (!id) throw new Error(`Linear label not found: ${name}`);
+    ids.push(id);
+  }
+  return ids;
+}
+
+async function createIssue({ apiKey, teamId, title, body, labelIds, dryRun, createCmd }) {
+  const payload = { teamId, title, description: body, labelIds };
+  if (dryRun) {
+    log(`dry-run create: ${JSON.stringify({ ...payload, description: body.slice(0, 200) })}`);
+    return { id: 'dry-run', identifier: 'DRY-0' };
+  }
+  if (createCmd) {
+    const result = spawnSync('bash', ['-lc', createCmd], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      input: JSON.stringify(payload),
+    });
+    if (result.status !== 0) {
+      throw new Error(`create cmd failed: ${result.stderr || result.stdout}`);
+    }
+    try {
+      return JSON.parse((result.stdout || '{}').trim() || '{}');
+    } catch {
+      return { id: 'stub', identifier: 'STUB-0', stdout: result.stdout };
+    }
+  }
+  if (!apiKey) throw new Error('LINEAR_API_KEY / INVOKER_LINEAR_API_KEY required');
+  if (!teamId) throw new Error('INVOKER_LINEAR_TEAM_ID required');
+  const data = await linearGraphql(
+    apiKey,
+    `mutation($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier url }
+      }
+    }`,
+    {
+      input: {
+        teamId,
+        title,
+        description: body,
+        ...(labelIds.length > 0 ? { labelIds } : {}),
+      },
+    },
+  );
+  if (!data?.issueCreate?.success) {
+    throw new Error(`issueCreate failed: ${JSON.stringify(data)}`);
+  }
+  return data.issueCreate.issue;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log('Usage: node scripts/linear-issue-create.mjs --artifact path.json | --title t --body-file f.md');
+    process.exit(0);
+  }
+
+  let title = args.title;
+  let body = '';
+  let labels = [...args.labelNames];
+  let verdict = '';
+
+  if (args.artifact) {
+    if (!existsSync(args.artifact)) throw new Error(`artifact not found: ${args.artifact}`);
+    const artifact = JSON.parse(readFileSync(args.artifact, 'utf8'));
+    title = title || artifact.title || '';
+    verdict = String(artifact.verdict ?? '').toLowerCase();
+    body = buildBodyFromArtifact(artifact);
+    if (verdict === 'skip' && !labels.includes(LABEL_SKIP)) {
+      labels.push(LABEL_SKIP);
+    }
+  } else if (args.bodyFile) {
+    if (!existsSync(args.bodyFile)) throw new Error(`body file not found: ${args.bodyFile}`);
+    body = readFileSync(args.bodyFile, 'utf8');
+  } else {
+    throw new Error('Provide --artifact or --body-file');
+  }
+
+  if (!title.trim()) throw new Error('title is required');
+  assertNoReadyLabel(labels);
+  validateBody(body);
+
+  const apiKey = env('INVOKER_LINEAR_API_KEY') || env('LINEAR_API_KEY');
+  const teamId = env('INVOKER_LINEAR_TEAM_ID');
+  const dryRun = env('INVOKER_LINEAR_DRY_RUN', '0') === '1';
+  const createCmd = env('INVOKER_LINEAR_CREATE_CMD');
+
+  let labelIds = [];
+  if (!dryRun && !createCmd && labels.length > 0) {
+    labelIds = await resolveLabelIds(apiKey, labels);
+  }
+
+  const issue = await createIssue({
+    apiKey,
+    teamId,
+    title: title.trim(),
+    body,
+    labelIds,
+    dryRun,
+    createCmd,
+  });
+  log(`created ${issue.identifier ?? issue.id} labels=${labels.join(',') || '(none)'} verdict=${verdict || 'n/a'}`);
+  console.log(JSON.stringify({ ok: true, issue, labels }));
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/test-cross-repo-research-watch.sh
+++ b/scripts/test-cross-repo-research-watch.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Fixture tests for cross-repo-research watch + linear-issue-create (no network).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SANDBOXES=()
+cleanup() {
+  local d
+  for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+mk_sb() {
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-cross-repo-research.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/work" "$sb/bin"
+}
+
+# ── A. Empty lookback / no activity → no chain ───────────────────────────────
+mk_sb
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/stablyai/orca": []
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "crossRepoResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        { "repoUrl": "https://github.com/stablyai/orca", "lookbackDays": 30 }
+      ]
+    }
+  }
+}
+JSON
+log="$sb/a.log"
+env \
+  INVOKER_CROSS_REPO_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_CROSS_REPO_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_CROSS_REPO_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_CROSS_REPO_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/cross-repo-research-watch.mjs" > "$log" 2>&1 \
+  || fail "A: watch should exit 0" "$log"
+grep -q "no new candidates" "$log" || fail "A: expected no-candidates log" "$log"
+test "$(find "$sb/work/runs" -name '*.yaml' 2>/dev/null | wc -l | tr -d ' ')" = "0" \
+  || fail "A: must not write chain yaml when empty" "$log"
+echo "PASS A: empty activity → no chain"
+
+# ── B. New feat → chain YAML with K research slots ───────────────────────────
+mk_sb
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/stablyai/orca": [
+    {
+      "date": "2026-08-20",
+      "kind": "feat",
+      "title": "feat(cmd-j): rank palette results by recency",
+      "url": "https://github.com/stablyai/orca/pull/15551",
+      "body": "Cmd+J search ranked by recency"
+    }
+  ]
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "crossRepoResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        { "repoUrl": "https://github.com/stablyai/orca", "lookbackDays": 30 }
+      ]
+    }
+  }
+}
+JSON
+log="$sb/b.log"
+env \
+  INVOKER_CROSS_REPO_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_CROSS_REPO_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_CROSS_REPO_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_CROSS_REPO_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/cross-repo-research-watch.mjs" > "$log" 2>&1 \
+  || fail "B: watch should exit 0" "$log"
+research="$(find "$sb/work/runs" -name '02-research.template.yaml' | head -1)"
+test -n "$research" || fail "B: missing research template" "$log"
+grep -q "id: research-1" "$research" || fail "B: missing research-1" "$research"
+grep -q "id: research-3" "$research" || fail "B: expected K=3 slots" "$research"
+grep -q "onFinish: none" "$research" || fail "B: research must be onFinish none" "$research"
+file_lin="$(find "$sb/work/runs" -name '03-file-linear.template.yaml' | head -1)"
+grep -q "linear-issue-create.mjs" "$file_lin" || fail "B: file-linear must call create script" "$file_lin"
+grep -vq "invoker-ready" "$file_lin" || fail "B: must not mention invoker-ready" "$file_lin"
+echo "PASS B: feat activity → chain with K slots"
+
+# ── C. Duplicate fingerprint → skip ──────────────────────────────────────────
+mk_sb
+# Seed ledger with the fingerprint of the feat title
+fp="$(node -e "const c=require('crypto');console.log(c.createHash('sha256').update('feat:feat(cmd-j): rank palette results by recency').digest('hex').slice(0,16))")"
+mkdir -p "$sb/work"
+cat > "$sb/work/ledger.json" <<JSON
+{ "fingerprints": { "$fp": { "at": "2026-08-01T00:00:00Z" } }, "watermarks": {} }
+JSON
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/stablyai/orca": [
+    {
+      "date": "2026-08-20",
+      "kind": "feat",
+      "title": "feat(cmd-j): rank palette results by recency",
+      "url": "https://example.com",
+      "body": ""
+    }
+  ]
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "crossRepoResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        "https://github.com/stablyai/orca"
+      ]
+    }
+  }
+}
+JSON
+log="$sb/c.log"
+env \
+  INVOKER_CROSS_REPO_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_CROSS_REPO_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_CROSS_REPO_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_CROSS_REPO_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/cross-repo-research-watch.mjs" > "$log" 2>&1 \
+  || fail "C: watch should exit 0" "$log"
+grep -q "no new candidates" "$log" || fail "C: expected duplicate skip" "$log"
+echo "PASS C: duplicate fingerprint skipped"
+
+# ── D. linear-issue-create steal body + skip label; never invoker-ready ───────
+mk_sb
+cat > "$sb/steal.json" <<'JSON'
+{
+  "title": "Steal Cmd+K recency ranking",
+  "verdict": "steal",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "Rank Needs Attention by needs_input before failed",
+  "motivation": "Orca ranked palette by recency; operators miss waiting agents",
+  "safetyInvariant": "Attention sort only; no worker behavior change",
+  "verify": "cd packages/ui && pnpm test -- workflow-progress-surfaces",
+  "reviewClaim": "needs_input ranks above failed in attention entries",
+  "reviewLane": "behavior",
+  "evidence": "orca #15551"
+}
+JSON
+cat > "$sb/skip.json" <<'JSON'
+{
+  "title": "Skip stacked PRs product",
+  "verdict": "skip",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "Do not rebuild stacked PR UX",
+  "motivation": "Invoker already orchestrates stacked PRs",
+  "safetyInvariant": "No product change; documentation of skip only",
+  "verify": "test -f skills/land-stack/SKILL.md",
+  "evidence": "land-stack skill exists"
+}
+JSON
+cat > "$sb/bin/create-stub" <<STUB
+#!/usr/bin/env bash
+cat >> "$sb/creates.jsonl"
+echo >> "$sb/creates.jsonl"
+echo '{"id":"stub","identifier":"STUB-1"}'
+STUB
+chmod +x "$sb/bin/create-stub"
+
+log="$sb/d-steal.log"
+env \
+  INVOKER_LINEAR_DRY_RUN=0 \
+  INVOKER_LINEAR_CREATE_CMD="$sb/bin/create-stub" \
+  INVOKER_LINEAR_TEAM_ID=team-test \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/steal.json" > "$log" 2>&1 \
+  || fail "D-steal: create should exit 0" "$log"
+grep -q "Goal:" "$sb/creates.jsonl" || fail "D-steal: body missing Goal" "$sb/creates.jsonl"
+grep -q "Motivation:" "$sb/creates.jsonl" || fail "D-steal: body missing Motivation" "$sb/creates.jsonl"
+grep -q "Safety invariant:" "$sb/creates.jsonl" || fail "D-steal: body missing Safety" "$sb/creates.jsonl"
+grep -q "Verify:" "$sb/creates.jsonl" || fail "D-steal: body missing Verify" "$sb/creates.jsonl"
+grep -vq "invoker-ready" "$sb/creates.jsonl" || fail "D-steal: must not include invoker-ready" "$sb/creates.jsonl"
+
+: > "$sb/creates.jsonl"
+log="$sb/d-skip.log"
+env \
+  INVOKER_LINEAR_DRY_RUN=0 \
+  INVOKER_LINEAR_CREATE_CMD="$sb/bin/create-stub" \
+  INVOKER_LINEAR_TEAM_ID=team-test \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/skip.json" > "$log" 2>&1 \
+  || fail "D-skip: create should exit 0" "$log"
+# stub receives labelIds only after network resolve; in create-cmd mode labels are in payload without ids.
+# Ensure skip path does not add invoker-ready and create succeeds.
+grep -vq "invoker-ready" "$sb/creates.jsonl" || fail "D-skip: must not include invoker-ready" "$sb/creates.jsonl"
+grep -q "labels=idea-skip" "$log" || fail "D-skip: expected idea-skip in log" "$log"
+echo "PASS D: create body fields + idea-skip; no invoker-ready"
+
+# ── E. Refuse invoker-ready label ────────────────────────────────────────────
+mk_sb
+cat > "$sb/bad.json" <<'JSON'
+{
+  "title": "Bad",
+  "verdict": "steal",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "g",
+  "motivation": "m",
+  "safetyInvariant": "s",
+  "verify": "true"
+}
+JSON
+log="$sb/e.log"
+if env INVOKER_LINEAR_LABEL_NAMES=invoker-ready INVOKER_LINEAR_DRY_RUN=1 \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/bad.json" > "$log" 2>&1; then
+  fail "E: must refuse invoker-ready label" "$log"
+fi
+grep -qi "Refusing\|invoker-ready" "$log" || fail "E: expected refusal message" "$log"
+echo "PASS E: refuses invoker-ready"
+
+echo "All cross-repo-research fixture tests passed."


### PR DESCRIPTION
## Summary

Adds watch and Linear filing scripts that mine mapped sources and build a mine→research→file-linear chain.

Fixture mode writes plans without network or Invoker submit.

Created tickets stay unlabeled for steal candidates. Decline outcomes use the idea_skip Linear label. The scripts refuse the invoker-ready label.

## Review Claim

Approve the offline mining chain generator and Linear create helper, including the label rules.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Mining workflows are generated with `onFinish: none`. Scripts never apply the `invoker-ready` label.

## Slice Rationale

Scripts are the offline mining surface and should review without process registration or UI copy.

## Non-goals

Does not register the built-in worker, change app config shape, or add workers-panel UI strings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-cross-repo-research-watch.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
