### PR TITLE
[Release v0.0.14](3) Bump release version strings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
     }
   },
   "scripts": {
-    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup",
+    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup && node scripts/verify-surfaces-bundled.cjs",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",

--- a/packages/app/scripts/verify-noexternal-completeness.cjs
+++ b/packages/app/scripts/verify-noexternal-completeness.cjs
@@ -30,7 +30,13 @@ const packageRoot = join(__dirname, '..');
 // specific.
 const KNOWN_SAFE_EXTERNAL = {
   '@invoker/cli': 'never imported into the bundle; spawned as a separate subprocess via packages/app/src/cli-helper.ts, pointing at its own independently-built dist',
-  '@invoker/surfaces': 'has a real compiled dist (main: dist/index.js); packaged separately into app-build-dist.tgz, see scripts/test-suites/required/08-build-artifact-surfaces-guard.sh',
+};
+
+// Compiled dist is not enough for these: electron-builder's asar omits pnpm-nested
+// deps (npm 0.0.13 owner-serve died on `Cannot find module 'form-data'` while
+// loading @invoker/surfaces → @slack/bolt → axios). Bundle them into dist/main.js.
+const MUST_BUNDLE_EVEN_IF_COMPILED = {
+  '@invoker/surfaces': 'dynamically imported by in-app-planner; nested @slack/bolt dep form-data is omitted from the packaged asar unless this package is in noExternal',
 };
 
 function readJson(path) {
@@ -77,6 +83,11 @@ for (const name of dependencies) {
   const isRawTypeScript = /\.tsx?$/.test(mainEntry) && !mainEntry.startsWith('dist/');
 
   if (!isRawTypeScript) {
+    if (name in MUST_BUNDLE_EVEN_IF_COMPILED && !noExternal.has(name)) {
+      failures.push(
+        `${name}: ${MUST_BUNDLE_EVEN_IF_COMPILED[name]} Add it to packages/app/tsup.config.ts's noExternal.`,
+      );
+    }
     continue; // has a real compiled entry point; safe to leave external either way
   }
 
@@ -94,6 +105,12 @@ for (const name of dependencies) {
     + `it will crash packages/app/dist/main.js at runtime the moment any code path touches it -- add it `
     + `to noExternal (bundle it), or to KNOWN_SAFE_EXTERNAL with a reason if it's genuinely never `
     + `imported into the bundle (e.g. spawned as a subprocess like @invoker/cli).`,
+  );
+}
+
+if (!noExternal.has('@slack/bolt')) {
+  failures.push(
+    '@slack/bolt: required in noExternal; @invoker/surfaces loads it and the packaged asar omits nested form-data',
   );
 }
 

--- a/packages/app/scripts/verify-surfaces-bundled.cjs
+++ b/packages/app/scripts/verify-surfaces-bundled.cjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// After tsup, dist/main.js must not keep a runtime import("@invoker/surfaces").
+// npm 0.0.13 shipped surfaces inside app.asar but still failed owner-serve:
+// the dynamic import loaded @slack/bolt → axios, and form-data was omitted
+// from the asar. Bundling surfaces (and bolt) into main.js removes that edge.
+const { readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const mainPath = join(__dirname, '..', 'dist', 'main.js');
+if (!existsSync(mainPath)) {
+  console.error(`FAIL: ${mainPath} does not exist; build @invoker/app first`);
+  process.exit(1);
+}
+
+const main = readFileSync(mainPath, 'utf8');
+if (/import\(\s*['"]@invoker\/surfaces['"]\s*\)/.test(main)) {
+  console.error('FAIL: packages/app/dist/main.js still dynamically imports @invoker/surfaces');
+  process.exit(1);
+}
+
+console.log('PASS: packages/app/dist/main.js does not dynamically import @invoker/surfaces');

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
     '@invoker/planning-core',
     '@invoker/shell',
     '@invoker/slack-bug-scan',
+    '@invoker/surfaces',
+    '@slack/bolt',
     'yaml',
   ],
   clean: true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -66,7 +66,7 @@ import {
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
-const VERSION = '0.0.13';
+const VERSION = '0.0.14';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,7 +28,7 @@ import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
-const VERSION = '0.0.13';
+const VERSION = '0.0.14';
 let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+++ b/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 # Guardrail: every path that builds the Electron app must compile
-# packages/surfaces/dist first. @invoker/surfaces stays external in
-# packages/app/tsup.config.ts (not bundled), so a missing dist makes
-# packages/app's verify-workspace-imports.cjs throw
+# packages/surfaces/dist first, and packages/app must bundle @invoker/surfaces
+# (noExternal) so the packaged asar does not depend on pnpm-nested bolt deps.
+# A missing dist still makes packages/app's verify-workspace-imports.cjs throw
 # "Unresolvable workspace dependency @invoker/surfaces".
 #
 # Siblings:
 # - CI build-artifacts "Build UI and app" step (app-build-dist.tgz)
 # - scripts/package-desktop.sh (tagged + daily GitHub Release cuts)
+# - packages/app/tsup.config.ts noExternal (desktop asar)
 #
 # Regression: build-artifacts only tarred packages/ui/dist and packages/app/dist.
 # required-fast/ssh/e2e-proof/playwright jobs then crashed with
 # "Cannot find module '.../@invoker/surfaces/dist/index.js'" and hung until
 # CI timeout (#5845). package-desktop.sh was not updated, so tagged/daily
 # desktop jobs hit the same class later.
+#
+# Separate regression (npm 0.0.13): surfaces/dist was inside app.asar, but
+# loading it pulled @slack/bolt → axios → form-data, and form-data was omitted
+# from the asar. owner-serve then reported "Unable to load @invoker/surfaces".
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -50,4 +55,15 @@ if [[ -z "$surfaces_line" || -z "$app_line" || "$surfaces_line" -ge "$app_line" 
   exit 1
 fi
 
-echo "PASS: app-build-dist.tgz and package-desktop.sh both build packages/surfaces/dist"
+TSUP_CONFIG="$ROOT/packages/app/tsup.config.ts"
+NOEXTERNAL_BLOCK="$(awk '/noExternal: \[/{flag=1} flag{print} flag && /\]/{exit}' "$TSUP_CONFIG")"
+if ! grep -q "'@invoker/surfaces'" <<<"$NOEXTERNAL_BLOCK"; then
+  echo "FAIL: packages/app/tsup.config.ts noExternal must include @invoker/surfaces (desktop asar omits nested form-data)" >&2
+  exit 1
+fi
+if ! grep -q "'@slack/bolt'" <<<"$NOEXTERNAL_BLOCK"; then
+  echo "FAIL: packages/app/tsup.config.ts noExternal must include @slack/bolt (nested dep of @invoker/surfaces)" >&2
+  exit 1
+fi
+
+echo "PASS: app-build-dist.tgz and package-desktop.sh both build packages/surfaces/dist; app tsup bundles @invoker/surfaces"


### PR DESCRIPTION
## Summary

This is the version-bump half of the v0.0.14 release cut.

It updates the version field in the root and every publishable package.json from 0.0.13 to 0.0.14.

The same bump applies to the VERSION constants in the CLI and Slack manager sources.

## Review Claim

Approve the literal 0.0.13 to 0.0.14 string change across the listed files, with no other edits.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every changed line is a version string literal. No logic, no control flow, no new dependencies.

## Slice Rationale

A separate PR from the packaging fix and from the CHANGELOG update so each PR fits one review lane.

## Non-goals

Does not change CHANGELOG.md. Does not change desktop bundling. Every touched line is a literal version string.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/check-version-sync.mjs` -- `ok all release versions are 0.0.14`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
