### PR TITLE
[mergify-queue-research](4) Add mergify-queue-research worker display copy

### DIFF
--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -120,6 +120,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No cross-repo-research runs recorded yet.',
     };
   }
+  if (kind === 'mergify-queue-research') {
+    return {
+      name: 'Mergify queue research',
+      idleText: 'Idle. Mines Mergify/admin-bypass ledger events and submits a research-swarm → Linear chain when turned on.',
+      noActionText: 'No mergify-queue-research runs recorded yet.',
+    };
+  }
   return {
     name: formatWorkerValue(kind),
     idleText: 'Idle. Waiting for worker-owned work.',


### PR DESCRIPTION
## Summary

Adds Workers-panel display copy for the `mergify-queue-research` kind.

The idle text describes the mine→research→Linear chain. No process start or stop behavior changes.

## Review Claim

Approve naming the kind and describing mine→research→Linear idle state in the Workers panel.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Display strings only; no process start/stop change.

## Slice Rationale

Workers-panel copy reviews separately from registration and scripts.

## Non-goals

Does not change worker scheduling, config validation, or mining scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "mergify-queue-research" packages/ui/src/lib/worker-display.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display support for the Mergify queue research worker, including its name, activity status, and no-action message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->