### PR TITLE
[Autofix push guards](2) Exclude admin-bypass workflows from autofix and auto-approve

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -76,13 +76,13 @@ function wakeup(overrides: Partial<RecoveryWorkerWakeupHint> = {}): RecoveryWork
 function makeStore(
   tasks: TaskState[],
   openIntents: WorkflowMutationIntent[] = [],
-  workflows: Array<{ id: string; mergeMode?: string | null; onFinish?: string | null }> = [{ id: 'wf-1' }],
+  workflows: Array<{ id: string; name?: string; mergeMode?: string | null; onFinish?: string | null }> = [{ id: 'wf-1' }],
 ) {
   const workflowMap = new Map(workflows.map((workflow) => [workflow.id, workflow]));
   const actions = new Map<string, WorkerActionRecord>();
   const writes: WorkerActionWrite[] = [];
   const store: AutoApproveWorkerStore = {
-    listWorkflows: vi.fn(() => workflows.map(({ id }) => ({ id }))),
+    listWorkflows: vi.fn(() => workflows.map(({ id, name }) => ({ id, name }))),
     loadWorkflow: vi.fn((workflowId: string) => workflowMap.get(workflowId)),
     loadTasks: vi.fn(() => tasks),
     loadTask: vi.fn((taskId: string) => tasks.find((candidate) => candidate.id === taskId)),
@@ -334,6 +334,20 @@ describe('autoapprove worker', () => {
     expect(writes[0]).toMatchObject({
       status: 'skipped',
       summary: 'Skipped AI fix approval: author-not-allowlisted',
+    });
+  });
+
+  it('skips admin-bypass-* workflows even with pending fix errors', () => {
+    const { store, writes } = makeStore(
+      [task()],
+      [],
+      [{ id: 'wf-1', name: 'admin-bypass-repair-check-pr-10514-typescript-d1f1cf5' }],
+    );
+
+    expect(collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()])).toEqual([]);
+    expect(writes[0]).toMatchObject({
+      status: 'skipped',
+      summary: 'Skipped AI fix approval: admin-bypass-excluded',
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -145,6 +145,43 @@ describe('collectValidatedAutoFixRecoveryCandidates', () => {
       expect(validated, failureClass).toEqual([]);
     }
   });
+
+  it('skips admin-bypass-* workflows so normalize gates are not rubber-stamped', () => {
+    const task = makeFailedTask({
+      id: 'wf-admin/normalize',
+      config: { workflowId: 'wf-admin', command: 'python3 scripts/mergify_admin_requeue_repair_normalize.py' },
+      execution: {
+        generation: 1,
+        selectedAttemptId: 'attempt-1',
+        error: 'blocked_invalid: Review Unit routing',
+        failureClass: undefined,
+      },
+    });
+    const store = {
+      listWorkflows: vi.fn(() => [{
+        id: 'wf-admin',
+        name: 'admin-bypass-repair-check-pr-10514-build-artifacts-d1f1cf5',
+      }]),
+      loadTasks: vi.fn((workflowId: string) => (workflowId === 'wf-admin' ? [task] : [])),
+      loadTask: vi.fn((taskId: string) => (taskId === task.id ? task : undefined)),
+      listWorkflowMutationIntents: vi.fn(() => []),
+      logEvent: vi.fn(),
+    };
+    const options = {
+      store,
+      submitter: { submit: vi.fn(() => 1) },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+    };
+
+    expect(collectValidatedAutoFixRecoveryCandidates(options)).toEqual([]);
+    expect(store.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'debug.auto-fix',
+      expect.objectContaining({ phase: 'worker-autofix-skip', reason: 'admin-bypass-excluded' }),
+    );
+  });
 });
 
 describe('shouldRecreateMergeGateInsteadOfAutoFix', () => {

--- a/packages/execution-engine/src/__tests__/workflow-name-gates.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-name-gates.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAdminBypassNamedWorkflow } from '../workflow-name-gates.js';
+
+describe('isAdminBypassNamedWorkflow', () => {
+  it('matches Mergify admin-bypass plan name prefixes', () => {
+    expect(isAdminBypassNamedWorkflow('admin-bypass-repair-check-pr-1-typescript-abc1234')).toBe(true);
+    expect(isAdminBypassNamedWorkflow('admin-bypass-rebase-onto-master-pr-1-abc1234')).toBe(true);
+  });
+
+  it('rejects non-admin-bypass names', () => {
+    expect(isAdminBypassNamedWorkflow('feature-workflow')).toBe(false);
+    expect(isAdminBypassNamedWorkflow('repair-pr-1-fingerprint')).toBe(false);
+    expect(isAdminBypassNamedWorkflow(undefined)).toBe(false);
+    expect(isAdminBypassNamedWorkflow(null)).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -45,6 +45,7 @@ import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecyc
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from './worker-runtime.js';
+import { isAdminBypassNamedWorkflow } from './workflow-name-gates.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
@@ -89,7 +90,8 @@ const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 
 };
 
 export interface AutoFixRecoveryStore {
-  listWorkflows(): ReadonlyArray<{ id: string }>;
+  listWorkflows(): ReadonlyArray<{ id: string; name?: string }>;
+  loadWorkflow?(workflowId: string): { name?: string | null } | undefined;
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents(
@@ -198,6 +200,17 @@ type AutoFixCandidateSnapshotComparison =
 
 function workflowIdForTask(task: TaskState): string | undefined {
   return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function workflowNameForId(
+  options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
+  workflowId: string,
+): string | undefined {
+  const listed = options.store.listWorkflows().find((workflow) => workflow.id === workflowId);
+  if (typeof listed?.name === 'string' && listed.name.length > 0) return listed.name;
+  const loaded = options.store.loadWorkflow?.(workflowId);
+  if (typeof loaded?.name === 'string' && loaded.name.length > 0) return loaded.name;
+  return undefined;
 }
 
 function taskRefFromTask(task: TaskState): AutoFixRecoveryTaskRef | undefined {
@@ -487,6 +500,14 @@ function validateAutoFixCandidate(
     return undefined;
   }
   const latestRef = snapshotComparison.ref;
+
+  const workflowName = workflowNameForId(options, latestRef.workflowId);
+  if (isAdminBypassNamedWorkflow(workflowName)) {
+    skipAutoFixCandidate(options, candidate, 'admin-bypass-excluded', {
+      workflowName: workflowName ?? null,
+    });
+    return undefined;
+  }
 
   if (latest.status === 'failed' && FailureClassifier.isUsageLimit(latest.execution.error)) {
     tripAutoFixCircuitBreaker(options);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -60,6 +60,7 @@ export * from './worker-lock.js';
 export * from './builtin-workers.js';
 export * from './worker-mutation-channels.js';
 export * from './auto-fix-recovery.js';
+export * from './workflow-name-gates.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';
 export * from './ci-failure-infra-classifier.js';

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -15,6 +15,7 @@ import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.j
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 import type { AutoApproveAuthorGateResult } from './auto-approve-author-allowlist.js';
+import { isAdminBypassNamedWorkflow } from '../workflow-name-gates.js';
 
 export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
 export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
@@ -24,8 +25,12 @@ const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
 type AutoApproveActionStatus = WorkerActionStatus;
 
 export interface AutoApproveWorkerStore {
-  listWorkflows(): ReadonlyArray<{ id: string }>;
-  loadWorkflow?(workflowId: string): { mergeMode?: string | null; onFinish?: string | null } | undefined;
+  listWorkflows(): ReadonlyArray<{ id: string; name?: string }>;
+  loadWorkflow?(workflowId: string): {
+    name?: string | null;
+    mergeMode?: string | null;
+    onFinish?: string | null;
+  } | undefined;
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents?(
@@ -140,6 +145,17 @@ function candidateFromTask(task: TaskState): AutoApproveCandidate | undefined {
   const ref = taskRefFromTask(task);
   if (!ref) return undefined;
   return { ...ref, source: 'scan' };
+}
+
+function workflowNameForId(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+  workflowId: string,
+): string | undefined {
+  const listed = options.store.listWorkflows().find((workflow) => workflow.id === workflowId);
+  if (typeof listed?.name === 'string' && listed.name.length > 0) return listed.name;
+  const loaded = options.store.loadWorkflow?.(workflowId);
+  if (typeof loaded?.name === 'string' && loaded.name.length > 0) return loaded.name;
+  return undefined;
 }
 
 function shouldAutoApproveReviewReadyTask(
@@ -375,6 +391,14 @@ function validateAutoApproveCandidate(
   const snapshotComparison = compareCandidateSnapshot(candidate, latest);
   if (!snapshotComparison.ok) {
     skipAutoApproveCandidate(options, candidate, snapshotComparison.reason, snapshotComparison.details);
+    return undefined;
+  }
+
+  const workflowName = workflowNameForId(options, snapshotComparison.ref.workflowId);
+  if (isAdminBypassNamedWorkflow(workflowName)) {
+    skipAutoApproveCandidate(options, candidate, 'admin-bypass-excluded', {
+      workflowName: workflowName ?? null,
+    });
     return undefined;
   }
 

--- a/packages/execution-engine/src/workflow-name-gates.ts
+++ b/packages/execution-engine/src/workflow-name-gates.ts
@@ -1,0 +1,7 @@
+/** Mergify admin-bypass repair/rebase plans use this plan-name prefix. */
+export const ADMIN_BYPASS_WORKFLOW_NAME_PREFIX = 'admin-bypass-';
+
+/** True when a workflow plan name belongs to Mergify admin-bypass automation. */
+export function isAdminBypassNamedWorkflow(name: string | undefined | null): boolean {
+  return typeof name === 'string' && name.startsWith(ADMIN_BYPASS_WORKFLOW_NAME_PREFIX);
+}

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -221,10 +221,11 @@ def build_repair_check_plan(
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 
-def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, trunk: str = "master") -> str:
+def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, onto: str | None = None) -> str:
+    onto_ref = onto or pr.base_ref_name or "master"
     return (
-        f"Rebase this pull request onto `{trunk}`.\n\n"
-        f"Checkout the PR head branch, rebase it onto origin/{trunk} while preserving the PR's intended "
+        f"Rebase this pull request onto `{onto_ref}`.\n\n"
+        f"Checkout the PR head branch, rebase it onto origin/{onto_ref} while preserving the PR's intended "
         "changes, resolve any conflicts if they appear, then commit locally. Do not push.\n\n"
         "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
         "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
@@ -232,10 +233,10 @@ def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, 
         "Then make no commit in this checkout and exit 0.\n\n"
         "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
-        f"Head SHA: {start_head}\nTrunk: {trunk}\nReason: {reason}\n"
+        f"Head SHA: {start_head}\nRebase onto: {onto_ref}\nReason: {reason}\n"
         f"Work directly on its branch:\n"
-        f"  git fetch origin {pr.head_ref_name} {trunk} && git checkout {pr.head_ref_name}\n"
-        f"  git rebase origin/{trunk}\n"
+        f"  git fetch origin {pr.head_ref_name} {onto_ref} && git checkout {pr.head_ref_name}\n"
+        f"  git rebase origin/{onto_ref}\n"
     )
 
 
@@ -247,11 +248,12 @@ def build_rebase_onto_master_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
+    onto_ref = pr.base_ref_name or "master"
     name = rebase_onto_master_plan_name(pr.number, start_head)
-    prompt = _rebase_onto_master_prompt(pr, reason, start_head)
+    prompt = _rebase_onto_master_prompt(pr, reason, start_head, onto=onto_ref)
     yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
     yaml_text += _repair_task_yaml(
-        description=f"Rebase PR #{pr.number} onto master",
+        description=f"Rebase PR #{pr.number} onto {onto_ref}",
         prompt=prompt,
     )
     yaml_text += _safe_push_task_yaml(

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -517,9 +517,9 @@ def norm_check_state(node: Mapping[str, object]) -> tuple[str, str, str, str, st
     status = str(node.get("status") or "").upper()
     if conclusion in {"SUCCESS"}:
         state = "success"
-    elif conclusion in {"FAILURE", "ACTION_REQUIRED", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE"}:
+    elif conclusion in {"FAILURE", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE"}:
         state = "failure"
-    elif conclusion == "SKIPPED":
+    elif conclusion in {"SKIPPED", "CANCELLED"}:
         state = "skipped"
     elif conclusion == "NEUTRAL":
         state = "neutral"

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -561,6 +561,11 @@ def effective_blockers(
     )
 
 
+def is_non_repairable_check_state(state: str) -> bool:
+    """Cancelled/skipped/neutral checks are not code failures to repair."""
+    return state in {"skipped", "cancelled", "neutral"}
+
+
 def mergify_failed_check_actions(
     pr: PrSnapshot,
     ledger: Ledger,
@@ -583,6 +588,9 @@ def mergify_failed_check_actions(
     )
     for name in ordered_failing_checks:
         if name in suppressed:
+            continue
+        ctx = pr.checks.get(name)
+        if ctx is not None and is_non_repairable_check_state(ctx.state):
             continue
         detail = f"Mergify queue check failed: {name}"
         decision = retry_decision(
@@ -1032,6 +1040,31 @@ def plan_mergify_queue_repairs(
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
+            continue
+        # GitHub CONFLICTING/DIRTY beats named CI (#10514): leftover parent
+        # commits after a squash+retarget make CI repair unable to push.
+        # Mergeable-but-behind named CI still never rebases (#10242).
+        conflict = next(
+            (blocker for blocker in facts.blockers_by_pr[pr.number] if blocker.kind == "conflict"),
+            None,
+        )
+        if conflict is not None:
+            legacy_key = f"conflict:{pr.number}"
+            if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+                continue
+            if infra_repair_owns_unit(ledger, pr.number, pr.head_ref_oid, "conflict-repair", legacy_key, now):
+                continue
+            action = plan_invoker_rebase_onto_master(
+                pr,
+                ledger,
+                max_repair_attempts,
+                now,
+                conflict.detail,
+                claim_repair_filing,
+                release_repair_filing,
+            )
+            if action is not None:
+                return action
             continue
         # Named CI failures always go to repair_check — never rebase because
         # the branch is also behind master (see #10242 rewrite incident).

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -167,6 +167,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertNotIn("/tmp/ledger.jsonl", plan.yaml_text)
         self.assertIn("Rebase this pull request onto `master`", plan.yaml_text)
         self.assertIn("commit locally. Do not push.", plan.yaml_text)
+        self.assertIn("--expected-head", plan.yaml_text)
         self.assertNotIn("executionAgent", plan.yaml_text)
 
     def test_rebase_onto_master_plan_includes_dequeue_reason(self):
@@ -182,6 +183,21 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("id: repair", plan.yaml_text)
         self.assertIn("id: safe-push", plan.yaml_text)
         self.assertNotIn("id: normalize", plan.yaml_text)
+
+    def test_rebase_plan_targets_stack_parent_base_not_master(self):
+        parent = "stack/EdbertChan/parent--aaaa"
+        plan = async_repair.build_rebase_onto_master_plan(
+            pr(base_ref_name=parent),
+            "GitHub reports merge conflict",
+            repo="owner/repo",
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn(f"Rebase this pull request onto `{parent}`", plan.yaml_text)
+        self.assertIn(f"git rebase origin/{parent}", plan.yaml_text)
+        self.assertIn(f"Rebase PR #2647 onto {parent}", plan.yaml_text)
+        self.assertNotIn("Rebase this pull request onto `master`", plan.yaml_text)
+        self.assertIn("--expected-head", plan.yaml_text)
 
     def test_repair_bot_thread_plan_keeps_thread_id_in_prompt_not_ledger(self):
         plan = async_repair.build_repair_bot_thread_plan(

--- a/scripts/test_mergify_admin_requeue_model.py
+++ b/scripts/test_mergify_admin_requeue_model.py
@@ -226,6 +226,7 @@ class CheckNormalisation(unittest.TestCase):
             )[1]
 
         self.assertEqual(state("TIMED_OUT"), "failure")
+        self.assertEqual(state("CANCELLED"), "skipped")
         self.assertEqual(state("SKIPPED"), "skipped")
         self.assertEqual(state("NEUTRAL"), "neutral")
         self.assertEqual(state("", status="IN_PROGRESS"), "pending")

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -494,20 +494,27 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual(actions[0].kind, "repair_check")
 
     def test_failed_check_with_stale_base_still_repairs_via_agent(self):
-        # Behind master must not steal a named CI failure into a blind rebase.
-        # File repair_check so the failing test/linter can be fixed in place.
+        # #10337 / #10242 invariant: behind master must not steal a named CI
+        # failure into a blind rebase. File repair_check so the failing
+        # test/linter can be fixed in place.
         ledger = self._ledger()
         snapshot = pr(number=42, checks={"build": check("failure")})
         actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={42: True})
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("repair_check", 42, "build"))
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
+        self.assertNotEqual(actions[0].kind, "rebase_onto_master")
 
     def test_failed_check_with_stale_base_still_repairs_via_mergify_dequeue(self):
+        # #10337 invariant: mergeable + Mergify-named CI failure → repair_check.
         ledger = self._ledger()
         snapshot = pr(number=43, latest_mergify=event(failing=("build",)))
         actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={43: True})
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("repair_check", 43, "build"))
+        self.assertNotEqual(actions[0].kind, "rebase_onto_master")
 
     def test_failed_pr_body_with_stale_base_still_repairs_not_rebases(self):
+        # #10242 invariant: MERGEABLE + stale + PR Body fail → repair_check,
+        # never Python rebase_onto_base / Invoker rebase_onto_master.
         actions = self._plan(
             pr(number=10242, checks={"PR Body": check("failure", "PR Body")}),
             required_checks={"PR Body"},
@@ -526,25 +533,30 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
 
     def test_clean_bottom_dequeued_with_no_ci_failure_rebases_via_invoker(self):
-        # Green Mergify dequeue that is also behind master → Invoker rebase,
-        # not a blind Python force-push and not a bare requeue.
+        # #10337 invariant: green Mergify dequeue that is also behind master →
+        # Invoker rebase, not a blind Python force-push and not a bare requeue.
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
         actions = self._plan(snapshot, stale_base_by_pr={1: True})
         self.assertEqual(actions[0].kind, "rebase_onto_master")
         self.assertIn("no named required-check failure", actions[0].detail)
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
 
     def test_clean_bottom_dequeued_up_to_date_still_requeues(self):
+        # #10337 invariant: green dequeue already on current master → requeue.
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
         actions = self._plan(snapshot, stale_base_by_pr={1: False})
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
 
     def test_clean_bottom_dequeued_with_named_ci_failure_still_repairs(self):
+        # #10337 invariant: dequeued + named CI + behind → repair_check, not rebase.
         snapshot = pr(
             labels=frozenset({"admin-bypass"}),
             latest_mergify=event(state="dequeued", failing=("build",)),
         )
         actions = self._plan(snapshot, stale_base_by_pr={1: True})
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+        self.assertNotEqual(actions[0].kind, "rebase_onto_master")
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
     def test_queued_label_with_headless_active_queue_event_waits(self):
         snapshot = pr(labels=frozenset({"admin-bypass", "queued"}), latest_mergify=event(state="queued", head=""))
         actions = self._plan(snapshot)
@@ -648,6 +660,102 @@ class PlanStackActions(PlannerTestCase):
         )
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_master", 77))
         self.assertEqual(actions[0].key, "rebase-onto-master:77")
+
+    def test_conflicting_master_base_with_named_ci_rebases_not_repairs(self):
+        # #10514: CONFLICTING after parent squash+retarget + named CI listed →
+        # rebase onto master, never burn repair_check attempts.
+        actions = self._plan(
+            pr(
+                number=10514,
+                labels=frozenset({"admin-bypass", "dequeued"}),
+                base_ref_name="master",
+                merge_state_status="DIRTY",
+                mergeable="CONFLICTING",
+                checks={"build": check("failure"), "quality / TypeScript Types": check("failure", "quality / TypeScript Types")},
+                latest_mergify=event(
+                    state="dequeued",
+                    failing=("build-artifacts", "quality / TypeScript Types", "UI Vitest"),
+                ),
+            ),
+            required_checks={"build", "quality / TypeScript Types"},
+        )
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+        self.assertEqual(actions[0].pr_number, 10514)
+        self.assertNotEqual(actions[0].kind, "repair_check")
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
+
+    def test_conflicting_stack_parent_base_with_named_ci_rebases_not_repairs(self):
+        # Active stack: CONFLICTING against parent stack branch + named CI →
+        # Invoker rebase (onto GitHub base), not repair_check.
+        parent = "stack/EdbertChan/parent--aaaa"
+        actions = self._plan(
+            pr(
+                number=10515,
+                labels=frozenset({"admin-bypass"}),
+                base_ref_name=parent,
+                merge_state_status="DIRTY",
+                mergeable="CONFLICTING",
+                checks={"build": check("failure")},
+                latest_mergify=event(state="dequeued", failing=("build",)),
+            ),
+        )
+        self.assertEqual(actions[0].kind, "rebase_onto_master")
+        self.assertEqual(actions[0].pr_number, 10515)
+        self.assertNotEqual(actions[0].kind, "repair_check")
+        self.assertNotEqual(actions[0].kind, "rebase_onto_base")
+
+    def test_conflicting_stack_bottom_rebases_before_upper_this_tick(self):
+        # One PR per tick: conflicting bottom on master is rebased; upper that
+        # is also CONFLICTING is not actioned in the same plan.
+        bottom = pr(
+            number=10514,
+            head_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            base_ref_name="master",
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            checks={"build": check("failure")},
+            latest_mergify=event(state="dequeued", failing=("build",)),
+        )
+        upper = pr(
+            number=10515,
+            base_ref_name="stack/bottom",
+            head_ref_name="stack/upper",
+            head_ref_oid="b" * 40,
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            checks={"build": check("failure")},
+            latest_mergify=event(state="dequeued", failing=("build",), head="b" * 40),
+        )
+        actions = self._plan(
+            m.StackGroup("s", (bottom, upper)),
+            open_pr_numbers={10514, 10515},
+            open_pr_numbers_by_head={"stack/bottom": (10514,), "stack/upper": (10515,)},
+        )
+        self.assertEqual(len(actions), 1)
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_onto_master", 10514))
+        self.assertNotEqual(actions[0].pr_number, 10515)
+
+    def test_inflight_repair_check_on_mergeable_pr_does_not_rebase(self):
+        # #10242 race: mergeable PR with an in-flight CI repair must not be
+        # stolen into a rebase just because it is also behind master.
+        ledger = self._ledger()
+        ledger.record("repair-check", 10242, HEAD, "PR Body", NOW - 30)
+        actions = self._plan(
+            pr(
+                number=10242,
+                labels=frozenset({"admin-bypass"}),
+                checks={"PR Body": check("failure", "PR Body")},
+                latest_mergify=event(state="dequeued", failing=("PR Body",)),
+            ),
+            ledger=ledger,
+            required_checks={"PR Body"},
+            stale_base_by_pr={10242: True},
+        )
+        self.assertEqual(actions, ())
+        self.assertNotIn("rebase_onto_master", {a.kind for a in actions})
+        self.assertNotIn("rebase_onto_base", {a.kind for a in actions})
 
     def test_dirty_conflict_waiting_dequeued_plans_rebase_despite_waiting(self):
         # PR #10278 shape: Mergify state=waiting with empty SHA and conflict
@@ -1504,6 +1612,37 @@ class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
             actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
         self.assertEqual(len(actions), 1)
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "UI Vitest"))
+
+    def test_mergify_failed_check_actions_skips_cancelled_checks(self):
+        # #10514: Mergify listed cancelled build-artifacts alongside a real
+        # TypeScript failure. Cancelled must not burn a repair_check attempt.
+        ledger = self._ledger()
+        snapshot = pr(
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={
+                "quality / TypeScript Types": check("failure", "quality / TypeScript Types"),
+                "build-artifacts": check("skipped", "build-artifacts"),
+            },
+            latest_mergify=event(
+                state="dequeued",
+                failing=("build-artifacts", "quality / TypeScript Types"),
+            ),
+        )
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "quality / TypeScript Types"))
+
+    def test_cancelled_only_failing_checks_do_not_repair(self):
+        ledger = self._ledger()
+        snapshot = pr(
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={"build-artifacts": check("skipped", "build-artifacts")},
+            latest_mergify=event(state="dequeued", failing=("build-artifacts",)),
+        )
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(actions, ())
 
     def test_cap_still_applies_once_genuine_non_infra_attempts_reach_it(self):
         # Three genuinely-attempted (not infra-crashed) repairs plus one more


### PR DESCRIPTION
## Summary

Autofix and auto-approve could act on admin-bypass normalize tasks.

That path can push through admin-bypass workflows that should stay parked.

This slice routes admin-bypass-* workflows out of autofix and auto-approve.

## Review Claim

admin-bypass-* workflows are never autofixed or auto-approved.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

admin-bypass normalize and repair tasks are never autofixed or auto-approved. Product workflows keep current autofix and autoapprove behavior.

## Slice Rationale

Worker routing exclusion is a separate claim from the Mergify planner policy in (1).

## Non-goals

Does not change Mergify planner ordering.
Does not add a normalize deletion gate.
Does not enable autoApproveAIFixes by itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/execution-engine test -- src/__tests__/workflow-name-gates.test.ts src/__tests__/auto-fix-recovery.test.ts src/__tests__/auto-approve-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit. Autofix and auto-approve again consider admin-bypass workflows eligible.

</details>
