### PR TITLE
[mergify-queue-research](2) Add watch and Linear filing scripts

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -758,6 +758,71 @@ describe('crossRepoResearch config', () => {
   });
 });
 
+describe('mergifyQueueResearch config', () => {
+  it('accepts omitted mergifyQueueResearch block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts empty maps without linearTeamId', () => {
+    expect(validateInvokerConfig({
+      mergifyQueueResearch: { maps: {} },
+    }).mergifyQueueResearch?.maps).toEqual({});
+  });
+
+  it('requires linearTeamId when maps are non-empty', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/Neko-Catpital-Labs/Invoker.git',
+          ],
+        },
+      },
+    })).toThrow(/linearTeamId is required/);
+  });
+
+  it('rejects lookbackDays of 0', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        linearTeamId: 'team-1',
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            { repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git', lookbackDays: 0 },
+          ],
+        },
+      },
+    })).toThrow(/lookbackDays must be an integer > 0/);
+  });
+
+  it('accepts string sources and object sources with lookbackDays', () => {
+    const config = validateInvokerConfig({
+      mergifyQueueResearch: {
+        intervalDays: 14,
+        linearTeamId: 'team-1',
+        maxCandidatesPerSource: 5,
+        maps: {
+          'https://github.com/Neko-Catpital-Labs/Invoker.git': [
+            'https://github.com/Neko-Catpital-Labs/Invoker.git',
+            { repoUrl: 'https://github.com/example/other', lookbackDays: 7 },
+          ],
+        },
+      },
+    });
+    expect(config.mergifyQueueResearch?.linearTeamId).toBe('team-1');
+    expect(config.mergifyQueueResearch?.maps?.['https://github.com/Neko-Catpital-Labs/Invoker.git']).toHaveLength(2);
+  });
+
+  it('rejects non-git map keys', () => {
+    expect(() => validateInvokerConfig({
+      mergifyQueueResearch: {
+        linearTeamId: 'team-1',
+        maps: { 'not-a-url': ['https://github.com/Neko-Catpital-Labs/Invoker.git'] },
+      },
+    })).toThrow(/maps key must be a git URL/);
+  });
+});
+
+
 describe('e2eAutoFix.targetRepos', () => {
   it('reads targetRepos from config', () => {
     expect(resolveE2eAutoFixTargetRepos({

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -4,7 +4,10 @@ import {
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
   type InvokerConfig,
+  type MergifyQueueResearchConfig,
+  type MergifyQueueResearchSource,
   DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS,
+  DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS,
 } from './config.js';
 
 const builtinAgents = registerBuiltinAgents();
@@ -138,6 +141,86 @@ export function normalizeCrossRepoResearchSource(entry: string | CrossRepoResear
   };
 }
 
+
+function validateMergifyQueueResearchSource(entry: unknown, path: string): void {
+  if (typeof entry === 'string') {
+    if (!isGitUrl(entry)) {
+      throw new Error(`${path} must be a git URL string; got ${JSON.stringify(entry)}`);
+    }
+    return;
+  }
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error(`${path} must be a git URL string or { repoUrl, lookbackDays? }`);
+  }
+  const source = entry as MergifyQueueResearchSource;
+  if (!isNonEmptyString(source.repoUrl) || !isGitUrl(source.repoUrl)) {
+    throw new Error(`${path}.repoUrl must be a git URL string`);
+  }
+  if (source.lookbackDays !== undefined) {
+    if (typeof source.lookbackDays !== 'number' || !Number.isInteger(source.lookbackDays) || source.lookbackDays <= 0) {
+      throw new Error(`${path}.lookbackDays must be an integer > 0`);
+    }
+  }
+}
+
+function validateMergifyQueueResearchConfig(config: InvokerConfig): void {
+  const mergifyQueueResearch = config.mergifyQueueResearch;
+  if (mergifyQueueResearch === undefined) return;
+  if (typeof mergifyQueueResearch !== 'object' || mergifyQueueResearch === null || Array.isArray(mergifyQueueResearch)) {
+    throw new Error('mergifyQueueResearch must be an object');
+  }
+  const typed = mergifyQueueResearch as MergifyQueueResearchConfig;
+  if (typed.intervalDays !== undefined) {
+    if (typeof typed.intervalDays !== 'number' || !Number.isInteger(typed.intervalDays) || typed.intervalDays <= 0) {
+      throw new Error('mergifyQueueResearch.intervalDays must be an integer > 0');
+    }
+  }
+  if (typed.maxCandidatesPerSource !== undefined) {
+    if (
+      typeof typed.maxCandidatesPerSource !== 'number'
+      || !Number.isInteger(typed.maxCandidatesPerSource)
+      || typed.maxCandidatesPerSource <= 0
+    ) {
+      throw new Error('mergifyQueueResearch.maxCandidatesPerSource must be an integer > 0');
+    }
+  }
+  if (typed.linearTeamId !== undefined && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('mergifyQueueResearch.linearTeamId must be a non-empty string when set');
+  }
+  if (typed.maps === undefined) return;
+  if (typeof typed.maps !== 'object' || typed.maps === null || Array.isArray(typed.maps)) {
+    throw new Error('mergifyQueueResearch.maps must be an object keyed by target repo URL');
+  }
+  const entries = Object.entries(typed.maps);
+  if (entries.length > 0 && !isNonEmptyString(typed.linearTeamId)) {
+    throw new Error('mergifyQueueResearch.linearTeamId is required when mergifyQueueResearch.maps is non-empty');
+  }
+  for (const [targetUrl, sources] of entries) {
+    if (!isGitUrl(targetUrl)) {
+      throw new Error(`mergifyQueueResearch.maps key must be a git URL; got ${JSON.stringify(targetUrl)}`);
+    }
+    if (!Array.isArray(sources)) {
+      throw new Error(`mergifyQueueResearch.maps[${JSON.stringify(targetUrl)}] must be an array`);
+    }
+    sources.forEach((source, index) => {
+      validateMergifyQueueResearchSource(source, `mergifyQueueResearch.maps[${JSON.stringify(targetUrl)}][${index}]`);
+    });
+  }
+}
+
+/** Normalize a Mergify queue research source entry with defaults applied. */
+export function normalizeMergifyQueueResearchSource(
+  entry: string | MergifyQueueResearchSource,
+): Required<MergifyQueueResearchSource> {
+  if (typeof entry === 'string') {
+    return { repoUrl: entry.trim(), lookbackDays: DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS };
+  }
+  return {
+    repoUrl: entry.repoUrl.trim(),
+    lookbackDays: entry.lookbackDays ?? DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS,
+  };
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -167,5 +250,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validatePrMaintenanceTargetRepos(config);
   validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);
+  validateMergifyQueueResearchConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -175,6 +175,40 @@ export const DEFAULT_CROSS_REPO_RESEARCH_INTERVAL_DAYS = 14;
 /** Default max candidates mined per source per tick. */
 export const DEFAULT_CROSS_REPO_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
 
+/**
+ * One source whose Mergify/admin-bypass ledger events are mined for research.
+ * Same shape as CrossRepoResearchSource so maps stay interchangeable.
+ */
+export type MergifyQueueResearchSource = CrossRepoResearchSource;
+
+/**
+ * Opt-in mergify-queue-research worker settings. Process on/off is SQLite
+ * `worker_desired_states`, not a config boolean.
+ */
+export interface MergifyQueueResearchConfig {
+  /** Poll cadence in days. Default: 14. */
+  intervalDays?: number;
+  /** Linear team id required when maps are non-empty. */
+  linearTeamId?: string;
+  /** Cap candidate events per source per tick. Default: 5. */
+  maxCandidatesPerSource?: number;
+  /**
+   * Target repo URL → list of sources whose queue/ledger to mine.
+   * Source entries may be a URL string (lookbackDays defaults to 30) or
+   * `{ repoUrl, lookbackDays }`.
+   */
+  maps?: Record<string, Array<string | MergifyQueueResearchSource>>;
+}
+
+/** Default lookback when a Mergify queue research source omits lookbackDays. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS = 30;
+
+/** Default Mergify queue research poll cadence when intervalDays is unset. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_INTERVAL_DAYS = 14;
+
+/** Default max Mergify queue candidates mined per source per tick. */
+export const DEFAULT_MERGIFY_QUEUE_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -517,6 +551,12 @@ export interface InvokerConfig {
    * Process on/off is SQLite `worker_desired_states`, not a config boolean.
    */
   crossRepoResearch?: CrossRepoResearchConfig;
+  /**
+   * Mergify queue research worker: maps target repos to sources whose
+   * Mergify/admin-bypass ledger events are mined for a research swarm.
+   * Process on/off is SQLite `worker_desired_states`, not a config boolean.
+   */
+  mergifyQueueResearch?: MergifyQueueResearchConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },

--- a/scripts/mergify-queue-research-watch.mjs
+++ b/scripts/mergify-queue-research-watch.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+/**
+ * Mergify queue research watch: for each configured target→sources map, mine
+ * Mergify/admin-bypass ledger events (and optional Mergify bot comments) in the
+ * per-source lookback window and submit a 3-workflow Invoker chain
+ * (discover → research-swarm → file-linear). Does not classify in-process and
+ * never labels tickets invoker-ready.
+ *
+ * Env:
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON   inline MergifyQueueResearchConfig (tests)
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE  JSON activity by source repoUrl
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_LEDGER_PATH   JSONL ledger path (default ~/.invoker/mergify-admin-requeue-state.jsonl)
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_DRY_RUN=1     generate chain only; do not submit
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_SUBMIT_CMD    override submit-workflow-chain.sh
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR      ledger + generated plans (default ~/.invoker/mergify-queue-research)
+ *   INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY=1  write chain YAML and exit 0 (tests)
+ */
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+const DEFAULT_MAX_CANDIDATES = 5;
+const INTERESTING_KINDS = new Set([
+  'requeue',
+  'repair_check',
+  'comment_blocked',
+  'queue-only-requeue',
+  'refresh_stale_queue',
+]);
+
+function env(name, fallback = '') {
+  return process.env[name] ?? fallback;
+}
+
+function log(msg) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[mergify-queue-research ${ts}] ${msg}`);
+}
+
+function slugify(text) {
+  return String(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'event';
+}
+
+function yamlQuote(value) {
+  return JSON.stringify(String(value ?? ''));
+}
+
+function loadOwnerConfig() {
+  const inline = env('INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON');
+  if (inline) return JSON.parse(inline);
+  const configPath = env('INVOKER_REPO_CONFIG_PATH')
+    || join(homedir(), '.invoker', 'config.json');
+  if (!existsSync(configPath)) return {};
+  return JSON.parse(readFileSync(configPath, 'utf8'));
+}
+
+function normalizeSource(entry) {
+  if (typeof entry === 'string') {
+    return { repoUrl: entry.trim(), lookbackDays: DEFAULT_LOOKBACK_DAYS };
+  }
+  return {
+    repoUrl: String(entry.repoUrl).trim(),
+    lookbackDays: entry.lookbackDays ?? DEFAULT_LOOKBACK_DAYS,
+  };
+}
+
+function normalizeMaps(mergifyQueueResearch) {
+  const maps = mergifyQueueResearch?.maps ?? {};
+  return Object.entries(maps).map(([targetRepoUrl, sources]) => ({
+    targetRepoUrl,
+    sources: (sources ?? []).map(normalizeSource),
+  }));
+}
+
+function fingerprint(text) {
+  return createHash('sha256').update(String(text).trim().toLowerCase()).digest('hex').slice(0, 16);
+}
+
+function sourceOwnerRepo(repoUrl) {
+  const m = repoUrl.match(/github\.com[/:]([^/]+)\/([^/.]+)(?:\.git)?/i);
+  if (!m) return null;
+  return `${m[1]}/${m[2]}`;
+}
+
+function readLedger(workDir) {
+  const path = join(workDir, 'ledger.json');
+  if (!existsSync(path)) return { fingerprints: {}, watermarks: {} };
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { fingerprints: {}, watermarks: {} };
+  }
+}
+
+function writeLedger(workDir, ledger) {
+  mkdirSync(workDir, { recursive: true });
+  writeFileSync(join(workDir, 'ledger.json'), `${JSON.stringify(ledger, null, 2)}\n`);
+}
+
+function loadActivityFixture() {
+  const path = env('INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE');
+  if (!path) return null;
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function defaultAdminBypassLedgerPath() {
+  return env('INVOKER_MERGIFY_QUEUE_RESEARCH_LEDGER_PATH')
+    || join(homedir(), '.invoker', 'mergify-admin-requeue-state.jsonl');
+}
+
+function rowToActivity(row) {
+  const kind = String(row.kind ?? '').trim();
+  if (!kind) return null;
+  const baseKind = kind.endsWith('-settled') ? kind.slice(0, -'-settled'.length) : kind;
+  if (!INTERESTING_KINDS.has(baseKind) && !kind.includes('infra') && !kind.includes('repair')) {
+    return null;
+  }
+  const pr = row.pr ?? row.pr_number ?? '';
+  const key = row.key ?? '';
+  const title = `${baseKind} PR #${pr} ${key}`.trim();
+  const epoch = Number(row.epoch ?? 0);
+  const date = epoch > 0
+    ? new Date(epoch * 1000).toISOString().slice(0, 10)
+    : (row.date ?? '');
+  return {
+    date,
+    kind: baseKind,
+    title,
+    url: row.url ?? (pr ? `https://github.com/pull/${pr}` : ''),
+    body: JSON.stringify({
+      kind,
+      pr,
+      headSha: row.headSha ?? '',
+      key,
+      meta: row.meta ?? null,
+    }).slice(0, 1200),
+  };
+}
+
+function readJsonlLedgerActivity(ledgerPath, sinceIso) {
+  if (!existsSync(ledgerPath)) return [];
+  const sinceEpoch = Math.floor(new Date(sinceIso).getTime() / 1000);
+  const out = [];
+  for (const line of readFileSync(ledgerPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!row || typeof row !== 'object') continue;
+    const epoch = Number(row.epoch ?? 0);
+    if (epoch > 0 && epoch < sinceEpoch) continue;
+    const activity = rowToActivity(row);
+    if (activity) out.push(activity);
+  }
+  return out;
+}
+
+function fetchMergifyComments(ownerRepo, sinceIso) {
+  const result = spawnSync(
+    'gh',
+    [
+      'api',
+      `repos/${ownerRepo}/issues/comments?since=${encodeURIComponent(sinceIso)}&per_page=100`,
+      '--jq',
+      '[.[] | select(.user.login == "mergify[bot]" or .user.login == "mergify")'
+      + ' | select(.body | contains("-*- Mergify Payload -*-"))'
+      + ' | {date: .created_at[0:10], kind: "mergify_dequeue",'
+      + ' title: ("mergify event " + (.html_url // "")),'
+      + ' url: (.html_url // ""), body: (.body // "")[0:1200]}]',
+    ],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    log(`gh mergify comment fetch warning: ${(result.stderr || result.stdout || '').slice(0, 200)}`);
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(result.stdout || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function fetchSourceActivity(source, sinceIso) {
+  const fixture = loadActivityFixture();
+  if (fixture) {
+    const rows = fixture[source.repoUrl] ?? fixture[sourceOwnerRepo(source.repoUrl) ?? ''] ?? [];
+    return rows.filter((row) => !row.date || row.date >= sinceIso.slice(0, 10));
+  }
+
+  const ownerRepo = sourceOwnerRepo(source.repoUrl);
+  const out = [];
+  out.push(...readJsonlLedgerActivity(defaultAdminBypassLedgerPath(), sinceIso));
+  if (ownerRepo) {
+    out.push(...fetchMergifyComments(ownerRepo, sinceIso));
+  } else {
+    log(`skip unparseable source url for gh comments: ${source.repoUrl}`);
+  }
+  return out;
+}
+
+function selectCandidates(activity, { maxCandidates, ledger }) {
+  const selected = [];
+  const seenThisTick = new Set();
+  for (const row of activity) {
+    const title = String(row.title ?? '').trim();
+    if (!title) continue;
+    const fp = fingerprint(`${row.kind ?? ''}:${title}`);
+    if (ledger.fingerprints[fp] || seenThisTick.has(fp)) continue;
+    seenThisTick.add(fp);
+    selected.push({
+      id: `c${selected.length + 1}`,
+      fingerprint: fp,
+      kind: row.kind ?? 'event',
+      title,
+      url: row.url ?? '',
+      date: row.date ?? '',
+      body: row.body ?? '',
+    });
+    if (selected.length >= maxCandidates) break;
+  }
+  return selected;
+}
+
+function researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+  const candidate = slot.candidate;
+  const noop = !candidate;
+  return [
+    'You are researching whether a Mergify/admin-bypass queue event warrants a durable improvement in the target repo.',
+    'Do not implement product code. Do not open PRs. Do not mutate the merge queue. Do not label Linear tickets invoker-ready.',
+    noop
+      ? 'No candidate was assigned to this slot. Write a JSON artifact with verdict skip and title "noop-slot", then exit.'
+      : `Candidate: ${candidate.title}`,
+    `Source queue/ledger: ${sourceRepoUrl}`,
+    `Target checkout: ${targetRepoUrl}`,
+    candidate ? `Evidence URL: ${candidate.url}` : '',
+    candidate ? `Event snippet: ${String(candidate.body).slice(0, 800)}` : '',
+    'Judge steal vs skip:',
+    '- steal = durable throughput/correctness/less-thrash improvement (flake quarantine, batch-vs-individual failure, repair looping on the alarm not the gate, missing test coverage of the repair subsystem, etc.).',
+    '- skip = noise, already fixed, or already handled correctly by pr-admin-bypass-land.',
+    `Write artifact JSON to ${artifactDir}/research-${slot.index}.json with fields:`,
+    'title, verdict (steal|skip), repo, goal, motivation, safetyInvariant, verify,',
+    'reviewClaim, reviewLane, sliceRationale, architecturalEffect, alternatives,',
+    'implementationDetails, nonGoals, files, changeTypes, acceptanceCriteria,',
+    'layer, featureState, evidence.',
+    'repo must be the target repo URL. verify must be a runnable command.',
+    'Justify good vs bad with target greps of scripts/mergify_admin_requeue*.py, .mergify.yml, and related workers.',
+  ].filter(Boolean).join('\n');
+}
+
+function buildDiscoverWorkflow({ targetRepoUrl, sourceRepoUrl, candidatesPath, lookbackDays }) {
+  return `name: "mergify-queue-research discover ${slugify(sourceOwnerRepo(sourceRepoUrl) ?? sourceRepoUrl)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+
+tasks:
+  - id: discover-candidates
+    description: |
+      Persist mined Mergify queue candidates for the research swarm.
+      Goal: Write candidates.json for ${sourceRepoUrl} lookback ${lookbackDays}d.
+      Motivation: Downstream research tasks need a stable candidate list.
+      Safety invariant: This task only writes planning artifacts under ${candidatesPath}; no product code.
+    command: "test -f ${candidatesPath} && python3 -c \\"import json; d=json.load(open('${candidatesPath}')); assert isinstance(d.get('candidates'), list)\\""
+    dependencies: []
+`;
+}
+
+function buildResearchWorkflow({
+  targetRepoUrl,
+  sourceRepoUrl,
+  artifactDir,
+  slots,
+  upstreamToken,
+}) {
+  const tasks = slots.map((slot) => {
+    const deps = [];
+    return `  - id: research-${slot.index}
+    description: |
+      Research Mergify queue candidate slot ${slot.index} for steal vs skip.
+      Goal: Produce research-${slot.index}.json with plan-to-invoker fields.
+      Motivation: Human triage needs full Goal/Motivation/Safety/Verify before invoker-ready.
+      Safety invariant: No product commits; artifact write only under ${artifactDir}; no queue mutation.
+      Review claim: The artifact records a justified steal or skip verdict for this queue event.
+      Review lane: docs
+      Slice rationale: One candidate per parallel research slot.
+      Architectural effect: None; research-only.
+      Alternative considerations: In-process classification was rejected; swarm research is required.
+      Implementation details: Grep mergify scripts and workers; write the artifact JSON.
+      Non-goals: No Linear create here; no product implementation; no requeue/merge.
+      Files: ${artifactDir}/research-${slot.index}.json
+      Change types: docs
+      Acceptance criteria:
+      - Artifact JSON exists with Goal, Motivation, Safety invariant, Verify, Verdict
+      Layer: docs
+      Feature state: active
+    prompt: |
+${researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir).split('\n').map((l) => `      ${l}`).join('\n')}
+    dependencies: ${JSON.stringify(deps)}
+`;
+  }).join('\n');
+
+  return `name: "mergify-queue-research research ${slugify(sourceOwnerRepo(sourceRepoUrl) ?? sourceRepoUrl)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+externalDependencies:
+  - workflowId: "${upstreamToken}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: completed
+
+tasks:
+${tasks}
+`;
+}
+
+function buildFileLinearWorkflow({
+  targetRepoUrl,
+  artifactDir,
+  slotCount,
+  upstreamToken,
+}) {
+  const fileCommands = [];
+  for (let i = 1; i <= slotCount; i += 1) {
+    fileCommands.push(
+      `if [ -f ${artifactDir}/research-${i}.json ]; then `
+      + `node scripts/linear-issue-create.mjs --artifact ${artifactDir}/research-${i}.json; `
+      + 'fi',
+    );
+  }
+  const command = fileCommands.join(' && ');
+
+  return `name: "mergify-queue-research file-linear ${slugify(artifactDir)}"
+onFinish: none
+mergeMode: no_op
+repoUrl: ${yamlQuote(targetRepoUrl)}
+externalDependencies:
+  - workflowId: "${upstreamToken}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: completed
+
+tasks:
+  - id: file-linear-tickets
+    description: |
+      Create Linear tickets from Mergify queue research artifacts.
+      Goal: File one Linear issue per research artifact (unlabeled steal, idea-skip for skip).
+      Motivation: Tickets must be triage-ready with plan-to-invoker fields.
+      Safety invariant: Never adds invoker-ready; Linear key stays in env/secrets only.
+    command: ${yamlQuote(command)}
+    dependencies: []
+`;
+}
+
+export function generateChainForPair({
+  targetRepoUrl,
+  source,
+  candidates,
+  workDir,
+  teamId,
+  maxCandidates,
+}) {
+  const ownerRepo = sourceOwnerRepo(source.repoUrl) ?? slugify(source.repoUrl);
+  const watermark = new Date().toISOString().replace(/[:.]/g, '-');
+  const runDir = join(workDir, 'runs', slugify(ownerRepo), watermark);
+  mkdirSync(runDir, { recursive: true });
+
+  const candidatesPath = join(runDir, 'candidates.json');
+  const capped = candidates.slice(0, maxCandidates);
+  writeFileSync(candidatesPath, `${JSON.stringify({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    lookbackDays: source.lookbackDays,
+    candidates: capped,
+  }, null, 2)}\n`);
+
+  const slots = [];
+  for (let i = 1; i <= maxCandidates; i += 1) {
+    slots.push({ index: i, candidate: capped[i - 1] ?? null });
+  }
+
+  const discoverPath = join(runDir, '01-discover.yaml');
+  const researchPath = join(runDir, '02-research.template.yaml');
+  const filePath = join(runDir, '03-file-linear.template.yaml');
+
+  writeFileSync(discoverPath, buildDiscoverWorkflow({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    candidatesPath,
+    lookbackDays: source.lookbackDays,
+  }));
+  writeFileSync(researchPath, buildResearchWorkflow({
+    targetRepoUrl,
+    sourceRepoUrl: source.repoUrl,
+    artifactDir: runDir,
+    slots,
+    upstreamToken: '__UPSTREAM_WORKFLOW_ID__',
+  }));
+  writeFileSync(filePath, buildFileLinearWorkflow({
+    targetRepoUrl,
+    artifactDir: runDir,
+    slotCount: maxCandidates,
+    upstreamToken: '__UPSTREAM_WORKFLOW_ID__',
+  }));
+
+  return {
+    runDir,
+    candidatesPath,
+    plans: [discoverPath, researchPath, filePath],
+    fingerprints: capped.map((c) => c.fingerprint),
+  };
+}
+
+function submitChain(plans, { dryRun, submitCmd }) {
+  if (dryRun || env('INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY') === '1') {
+    log(`dry-run/generate-only chain: ${plans.join(' ')}`);
+    return { status: 0, stdout: plans.join('\n') };
+  }
+  const cmd = submitCmd || join(REPO_ROOT, 'scripts/submit-workflow-chain.sh');
+  const result = spawnSync('bash', [cmd, '--gate-policy', 'completed', ...plans], {
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error(`submit chain failed: ${result.stderr || result.stdout}`);
+  }
+  return result;
+}
+
+export function runMergifyQueueResearchWatch(options = {}) {
+  const config = options.config ?? loadOwnerConfig();
+  const mergifyQueueResearch = config.mergifyQueueResearch ?? {};
+  const pairs = normalizeMaps(mergifyQueueResearch);
+  const workDir = options.workDir
+    ?? env('INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR')
+    ?? join(homedir(), '.invoker', 'mergify-queue-research');
+  const dryRun = options.dryRun ?? env('INVOKER_MERGIFY_QUEUE_RESEARCH_DRY_RUN', '0') === '1';
+  const maxCandidates = mergifyQueueResearch.maxCandidatesPerSource ?? DEFAULT_MAX_CANDIDATES;
+  const teamId = mergifyQueueResearch.linearTeamId ?? env('INVOKER_LINEAR_TEAM_ID');
+  const ledger = readLedger(workDir);
+
+  if (pairs.length === 0) {
+    log('no mergifyQueueResearch.maps configured; no-op');
+    return { submitted: 0, pairs: 0 };
+  }
+  if (!teamId) {
+    throw new Error('mergifyQueueResearch.linearTeamId (or INVOKER_LINEAR_TEAM_ID) is required');
+  }
+
+  let submitted = 0;
+  for (const pair of pairs) {
+    for (const source of pair.sources) {
+      const since = new Date(Date.now() - source.lookbackDays * 86400000).toISOString();
+      const activity = fetchSourceActivity(source, since);
+      const candidates = selectCandidates(activity, { maxCandidates, ledger });
+      if (candidates.length === 0) {
+        log(`no new candidates for ${source.repoUrl} (lookback ${source.lookbackDays}d)`);
+        ledger.watermarks[source.repoUrl] = since;
+        continue;
+      }
+      log(`mining ${candidates.length} candidate(s) from ${source.repoUrl} → ${pair.targetRepoUrl}`);
+      const chain = generateChainForPair({
+        targetRepoUrl: pair.targetRepoUrl,
+        source,
+        candidates,
+        workDir,
+        teamId,
+        maxCandidates,
+      });
+      submitChain(chain.plans, {
+        dryRun,
+        submitCmd: options.submitCmd ?? env('INVOKER_MERGIFY_QUEUE_RESEARCH_SUBMIT_CMD'),
+      });
+      for (const fp of chain.fingerprints) {
+        ledger.fingerprints[fp] = {
+          at: new Date().toISOString(),
+          source: source.repoUrl,
+          target: pair.targetRepoUrl,
+        };
+      }
+      ledger.watermarks[source.repoUrl] = since;
+      submitted += 1;
+    }
+  }
+
+  writeLedger(workDir, ledger);
+  return { submitted, pairs: pairs.length };
+}
+
+function main() {
+  const result = runMergifyQueueResearchWatch();
+  log(`done submitted=${result.submitted} pairs=${result.pairs}`);
+}
+
+function samePath(a, b) {
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return resolve(a) === resolve(b);
+  }
+}
+
+const isDirect = Boolean(process.argv[1] && samePath(process.argv[1], fileURLToPath(import.meta.url)));
+if (isDirect) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/mergify-queue-research-watch.sh
+++ b/scripts/mergify-queue-research-watch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Cron/worker entrypoint for mergify-queue-research watch. Lock + log only;
+# logic lives in scripts/mergify-queue-research-watch.mjs.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK="${INVOKER_MERGIFY_QUEUE_RESEARCH_LOCK:-${TMPDIR:-/tmp}/invoker-mergify-queue-research-watch.lock}"
+
+log_line() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    log_line "mergify-queue-research-watch already running; exiting"
+    exit 0
+  fi
+else
+  lockdir="${LOCK}.d"
+  if [ -d "$lockdir" ]; then
+    holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lockdir" 2>/dev/null || true
+    fi
+  fi
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    log_line "mergify-queue-research-watch already running; exiting"
+    exit 0
+  fi
+  printf '%s\n' "$$" > "$lockdir/pid"
+  # shellcheck disable=SC2064
+  trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
+fi
+
+log_line "mergify-queue-research-watch sweep starting"
+if node "$REPO_ROOT/scripts/mergify-queue-research-watch.mjs"; then
+  log_line "mergify-queue-research-watch sweep finished"
+else
+  status=$?
+  log_line "mergify-queue-research-watch sweep failed (exit $status)"
+  exit "$status"
+fi

--- a/scripts/test-mergify-queue-research-watch.sh
+++ b/scripts/test-mergify-queue-research-watch.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Fixture tests for mergify-queue-research watch + linear-issue-create (no network).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SANDBOXES=()
+cleanup() {
+  local d
+  for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+mk_sb() {
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-mergify-queue-research.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/work" "$sb/bin"
+}
+
+# ── A. Empty lookback / no activity → no chain ───────────────────────────────
+mk_sb
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/Neko-Catpital-Labs/Invoker.git": []
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "mergifyQueueResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        { "repoUrl": "https://github.com/Neko-Catpital-Labs/Invoker.git", "lookbackDays": 30 }
+      ]
+    }
+  }
+}
+JSON
+log="$sb/a.log"
+env \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/mergify-queue-research-watch.mjs" > "$log" 2>&1 \
+  || fail "A: watch should exit 0" "$log"
+grep -q "no new candidates" "$log" || fail "A: expected no-candidates log" "$log"
+test "$(find "$sb/work/runs" -name '*.yaml' 2>/dev/null | wc -l | tr -d ' ')" = "0" \
+  || fail "A: must not write chain yaml when empty" "$log"
+echo "PASS A: empty activity → no chain"
+
+# ── B. New queue event → chain YAML with K research slots ────────────────────
+mk_sb
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+    {
+      "date": "2026-08-20",
+      "kind": "requeue",
+      "title": "requeue PR #9403 check=required-fast / Guardrails",
+      "url": "https://github.com/Neko-Catpital-Labs/Invoker/pull/9403",
+      "body": "{\"kind\":\"requeue\",\"pr\":9403,\"key\":\"required-fast / Guardrails\"}"
+    }
+  ]
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "mergifyQueueResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        { "repoUrl": "https://github.com/Neko-Catpital-Labs/Invoker.git", "lookbackDays": 30 }
+      ]
+    }
+  }
+}
+JSON
+log="$sb/b.log"
+env \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/mergify-queue-research-watch.mjs" > "$log" 2>&1 \
+  || fail "B: watch should exit 0" "$log"
+research="$(find "$sb/work/runs" -name '02-research.template.yaml' | head -1)"
+test -n "$research" || fail "B: missing research template" "$log"
+grep -q "id: research-1" "$research" || fail "B: missing research-1" "$research"
+grep -q "id: research-3" "$research" || fail "B: expected K=3 slots" "$research"
+grep -q "onFinish: none" "$research" || fail "B: research must be onFinish none" "$research"
+file_lin="$(find "$sb/work/runs" -name '03-file-linear.template.yaml' | head -1)"
+grep -q "linear-issue-create.mjs" "$file_lin" || fail "B: file-linear must call create script" "$file_lin"
+grep -vq "invoker-ready" "$file_lin" || fail "B: must not mention invoker-ready" "$file_lin"
+echo "PASS B: queue event → chain with K slots"
+
+# ── C. Duplicate fingerprint → skip ──────────────────────────────────────────
+mk_sb
+fp="$(node -e "const c=require('crypto');console.log(c.createHash('sha256').update('requeue:requeue PR #9403 check=required-fast / Guardrails'.trim().toLowerCase()).digest('hex').slice(0,16))")"
+mkdir -p "$sb/work"
+cat > "$sb/work/ledger.json" <<JSON
+{ "fingerprints": { "$fp": { "at": "2026-08-01T00:00:00Z" } }, "watermarks": {} }
+JSON
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+    {
+      "date": "2026-08-20",
+      "kind": "requeue",
+      "title": "requeue PR #9403 check=required-fast / Guardrails",
+      "url": "https://example.com",
+      "body": ""
+    }
+  ]
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "mergifyQueueResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 3,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        "https://github.com/Neko-Catpital-Labs/Invoker.git"
+      ]
+    }
+  }
+}
+JSON
+log="$sb/c.log"
+env \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/mergify-queue-research-watch.mjs" > "$log" 2>&1 \
+  || fail "C: watch should exit 0" "$log"
+grep -q "no new candidates" "$log" || fail "C: expected duplicate skip" "$log"
+echo "PASS C: duplicate fingerprint skipped"
+
+# ── C2. Same fingerprint twice in one activity list → one candidate only ─────
+mk_sb
+cat > "$sb/activity.json" <<'JSON'
+{
+  "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+    {
+      "date": "2026-08-20",
+      "kind": "repair-bot-thread",
+      "title": "repair-bot-thread PR #9961 PRRT_kwDOSFkSDM6a5nT4",
+      "url": "https://example.com/a",
+      "body": "{\"kind\":\"repair-bot-thread\"}"
+    },
+    {
+      "date": "2026-08-20",
+      "kind": "repair-bot-thread",
+      "title": "repair-bot-thread PR #9961 PRRT_kwDOSFkSDM6a5nT4",
+      "url": "https://example.com/b",
+      "body": "{\"kind\":\"repair-bot-thread-settled\"}"
+    },
+    {
+      "date": "2026-08-20",
+      "kind": "requeue",
+      "title": "requeue PR #1 ready",
+      "url": "https://example.com/c",
+      "body": ""
+    }
+  ]
+}
+JSON
+cat > "$sb/config.json" <<'JSON'
+{
+  "mergifyQueueResearch": {
+    "linearTeamId": "team-test",
+    "maxCandidatesPerSource": 5,
+    "maps": {
+      "https://github.com/Neko-Catpital-Labs/Invoker.git": [
+        "https://github.com/Neko-Catpital-Labs/Invoker.git"
+      ]
+    }
+  }
+}
+JSON
+log="$sb/c2.log"
+env \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_CONFIG_JSON="$(cat "$sb/config.json")" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_ACTIVITY_FIXTURE="$sb/activity.json" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_WORK_DIR="$sb/work" \
+  INVOKER_MERGIFY_QUEUE_RESEARCH_GENERATE_ONLY=1 \
+  node "$REPO_ROOT/scripts/mergify-queue-research-watch.mjs" > "$log" 2>&1 \
+  || fail "C2: watch should exit 0" "$log"
+cands="$(find "$sb/work/runs" -name candidates.json | head -1)"
+test -n "$cands" || fail "C2: missing candidates.json" "$log"
+count="$(node -e "const d=require('$cands'); console.log(d.candidates.length)")"
+test "$count" = "2" || fail "C2: expected 2 unique fingerprints, got $count" "$cands"
+fps="$(node -e "const d=require('$cands'); console.log([...new Set(d.candidates.map(c=>c.fingerprint))].length)")"
+test "$fps" = "2" || fail "C2: candidate fingerprints must be unique" "$cands"
+echo "PASS C2: within-tick fingerprint dedupe"
+
+# ── D. linear-issue-create steal body + skip label; never invoker-ready ───────
+mk_sb
+cat > "$sb/steal.json" <<'JSON'
+{
+  "title": "Quarantine batch-only Guardrails flake",
+  "verdict": "steal",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "Stop speculative-draft-only Guardrails failures from thrashing admin-bypass",
+  "motivation": "Same check fails on queue draft but passes on the individual PR",
+  "safetyInvariant": "Individual PR required-check policy unchanged",
+  "verify": "bash scripts/test-mergify-queue-research-watch.sh",
+  "reviewClaim": "Document and quarantine the batch-only failure signature",
+  "reviewLane": "policy",
+  "evidence": "requeue PR #9403"
+}
+JSON
+cat > "$sb/skip.json" <<'JSON'
+{
+  "title": "Skip already-capped requeue",
+  "verdict": "skip",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "Do not file a ticket for a normal capped requeue",
+  "motivation": "pr-admin-bypass-land already handles this correctly",
+  "safetyInvariant": "No product change; documentation of skip only",
+  "verify": "test -f scripts/mergify_admin_requeue.py",
+  "evidence": "requeue ledger row within retry cap"
+}
+JSON
+cat > "$sb/bin/create-stub" <<STUB
+#!/usr/bin/env bash
+cat >> "$sb/creates.jsonl"
+echo >> "$sb/creates.jsonl"
+echo '{"id":"stub","identifier":"STUB-1"}'
+STUB
+chmod +x "$sb/bin/create-stub"
+
+log="$sb/d-steal.log"
+env \
+  INVOKER_LINEAR_DRY_RUN=0 \
+  INVOKER_LINEAR_CREATE_CMD="$sb/bin/create-stub" \
+  INVOKER_LINEAR_TEAM_ID=team-test \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/steal.json" > "$log" 2>&1 \
+  || fail "D-steal: create should exit 0" "$log"
+grep -q "Goal:" "$sb/creates.jsonl" || fail "D-steal: body missing Goal" "$sb/creates.jsonl"
+grep -q "Motivation:" "$sb/creates.jsonl" || fail "D-steal: body missing Motivation" "$sb/creates.jsonl"
+grep -q "Safety invariant:" "$sb/creates.jsonl" || fail "D-steal: body missing Safety" "$sb/creates.jsonl"
+grep -q "Verify:" "$sb/creates.jsonl" || fail "D-steal: body missing Verify" "$sb/creates.jsonl"
+grep -vq "invoker-ready" "$sb/creates.jsonl" || fail "D-steal: must not include invoker-ready" "$sb/creates.jsonl"
+
+: > "$sb/creates.jsonl"
+log="$sb/d-skip.log"
+env \
+  INVOKER_LINEAR_DRY_RUN=0 \
+  INVOKER_LINEAR_CREATE_CMD="$sb/bin/create-stub" \
+  INVOKER_LINEAR_TEAM_ID=team-test \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/skip.json" > "$log" 2>&1 \
+  || fail "D-skip: create should exit 0" "$log"
+grep -vq "invoker-ready" "$sb/creates.jsonl" || fail "D-skip: must not include invoker-ready" "$sb/creates.jsonl"
+grep -q "labels=idea-skip" "$log" || fail "D-skip: expected idea-skip in log" "$log"
+echo "PASS D: create body fields + idea-skip; no invoker-ready"
+
+# ── E. Refuse invoker-ready label ────────────────────────────────────────────
+mk_sb
+cat > "$sb/bad.json" <<'JSON'
+{
+  "title": "Bad",
+  "verdict": "steal",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "g",
+  "motivation": "m",
+  "safetyInvariant": "s",
+  "verify": "true"
+}
+JSON
+log="$sb/e.log"
+if env INVOKER_LINEAR_LABEL_NAMES=invoker-ready INVOKER_LINEAR_DRY_RUN=1 \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/bad.json" > "$log" 2>&1; then
+  fail "E: must refuse invoker-ready label" "$log"
+fi
+grep -qi "Refusing\|invoker-ready" "$log" || fail "E: expected refusal message" "$log"
+echo "PASS E: refuses invoker-ready"
+
+echo "All mergify-queue-research fixture tests passed."


### PR DESCRIPTION
## Summary

Adds watch and Linear filing scripts that mine Mergify/admin-bypass ledger events and build a mine→research→file-linear chain.

Fixture mode writes plans without network or Invoker submit.

Created tickets stay unlabeled for steal candidates. Decline outcomes use the idea-skip Linear label. The scripts refuse the invoker-ready label.

Within-tick fingerprint dedupe prevents settled twin rows from burning two research slots.

## Review Claim

Approve the offline mining chain generator and Linear create helper, including the label rules and fingerprint dedupe.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Mining workflows are generated with `onFinish: none`. Scripts never apply the `invoker-ready` label. `GENERATE_ONLY` / fixtures never call `gh` writes or Linear.

## Slice Rationale

Scripts are the offline mining surface and should review without process registration or UI copy.

## Non-goals

Does not register the built-in worker, change app config shape, or add workers-panel UI strings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-mergify-queue-research-watch.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
