### PR TITLE
[catstack-deploy](1) Add catstack-deploy builtin worker with host-isolated clone/pull/install

### DIFF
--- a/packages/execution-engine/src/__tests__/catstack-deploy-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/catstack-deploy-worker.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildCatstackDeployScript,
+  createCatstackDeployWorker,
+  DEFAULT_CATSTACK_DEPLOY_INTERVAL_MS,
+  DEFAULT_CATSTACK_REPO_PATH,
+  DEFAULT_CATSTACK_REPO_URL,
+  expandLocalRepoPath,
+  runCatstackDeployTick,
+  type CatstackDeployTarget,
+  type CatstackDeployWorkerOptions,
+} from '../workers/catstack-deploy-worker.js';
+import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as CatstackDeployWorkerOptions['logger'];
+}
+
+function makeTarget(name: string): CatstackDeployTarget {
+  return {
+    name,
+    connection: { host: `${name}.example.test`, user: 'invoker', sshKeyPath: '/tmp/key' },
+  };
+}
+
+function makeStore(): { store: WorkerDecisionStore; rows: { subjectId: string; status: string }[] } {
+  const rows: { subjectId: string; status: string }[] = [];
+  return {
+    rows,
+    store: {
+      getWorkerAction: () => undefined,
+      upsertWorkerAction: (action) => {
+        rows.push({ subjectId: action.subjectId, status: action.status });
+        return action as never;
+      },
+    },
+  };
+}
+
+describe('buildCatstackDeployScript', () => {
+  it('clones when missing, ff-only pulls when present, and runs install.sh without --force', () => {
+    const script = buildCatstackDeployScript('~/Documents/GitHub/catstack', DEFAULT_CATSTACK_REPO_URL);
+    expect(script).toContain('git clone');
+    expect(script).toContain('git merge --ff-only');
+    expect(script).toContain('./install.sh');
+    expect(script).not.toMatch(/\.\/install\.sh[^\n]*--force/);
+    expect(script).not.toContain('--with-session-mine');
+    expect(script).not.toContain('--with-dora-snapshot');
+    expect(script).toContain('git status --porcelain');
+  });
+});
+
+describe('expandLocalRepoPath', () => {
+  it('expands a leading tilde', () => {
+    const expanded = expandLocalRepoPath('~/Documents/GitHub/catstack');
+    expect(expanded.endsWith('/Documents/GitHub/catstack')).toBe(true);
+    expect(expanded.startsWith('~')).toBe(false);
+  });
+});
+
+describe('runCatstackDeployTick', () => {
+  it('deploys local then every remote target', async () => {
+    const deployLocal = vi.fn(async () => undefined);
+    const deployRemote = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    await runCatstackDeployTick({
+      logger: makeLogger(),
+      repoUrl: DEFAULT_CATSTACK_REPO_URL,
+      localRepoPath: DEFAULT_CATSTACK_REPO_PATH,
+      remoteRepoPath: DEFAULT_CATSTACK_REPO_PATH,
+      remoteTargets: [makeTarget('do1'), makeTarget('do2')],
+      store,
+      deployLocal,
+      deployRemote,
+    });
+
+    expect(deployLocal).toHaveBeenCalledTimes(1);
+    expect(deployLocal.mock.calls[0]?.[1]).toBe(DEFAULT_CATSTACK_REPO_URL);
+    expect(deployRemote).toHaveBeenCalledTimes(2);
+    expect(rows.map((r) => r.subjectId)).toEqual(['local', 'do1', 'do2']);
+    expect(rows.every((r) => r.status === 'completed')).toBe(true);
+  });
+
+  it('continues remaining hosts when local or a remote fails, and skips install on that host only via the deploy seam', async () => {
+    const deployLocal = vi.fn(async () => {
+      throw new Error('dirty working tree');
+    });
+    const deployRemote = vi.fn(async (target) => {
+      if (target.name === 'do1') throw new Error('merge --ff-only rejected');
+    });
+    const { store, rows } = makeStore();
+
+    await runCatstackDeployTick({
+      logger: makeLogger(),
+      repoUrl: DEFAULT_CATSTACK_REPO_URL,
+      localRepoPath: '/tmp/catstack',
+      remoteRepoPath: '~/Documents/GitHub/catstack',
+      remoteTargets: [makeTarget('do1'), makeTarget('do2')],
+      store,
+      deployLocal,
+      deployRemote,
+    });
+
+    expect(deployLocal).toHaveBeenCalledTimes(1);
+    expect(deployRemote).toHaveBeenCalledTimes(2);
+    const statuses = Object.fromEntries(rows.map((r) => [r.subjectId, r.status]));
+    expect(statuses).toEqual({
+      local: 'failed',
+      do1: 'failed',
+      do2: 'completed',
+    });
+  });
+
+  it('passes expanded local path and configured remote path to deploy seams', async () => {
+    const deployLocal = vi.fn(async () => undefined);
+    const deployRemote = vi.fn(async () => undefined);
+
+    await runCatstackDeployTick({
+      logger: makeLogger(),
+      repoUrl: 'https://github.com/EdbertChan/catstack.git',
+      localRepoPath: '~/Documents/GitHub/catstack',
+      remoteRepoPath: '~/Documents/GitHub/catstack',
+      remoteTargets: [makeTarget('do1')],
+      deployLocal,
+      deployRemote,
+    });
+
+    expect(deployLocal.mock.calls[0]?.[0]).toBe(expandLocalRepoPath('~/Documents/GitHub/catstack'));
+    expect(deployRemote.mock.calls[0]?.[1]).toBe('~/Documents/GitHub/catstack');
+  });
+});
+
+describe('createCatstackDeployWorker', () => {
+  it('uses the default fifteen-minute interval', () => {
+    const worker = createCatstackDeployWorker({
+      logger: makeLogger(),
+      onTick: async () => undefined,
+      tickOnStart: false,
+    });
+    expect(worker.identity.kind).toBe('catstack-deploy');
+    expect(DEFAULT_CATSTACK_DEPLOY_INTERVAL_MS).toBe(15 * 60 * 1000);
+    worker.stop();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -29,6 +29,7 @@ import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
 import { SLACK_BUG_SCAN_WORKER_KIND } from '../workers/slack-bug-scan-worker.js';
 import { IDLE_TASK_CLEANUP_WORKER_KIND } from '../workers/idle-task-cleanup-worker.js';
 import { CROSS_REPO_RESEARCH_WORKER_KIND } from '../workers/cross-repo-research-worker.js';
+import { CATSTACK_DEPLOY_WORKER_KIND } from '../workers/catstack-deploy-worker.js';
 
 const silentLogger = {
   debug: () => {},
@@ -93,6 +94,7 @@ describe('worker registry', () => {
       SLACK_BUG_SCAN_WORKER_KIND,
       IDLE_TASK_CLEANUP_WORKER_KIND,
       CROSS_REPO_RESEARCH_WORKER_KIND,
+      CATSTACK_DEPLOY_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(REQUEUE_WORKER_KIND)).toBeDefined();
@@ -112,6 +114,7 @@ describe('worker registry', () => {
     expect(registry.get(SLACK_BUG_SCAN_WORKER_KIND)).toBeDefined();
     expect(registry.get(IDLE_TASK_CLEANUP_WORKER_KIND)).toBeDefined();
     expect(registry.get(CROSS_REPO_RESEARCH_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CATSTACK_DEPLOY_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -14,6 +14,7 @@ import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerSlackBugScanWorker } from './workers/slack-bug-scan-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 import { registerCrossRepoResearchWorker } from './workers/cross-repo-research-worker.js';
+import { registerCatstackDeployWorker } from './workers/catstack-deploy-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
 export function registerBuiltinWorkers(
@@ -33,5 +34,6 @@ export function registerBuiltinWorkers(
   registerSlackBugScanWorker(registry);
   registerIdleTaskCleanupWorker(registry);
   registerCrossRepoResearchWorker(registry);
+  registerCatstackDeployWorker(registry);
   return registry;
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -82,6 +82,7 @@ export * from './workers/idle-task-cleanup-policy.js';
 export * from './workers/idle-task-cleanup-worker.js';
 export * from './workers/e2e-autofix-worker.js';
 export * from './workers/cross-repo-research-worker.js';
+export * from './workers/catstack-deploy-worker.js';
 export * from './workers/reaper-worker.js';
 export * from './workers/requeue-worker.js';
 export * from './workers/workflow-resume-worker.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -20,6 +20,7 @@ import type { ClaudeOauthRefreshWorkerConfig } from './workers/claude-oauth-refr
 import type { DiskHeadroomWorkerStore } from './workers/disk-headroom-reclaim.js';
 import type { SlackBugScanWorkerConfig } from './workers/slack-bug-scan-worker.js';
 import type { CrossRepoResearchWorkerConfig } from './workers/cross-repo-research-worker.js';
+import type { CatstackDeployWorkerConfig } from './workers/catstack-deploy-worker.js';
 import type {
   InfraRepairWorkerConfig,
   InfraRepairWorkerStore,
@@ -85,6 +86,8 @@ export interface WorkerRuntimeDependencies {
   slackBugScan?: SlackBugScanWorkerConfig;
   /** Cross-repo research worker configuration. */
   crossRepoResearch?: CrossRepoResearchWorkerConfig;
+  /** Catstack deploy worker configuration (local + remoteTargets clone/pull/install). */
+  catstackDeploy?: CatstackDeployWorkerConfig;
   /** Idle-task-cleanup worker configuration (dry-run only; see the worker's own docs). */
   idleTaskCleanup?: IdleTaskCleanupWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/catstack-deploy-worker.ts
+++ b/packages/execution-engine/src/workers/catstack-deploy-worker.ts
@@ -1,0 +1,253 @@
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+import type { Logger } from '@invoker/contracts';
+
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
+import { buildSshConnectionArgs, type SshTargetConnection } from '../ssh-transport-options.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const CATSTACK_DEPLOY_WORKER_KIND = 'catstack-deploy';
+export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
+export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MS = DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES * 60 * 1000;
+export const DEFAULT_CATSTACK_REPO_URL = 'https://github.com/EdbertChan/catstack.git';
+export const DEFAULT_CATSTACK_REPO_PATH = '~/Documents/GitHub/catstack';
+
+export interface CatstackDeployTarget {
+  name: string;
+  connection: SshTargetConnection;
+}
+
+export interface CatstackDeployWorkerConfig {
+  /** Poll cadence in milliseconds. Defaults to fifteen minutes. */
+  intervalMs?: number;
+  /** Git clone URL. Defaults to EdbertChan/catstack. */
+  repoUrl?: string;
+  /** Local checkout path (tilde expanded). Defaults to ~/Documents/GitHub/catstack. */
+  localRepoPath?: string;
+  /** Remote checkout path on each SSH host. Defaults to ~/Documents/GitHub/catstack. */
+  remoteRepoPath?: string;
+  remoteTargets?: CatstackDeployTarget[];
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  /** Test seam: override local deploy. */
+  deployLocal?: (repoPath: string, repoUrl: string) => Promise<void>;
+  /** Test seam: override remote deploy. */
+  deployRemote?: (target: CatstackDeployTarget, repoPath: string, repoUrl: string) => Promise<void>;
+  onTick?: WorkerTick;
+}
+
+export interface CatstackDeployWorkerOptions {
+  logger: Logger;
+  intervalMs?: number;
+  repoUrl: string;
+  localRepoPath: string;
+  remoteRepoPath: string;
+  remoteTargets: CatstackDeployTarget[];
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  deployLocal?: (repoPath: string, repoUrl: string) => Promise<void>;
+  deployRemote?: (target: CatstackDeployTarget, repoPath: string, repoUrl: string) => Promise<void>;
+  onTick?: WorkerTick;
+}
+
+/**
+ * Expand a leading `~` for local filesystem paths. Remote paths keep `~` and
+ * expand inside the SSH shell via bashNormalizeTildePath.
+ */
+export function expandLocalRepoPath(repoPath: string): string {
+  const trimmed = repoPath.trim();
+  if (trimmed === '~') return homedir();
+  if (trimmed.startsWith('~/')) return resolve(homedir(), trimmed.slice(2));
+  return resolve(trimmed);
+}
+
+/**
+ * Portable shell that clone-or-ff-only-pulls catstack then runs ./install.sh
+ * with no --force / launchd extras. Dirty or diverged trees exit non-zero
+ * before install.sh so the caller can skip that host.
+ */
+export function buildCatstackDeployScript(repoPath: string, repoUrl: string): string {
+  const pathQ = shellPosixSingleQuote(repoPath);
+  const urlQ = shellPosixSingleQuote(repoUrl);
+  return `set -euo pipefail
+REPO_PATH=${pathQ}
+REPO_URL=${urlQ}
+${bashNormalizeTildePath('REPO_PATH')}
+if [ ! -d "$REPO_PATH/.git" ]; then
+  mkdir -p "$(dirname "$REPO_PATH")"
+  git clone "$REPO_URL" "$REPO_PATH"
+else
+  cd "$REPO_PATH"
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "catstack-deploy: dirty working tree at $REPO_PATH; skipping install" >&2
+    exit 1
+  fi
+  git fetch origin
+  if git rev-parse --verify refs/remotes/origin/HEAD >/dev/null 2>&1; then
+    DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+  else
+    git remote set-head origin -a
+    DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+  fi
+  git checkout "$DEFAULT_BRANCH"
+  git merge --ff-only "origin/$DEFAULT_BRANCH"
+fi
+cd "$REPO_PATH"
+./install.sh
+`;
+}
+
+function assertInstallHasNoForce(script: string): void {
+  // Defense-in-depth for the safety invariant: install.sh must never receive --force.
+  if (/(?:^|[\s;])\.\/install\.sh\s+[^\n]*--force\b/m.test(script)) {
+    throw new Error('catstack-deploy: install.sh must not be invoked with --force');
+  }
+}
+
+async function runLocalBashScript(script: string): Promise<void> {
+  assertInstallHasNoForce(script);
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn('bash', ['-lc', script], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+    child.once('error', rejectPromise);
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      rejectPromise(new Error(`local catstack deploy failed (exit=${code ?? 'unknown'}): ${stderr.trim() || 'no stderr'}`));
+    });
+  });
+}
+
+async function defaultDeployLocal(repoPath: string, repoUrl: string): Promise<void> {
+  await runLocalBashScript(buildCatstackDeployScript(repoPath, repoUrl));
+}
+
+async function defaultDeployRemote(
+  target: CatstackDeployTarget,
+  repoPath: string,
+  repoUrl: string,
+): Promise<void> {
+  const script = buildCatstackDeployScript(repoPath, repoUrl);
+  assertInstallHasNoForce(script);
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  await execRemoteCapture({
+    sshArgs,
+    script,
+    phase: `catstack-deploy:${target.name}`,
+  });
+}
+
+function recordDecision(
+  store: WorkerDecisionStore | undefined,
+  subjectId: string,
+  status: 'completed' | 'failed' | 'skipped',
+  summary: string,
+  payload: Record<string, unknown> = {},
+): void {
+  if (!store) return;
+  recordWorkerDecisionRow(store, {
+    workerKind: CATSTACK_DEPLOY_WORKER_KIND,
+    actionType: 'catstack-deploy',
+    externalKey: subjectId,
+    subjectType: 'host',
+    subjectId,
+    status,
+    summary,
+    payload,
+  });
+}
+
+export async function runCatstackDeployTick(options: CatstackDeployWorkerOptions): Promise<void> {
+  const deployLocal = options.deployLocal ?? defaultDeployLocal;
+  const deployRemote = options.deployRemote ?? defaultDeployRemote;
+  const localPath = expandLocalRepoPath(options.localRepoPath);
+
+  try {
+    await deployLocal(localPath, options.repoUrl);
+    recordDecision(options.store, 'local', 'completed', `Deployed catstack at ${localPath}`);
+    options.logger.info(`[${CATSTACK_DEPLOY_WORKER_KIND}] local deploy ok`, {
+      module: CATSTACK_DEPLOY_WORKER_KIND,
+      path: localPath,
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    options.logger.error(`[${CATSTACK_DEPLOY_WORKER_KIND}] local deploy failed: ${detail}`, {
+      module: CATSTACK_DEPLOY_WORKER_KIND,
+      path: localPath,
+    });
+    recordDecision(options.store, 'local', 'failed', `Local catstack deploy failed: ${detail}`);
+  }
+
+  for (const target of options.remoteTargets) {
+    try {
+      await deployRemote(target, options.remoteRepoPath, options.repoUrl);
+      recordDecision(options.store, target.name, 'completed', `Deployed catstack on ${target.name}`);
+      options.logger.info(`[${CATSTACK_DEPLOY_WORKER_KIND}] remote deploy ok`, {
+        module: CATSTACK_DEPLOY_WORKER_KIND,
+        target: target.name,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(`[${CATSTACK_DEPLOY_WORKER_KIND}] remote deploy failed for ${target.name}: ${detail}`, {
+        module: CATSTACK_DEPLOY_WORKER_KIND,
+        target: target.name,
+      });
+      recordDecision(options.store, target.name, 'failed', `Remote catstack deploy failed: ${detail}`);
+    }
+  }
+}
+
+export function createCatstackDeployWorker(config: CatstackDeployWorkerConfig & { logger: Logger }): WorkerRuntime {
+  const options: CatstackDeployWorkerOptions = {
+    logger: config.logger,
+    intervalMs: config.intervalMs,
+    repoUrl: config.repoUrl ?? DEFAULT_CATSTACK_REPO_URL,
+    localRepoPath: config.localRepoPath ?? DEFAULT_CATSTACK_REPO_PATH,
+    remoteRepoPath: config.remoteRepoPath ?? DEFAULT_CATSTACK_REPO_PATH,
+    remoteTargets: config.remoteTargets ?? [],
+    tickOnStart: config.tickOnStart,
+    store: config.store,
+    deployLocal: config.deployLocal,
+    deployRemote: config.deployRemote,
+  };
+  const onTick: WorkerTick = config.onTick ?? (async () => {
+    await runCatstackDeployTick(options);
+  });
+  return createWorkerRuntime({
+    kind: CATSTACK_DEPLOY_WORKER_KIND,
+    logger: config.logger,
+    onTick,
+    intervalMs: config.intervalMs ?? DEFAULT_CATSTACK_DEPLOY_INTERVAL_MS,
+    tickOnStart: config.tickOnStart ?? true,
+  });
+}
+
+/** Register the built-in catstack-deploy worker. */
+export function registerCatstackDeployWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CATSTACK_DEPLOY_WORKER_KIND,
+    note: 'Clones or ff-only-pulls catstack and runs ./install.sh on the owner machine and every remoteTargets host.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCatstackDeployWorker({
+        logger: deps.logger,
+        ...deps.catstackDeploy,
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `catstack-deploy` builtin worker that clone-or-ff-only-pulls catstack and runs `./install.sh`.

Each tick covers the local machine and every SSH host, and one host failure does not stop the rest.

## Review Claim

Approve registering `catstack-deploy` as a createWorkerRuntime builtin with host-isolated deploy and no `--force`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

One host failure does not stop remaining hosts. `install.sh` never gets `--force`. Git is `--ff-only`, so a dirty or diverged checkout is skipped rather than overwritten.

## Slice Rationale

Worker implementation and registry registration are the routing claim. Later slices own config, owner wiring, UI copy, and operator guides.

## Non-goals

Does not add config fields, owner wiring, UI copy, operator guides, or always-on boot.


## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/catstack-deploy-worker.test.ts src/__tests__/worker-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
