### PR TITLE
[catstack-deploy](5) Add Workers UI display copy for catstack-deploy

### DIFF
--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -127,6 +127,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No mergify-queue-research runs recorded yet.',
     };
   }
+  if (kind === 'catstack-deploy') {
+    return {
+      name: 'Catstack deploy',
+      idleText: 'Idle. Clone/pulls catstack and runs ./install.sh on this machine and every remoteTargets host when turned on.',
+      noActionText: 'No catstack-deploy runs recorded yet.',
+    };
+  }
   return {
     name: formatWorkerValue(kind),
     idleText: 'Idle. Waiting for worker-owned work.',


### PR DESCRIPTION
## Summary

Adds display name and idle copy for the `catstack-deploy` worker kind in the workers panel.

Without this, the kind falls back to a formatted raw string.

## Review Claim

Approve the workers-panel copy for the `catstack-deploy` kind.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Copy-only change. It does not enable the worker, change desired-state defaults, or spawn processes.

## Slice Rationale

UI copy is a separate review unit from process registration and must not mix into the worker PR.

## Non-goals

Does not register the worker, change config, or alter deploy behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n \"catstack-deploy\" packages/ui/src/lib/worker-display.ts`

</details>

## Visual Proof

![Workers list showing Catstack deploy display name](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260826-900b7f/catstack-worker-row.png)

![Selected Catstack deploy worker detail with display copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260826-900b7f/catstack-worker-detail.png)

Manually inspected: List card titled "Catstack deploy" with kind `catstack-deploy` and the idle sentence about clone/pull and ./install.sh. Detail heading matches the same display name; status badge reads Stopped; empty-history line says "No catstack-deploy runs recorded yet."

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
