### PR TITLE
[Slack workflow mention silence](2) Add live workflow-mention e2e

### DIFF
--- a/packages/slack-manager/src/__tests__/local-smoke-inject.test.ts
+++ b/packages/slack-manager/src/__tests__/local-smoke-inject.test.ts
@@ -1,0 +1,115 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SMOKE_INJECT_PORT, startLocalSmokeInject } from '../local-smoke-inject.js';
+
+async function postJson(
+  port: number,
+  path: string,
+  body: unknown,
+  host = '127.0.0.1',
+): Promise<{ status: number; json: { ok: boolean; error?: string } }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = http.request({
+      host,
+      port,
+      path,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          json: JSON.parse(Buffer.concat(chunks).toString('utf8')) as { ok: boolean; error?: string },
+        });
+      });
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe('local smoke inject', () => {
+  const stops: Array<() => void> = [];
+
+  afterEach(() => {
+    while (stops.length > 0) stops.pop()?.();
+  });
+
+  it('does nothing when INVOKER_SLACK_ALLOW_LOCAL_SMOKE is unset', async () => {
+    const injectMention = vi.fn();
+    // Use an unused port so a live host's smoke inject on 4177 cannot mask this.
+    const unusedPort = 43177;
+    const stop = startLocalSmokeInject({
+      injectMention,
+      log: () => {},
+      env: {
+        INVOKER_SLACK_SMOKE_PORT: String(unusedPort),
+      },
+    });
+    stops.push(stop);
+    await expect(postJson(unusedPort, '/smoke/mention', {
+      channelId: 'C1',
+      threadTs: '1.1',
+      text: 'hi',
+      userId: 'U1',
+    })).rejects.toThrow();
+    expect(injectMention).not.toHaveBeenCalled();
+  });
+
+  it('injects a mention on loopback POST /smoke/mention', async () => {
+    const injectMention = vi.fn().mockResolvedValue(undefined);
+    const port = 4178;
+    const stop = startLocalSmokeInject({
+      injectMention,
+      log: () => {},
+      env: {
+        INVOKER_SLACK_ALLOW_LOCAL_SMOKE: '1',
+        INVOKER_SLACK_SMOKE_PORT: String(port),
+      },
+    });
+    stops.push(stop);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await postJson(port, '/smoke/mention', {
+      channelId: 'CWF',
+      threadTs: '1787782726.780619',
+      text: 'Can you help me figure out why that failed and execute a fix with claude?',
+      userId: 'U_SMOKE',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.json.ok).toBe(true);
+    expect(injectMention).toHaveBeenCalledWith({
+      channelId: 'CWF',
+      threadTs: '1787782726.780619',
+      text: 'Can you help me figure out why that failed and execute a fix with claude?',
+      userId: 'U_SMOKE',
+    });
+  });
+
+  it('rejects missing fields', async () => {
+    const port = 4179;
+    const stop = startLocalSmokeInject({
+      injectMention: vi.fn(),
+      log: () => {},
+      env: {
+        INVOKER_SLACK_ALLOW_LOCAL_SMOKE: '1',
+        INVOKER_SLACK_SMOKE_PORT: String(port),
+      },
+    });
+    stops.push(stop);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await postJson(port, '/smoke/mention', { channelId: 'C1' });
+    expect(res.status).toBe(500);
+    expect(res.json.ok).toBe(false);
+    expect(res.json.error).toContain('channelId');
+  });
+});

--- a/packages/slack-manager/src/__tests__/slack-workflow-mention-live.e2e.test.ts
+++ b/packages/slack-manager/src/__tests__/slack-workflow-mention-live.e2e.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Live Slack-channel e2e for workflow-channel @mention replies.
+ *
+ * Credential-gated. Skip (do not pass) without INVOKER_E2E_SLACK_LIVE=1 and
+ * SLACK_BOT_TOKEN. Intended to run on DO1 against the live slack-manager smoke
+ * inject (INVOKER_SLACK_ALLOW_LOCAL_SMOKE=1) while polling the real channel.
+ *
+ * Target default: C0BTTHFM02U (workflow-1787780633273-11).
+ *
+ * Literal property: after inject, conversations.replies contains a bot reply
+ * (Processing your request... or any bot message) within 15s.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { DEFAULT_SMOKE_INJECT_PORT } from '../local-smoke-inject.js';
+
+const LIVE = process.env.INVOKER_E2E_SLACK_LIVE === '1';
+const CHANNEL_ID = process.env.INVOKER_E2E_SLACK_CHANNEL_ID ?? 'C0BTTHFM02U';
+const SMOKE_PORT = Number.parseInt(
+  process.env.INVOKER_SLACK_SMOKE_PORT ?? String(DEFAULT_SMOKE_INJECT_PORT),
+  10,
+);
+const PROBE_TEXT = 'Can you help me figure out why that failed and execute a fix with claude?';
+const REPLY_TIMEOUT_MS = 15_000;
+const POLL_MS = 500;
+
+function loadBotToken(): string | undefined {
+  if (process.env.SLACK_BOT_TOKEN) return process.env.SLACK_BOT_TOKEN;
+  const legacy = path.join(homedir(), '.invoker', '.slack-owner.env');
+  const canonical = path.join(homedir(), '.invoker', '.env');
+  const envPath = process.env.INVOKER_SLACK_OWNER_ENV
+    ?? (existsSync(legacy) ? legacy : canonical);
+  if (!existsSync(envPath)) return undefined;
+  const line = readFileSync(envPath, 'utf8').split('\n').find((l) => l.startsWith('SLACK_BOT_TOKEN='));
+  return line?.slice('SLACK_BOT_TOKEN='.length).trim();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function slackApi<T>(token: string, method: string, body: Record<string, unknown>): Promise<T & { ok: boolean; error?: string }> {
+  // Slack Web API expects form-urlencoded for most methods; JSON can yield invalid_arguments.
+  const form = new URLSearchParams();
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined || value === null) continue;
+    form.set(key, typeof value === 'string' ? value : String(value));
+  }
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+    },
+    body: form.toString(),
+  });
+  const json = await res.json() as T & { ok: boolean; error?: string };
+  if (!json.ok) throw new Error(`Slack ${method} failed: ${json.error ?? res.status}`);
+  return json;
+}
+
+async function injectMention(body: {
+  channelId: string;
+  threadTs: string;
+  text: string;
+  userId: string;
+}): Promise<void> {
+  const payload = JSON.stringify(body);
+  await new Promise<void>((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port: SMOKE_PORT,
+      path: '/smoke/mention',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        let parsed: { ok?: boolean; error?: string } = {};
+        try {
+          parsed = JSON.parse(raw) as { ok?: boolean; error?: string };
+        } catch {
+          reject(new Error(`smoke inject non-JSON response (${res.statusCode}): ${raw}`));
+          return;
+        }
+        if (res.statusCode !== 200 || !parsed.ok) {
+          reject(new Error(`smoke inject failed (${res.statusCode}): ${parsed.error ?? raw}`));
+          return;
+        }
+        resolve();
+      });
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe.skipIf(!LIVE)('live Slack workflow-channel mention reply', () => {
+  it('posts a bot reply into the mapped workflow channel within 15s', async () => {
+    const token = loadBotToken();
+    if (!token) {
+      throw new Error('INVOKER_E2E_SLACK_LIVE=1 requires SLACK_BOT_TOKEN (or ~/.invoker/.slack-owner.env)');
+    }
+
+    const auth = await slackApi<{ user_id?: string }>(token, 'auth.test', {});
+    const botUserId = auth.user_id;
+    const marker = `invoker-live-e2e-${Date.now()}`;
+    const posted = await slackApi<{ ts?: string }>(token, 'chat.postMessage', {
+      channel: CHANNEL_ID,
+      text: marker,
+    });
+    const threadTs = posted.ts;
+    if (!threadTs) throw new Error('chat.postMessage returned no ts');
+
+    const toDelete: string[] = [threadTs];
+    try {
+      // Fire-and-forget: inject may wait on the planner; the ack must land first.
+      const injectPromise = injectMention({
+        channelId: CHANNEL_ID,
+        threadTs,
+        text: PROBE_TEXT,
+        userId: process.env.INVOKER_E2E_SLACK_USER_ID ?? 'U_LIVE_E2E',
+      }).catch((err) => {
+        console.warn(`[live-e2e] inject settled with error (ok if ack already posted): ${err}`);
+      });
+
+      const deadline = Date.now() + REPLY_TIMEOUT_MS;
+      let botReply: { ts?: string; text?: string; bot_id?: string; user?: string } | undefined;
+      while (Date.now() < deadline) {
+        const replies = await slackApi<{ messages?: Array<{ ts?: string; text?: string; bot_id?: string; user?: string }> }>(
+          token,
+          'conversations.replies',
+          {
+            channel: CHANNEL_ID,
+            ts: threadTs,
+            limit: 50,
+          },
+        );
+        botReply = (replies.messages ?? []).find((m) => {
+          if (m.ts === threadTs) return false;
+          if (m.bot_id) return true;
+          if (m.user && botUserId && m.user === botUserId) return true;
+          return false;
+        });
+        if (botReply) break;
+        await sleep(POLL_MS);
+      }
+
+      if (botReply?.ts) toDelete.push(botReply.ts);
+
+      expect(
+        botReply,
+        `Expected a bot reply in ${CHANNEL_ID} thread ${threadTs} within ${REPLY_TIMEOUT_MS}ms (marker=${marker})`,
+      ).toBeDefined();
+      expect(botReply?.text ?? '').toMatch(/Processing your request|Error:|Still thinking|I answer questions|workflow/i);
+
+      await Promise.race([injectPromise, sleep(2_000)]);
+    } finally {
+      for (const ts of toDelete.reverse()) {
+        try {
+          await slackApi(token, 'chat.delete', { channel: CHANNEL_ID, ts });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  }, 60_000);
+});

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,6 +28,7 @@ import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
+import { startLocalSmokeInject } from './local-smoke-inject.js';
 const VERSION = '0.0.14';
 let runDaemon = true;
 
@@ -175,6 +176,10 @@ async function main(): Promise<void> {
 
   await slack.start(commandHandler);
   watchdog.start();
+  const stopSmokeInject = startLocalSmokeInject({
+    injectMention: (request) => slack.injectMention(request),
+    log,
+  });
   // Establish the IPC connection (and re-apply subscriptions) if Invoker is already up.
   void client.ping();
   log('info', `slack-manager started (store=${managerHome})`);
@@ -184,6 +189,7 @@ async function main(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     log('info', `received ${signal}, shutting down`);
+    stopSmokeInject();
     watchdog.stop();
     stopEvents();
     await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));

--- a/packages/slack-manager/src/local-smoke-inject.ts
+++ b/packages/slack-manager/src/local-smoke-inject.ts
@@ -1,0 +1,108 @@
+/**
+ * Localhost-only smoke inject for Slack mention e2e.
+ *
+ * Slack bots do not receive their own app_mention events, so live tests on a
+ * bot-token host need a way to drive SlackSurface.injectMention while still
+ * posting replies into a real Slack thread.
+ *
+ * Off by default. Enabled only when INVOKER_SLACK_ALLOW_LOCAL_SMOKE=1.
+ * Binds exclusively to 127.0.0.1 and rejects non-loopback remotes.
+ */
+
+import http from 'node:http';
+import type { InjectMentionRequest } from '@invoker/surfaces';
+
+export const DEFAULT_SMOKE_INJECT_PORT = 4177;
+
+export interface LocalSmokeInjectDeps {
+  injectMention: (request: InjectMentionRequest) => Promise<void>;
+  log: (level: string, message: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+      if (Buffer.concat(chunks).length > 64 * 1024) {
+        reject(new Error('request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  return address === '127.0.0.1'
+    || address === '::1'
+    || address === '::ffff:127.0.0.1';
+}
+
+function parseInjectBody(raw: string): InjectMentionRequest {
+  const body = JSON.parse(raw) as Partial<InjectMentionRequest>;
+  if (!body.channelId || !body.threadTs || !body.text || !body.userId) {
+    throw new Error('body must include channelId, threadTs, text, and userId');
+  }
+  return {
+    channelId: String(body.channelId),
+    threadTs: String(body.threadTs),
+    text: String(body.text),
+    userId: String(body.userId),
+  };
+}
+
+/** Start the inject listener when enabled; returns a no-op stop when disabled. */
+export function startLocalSmokeInject(deps: LocalSmokeInjectDeps): () => void {
+  const env = deps.env ?? process.env;
+  if (env.INVOKER_SLACK_ALLOW_LOCAL_SMOKE !== '1') {
+    return () => {};
+  }
+
+  const port = Number.parseInt(env.INVOKER_SLACK_SMOKE_PORT ?? String(DEFAULT_SMOKE_INJECT_PORT), 10);
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`invalid INVOKER_SLACK_SMOKE_PORT: ${env.INVOKER_SLACK_SMOKE_PORT}`);
+  }
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const remote = req.socket.remoteAddress;
+      if (!isLoopbackAddress(remote)) {
+        deps.log('warn', `smoke inject rejected non-loopback remote=${remote ?? 'unknown'}`);
+        res.writeHead(403, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'loopback only' }));
+        return;
+      }
+
+      if (req.method !== 'POST' || req.url !== '/smoke/mention') {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'not found' }));
+        return;
+      }
+
+      try {
+        const request = parseInjectBody(await readBody(req));
+        deps.log('info', `smoke inject mention channel=${request.channelId} thread_ts=${request.threadTs}`);
+        await deps.injectMention(request);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.log('error', `smoke inject failed: ${message}`);
+        res.writeHead(500, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: message }));
+      }
+    })();
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    deps.log('info', `local smoke inject listening on 127.0.0.1:${port}`);
+  });
+
+  return () => {
+    server.close();
+  };
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -140,6 +140,15 @@ export interface SlackSurfaceConfig {
   harnessSessionDriverFactory?: (preset: HarnessPreset) => HarnessSessionDriver | undefined;
 }
 
+
+/** Payload for {@link SlackSurface.injectMention} (localhost smoke inject). */
+export interface InjectMentionRequest {
+  channelId: string;
+  threadTs: string;
+  text: string;
+  userId: string;
+}
+
 export interface HarnessPreset {
   tool: string;
   model?: string;
@@ -879,6 +888,39 @@ export class SlackSurface implements Surface {
     this.progressCardTs.clear();
     await this.app.stop();
     this.log('slack', 'info', 'Slack bot stopped');
+  }
+
+
+  /**
+   * Drive the same mention path Socket Mode uses, posting replies into a real
+   * Slack thread via the bot client. Used by the localhost-only smoke inject
+   * because Slack bots do not receive their own app_mention events.
+   */
+  async injectMention(request: InjectMentionRequest): Promise<void> {
+    const channel = request.channelId;
+    const threadTs = request.threadTs;
+    const text = request.text.includes('<@')
+      ? request.text
+      : (this.botUserId ? `<@${this.botUserId}> ${request.text}` : request.text);
+    const event: SlackMentionEvent = {
+      text,
+      ts: threadTs,
+      thread_ts: threadTs,
+      user: request.userId,
+      channel,
+    };
+    const say: SayFn = async ({ text: replyText, thread_ts, blocks }) => {
+      const res = await this.app.client.chat.postMessage({
+        channel,
+        text: replyText,
+        thread_ts,
+        ...(blocks ? { blocks: blocks as never } : {}),
+      });
+      return { ts: res.ts as string };
+    };
+    this.log('slack', 'info', `[SMOKE_INJECT] channel=${channel} thread_ts=${threadTs} user=${request.userId}`);
+    const mapping = this.workflowChannelRepo?.getByChannelId(channel);
+    await this.handleMention(event, say, channel, mapping ?? undefined);
   }
 
   // ── Slash Command ───────────────────────────────────────


### PR DESCRIPTION
## Summary

The reported silence was a missing Slack reply in a mapped workflow channel, not a journal line alone.

This slice adds a credential-gated live e2e that posts a unique parent, injects the mention, and polls conversations.replies for a bot message within 15s.

Without INVOKER_E2E_SLACK_LIVE=1 and SLACK_BOT_TOKEN the test skips, so normal package test runs stay green.

## Review Claim

Approve this live channel e2e as the named proof that a bot reply appears after a workflow-channel @mention.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The test is off by default, deletes probe messages in finally, and does not change production Slack handling.

## Slice Rationale

Proof sits before the ack fix so the bug is demonstrated as an empty replies poll, then the fix flips the same check to pass.

## Non-goals

Does not implement Processing ack. Does not change smoke inject binding rules. Does not replace the fast non-lobby mention unit test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/slack-workflow-mention-live.e2e.test.ts` (skips without INVOKER_E2E_SLACK_LIVE=1)
- [x] On DO1 with INVOKER_E2E_SLACK_LIVE=1 against C0BTTHFM02U after the ack fix: live e2e passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10628