### PR TITLE
[Release v0.0.14](4) Record 0.0.14 in CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+## 0.0.14
+
+- Fix packaged desktop owner-serve: bundle `@invoker/surfaces` and `@slack/bolt` into the Electron main bundle so loading the in-app planner no longer depends on pnpm-nested asar deps (npm 0.0.13 died with `Cannot find module 'form-data'`).
+
 ## 0.0.13
 
 - Bring planning chat to the web surfaces: bind a repo before the conversation starts, wire planning and task terminals through web dispatch, persist and retry turns, and keep Send from racing a repo bind or an in-flight turn (#9955-#9981, #9995).


### PR DESCRIPTION
## Summary

This records the v0.0.14 desktop packaging fix in CHANGELOG.md.

The Unreleased heading stays empty. The new 0.0.14 heading carries the one shipped note.

## Review Claim

Approve adding the v0.0.14 CHANGELOG heading and its one packaging note.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only CHANGELOG.md changes. No application code, no package versions, no bundling config.

## Slice Rationale

A separate PR from the version-string bump so docs stay in the docs lane.

## Non-goals

Does not change package.json version fields. Does not change desktop bundling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "^## 0.0.14$" CHANGELOG.md` -- heading present above the 0.0.13 section

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
