### PR TITLE
[E2E watch target repo](1) script identity

### DIFF
--- a/scripts/cron-e2e-regression-watch.sh
+++ b/scripts/cron-e2e-regression-watch.sh
@@ -4,7 +4,32 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOCK="${INVOKER_E2E_WATCH_LOCK:-${TMPDIR:-/tmp}/invoker-e2e-regression-watch.lock}"
+
+# Mirror scripts/e2e-regression-watch.mjs's own CLI > env target-repo
+# precedence just enough to pick a non-colliding lock file: a --target-repo
+# flag on argv wins, otherwise INVOKER_GITHUB_TARGET_REPO, otherwise the
+# Invoker default. (A targetRepo set only via --config's JSON is not read
+# here; that target still gets its own isolated state dir and ledger subject
+# from the node script, it just serializes on the default lock unless
+# INVOKER_E2E_WATCH_LOCK is also set explicitly.)
+TARGET_REPO="${INVOKER_GITHUB_TARGET_REPO:-Neko-Catpital-Labs/Invoker}"
+args=("$@")
+i=0
+while [ "$i" -lt "${#args[@]}" ]; do
+  case "${args[$i]}" in
+    --target-repo=*) TARGET_REPO="${args[$i]#--target-repo=}" ;;
+    --target-repo) i=$((i + 1)); TARGET_REPO="${args[$i]:-$TARGET_REPO}" ;;
+  esac
+  i=$((i + 1))
+done
+
+if [ "$TARGET_REPO" = "Neko-Catpital-Labs/Invoker" ]; then
+  DEFAULT_LOCK="${TMPDIR:-/tmp}/invoker-e2e-regression-watch.lock"
+else
+  TARGET_SLUG="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//')"
+  DEFAULT_LOCK="${TMPDIR:-/tmp}/invoker-e2e-regression-watch-${TARGET_SLUG:-target}.lock"
+fi
+LOCK="${INVOKER_E2E_WATCH_LOCK:-$DEFAULT_LOCK}"
 
 log_line() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -34,7 +59,7 @@ else
 fi
 
 log_line "ci-regression-watch sweep starting"
-if node "$REPO_ROOT/scripts/e2e-regression-watch.mjs"; then
+if node "$REPO_ROOT/scripts/e2e-regression-watch.mjs" "$@"; then
   log_line "ci-regression-watch sweep finished"
 else
   status=$?

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -28,7 +28,90 @@ function resolveYamlModulePath() {
 }
 const { parse: parseYaml } = await import(resolveYamlModulePath());
 
-export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
+export const DEFAULT_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
+
+export function parseTargetRepoFlag(argv = []) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--target-repo') return argv[i + 1];
+    if (arg.startsWith('--target-repo=')) return arg.slice('--target-repo='.length);
+  }
+  return undefined;
+}
+
+export function parseWatchConfigFlag(argv = []) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--config') return argv[i + 1];
+    if (arg.startsWith('--config=')) return arg.slice('--config='.length);
+  }
+  return undefined;
+}
+
+export function loadWatchConfigFile(configPath, { readFile = readFileSync, exists = existsSync } = {}) {
+  if (!configPath) return {};
+  if (!exists(configPath)) {
+    throw new Error(`ci-regression-watch: config file not found: ${configPath}`);
+  }
+  const parsed = JSON.parse(readFile(configPath, 'utf8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`ci-regression-watch: config file must contain a JSON object: ${configPath}`);
+  }
+  return parsed;
+}
+
+/**
+ * Resolution order for the watched GitHub repo: CLI flag, then env var, then
+ * a JSON config file's `targetRepo` key, then the Invoker default. Omitting
+ * all three keeps today's behavior (and default state path) unchanged.
+ */
+export function resolveTargetRepo({
+  argv = [],
+  env = {},
+  readFile = readFileSync,
+  exists = existsSync,
+} = {}) {
+  const cliRepo = parseTargetRepoFlag(argv);
+  if (typeof cliRepo === 'string' && cliRepo.trim()) return cliRepo.trim();
+
+  const envRepo = env.INVOKER_GITHUB_TARGET_REPO;
+  if (typeof envRepo === 'string' && envRepo.trim()) return envRepo.trim();
+
+  const configPath = parseWatchConfigFlag(argv) ?? env.INVOKER_CI_WATCH_CONFIG_FILE;
+  const config = loadWatchConfigFile(configPath, { readFile, exists });
+  if (typeof config.targetRepo === 'string' && config.targetRepo.trim()) return config.targetRepo.trim();
+
+  return DEFAULT_TARGET_REPO;
+}
+
+/**
+ * Per-repo state isolation: any target repo other than the Invoker default
+ * gets its own state dir nested under `-targets/<slug>`, so its observed-SHA
+ * and attempt history can never collide with -- or get silently mixed into --
+ * Invoker's own `~/.invoker/e2e-regression-watch` history. An explicit
+ * INVOKER_CI_WATCH_STATE_DIR/INVOKER_E2E_WATCH_STATE_DIR always wins.
+ */
+export function resolveStateDir(targetRepo, { env = {}, homeDir = homedir() } = {}) {
+  const explicit = env.INVOKER_CI_WATCH_STATE_DIR ?? env.INVOKER_E2E_WATCH_STATE_DIR;
+  if (typeof explicit === 'string' && explicit.trim()) return explicit;
+  if (targetRepo === DEFAULT_TARGET_REPO) {
+    return join(homeDir, '.invoker', 'e2e-regression-watch');
+  }
+  return join(homeDir, '.invoker', 'e2e-regression-watch-targets', slugify(targetRepo, 128));
+}
+
+/**
+ * Per-repo repair_filings ledger subject: the Invoker default keeps its
+ * existing 'master' subject exactly as-is (dedup history already lives under
+ * that key), while any other target repo claims its own namespaced subject
+ * so a same-named job/sha in two different repos can never collapse onto the
+ * same ledger row.
+ */
+export function resolveRepairFilingSubject(targetRepo) {
+  return targetRepo === DEFAULT_TARGET_REPO ? 'master' : `${targetRepo}:master`;
+}
+
+export const TARGET_REPO = resolveTargetRepo({ argv: process.argv.slice(2), env: process.env });
 export const WORKFLOW_FILE = process.env.INVOKER_CI_WATCH_WORKFLOW_FILE
   ?? process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE
   ?? 'ci.yml';
@@ -88,9 +171,7 @@ export function isObservationStale(failure, nowMs, staleMs = STALE_OBSERVATION_M
   return isStale({ lastObservedAt: failure?.lastObservedAt, nowMs, staleMs });
 }
 
-const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
-  ?? process.env.INVOKER_E2E_WATCH_STATE_DIR
-  ?? join(homedir(), '.invoker', 'e2e-regression-watch');
+const STATE_DIR = resolveStateDir(TARGET_REPO, { env: process.env });
 const STATE_FILE = join(STATE_DIR, 'state.json');
 const SWEEP_LOG_FILE = join(STATE_DIR, 'sweep-log.jsonl');
 const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', WORKFLOW_FILE);
@@ -1217,7 +1298,7 @@ export function claimRepairFiling(failure, insert = insertRepairFiling) {
   try {
     const result = insert({
       kind: repairFilingKind(failure),
-      subject: 'master',
+      subject: resolveRepairFilingSubject(TARGET_REPO),
       stateSha: failure.firstBadSha,
       metadata: buildRepairFilingMetadata(failure),
     });
@@ -1250,7 +1331,7 @@ export function shouldSkipFilingAlreadyAddressed(failure, {
  */
 export function releaseRepairFilingClaim(failure, release = releaseRepairFiling) {
   try {
-    release({ kind: repairFilingKind(failure), subject: 'master', stateSha: failure.firstBadSha });
+    release({ kind: repairFilingKind(failure), subject: resolveRepairFilingSubject(TARGET_REPO), stateSha: failure.firstBadSha });
   } catch (err) {
     console.error(`ci-regression-watch: releaseRepairFilingClaim failed for kind="${repairFilingKind(failure)}" sha="${failure.firstBadSha}"; this key stays claimed until manually cleared: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -10,6 +10,7 @@ import {
   buildRepairFilingMetadata,
   claimRepairFiling,
   CATSTACK_REPO_URL,
+  DEFAULT_TARGET_REPO,
   extractFailureIdentitiesFromLog,
   failureStorageKey,
   fileBugfixPlan,
@@ -22,11 +23,17 @@ import {
   jobNameIsMapped,
   loadEmptyState,
   liveQueryHasNonTerminalWork,
+  loadWatchConfigFile,
   normalizeState,
+  parseTargetRepoFlag,
+  parseWatchConfigFlag,
   processFailureFilingSweep,
   reconcileCiRun,
   releaseRepairFilingClaim,
   repairFilingKind,
+  resolveRepairFilingSubject,
+  resolveStateDir,
+  resolveTargetRepo,
   RECOVERY_COOLDOWN_MS,
   shouldSkipFilingAlreadyAddressed,
   STALE_OBSERVATION_MS,
@@ -1436,5 +1443,133 @@ describe('per-test failure identity under one CI job', () => {
     assert.equal(migrated.activeFailures[jobName].failureId, JOB_LEVEL_FAILURE_ID);
     assert.equal(migrated.activeFailures[jobName].failureKey, jobName);
     assert.equal(migrated.activeFailures[jobName].attempts, 2);
+  });
+});
+
+describe('watch-target-repo config resolution', () => {
+  const CATSTACK_TARGET_REPO = 'EdbertChan/catstack';
+
+  it('resolves the Invoker default when no CLI flag, env var, or config file is set', () => {
+    assert.equal(resolveTargetRepo({ argv: [], env: {} }), DEFAULT_TARGET_REPO);
+  });
+
+  it('parseTargetRepoFlag reads both "--target-repo value" and "--target-repo=value" forms', () => {
+    assert.equal(parseTargetRepoFlag(['--target-repo', CATSTACK_TARGET_REPO]), CATSTACK_TARGET_REPO);
+    assert.equal(parseTargetRepoFlag([`--target-repo=${CATSTACK_TARGET_REPO}`]), CATSTACK_TARGET_REPO);
+    assert.equal(parseTargetRepoFlag([]), undefined);
+  });
+
+  it('parseWatchConfigFlag reads both "--config value" and "--config=value" forms', () => {
+    assert.equal(parseWatchConfigFlag(['--config', '/tmp/watch.json']), '/tmp/watch.json');
+    assert.equal(parseWatchConfigFlag(['--config=/tmp/watch.json']), '/tmp/watch.json');
+    assert.equal(parseWatchConfigFlag([]), undefined);
+  });
+
+  it('CLI flag wins over env var and config file', () => {
+    const repo = resolveTargetRepo({
+      argv: ['--target-repo', CATSTACK_TARGET_REPO],
+      env: { INVOKER_GITHUB_TARGET_REPO: 'someone/else', INVOKER_CI_WATCH_CONFIG_FILE: '/tmp/unused.json' },
+      exists: () => { throw new Error('config file must not be read when a CLI flag is present'); },
+    });
+    assert.equal(repo, CATSTACK_TARGET_REPO);
+  });
+
+  it('env var wins over config file when no CLI flag is present', () => {
+    const repo = resolveTargetRepo({
+      argv: [],
+      env: { INVOKER_GITHUB_TARGET_REPO: CATSTACK_TARGET_REPO, INVOKER_CI_WATCH_CONFIG_FILE: '/tmp/unused.json' },
+      exists: () => { throw new Error('config file must not be read when an env var is present'); },
+    });
+    assert.equal(repo, CATSTACK_TARGET_REPO);
+  });
+
+  it('falls back to a JSON config file\'s targetRepo when no CLI flag or env var is set', () => {
+    const repo = resolveTargetRepo({
+      argv: ['--config', '/tmp/watch.json'],
+      env: {},
+      exists: (path) => path === '/tmp/watch.json',
+      readFile: () => JSON.stringify({ targetRepo: CATSTACK_TARGET_REPO }),
+    });
+    assert.equal(repo, CATSTACK_TARGET_REPO);
+  });
+
+  it('loadWatchConfigFile returns {} when no config path is given, and throws on a missing file or non-object JSON', () => {
+    assert.deepEqual(loadWatchConfigFile(undefined), {});
+    assert.throws(() => loadWatchConfigFile('/tmp/missing.json', { exists: () => false }));
+    assert.throws(() => loadWatchConfigFile('/tmp/array.json', {
+      exists: () => true,
+      readFile: () => '[1,2,3]',
+    }));
+  });
+
+  it('resolveStateDir keeps the default Invoker state path unchanged for the default target repo', () => {
+    const dir = resolveStateDir(DEFAULT_TARGET_REPO, { env: {}, homeDir: '/home/tester' });
+    assert.equal(dir, join('/home/tester', '.invoker', 'e2e-regression-watch'));
+  });
+
+  it('resolveStateDir isolates a non-default target repo under its own slugged subdirectory', () => {
+    const dir = resolveStateDir(CATSTACK_TARGET_REPO, { env: {}, homeDir: '/home/tester' });
+    assert.equal(dir, join('/home/tester', '.invoker', 'e2e-regression-watch-targets', 'edbertchan-catstack'));
+    assert.notEqual(dir, resolveStateDir(DEFAULT_TARGET_REPO, { env: {}, homeDir: '/home/tester' }));
+  });
+
+  it('resolveStateDir lets an explicit state-dir env var override isolation for any target repo', () => {
+    const explicit = '/custom/state/dir';
+    assert.equal(resolveStateDir(DEFAULT_TARGET_REPO, { env: { INVOKER_CI_WATCH_STATE_DIR: explicit } }), explicit);
+    assert.equal(resolveStateDir(CATSTACK_TARGET_REPO, { env: { INVOKER_CI_WATCH_STATE_DIR: explicit } }), explicit);
+  });
+
+  it('resolveRepairFilingSubject keeps the default repo\'s existing "master" subject unchanged', () => {
+    assert.equal(resolveRepairFilingSubject(DEFAULT_TARGET_REPO), 'master');
+  });
+
+  it('resolveRepairFilingSubject namespaces a non-default target repo so its ledger rows can never collapse onto Invoker\'s own', () => {
+    const catstackSubject = resolveRepairFilingSubject(CATSTACK_TARGET_REPO);
+    assert.notEqual(catstackSubject, 'master');
+    assert.equal(catstackSubject, `${CATSTACK_TARGET_REPO}:master`);
+  });
+
+  it('claimRepairFiling on the default-target process claims the unmodified "master" subject', () => {
+    // TARGET_REPO is resolved once at module load from this test process's
+    // own argv/env (neither is set to a non-default repo here), so this
+    // exercises the real exported claimRepairFiling end-to-end rather than
+    // resolveRepairFilingSubject in isolation.
+    const rows = new Map();
+    const insert = ({ kind, subject, stateSha, metadata }) => {
+      const key = `${kind} ${subject} ${stateSha}`;
+      if (rows.has(key)) return { inserted: false, row: rows.get(key) };
+      const row = { kind, subject, stateSha, metadata };
+      rows.set(key, row);
+      return { inserted: true, row };
+    };
+    const failure = makeFailure({ firstBadSha: 'shaSharedAcrossRepos' });
+
+    assert.equal(claimRepairFiling(failure, insert), false, 'claim must succeed');
+    assert.equal(rows.size, 1);
+    const [[, row]] = rows;
+    assert.equal(row.subject, 'master', 'default repo keeps the unmodified "master" subject');
+  });
+
+  it('a catstack-scoped subject and the default-repo subject can never collapse onto the same ledger row for an identical (kind, sha)', () => {
+    // claimRepairFiling itself can't be re-targeted per-call (TARGET_REPO is
+    // resolved once at module load), so this simulates two isolated watcher
+    // processes -- one on the Invoker default, one on catstack -- racing the
+    // same underlying (kind, sha) against one shared ledger, using the same
+    // composite-key shape claimRepairFiling builds internally.
+    const rows = new Map();
+    const insertUnderSubject = (subject, failure) => {
+      const key = `${repairFilingKind(failure)} ${subject} ${failure.firstBadSha}`;
+      if (rows.has(key)) return { inserted: false };
+      rows.set(key, { subject });
+      return { inserted: true };
+    };
+    const failure = makeFailure({ firstBadSha: 'shaSharedAcrossRepos' });
+
+    const defaultResult = insertUnderSubject(resolveRepairFilingSubject(DEFAULT_TARGET_REPO), failure);
+    const catstackResult = insertUnderSubject(resolveRepairFilingSubject(CATSTACK_TARGET_REPO), failure);
+
+    assert.equal(defaultResult.inserted, true);
+    assert.equal(catstackResult.inserted, true, 'catstack must claim its own row, not collide with the default repo\'s');
+    assert.equal(rows.size, 2);
   });
 });


### PR DESCRIPTION
## Summary

The watch script now accepts one target repository through `--target-repo`, `INVOKER_GITHUB_TARGET_REPO`, or a JSON config file.

Non-default targets receive separate default state directories and ledger subjects. Cron forwards flags and gives CLI- or env-selected targets separate default lock files.

Omitting target settings preserves the existing Invoker repository, state path, lock, and ledger subject.

## Review Claim

Approve target selection and default state, lock, and ledger isolation for one watched repository while preserving the no-argument Invoker defaults.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Omitting target settings keeps `Neko-Catpital-Labs/Invoker`, `~/.invoker/e2e-regression-watch`, the existing lock name, and the `master` ledger subject. Non-default targets use namespaced state and ledger defaults, while CLI- or env-selected targets also use a namespaced lock. Existing explicit state and lock overrides retain authority.

## Slice Rationale

Script identity is independently usable from cron before app configuration wiring. Multi-repository sweeps and repository-specific repair construction remain separate changes.

## Non-goals

Does not add a multi-repository sweep. Does not change repair repository URLs, base branches, remote workflow loading, or Invoker job command mapping. Does not touch `packages/app`, e2e-autofix, PR maintenance, live configuration, or docs.

## Architecture

### Before

```mermaid
flowchart LR
    Fixed["Fixed Invoker target"] --> Queries["GitHub run queries"]
    Fixed --> Shared["Shared state, lock, and ledger defaults"]
```

### After

```mermaid
flowchart LR
    Input["CLI, environment, or JSON config"] --> Target["One resolved target repository"]
    Target --> Queries["GitHub run queries"]
    Target --> State["Per-target state and ledger defaults"]
    Target --> Lock["Per-target cron lock for CLI or environment selection"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test --test-name-pattern='watch-target-repo' scripts/e2e-regression-watch.test.mjs`

```text
✔ watch-target-repo config resolution (5.449667ms)
ℹ tests 14
ℹ pass 14
ℹ fail 0
```

- [x] `bash -n scripts/cron-e2e-regression-watch.sh`

```text
bash_syntax_exit=0
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 347bd2bfe03d48d8e722e35647843ac266088e5b`
- Post-revert steps: None
- Data migration? No

</details>
