### PR TITLE
[E2E watch target repo](2a) config.json wiring

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -16,7 +16,10 @@ import {
   resolveEnabledExecutionAgents,
   resolvePrMaintenanceTargetRepos,
   resolvePrMaintenanceWorkerConfig,
+  resolveE2eAutoFixTargetRepos,
+  resolveE2eAutoFixWorkerConfig,
   DEFAULT_PR_MAINTENANCE_TARGET_REPO,
+  DEFAULT_E2E_AUTOFIX_TARGET_REPO,
 } from '../config.js';
 import { validateInvokerConfig } from '../config-validation.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -752,5 +755,62 @@ describe('crossRepoResearch config', () => {
         },
       },
     })).toThrow(/must be a git URL string/);
+  });
+});
+
+describe('e2eAutoFix.targetRepos', () => {
+  it('reads targetRepos from config', () => {
+    expect(resolveE2eAutoFixTargetRepos({
+      e2eAutoFix: {
+        targetRepos: ['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack'],
+      },
+    })).toEqual(['Neko-Catpital-Labs/Invoker', 'EdbertChan/catstack']);
+  });
+
+  it('defaults to the Invoker repo when targetRepos is omitted', () => {
+    expect(resolveE2eAutoFixTargetRepos({})).toEqual([DEFAULT_E2E_AUTOFIX_TARGET_REPO]);
+    expect(resolveE2eAutoFixTargetRepos({
+      e2eAutoFix: { targetRepos: [] },
+    })).toEqual([DEFAULT_E2E_AUTOFIX_TARGET_REPO]);
+  });
+
+  it('forwards config targetRepos into worker env for the shell entrypoint', () => {
+    const launch = resolveE2eAutoFixWorkerConfig({
+      e2eAutoFix: {
+        targetRepos: ['Neko-Capital-Labs/Invoker', 'EdbertChan/catstack'],
+        env: {
+          INVOKER_GITHUB_TARGET_REPOS: 'should/not-win',
+          INVOKER_GITHUB_TARGET_REPO: 'should/not-win',
+        },
+      },
+    });
+    expect(launch.env?.INVOKER_GITHUB_TARGET_REPOS).toBe(
+      'Neko-Capital-Labs/Invoker,EdbertChan/catstack',
+    );
+    expect(launch.env?.INVOKER_GITHUB_TARGET_REPO).toBe('Neko-Capital-Labs/Invoker');
+  });
+
+  it('defaults to watching only Invoker when e2eAutoFix is omitted', () => {
+    const launch = resolveE2eAutoFixWorkerConfig({});
+    expect(launch.env?.INVOKER_GITHUB_TARGET_REPOS).toBe(DEFAULT_E2E_AUTOFIX_TARGET_REPO);
+    expect(launch.env?.INVOKER_GITHUB_TARGET_REPO).toBe(DEFAULT_E2E_AUTOFIX_TARGET_REPO);
+    expect(launch.intervalMs).toBeUndefined();
+  });
+
+  it('carries the flat e2eAutoFixIntervalMs through unchanged', () => {
+    const launch = resolveE2eAutoFixWorkerConfig({ e2eAutoFixIntervalMs: 60_000 });
+    expect(launch.intervalMs).toBe(60_000);
+  });
+
+  it('rejects invalid targetRepos entries', () => {
+    expect(() => validateInvokerConfig({
+      e2eAutoFix: { targetRepos: ['not-a-repo'] },
+    })).toThrow(/owner\/repo/);
+  });
+
+  it('rejects targetRepos entries containing a comma', () => {
+    expect(() => validateInvokerConfig({
+      e2eAutoFix: { targetRepos: ['owner,other/repo'] },
+    })).toThrow(/owner\/repo/);
   });
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -67,6 +67,21 @@ function validateCrossRepoResearchSource(entry: unknown, path: string): void {
   }
 }
 
+function validateE2eAutoFixTargetRepos(config: InvokerConfig): void {
+  const targetRepos = config.e2eAutoFix?.targetRepos;
+  if (targetRepos === undefined) return;
+  if (!Array.isArray(targetRepos)) {
+    throw new Error('e2eAutoFix.targetRepos must be an array of "owner/repo" strings');
+  }
+  for (const entry of targetRepos) {
+    if (typeof entry !== 'string' || !normalizeGithubOwnerRepo(entry)) {
+      throw new Error(
+        `e2eAutoFix.targetRepos entries must be "owner/repo" strings; got ${JSON.stringify(entry)}`,
+      );
+    }
+  }
+}
+
 function validateCrossRepoResearchConfig(config: InvokerConfig): void {
   const crossRepoResearch = config.crossRepoResearch;
   if (crossRepoResearch === undefined) return;
@@ -150,6 +165,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   validatePrMaintenanceTargetRepos(config);
+  validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
-import type { PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
+import type { E2eAutoFixWorkerConfig, PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
 
 const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
@@ -70,6 +70,24 @@ export interface PrMaintenanceConfig {
 
 export const DEFAULT_PR_MAINTENANCE_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
 
+/**
+ * Owner-side e2e-autofix worker target settings.
+ *
+ * Cadence lives in the flat `e2eAutoFixIntervalMs`; this block only carries
+ * the GitHub scan list and env overrides forwarded to the shell entrypoint.
+ */
+export interface E2eAutoFixConfig {
+  /** Environment overrides forwarded to the shell entrypoint. `undefined` removes a variable. */
+  env?: Record<string, string | undefined>;
+  /**
+   * GitHub `owner/repo` list watched by the e2e-autofix worker (CI regression
+   * watch + repair filing). When omitted, defaults to the Invoker repo only.
+   */
+  targetRepos?: string[];
+}
+
+export const DEFAULT_E2E_AUTOFIX_TARGET_REPO = 'Neko-Catpital-Labs/Invoker';
+
 const GITHUB_OWNER_REPO_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/;
 
 /** Normalize and validate a GitHub `owner/repo` string; returns null when invalid. */
@@ -95,6 +113,24 @@ export function resolvePrMaintenanceTargetRepos(config: InvokerConfig): string[]
     if (repos.length > 0) return repos;
   }
   return [DEFAULT_PR_MAINTENANCE_TARGET_REPO];
+}
+
+/**
+ * Resolve the e2e-autofix scan list from `e2eAutoFix.targetRepos`.
+ * When omitted or empty, defaults to the Invoker repo only.
+ */
+export function resolveE2eAutoFixTargetRepos(config: InvokerConfig): string[] {
+  const fromConfig = config.e2eAutoFix?.targetRepos;
+  if (Array.isArray(fromConfig) && fromConfig.length > 0) {
+    const repos: string[] = [];
+    for (const entry of fromConfig) {
+      if (typeof entry !== 'string') continue;
+      const normalized = normalizeGithubOwnerRepo(entry);
+      if (normalized && !repos.includes(normalized)) repos.push(normalized);
+    }
+    if (repos.length > 0) return repos;
+  }
+  return [DEFAULT_E2E_AUTOFIX_TARGET_REPO];
 }
 
 export interface SlackBugScanConfig {
@@ -184,6 +220,11 @@ export interface InvokerConfig {
   autoFixRetries?: number;
   /** Cadence for the e2e-autofix worker in milliseconds. Default: 43_200_000 (12h). */
   e2eAutoFixIntervalMs?: number;
+  /**
+   * Owner-side e2e-autofix worker target settings (GitHub scan list, env overrides).
+   * Cadence stays in the flat `e2eAutoFixIntervalMs` above.
+   */
+  e2eAutoFix?: E2eAutoFixConfig;
   stallRequeueRetries?: number;
   stallRequeueBackoffMs?: number;
   /**
@@ -701,4 +742,26 @@ export function resolvePrMaintenanceWorkerConfig(
   launch.env = env;
 
   return Object.keys(launch).length > 0 ? launch : {};
+}
+
+/**
+ * Build e2e-autofix worker launch dependencies from config.
+ *
+ * Always returns `intervalMs` and `env` (with the resolved target-repo scan
+ * list injected), so the worker keeps watching only Invoker by default when
+ * `e2eAutoFix` is absent or `targetRepos` is omitted/empty.
+ */
+export function resolveE2eAutoFixWorkerConfig(
+  config: InvokerConfig,
+): E2eAutoFixWorkerConfig {
+  const targetRepos = resolveE2eAutoFixTargetRepos(config);
+  const env: Record<string, string | undefined> = {
+    ...(config.e2eAutoFix?.env ?? {}),
+    INVOKER_GITHUB_TARGET_REPOS: targetRepos.join(','),
+    INVOKER_GITHUB_TARGET_REPO: targetRepos[0],
+  };
+  return {
+    intervalMs: config.e2eAutoFixIntervalMs,
+    env,
+  };
 }


### PR DESCRIPTION
## Summary

Invoker's owner config gains an `e2eAutoFix.targetRepos` array, matching the existing `prMaintenance.targetRepos` field.

A new `resolveE2eAutoFixWorkerConfig` builds worker spawn env from that array: `INVOKER_GITHUB_TARGET_REPOS` and `INVOKER_GITHUB_TARGET_REPO`.

Omitting the field, or leaving it empty, still resolves to the Invoker repo only. Nothing changes for operators who never set it.

Nested `env` overrides on `e2eAutoFix` cannot win over the resolved target-repo keys, matching the existing `prMaintenance` rule.

Wiring this resolver into the running worker is a separate PR in this stack, since it touches a different review unit.

## Review Claim

Approve `e2eAutoFix.targetRepos` and its resolvers (`resolveE2eAutoFixTargetRepos`, `resolveE2eAutoFixWorkerConfig`) as config-layer additions that default to Invoker only when omitted or empty.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Omitted or empty `e2eAutoFix.targetRepos` resolves to `Neko-Catpital-Labs/Invoker` only. `e2eAutoFixEnabled`, the SQLite desired-worker-state gate, and `e2eAutoFixIntervalMs` are untouched. `prMaintenance.targetRepos` and its resolver are not modified. These new functions are not called from `main.ts` in this PR, so no running worker behavior changes yet.

## Slice Rationale

This PR only adds the config field, its resolvers, and their tests. Connecting the resolver into the worker's launch dependencies in `main.ts` touches a different part of the codebase, so it ships as the next PR in this stack.

## Non-goals

Does not edit `packages/app/src/main.ts` or any worker launch wiring. Does not edit `scripts/e2e-regression-watch.mjs` or the cron entrypoint. Does not edit `e2e-autofix-worker.ts` spawn or loop behavior. Does not change PR-maintenance config or its resolver. Does not write to a live `~/.invoker/config.json`. Does not add docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/config.test.ts`

```text
 ✓ src/__tests__/config.test.ts (72 tests) 939ms
 Test Files  1 passed (1)
      Tests  72 passed (72)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
