### PR TITLE
[CI regression: 33ecd0c-ssh-shard-31](1) Reclaim disk space in ssh matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1095,6 +1095,10 @@ jobs:
     name: ssh / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim disk space
+        run: find /tmp -maxdepth 1 -name 'invoker-*' -mmin +360 -exec rm -rf {} + 2>/dev/null || true
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

CI job `ssh / shard-31` was failing on its self-hosted runner because leftover
`/tmp/invoker-*` directories from earlier job runs filled up available disk space.

This adds a `Reclaim disk space` step to the `ssh` matrix job in `.github/workflows/ci.yml`,
before `Checkout`. It clears `/tmp/invoker-*` entries older than six hours.

The added step is best-effort. It always exits successfully on its own, so it cannot fail
the job.

## Review Claim

Approve adding one `Reclaim disk space` step to the `ssh` matrix job in
`.github/workflows/ci.yml`, ahead of the existing `Checkout` step.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new step only removes `/tmp/invoker-*` paths older than 360 minutes and always exits 0
(`|| true`), so it cannot fail the job itself. Every other step in the `ssh` matrix job, every
other CI job, and all product code are byte-identical to before this change.

## Slice Rationale

This is the entire fix needed to repair `ssh / shard-31`. The workflow's paired verification
task re-ran the same suite against this change and recorded exit code 0, but produced no file
changes of its own, so there is no separate non-empty slice to publish for it.

## Non-goals

No changes to any other CI job, no product code changes, no test weakening, no refactor of
unrelated workflow steps.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/31-e2e-ssh-merge.sh'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dba58095c`
- Post-revert steps: None
- Data migration? No

</details>
