### PR TITLE
[catstack-deploy](6) Document the catstack-deploy worker and config example

### DIFF
--- a/docs/catstack-deploy-worker.md
+++ b/docs/catstack-deploy-worker.md
@@ -1,0 +1,48 @@
+# Catstack deploy worker
+
+Opt-in owner worker that every N minutes clones (if missing) or fast-forward
+pulls [catstack](https://github.com/EdbertChan/catstack) and runs `./install.sh`
+on the owner machine plus every `remoteTargets` SSH host.
+
+Process on/off is SQLite `worker_desired_states` (Workers UI / `worker toggles`).
+It is **not** in the always-on boot list.
+
+## Config (`~/.invoker/config.json`)
+
+```json
+"catstackDeploy": {
+  "intervalMinutes": 15,
+  "repoUrl": "https://github.com/EdbertChan/catstack.git",
+  "localRepoPath": "~/Documents/GitHub/catstack",
+  "remoteRepoPath": "~/Documents/GitHub/catstack"
+}
+```
+
+- `intervalMinutes` defaults to 15 (must be an integer > 0).
+- Paths default to `~/Documents/GitHub/catstack`.
+- Remotes always come from top-level `remoteTargets` (not from this block).
+- Omitting `catstackDeploy` uses the defaults above; it does **not** start the worker.
+
+## What each tick does
+
+For local, then each remote host (continue on failure):
+
+1. If the checkout has no `.git`, `git clone` the configured URL.
+2. Else: refuse dirty trees, `git fetch`, checkout origin's default branch, `git merge --ff-only`.
+3. Run `./install.sh` with **no** `--force`, `--with-session-mine`, or `--with-dora-snapshot`.
+
+A dirty or diverged checkout fails that host and skips `install.sh` there so the worker never overwrites local work.
+
+## Enable
+
+Start from the Workers UI, or:
+
+```bash
+./run.sh --headless worker start catstack-deploy
+```
+
+## Remote GitHub access
+
+Each SSH host needs its own credentials for clone/pull (HTTPS token, SSH key,
+or credential helper). Invoker only opens the SSH session; it does not
+distribute GitHub credentials for this worker.

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -119,6 +119,14 @@
     }
   },
 
+  "catstackDeploy": {
+    "comment": "Opt-in worker: every intervalMinutes, clone-or-ff-only-pull catstack and run ./install.sh on the owner machine plus every remoteTargets host. Start from Workers UI; process on/off is worker_desired_states, not this block.",
+    "intervalMinutes": 15,
+    "repoUrl": "https://github.com/EdbertChan/catstack.git",
+    "localRepoPath": "~/Documents/GitHub/catstack",
+    "remoteRepoPath": "~/Documents/GitHub/catstack"
+  },
+
   "webToken": "change-me-to-a-long-random-secret",
   "webHost": "127.0.0.1",
   "webPort": 4200,


### PR DESCRIPTION
## Summary

Documents how to enable `catstack-deploy` and what each tick does.

Also adds a `catstackDeploy` example block to the sample config file.

## Review Claim

Approve the operator docs and config example for catstack-deploy.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs and example config only. No product code, start/stop, or cadence change.

## Slice Rationale

Docs stay separate from product and activation-surface units so review stays local.

## Non-goals

Does not change worker code, config validation, or UI copy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/catstack-deploy-worker.md`
- [x] `rg -n \"catstackDeploy\" docs/invoker-config-example.json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
