### PR TITLE
[Slack workflow mention silence](3) Ack and settle workflow @mentions

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -81,6 +81,7 @@ function mockProcess(stdout: string, exitCode = 0): any {
   // Defer the emit to the next microtask so the close listener is attached first.
   queueMicrotask(() => {
     proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('exit', exitCode);
     proc.emit('close', exitCode);
   });
   return proc;
@@ -524,6 +525,8 @@ describe('in-channel workflow assistant', () => {
       workflowChannelRepo: repo,
       planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
       gatherWorkflowContext: gather,
+      // Keep legacy free-form tests on the say()-reply path; ack coverage is in dedicated tests below.
+      enableImmediateAck: false,
     });
     return surface;
   }
@@ -567,6 +570,103 @@ describe('in-channel workflow assistant', () => {
     expect(received).toHaveLength(0);
   });
 
+  it('posts Processing ack for free-form workflow Q&A while the planner is still in flight', async () => {
+    const gather = vi.fn(async (): Promise<WorkflowContext> => ({
+      workflowId: 'wf-1-2',
+      planning: [],
+      tasks: [{ id: 'wf-1-2/api', status: 'failed', agentName: 'omp', transcript: [], output: 'boom' }],
+    }));
+    // Hung planner: never emits exit/close — mirrors the DO1 silent-mention hang.
+    mockSpawn.mockImplementationOnce(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      proc.pid = 1238103;
+      return proc;
+    });
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      planningCommandBuilder: () => ({ command: 'claude', args: ['-p', 'x'] }),
+      gatherWorkflowContext: gather,
+      enableImmediateAck: true,
+      planningHeartbeatIntervalSeconds: 0,
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'ack-1' });
+    const pending = mentionHandler(surface)({
+      event: {
+        text: '<@BOT> Can you help me figure out why that failed and execute a fix with claude?',
+        ts: 't-live',
+        user: 'U1',
+        channel: 'C123',
+      },
+      say,
+    });
+
+    await vi.waitFor(() => {
+      expect(say).toHaveBeenCalledWith(expect.objectContaining({
+        text: 'Processing your request...',
+        thread_ts: 't-live',
+      }));
+    });
+    await vi.waitFor(() => {
+      expect(mockSpawn).toHaveBeenCalled();
+    });
+    // Mention handler is still awaiting the hung planner — do not await forever.
+    void pending;
+  });
+
+  it('does not post Processing ack for an instant workflow status verb', async () => {
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      enableImmediateAck: true,
+      planningHeartbeatIntervalSeconds: 0,
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> status', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...' }));
+    expect(received).toContainEqual({ type: 'get_status', workflowId: 'wf-1-2' });
+  });
+
+  it('settles a one-shot planner on child exit without waiting for close', async () => {
+    const gather = vi.fn(async (): Promise<WorkflowContext> => ({
+      workflowId: 'wf-1-2',
+      planning: [],
+      tasks: [],
+    }));
+    mockSpawn.mockImplementationOnce(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      queueMicrotask(() => {
+        proc.stdout.emit('data', Buffer.from('exit-only reply'));
+        proc.emit('exit', 0);
+        // intentionally no 'close'
+      });
+      return proc;
+    });
+    const surface = assistantSurface(gather);
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> how are we doing', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('exit-only reply'),
+    }));
+  });
+
   it('uses a temporary prompt file for oversized workflow assistant context', async () => {
     const hugeOutput = 'running task details\n'.repeat(10_000);
     const gather = vi.fn(async (): Promise<WorkflowContext> => ({
@@ -591,6 +691,7 @@ describe('in-channel workflow assistant', () => {
       workflowChannelRepo: repo,
       planningCommandBuilder,
       gatherWorkflowContext: gather,
+      enableImmediateAck: false,
     });
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -667,6 +667,39 @@ describe('in-channel workflow assistant', () => {
     }));
   });
 
+  it('settles a one-shot planner timeout even when SIGTERM is ignored', async () => {
+    const gather = vi.fn(async (): Promise<WorkflowContext> => ({
+      workflowId: 'wf-1-2',
+      planning: [],
+      tasks: [],
+    }));
+    mockSpawn.mockImplementationOnce(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      return proc;
+    });
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
+      gatherWorkflowContext: gather,
+      enableImmediateAck: false,
+      planningTimeoutSeconds: 0,
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> how are we doing', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Planner timed out after 0ms'),
+    }));
+  });
+
   it('uses a temporary prompt file for oversized workflow assistant context', async () => {
     const hugeOutput = 'running task details\n'.repeat(10_000);
     const gather = vi.fn(async (): Promise<WorkflowContext> => ({

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2563,6 +2563,7 @@ ${text}`;
     say: SayFn,
   ): Promise<void> {
     const threadTs = event.thread_ts ?? event.ts;
+    const channel = event.channel ?? mapping.channelId;
     const text = (event.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
     this.log('slack', 'info', `[WORKFLOW_MENTION] instance=${this.instanceId} event_ts=${event.ts} thread_ts=${threadTs} workflow=${mapping.workflowId}`);
     if (!text) {
@@ -2584,14 +2585,65 @@ ${text}`;
       return;
     }
 
+    if (this.enableImmediateAck) {
+      await this.sendImmediateAck(threadTs, say);
+    }
+
+    const heartbeatMs = (this.planningHeartbeatIntervalSeconds ?? 120) * 1_000;
+    let heartbeatTimer: NodeJS.Timeout | undefined;
+    const heartbeatTimestamps: string[] = [];
+    let heartbeatInFlight = false;
+    const cleanupHeartbeats = async (): Promise<void> => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = undefined;
+      }
+      for (const hbTs of heartbeatTimestamps) {
+        try {
+          await this.deleteMessage(channel, hbTs);
+        } catch (err) {
+          this.log('slack', 'warn', `[HEARTBEAT] Failed to delete heartbeat message ${hbTs}: ${err}`);
+        }
+      }
+    };
+    if (heartbeatMs > 0) {
+      heartbeatTimer = setInterval(async () => {
+        if (heartbeatInFlight) return;
+        heartbeatInFlight = true;
+        try {
+          const result = await this.sayWithRateLimitRetry(say, {
+            text: ':hourglass_flowing_sand: Still thinking...',
+            thread_ts: threadTs,
+          });
+          if (result?.ts) heartbeatTimestamps.push(result.ts);
+          this.log('slack', 'info', `[HEARTBEAT] Sent planning heartbeat (thread_ts=${threadTs})`);
+        } catch (err) {
+          this.log('slack', 'error', `[HEARTBEAT] Failed to send planning heartbeat: ${err}`);
+        } finally {
+          heartbeatInFlight = false;
+        }
+      }, heartbeatMs);
+    }
+
     try {
       const ctx = await this.gatherWorkflowContext(mapping.workflowId);
       const harness = this.resolveHarnessPreset(mapping.harnessPreset ?? this.defaultHarnessPreset);
       this.log('slack', 'info', `[WORKFLOW_PLANNER] instance=${this.instanceId} event_ts=${event.ts} tool=${harness.tool} model=${harness.model ?? 'default'}`);
       const reply = await this.runOneShotPlanner(harness, buildAssistantPrompt(text, ctx));
       const chunks = splitForSlack(sanitizeSlackOutbound(reply));
-      for (let i = 0; i < chunks.length; i++) {
-        if (i > 0) await this.sleep(this.messagePacingMs);
+      const ackTs = this.ackMessages.get(threadTs);
+      if (ackTs && chunks[0]) {
+        const updated = await this.updateMessage(channel, ackTs, { text: chunks[0], blocks: [] });
+        this.ackMessages.delete(threadTs);
+        if (!updated) {
+          await this.deleteMessage(channel, ackTs);
+          await this.sayWithRateLimitRetry(say, { text: chunks[0], thread_ts: threadTs });
+        }
+      } else if (chunks[0]) {
+        await this.sayWithRateLimitRetry(say, { text: chunks[0], thread_ts: threadTs });
+      }
+      for (let i = 1; i < chunks.length; i++) {
+        await this.sleep(this.messagePacingMs);
         await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
       }
     } catch (err) {
@@ -2600,6 +2652,9 @@ ${text}`;
         text: `Error: ${err instanceof Error ? err.message : String(err)}`,
         thread_ts: threadTs,
       });
+    } finally {
+      await cleanupHeartbeats();
+      await this.clearImmediateAck(channel, threadTs);
     }
   }
 
@@ -2717,33 +2772,44 @@ ${text}`;
       let stdout = '';
       let stderr = '';
       let timedOut = false;
+      let settled = false;
+      const settle = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
       child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
       child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
       const timer = setTimeout(() => {
         timedOut = true;
         try { child.kill('SIGTERM'); } catch { /* already dead */ }
       }, timeoutMs);
-      child.on('close', (code) => {
-        clearTimeout(timer);
-        if (timedOut) {
-          reject(new Error(`Planner timed out after ${timeoutMs}ms`));
-          return;
-        }
-        if (code === 0) {
-          const trimmed = stdout.trim();
-          if (trimmed) {
-            const message = formatCodexPlannerStdout(trimmed).message;
-            resolve(message || 'The planner completed without a final user-facing reply.');
-          } else {
-            reject(new EmptyOutputAttemptError(stderr));
+      const onProcessEnd = (code: number | null): void => {
+        settle(() => {
+          if (timedOut) {
+            reject(new Error(`Planner timed out after ${timeoutMs}ms`));
+            return;
           }
-        } else {
-          reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
-        }
-      });
+          if (code === 0) {
+            const trimmed = stdout.trim();
+            if (trimmed) {
+              const message = formatCodexPlannerStdout(trimmed).message;
+              resolve(message || 'The planner completed without a final user-facing reply.');
+            } else {
+              reject(new EmptyOutputAttemptError(stderr));
+            }
+          } else {
+            reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
+          }
+        });
+      };
+      child.on('exit', (code) => { onProcessEnd(code); });
+      child.on('close', (code) => { onProcessEnd(code); });
       child.on('error', (err) => {
-        clearTimeout(timer);
-        reject(new Error(`Failed to spawn planner CLI: ${err.message}`));
+        settle(() => {
+          reject(new Error(`Failed to spawn planner CLI: ${err.message}`));
+        });
       });
     });
   }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2784,6 +2784,9 @@ ${text}`;
       const timer = setTimeout(() => {
         timedOut = true;
         try { child.kill('SIGTERM'); } catch { /* already dead */ }
+        settle(() => {
+          reject(new Error(`Planner timed out after ${timeoutMs}ms`));
+        });
       }, timeoutMs);
       const onProcessEnd = (code: number | null): void => {
         settle(() => {


### PR DESCRIPTION
## Summary

Workflow-channel free-form Q&A waited on the planner with no Processing post, so users saw silence when the spawn never settled.

This slice reuses the lobby Processing ack and Still-thinking heartbeat on that Q&A path only.

It also settles the one-shot planner on child exit as well as close, so a dead planner can post an error instead of hanging.

## Review Claim

Approve posting Processing and Still-thinking on workflow-channel Q&A, plus settling the planner on exit.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Workflow-channel control verbs still dispatch the same commands and do not wait on the planner. Lobby mention handling is unchanged. The only new Slack posts on this Q&A path are Processing, Still thinking, and an error if the planner ends without a reply.

## Slice Rationale

Behavior fix after harness and live proof so reviewers see the channel reply property fail then pass.

## Non-goals

Does not change lobby planning. Does not change control-verb dispatch. Does not teach the assistant to file a repair workflow from free-form text.

## Architecture

### Before

```mermaid
sequenceDiagram
  participant User
  participant Surface
  participant Planner
  User->>Surface: at-Invoker in workflow channel
  Note over Surface: no ack
  Surface->>Planner: spawn
  Note over User: silence until settle
```

### After

```mermaid
sequenceDiagram
  participant User
  participant Surface
  participant Planner
  User->>Surface: at-Invoker in workflow channel
  Surface->>User: Processing your request
  Surface->>Planner: spawn
  Note over Surface: settle on exit or close
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-workflows.test.ts`
- [x] DO1 live e2e against C0BTTHFM02U: bot Processing ack within 15s

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immediate acknowledgments for long-running workflow requests.
  * Added periodic “Still thinking…” updates while workflows are processing.
  * Replaces the acknowledgment with the first response when available.

* **Bug Fixes**
  * Improved message routing using the event channel when available.
  * Prevented duplicate workflow completions and ensured processing updates are cleaned up reliably.
  * Improved handling of workflows that finish without a standard completion event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->