### PR TITLE
[Slack workflow mention silence](1) Add localhost smoke inject

### DIFF
--- a/packages/slack-manager/src/__tests__/local-smoke-inject.test.ts
+++ b/packages/slack-manager/src/__tests__/local-smoke-inject.test.ts
@@ -1,0 +1,115 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SMOKE_INJECT_PORT, startLocalSmokeInject } from '../local-smoke-inject.js';
+
+async function postJson(
+  port: number,
+  path: string,
+  body: unknown,
+  host = '127.0.0.1',
+): Promise<{ status: number; json: { ok: boolean; error?: string } }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = http.request({
+      host,
+      port,
+      path,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          json: JSON.parse(Buffer.concat(chunks).toString('utf8')) as { ok: boolean; error?: string },
+        });
+      });
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe('local smoke inject', () => {
+  const stops: Array<() => void> = [];
+
+  afterEach(() => {
+    while (stops.length > 0) stops.pop()?.();
+  });
+
+  it('does nothing when INVOKER_SLACK_ALLOW_LOCAL_SMOKE is unset', async () => {
+    const injectMention = vi.fn();
+    // Use an unused port so a live host's smoke inject on 4177 cannot mask this.
+    const unusedPort = 43177;
+    const stop = startLocalSmokeInject({
+      injectMention,
+      log: () => {},
+      env: {
+        INVOKER_SLACK_SMOKE_PORT: String(unusedPort),
+      },
+    });
+    stops.push(stop);
+    await expect(postJson(unusedPort, '/smoke/mention', {
+      channelId: 'C1',
+      threadTs: '1.1',
+      text: 'hi',
+      userId: 'U1',
+    })).rejects.toThrow();
+    expect(injectMention).not.toHaveBeenCalled();
+  });
+
+  it('injects a mention on loopback POST /smoke/mention', async () => {
+    const injectMention = vi.fn().mockResolvedValue(undefined);
+    const port = 4178;
+    const stop = startLocalSmokeInject({
+      injectMention,
+      log: () => {},
+      env: {
+        INVOKER_SLACK_ALLOW_LOCAL_SMOKE: '1',
+        INVOKER_SLACK_SMOKE_PORT: String(port),
+      },
+    });
+    stops.push(stop);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await postJson(port, '/smoke/mention', {
+      channelId: 'CWF',
+      threadTs: '1787782726.780619',
+      text: 'Can you help me figure out why that failed and execute a fix with claude?',
+      userId: 'U_SMOKE',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.json.ok).toBe(true);
+    expect(injectMention).toHaveBeenCalledWith({
+      channelId: 'CWF',
+      threadTs: '1787782726.780619',
+      text: 'Can you help me figure out why that failed and execute a fix with claude?',
+      userId: 'U_SMOKE',
+    });
+  });
+
+  it('rejects missing fields', async () => {
+    const port = 4179;
+    const stop = startLocalSmokeInject({
+      injectMention: vi.fn(),
+      log: () => {},
+      env: {
+        INVOKER_SLACK_ALLOW_LOCAL_SMOKE: '1',
+        INVOKER_SLACK_SMOKE_PORT: String(port),
+      },
+    });
+    stops.push(stop);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await postJson(port, '/smoke/mention', { channelId: 'C1' });
+    expect(res.status).toBe(500);
+    expect(res.json.ok).toBe(false);
+    expect(res.json.error).toContain('channelId');
+  });
+});

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,6 +28,7 @@ import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
+import { startLocalSmokeInject } from './local-smoke-inject.js';
 const VERSION = '0.0.14';
 let runDaemon = true;
 
@@ -175,6 +176,10 @@ async function main(): Promise<void> {
 
   await slack.start(commandHandler);
   watchdog.start();
+  const stopSmokeInject = startLocalSmokeInject({
+    injectMention: (request) => slack.injectMention(request),
+    log,
+  });
   // Establish the IPC connection (and re-apply subscriptions) if Invoker is already up.
   void client.ping();
   log('info', `slack-manager started (store=${managerHome})`);
@@ -184,6 +189,7 @@ async function main(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     log('info', `received ${signal}, shutting down`);
+    stopSmokeInject();
     watchdog.stop();
     stopEvents();
     await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));

--- a/packages/slack-manager/src/local-smoke-inject.ts
+++ b/packages/slack-manager/src/local-smoke-inject.ts
@@ -1,0 +1,108 @@
+/**
+ * Localhost-only smoke inject for Slack mention e2e.
+ *
+ * Slack bots do not receive their own app_mention events, so live tests on a
+ * bot-token host need a way to drive SlackSurface.injectMention while still
+ * posting replies into a real Slack thread.
+ *
+ * Off by default. Enabled only when INVOKER_SLACK_ALLOW_LOCAL_SMOKE=1.
+ * Binds exclusively to 127.0.0.1 and rejects non-loopback remotes.
+ */
+
+import http from 'node:http';
+import type { InjectMentionRequest } from '@invoker/surfaces';
+
+export const DEFAULT_SMOKE_INJECT_PORT = 4177;
+
+export interface LocalSmokeInjectDeps {
+  injectMention: (request: InjectMentionRequest) => Promise<void>;
+  log: (level: string, message: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+      if (Buffer.concat(chunks).length > 64 * 1024) {
+        reject(new Error('request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  return address === '127.0.0.1'
+    || address === '::1'
+    || address === '::ffff:127.0.0.1';
+}
+
+function parseInjectBody(raw: string): InjectMentionRequest {
+  const body = JSON.parse(raw) as Partial<InjectMentionRequest>;
+  if (!body.channelId || !body.threadTs || !body.text || !body.userId) {
+    throw new Error('body must include channelId, threadTs, text, and userId');
+  }
+  return {
+    channelId: String(body.channelId),
+    threadTs: String(body.threadTs),
+    text: String(body.text),
+    userId: String(body.userId),
+  };
+}
+
+/** Start the inject listener when enabled; returns a no-op stop when disabled. */
+export function startLocalSmokeInject(deps: LocalSmokeInjectDeps): () => void {
+  const env = deps.env ?? process.env;
+  if (env.INVOKER_SLACK_ALLOW_LOCAL_SMOKE !== '1') {
+    return () => {};
+  }
+
+  const port = Number.parseInt(env.INVOKER_SLACK_SMOKE_PORT ?? String(DEFAULT_SMOKE_INJECT_PORT), 10);
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`invalid INVOKER_SLACK_SMOKE_PORT: ${env.INVOKER_SLACK_SMOKE_PORT}`);
+  }
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const remote = req.socket.remoteAddress;
+      if (!isLoopbackAddress(remote)) {
+        deps.log('warn', `smoke inject rejected non-loopback remote=${remote ?? 'unknown'}`);
+        res.writeHead(403, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'loopback only' }));
+        return;
+      }
+
+      if (req.method !== 'POST' || req.url !== '/smoke/mention') {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'not found' }));
+        return;
+      }
+
+      try {
+        const request = parseInjectBody(await readBody(req));
+        deps.log('info', `smoke inject mention channel=${request.channelId} thread_ts=${request.threadTs}`);
+        await deps.injectMention(request);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.log('error', `smoke inject failed: ${message}`);
+        res.writeHead(500, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: message }));
+      }
+    })();
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    deps.log('info', `local smoke inject listening on 127.0.0.1:${port}`);
+  });
+
+  return () => {
+    server.close();
+  };
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -140,6 +140,15 @@ export interface SlackSurfaceConfig {
   harnessSessionDriverFactory?: (preset: HarnessPreset) => HarnessSessionDriver | undefined;
 }
 
+
+/** Payload for {@link SlackSurface.injectMention} (localhost smoke inject). */
+export interface InjectMentionRequest {
+  channelId: string;
+  threadTs: string;
+  text: string;
+  userId: string;
+}
+
 export interface HarnessPreset {
   tool: string;
   model?: string;
@@ -879,6 +888,39 @@ export class SlackSurface implements Surface {
     this.progressCardTs.clear();
     await this.app.stop();
     this.log('slack', 'info', 'Slack bot stopped');
+  }
+
+
+  /**
+   * Drive the same mention path Socket Mode uses, posting replies into a real
+   * Slack thread via the bot client. Used by the localhost-only smoke inject
+   * because Slack bots do not receive their own app_mention events.
+   */
+  async injectMention(request: InjectMentionRequest): Promise<void> {
+    const channel = request.channelId;
+    const threadTs = request.threadTs;
+    const text = request.text.includes('<@')
+      ? request.text
+      : (this.botUserId ? `<@${this.botUserId}> ${request.text}` : request.text);
+    const event: SlackMentionEvent = {
+      text,
+      ts: threadTs,
+      thread_ts: threadTs,
+      user: request.userId,
+      channel,
+    };
+    const say: SayFn = async ({ text: replyText, thread_ts, blocks }) => {
+      const res = await this.app.client.chat.postMessage({
+        channel,
+        text: replyText,
+        thread_ts,
+        ...(blocks ? { blocks: blocks as never } : {}),
+      });
+      return { ts: res.ts as string };
+    };
+    this.log('slack', 'info', `[SMOKE_INJECT] channel=${channel} thread_ts=${threadTs} user=${request.userId}`);
+    const mapping = this.workflowChannelRepo?.getByChannelId(channel);
+    await this.handleMention(event, say, channel, mapping ?? undefined);
   }
 
   // ── Slash Command ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Workflow-channel Slack e2e needs a way to drive @Invoker without a human user token.

Slack bots do not receive their own app_mention events, so a bot-posted mention never reaches Socket Mode.

This slice adds an env-gated 127.0.0.1 inject that calls the existing mention handler and posts replies into the real thread.

## Review Claim

Approve the localhost-only smoke inject as the harness for live Slack mention checks.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The inject listens on 127.0.0.1 only, is off unless INVOKER_SLACK_ALLOW_LOCAL_SMOKE=1, and does not change production mention handling.

## Slice Rationale

Harness first so the later live e2e and ack fix can prove replies in a real mapped workflow channel.

## Non-goals

Does not add Processing ack on workflow Q&A. Does not change lobby planning. Does not teach the assistant to file repair workflows.

## Architecture

### Before

```mermaid
sequenceDiagram
  participant Test
  participant Slack
  participant Manager
  Test->>Slack: bot posts at-Invoker
  Note over Manager: no app_mention for own message
```

### After

```mermaid
sequenceDiagram
  participant Test
  participant Inject
  participant Manager
  participant Slack
  Test->>Inject: POST loopback smoke mention
  Inject->>Manager: injectMention
  Manager->>Slack: say into real thread
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/local-smoke-inject.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>