### PR TITLE
[admin-bypass-repair-bot-thread-pr-10545-00fef04](1) Look up PR by head branch when --json-pr is absent in safe-push

### DIFF
--- a/scripts/pr_worker_safe_push.py
+++ b/scripts/pr_worker_safe_push.py
@@ -157,9 +157,9 @@ def repo_slug(remote: str, *, cwd: Path | str | None = None) -> str | None:
     return match.group("slug") if match else None
 
 
-def pr_state(pr_number: int, *, repo: str, cwd: Path | str | None = None) -> str | None:
+def pr_state(pr_identifier: int | str, *, repo: str, cwd: Path | str | None = None) -> str | None:
     completed = subprocess.run(
-        ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "state", "-q", ".state"],
+        ["gh", "pr", "view", str(pr_identifier), "--repo", repo, "--json", "state", "-q", ".state"],
         cwd=str(cwd) if cwd is not None else None,
         check=False,
         text=True,
@@ -337,14 +337,16 @@ def _record_ledgers(args: argparse.Namespace) -> None:
 # race with another writer. In that case there is nothing left to push and no
 # unsafe write to guard against, so settle quietly instead of failing the same
 # way a real stale-head race would (mirrors mergify_admin_requeue_repair_normalize.py's
-# handling of a PR merged/closed mid-repair).
+# handling of a PR merged/closed mid-repair). --json-pr is optional plumbing for
+# ledger recording, not a precondition for this check: callers that only pass
+# --branch/--expected-head (no ledger flags) still need the merge/close settle
+# path, so fall back to looking the PR up by head branch name via `gh pr view`.
 def _settled_via_pr_merge_or_close(args: argparse.Namespace) -> str | None:
-    if args.json_pr is None:
-        return None
     repo = repo_slug(args.remote, cwd=Path(args.cwd))
     if repo is None:
         return None
-    state = pr_state(args.json_pr, repo=repo, cwd=Path(args.cwd))
+    pr_identifier: int | str = args.json_pr if args.json_pr is not None else normalize_branch(args.branch)
+    state = pr_state(pr_identifier, repo=repo, cwd=Path(args.cwd))
     return state if state in ("MERGED", "CLOSED") else None
 
 
@@ -370,8 +372,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"pr-worker-safe-push: {exc}", file=sys.stderr)
             return exc.exit_code or 1
         _record_ledgers(args)
+        pr_label = f"PR #{args.json_pr}" if args.json_pr is not None else f"the PR for refs/heads/{normalize_branch(args.branch)}"
         print(
-            f"pr-worker-safe-push: noop: PR #{args.json_pr} is already {state.lower()}; "
+            f"pr-worker-safe-push: noop: {pr_label} is already {state.lower()}; "
             f"refs/heads/{normalize_branch(args.branch)} no longer exists, nothing to push",
             file=sys.stderr,
         )

--- a/scripts/test_pr_worker_safe_push.py
+++ b/scripts/test_pr_worker_safe_push.py
@@ -206,11 +206,13 @@ class SafePushTests(unittest.TestCase):
         self.assertIn("git push", result.stderr)
         self.assertFalse(ledger.exists())
 
-    def _fake_github_remote_and_gh(self, *, pr_number: int, state: str) -> dict[str, str]:
+    def _fake_github_remote_and_gh(self, *, pr_identifier: int | str, state: str) -> dict[str, str]:
         # Fakes just enough of `git remote get-url` (so repo_slug() sees a
         # github.com URL) and `gh pr view` (so pr_state() sees a merged/closed
         # PR) while every other git subcommand still hits the real local
-        # bare-repo remote used by the rest of the test.
+        # bare-repo remote used by the rest of the test. `gh pr view` accepts
+        # either a PR number or a head branch name as its identifier, so the
+        # wrapper matches on whichever this test passes.
         wrapper_dir = self.root / "bin"
         wrapper_dir.mkdir(exist_ok=True)
         git_wrapper = wrapper_dir / "git"
@@ -235,7 +237,7 @@ class SafePushTests(unittest.TestCase):
                 f"""\
                 #!/usr/bin/env bash
                 set -euo pipefail
-                if [ "${{1:-}}" = "pr" ] && [ "${{2:-}}" = "view" ] && [ "${{3:-}}" = "{pr_number}" ]; then
+                if [ "${{1:-}}" = "pr" ] && [ "${{2:-}}" = "view" ] && [ "${{3:-}}" = "{pr_identifier}" ]; then
                   echo '{state}'
                   exit 0
                 fi
@@ -248,7 +250,7 @@ class SafePushTests(unittest.TestCase):
         return {"PATH": f"{wrapper_dir}:{os.environ['PATH']}"}
 
     def test_missing_branch_settles_as_noop_when_pr_already_merged(self) -> None:
-        env = self._fake_github_remote_and_gh(pr_number=456, state="MERGED")
+        env = self._fake_github_remote_and_gh(pr_identifier=456, state="MERGED")
         ledger = self.root / "ledger.jsonl"
 
         result = self.invoke_helper(
@@ -270,8 +272,27 @@ class SafePushTests(unittest.TestCase):
         self.assertEqual(recorded["kind"], "repair-bot-thread-settled")
         self.assertEqual(recorded["pr"], 456)
 
+    def test_missing_branch_settles_as_noop_when_pr_merged_and_no_json_pr_given(self) -> None:
+        # Reproduces the safe-push worker command: only --branch/--expected-head
+        # (no ledger flags, so no --json-pr) is passed when the branch's PR
+        # merged and GitHub deleted the head branch out from under the worker.
+        # Without a PR number, the merge/close settle check must fall back to
+        # looking the PR up by its head branch name.
+        env = self._fake_github_remote_and_gh(pr_identifier="gone", state="MERGED")
+
+        result = self.invoke_helper(
+            "--branch", "gone",
+            "--expected-head", self.expected,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("noop", result.stderr)
+        self.assertIn("merged", result.stderr)
+        self.assertIsNone(safe_push.remote_branch_sha("gone", remote="origin", cwd=self.repo))
+
     def test_missing_branch_stays_stale_when_pr_still_open(self) -> None:
-        env = self._fake_github_remote_and_gh(pr_number=456, state="OPEN")
+        env = self._fake_github_remote_and_gh(pr_identifier=456, state="OPEN")
         ledger = self.root / "ledger.jsonl"
 
         result = self.invoke_helper(


### PR DESCRIPTION
## Summary

`pr_worker_safe_push.py` can settle quietly when a branch disappears because its PR was merged or closed mid-repair. That settle-check only ran when the caller passed `--json-pr`.

The common safe-push invocation only passes `--branch` and `--expected-head`, with no PR number. A merged/closed PR then made the branch-missing case a hard failure instead of a quiet noop.

This change makes `_settled_via_pr_merge_or_close` fall back to looking the PR up by its head branch name when `--json-pr` is absent, so the settle-check fires either way.

## Review Claim

Approve teaching `_settled_via_pr_merge_or_close` to resolve the PR by head branch name when `--json-pr` is absent, instead of returning `None` early and forcing a hard failure.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only affects the already-missing-branch code path inside `pr_worker_safe_push.py`: it runs after `safe_push` has already determined the target branch does not exist, and only changes whether that case exits 0 (noop) or exits non-zero. `pr_state` already accepted any `gh pr view` identifier, so passing a branch name reuses that existing lookup rather than adding a new one. A normal (branch-present) safe-push run is byte-for-byte unaffected.

## Slice Rationale

This is the one behavioral gap found while resolving the bot review thread on PR #10545: the paired repair task made no net code change of its own (its `.github/workflows/ci.yml` edit was reconciled away by a merge with master's own disk-reclaim fix), so this is the only diff in the stack.

## Non-goals

Does not change `safe_push`'s push/replay logic or its ledger recording. Does not add new CLI flags. Does not touch the `--json-pr`-present code path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_pr_worker_safe_push -v`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
