### PR TITLE
[mergify-queue-research](1) Add mergifyQueueResearch config schema and validation

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -758,6 +758,71 @@ describe('crossRepoResearch config', () => {
   });
 });
 
+describe('mergifyQueueResearch config', () => {
+  it('accepts omitted mergifyQueueResearch block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts empty maps without linearTeamId', () => {
+    expect(validateInvokerConfig({
+      mergifyQueueResearch: { maps: {} },
+    }).mergifyQueueResearch?.maps).toEqual({});
+  });
+
+  it('requires linearTeamId when maps are non-empty', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/Neko-Catpital-Labs/Invoker.git',
+          ],
+        },
+      },
+    })).toThrow(/linearTeamId is required/);
+  });
+
+  it('rejects lookbackDays of 0', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        linearTeamId: 'team-1',
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            { repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git', lookbackDays: 0 },
+          ],
+        },
+      },
+    })).toThrow(/lookbackDays must be an integer > 0/);
+  });
+
+  it('accepts string sources and object sources with lookbackDays', () => {
+    const config = validateInvokerConfig({
+      mergifyQueueResearch: {
+        intervalDays: 14,
+        linearTeamId: 'team-1',
+        maxCandidatesPerSource: 5,
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/Neko-Catpital-Labs/Invoker.git',
+            { repoUrl: 'https://github.com/example/other', lookbackDays: 7 },
+          ],
+        },
+      },
+    });
+    expect(config.mergifyQueueResearch?.linearTeamId).toBe('team-1');
+    expect(config.mergifyQueueResearch?.maps?.['https://github.com/Neko-Catpital-Labs/Invoker.git']).toHaveLength(2);
+  });
+
+  it('rejects non-git map keys', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        linearTeamId: 'team-1',
+        maps: { 'not-a-url': ['https://github.com/Neko-Catpital-Labs/Invoker.git'] },
+      },
+    })).toThrow(/maps key must be a git URL/);
+  });
+});
+
+
 describe('e2eAutoFix.targetRepos', () => {
   it('reads targetRepos from config', () => {
     expect(resolveE2eAutoFixTargetRepos({

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -4,7 +4,10 @@ import {
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
   type InvokerConfig,
+  type MergifyQueueResearchConfig,
+  type MergifyQueueResearchSource,
   DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS,
+  DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS,
 } from './config.js';
 
 const builtinAgents = registerBuiltinAgents();
@@ -138,6 +141,86 @@ export function normalizeCrossRepoResearchSource(entry: string | CrossRepoResear
   };
 }
 
+
+function validateMergifyQueueResearchSource(entry: unknown, path: string): void {
+  if (typeof entry === 'string') {
+    if (!isGitUrl(entry)) {
+      throw new Error(`${path} must be a git URL string; got ${JSON.stringify(entry)}`);
+    }
+    return;
+  }
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error(`${path} must be a git URL string or { repoUrl, lookbackDays? }`);
+  }
+  const source = entry as MergifyQueueResearchSource;
+  if (!isNonEmptyString(source.repoUrl) || !isGitUrl(source.repoUrl)) {
+    throw new Error(`${path}.repoUrl must be a git URL string`);
+  }
+  if (source.lookbackDays !== undefined) {
+    if (typeof source.lookbackDays !== 'number' || !Number.isInteger(source.lookbackDays) || source.lookbackDays <= 0) {
+      throw new Error(`${path}.lookbackDays must be an integer > 0`);
+    }
+  }
+}
+
+function validateMergifyQueueResearchConfig(config: InvokerConfig): void {
+  const mergifyQueueResearch = config.mergifyQueueResearch;
+  if (mergifyQueueResearch === undefined) return;
+  if (typeof mergifyQueueResearch !== 'object' || mergifyQueueResearch === null || Array.isArray(mergifyQueueResearch)) {
+    throw new Error('mergifyQueueResearch must be an object');
+  }
+  const typed = mergifyQueueResearch as MergifyQueueResearchConfig;
+  if (typed.intervalDays !== undefined) {
+    if (typeof typed.intervalDays !== 'number' || !Number.isInteger(typed.intervalDays) || typed.intervalDays <= 0) {
+      throw new Error('mergifyQueueResearch.intervalDays must be an integer > 0');
+    }
+  }
+  if (typed.maxCandidatesPerSource !== undefined) {
+    if (
+      typeof typed.maxCandidatesPerSource !== 'number'
+      || !Number.isInteger(typed.maxCandidatesPerSource)
+      || typed.maxCandidatesPerSource <= 0
+    ) {
+      throw new Error('mergifyQueueResearch.maxCandidatesPerSource must be an integer > 0');
+    }
+  }
+  if (typed.linearTeamId !== undefined && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('mergifyQueueResearch.linearTeamId must be a non-empty string when set');
+  }
+  if (typed.maps === undefined) return;
+  if (typeof typed.maps !== 'object' || typed.maps === null || Array.isArray(typed.maps)) {
+    throw new Error('mergifyQueueResearch.maps must be an object keyed by target repo URL');
+  }
+  const entries = Object.entries(typed.maps);
+  if (entries.length > 0 && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('mergifyQueueResearch.linearTeamId is required when mergifyQueueResearch.maps is non-empty');
+  }
+  for (const [targetUrl, sources] of entries) {
+    if (!isGitUrl(targetUrl)) {
+      throw new Error(`mergifyQueueResearch.maps key must be a git URL; got ${JSON.stringify(targetUrl)}`);
+    }
+    if (!Array.isArray(sources)) {
+      throw new Error(`mergifyQueueResearch.maps[${JSON.stringify(targetUrl)}] must be an array`);
+    }
+    sources.forEach((source, index) => {
+      validateMergifyQueueResearchSource(source, `mergifyQueueResearch.maps[${JSON.stringify(targetUrl)}][${index}]`);
+    });
+  }
+}
+
+/** Normalize a Mergify queue research source entry with defaults applied. */
+export function normalizeMergifyQueueResearchSource(
+  entry: string | MergifyQueueResearchSource,
+): Required<MergifyQueueResearchSource> {
+  if (typeof entry === 'string') {
+    return { repoUrl: entry.trim(), lookbackDays: DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS };
+  }
+  return {
+    repoUrl: entry.repoUrl.trim(),
+    lookbackDays: entry.lookbackDays ?? DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS,
+  };
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -167,5 +250,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validatePrMaintenanceTargetRepos(config);
   validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);
+  validateMergifyQueueResearchConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -175,6 +175,40 @@ export const DEFAULT_CROSS_REPO_RESEARCH_INTERVAL_DAYS = 14;
 /** Default max candidates mined per source per tick. */
 export const DEFAULT_CROSS_REPO_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
 
+/**
+ * One source whose Mergify/admin-bypass ledger events are mined for research.
+ * Same shape as CrossRepoResearchSource so maps stay interchangeable.
+ */
+export type MergifyQueueResearchSource = CrossRepoResearchSource;
+
+/**
+ * Opt-in mergify-queue-research worker settings. Process on/off is SQLite
+ * `worker_desired_states`, not a config boolean.
+ */
+export interface MergifyQueueResearchConfig {
+  /** Poll cadence in days. Default: 14. */
+  intervalDays?: number;
+  /** Linear team id required when maps are non-empty. */
+  linearTeamId?: string;
+  /** Cap candidate events per source per tick. Default: 5. */
+  maxCandidatesPerSource?: number;
+  /**
+   * Target repo URL → list of sources whose queue/ledger to mine.
+   * Source entries may be a URL string (lookbackDays defaults to 30) or
+   * `{ repoUrl, lookbackDays }`.
+   */
+  maps?: Record<string, Array<string | MergifyQueueResearchSource>>;
+}
+
+/** Default lookback when a Mergify queue research source omits lookbackDays. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS = 30;
+
+/** Default Mergify queue research poll cadence when intervalDays is unset. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_INTERVAL_DAYS = 14;
+
+/** Default max Mergify queue candidates mined per source per tick. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -517,6 +551,12 @@ export interface InvokerConfig {
    * Process on/off is SQLite `worker_desired_states`, not a config boolean.
    */
   crossRepoResearch?: CrossRepoResearchConfig;
+  /**
+   * Mergify queue research worker: maps target repos to sources whose
+   * Mergify/admin-bypass ledger events are mined for a research swarm.
+   * Process on/off is SQLite `worker_desired_states`, not a config boolean.
+   */
+  mergifyQueueResearch?: MergifyQueueResearchConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },


### PR DESCRIPTION
## Summary

Adds an optional `mergifyQueueResearch` config block for target→source mining maps.

Per-source lookback defaults to 30 days. Worker interval defaults to 14 days.

Missing the block leaves boot and config load unchanged.

Invalid maps fail validation only when present and malformed.

## Review Claim

Approve the `mergifyQueueResearch` fields and validation rules without enabling any worker process.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Omitting `mergifyQueueResearch` does not change boot, defaults, or existing config acceptance. Only explicit invalid maps fail validation.

## Slice Rationale

Config shape is foundation for later scripts and worker wiring and must review alone.

## Non-goals

Does not register a worker, spawn scripts, forward Linear secrets, or file Linear issues.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts -t "mergifyQueueResearch"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
