### PR TITLE
[catstack-deploy](2) Add catstackDeploy config schema and intervalMinutes validation

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -822,6 +822,35 @@ describe('mergifyQueueResearch config', () => {
   });
 });
 
+describe('catstackDeploy config', () => {
+  it('accepts omitted catstackDeploy block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts a valid intervalMinutes and paths', () => {
+    const config = validateInvokerConfig({
+      catstackDeploy: {
+        intervalMinutes: 15,
+        repoUrl: 'https://github.com/EdbertChan/catstack.git',
+        localRepoPath: '~/Documents/GitHub/catstack',
+        remoteRepoPath: '~/Documents/GitHub/catstack',
+      },
+    });
+    expect(config.catstackDeploy?.intervalMinutes).toBe(15);
+  });
+
+  it('rejects intervalMinutes of 0', () => {
+    expect(() => validateInvokerConfig({
+      catstackDeploy: { intervalMinutes: 0 },
+    })).toThrow(/catstackDeploy.intervalMinutes must be an integer > 0/);
+  });
+
+  it('rejects non-integer intervalMinutes', () => {
+    expect(() => validateInvokerConfig({
+      catstackDeploy: { intervalMinutes: 1.5 },
+    })).toThrow(/catstackDeploy.intervalMinutes must be an integer > 0/);
+  });
+});
 
 describe('e2eAutoFix.targetRepos', () => {
   it('reads targetRepos from config', () => {

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,6 +1,7 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
 import {
   normalizeGithubOwnerRepo,
+  type CatstackDeployConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
   type InvokerConfig,
@@ -221,6 +222,39 @@ export function normalizeMergifyQueueResearchSource(
   };
 }
 
+function validateCatstackDeployConfig(config: InvokerConfig): void {
+  const catstackDeploy = config.catstackDeploy;
+  if (catstackDeploy === undefined) return;
+  if (typeof catstackDeploy !== 'object' || catstackDeploy === null || Array.isArray(catstackDeploy)) {
+    throw new Error('catstackDeploy must be an object');
+  }
+  const typed = catstackDeploy as CatstackDeployConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('catstackDeploy.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.repoUrl !== undefined) {
+    if (typeof typed.repoUrl !== 'string' || typed.repoUrl.trim().length === 0) {
+      throw new Error('catstackDeploy.repoUrl must be a non-empty string when set');
+    }
+  }
+  if (typed.localRepoPath !== undefined) {
+    if (typeof typed.localRepoPath !== 'string' || typed.localRepoPath.trim().length === 0) {
+      throw new Error('catstackDeploy.localRepoPath must be a non-empty string when set');
+    }
+  }
+  if (typed.remoteRepoPath !== undefined) {
+    if (typeof typed.remoteRepoPath !== 'string' || typed.remoteRepoPath.trim().length === 0) {
+      throw new Error('catstackDeploy.remoteRepoPath must be a non-empty string when set');
+    }
+  }
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -251,5 +285,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
+  validateCatstackDeployConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -209,6 +209,30 @@ export const DEFAULT_MERGIFY_QUEUE_RESEARCH_INTERVAL_DAYS = 14;
 /** Default max Mergify queue candidates mined per source per tick. */
 export const DEFAULT_MERGIFY_QUEUE_RESEARCH_MAX_CANDIDATES_PER_SOURCE = 5;
 
+/**
+ * Opt-in catstack-deploy worker settings. Process on/off is SQLite
+ * `worker_desired_states`, not a config boolean.
+ */
+export interface CatstackDeployConfig {
+  /** Poll cadence in minutes. Default: 15. */
+  intervalMinutes?: number;
+  /** Git clone URL. Default: https://github.com/EdbertChan/catstack.git */
+  repoUrl?: string;
+  /** Local checkout path. Default: ~/Documents/GitHub/catstack */
+  localRepoPath?: string;
+  /** Remote checkout path on each SSH host. Default: ~/Documents/GitHub/catstack */
+  remoteRepoPath?: string;
+}
+
+/** Default poll cadence when catstackDeploy.intervalMinutes is unset. */
+export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
+
+/** Default catstack clone URL. */
+export const DEFAULT_CATSTACK_DEPLOY_REPO_URL = 'https://github.com/EdbertChan/catstack.git';
+
+/** Default local/remote checkout path for catstack. */
+export const DEFAULT_CATSTACK_DEPLOY_REPO_PATH = '~/Documents/GitHub/catstack';
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -557,6 +581,12 @@ export interface InvokerConfig {
    * Process on/off is SQLite `worker_desired_states`, not a config boolean.
    */
   mergifyQueueResearch?: MergifyQueueResearchConfig;
+  /**
+   * Catstack deploy worker: clone/pull/install cadence and paths.
+   * Process on/off is SQLite `worker_desired_states`, not a config boolean.
+   * Remotes always come from top-level `remoteTargets`.
+   */
+  catstackDeploy?: CatstackDeployConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },


### PR DESCRIPTION
## Summary

Adds the `catstackDeploy` block to Invoker config with `intervalMinutes` and path fields.

Validation rejects non-positive intervals so bad cadence cannot load.

## Review Claim

Approve the `catstackDeploy` config fields and `intervalMinutes` validation.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

No config boolean starts or stops the worker. Remotes stay on top-level `remoteTargets`. Omitting `catstackDeploy` does not auto-start it.

## Slice Rationale

Config fields are a separate validation-policy unit from the worker implementation and owner wiring.

## Non-goals

Does not register the worker, wire owner deps, change UI copy, or add operator guides.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
