### PR TITLE
[Release v0.0.14](1) Bundle @invoker/surfaces into the desktop app.

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
     }
   },
   "scripts": {
-    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup",
+    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup && node scripts/verify-surfaces-bundled.cjs",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",

--- a/packages/app/scripts/verify-noexternal-completeness.cjs
+++ b/packages/app/scripts/verify-noexternal-completeness.cjs
@@ -30,7 +30,13 @@ const packageRoot = join(__dirname, '..');
 // specific.
 const KNOWN_SAFE_EXTERNAL = {
   '@invoker/cli': 'never imported into the bundle; spawned as a separate subprocess via packages/app/src/cli-helper.ts, pointing at its own independently-built dist',
-  '@invoker/surfaces': 'has a real compiled dist (main: dist/index.js); packaged separately into app-build-dist.tgz, see scripts/test-suites/required/08-build-artifact-surfaces-guard.sh',
+};
+
+// Compiled dist is not enough for these: electron-builder's asar omits pnpm-nested
+// deps (npm 0.0.13 owner-serve died on `Cannot find module 'form-data'` while
+// loading @invoker/surfaces → @slack/bolt → axios). Bundle them into dist/main.js.
+const MUST_BUNDLE_EVEN_IF_COMPILED = {
+  '@invoker/surfaces': 'dynamically imported by in-app-planner; nested @slack/bolt dep form-data is omitted from the packaged asar unless this package is in noExternal',
 };
 
 function readJson(path) {
@@ -77,6 +83,11 @@ for (const name of dependencies) {
   const isRawTypeScript = /\.tsx?$/.test(mainEntry) && !mainEntry.startsWith('dist/');
 
   if (!isRawTypeScript) {
+    if (name in MUST_BUNDLE_EVEN_IF_COMPILED && !noExternal.has(name)) {
+      failures.push(
+        `${name}: ${MUST_BUNDLE_EVEN_IF_COMPILED[name]} Add it to packages/app/tsup.config.ts's noExternal.`,
+      );
+    }
     continue; // has a real compiled entry point; safe to leave external either way
   }
 
@@ -94,6 +105,12 @@ for (const name of dependencies) {
     + `it will crash packages/app/dist/main.js at runtime the moment any code path touches it -- add it `
     + `to noExternal (bundle it), or to KNOWN_SAFE_EXTERNAL with a reason if it's genuinely never `
     + `imported into the bundle (e.g. spawned as a subprocess like @invoker/cli).`,
+  );
+}
+
+if (!noExternal.has('@slack/bolt')) {
+  failures.push(
+    '@slack/bolt: required in noExternal; @invoker/surfaces loads it and the packaged asar omits nested form-data',
   );
 }
 

--- a/packages/app/scripts/verify-surfaces-bundled.cjs
+++ b/packages/app/scripts/verify-surfaces-bundled.cjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// After tsup, dist/main.js must not keep a runtime import("@invoker/surfaces").
+// npm 0.0.13 shipped surfaces inside app.asar but still failed owner-serve:
+// the dynamic import loaded @slack/bolt → axios, and form-data was omitted
+// from the asar. Bundling surfaces (and bolt) into main.js removes that edge.
+const { readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const mainPath = join(__dirname, '..', 'dist', 'main.js');
+if (!existsSync(mainPath)) {
+  console.error(`FAIL: ${mainPath} does not exist; build @invoker/app first`);
+  process.exit(1);
+}
+
+const main = readFileSync(mainPath, 'utf8');
+if (/import\(\s*['"]@invoker\/surfaces['"]\s*\)/.test(main)) {
+  console.error('FAIL: packages/app/dist/main.js still dynamically imports @invoker/surfaces');
+  process.exit(1);
+}
+
+console.log('PASS: packages/app/dist/main.js does not dynamically import @invoker/surfaces');

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
     '@invoker/planning-core',
     '@invoker/shell',
     '@invoker/slack-bug-scan',
+    '@invoker/surfaces',
+    '@slack/bolt',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

npm 0.0.13 owner-serve died while loading the in-app planner from a packaged desktop asar.

The asar already contained `@invoker/surfaces`. Loading it pulled `@slack/bolt`, then axios, then a missing `form-data` module.

This change puts `@invoker/surfaces` and `@slack/bolt` into the Electron main bundle so that load no longer depends on nested asar modules.

A build-time check fails if the compiled main file still dynamically imports `@invoker/surfaces`.

## Review Claim

Approve putting `@invoker/surfaces` and `@slack/bolt` into the desktop main bundle, plus the matching build-time checks under packages/app.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only changes desktop packaging under packages/app. Git-checkout owner-serve already resolved surfaces from workspace `node_modules`. Planner logic is unchanged.

## Slice Rationale

Keep the asar load-path fix in its own review lane. The required packager guard, version strings, and CHANGELOG.md stay in later slices.

## Non-goals

Does not change `scripts/test-suites/required/08-build-artifact-surfaces-guard.sh`. Does not change version numbers. Does not change CHANGELOG.md. Does not publish `@invoker/surfaces` as its own npm package.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build` -- PASS, `packages/app/dist/main.js` no longer dynamically imports `@invoker/surfaces`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
