### PR TITLE
[Planning chat follower delegation](2) Forward leftover planning-chat mutations to the owner

### DIFF
--- a/packages/app/src/__tests__/planning-chat-follower-delegation.test.ts
+++ b/packages/app/src/__tests__/planning-chat-follower-delegation.test.ts
@@ -7,7 +7,7 @@ import { registerGuiMutationHandler } from '../ipc/ipc-registration.js';
 
 const CHANNEL = 'invoker:planning-chat-rebind-repo';
 const REPORTED_URL = 'https://github.com/Neko-Catpital-Labs/Invoker';
-const MISSING_PLANNING_CHAT_CHANNELS = [
+const PREVIOUSLY_UNWIRED_PLANNING_CHAT_CHANNELS = [
   'invoker:planning-chat-discard-draft',
   'invoker:planning-chat-rebind-repo',
   'invoker:planning-chat-set-terminal-mode',
@@ -90,18 +90,23 @@ async function invokeFollower(channel: string, args: unknown[]) {
 }
 
 describe('planning-chat follower owner delegation', () => {
-  it('reproduces the reported repo-field error for a follower GUI', async () => {
+  it('forwards the reported repo-field rebind to the owner instead of throwing', async () => {
     await expect(
       invokeFollower(CHANNEL, [{ sessionId: 'session-1', repoUrl: REPORTED_URL }]),
-    ).rejects.toThrow(`No owner delegation route is available for ${CHANNEL}`);
+    ).resolves.toMatchObject({
+      delegated: true,
+      translatedChannel: 'headless.gui-mutation',
+      payload: { channel: CHANNEL, args: [{ sessionId: 'session-1', repoUrl: REPORTED_URL }] },
+    });
   });
 
-  it.each([...MISSING_PLANNING_CHAT_CHANNELS])(
-    'throws the missing-delegation error for follower %s',
+  it.each([...PREVIOUSLY_UNWIRED_PLANNING_CHAT_CHANNELS])(
+    'forwards follower %s to the owner GUI mutation handler',
     async (channel) => {
-      await expect(invokeFollower(channel, [{ sessionId: 'session-1' }])).rejects.toThrow(
-        `No owner delegation route is available for ${channel}`,
-      );
+      await expect(invokeFollower(channel, [{ sessionId: 'session-1' }])).resolves.toMatchObject({
+        delegated: true,
+        translatedChannel: 'headless.gui-mutation',
+      });
     },
   );
 
@@ -111,9 +116,9 @@ describe('planning-chat follower owner delegation', () => {
     ).resolves.toMatchObject({ delegated: true, translatedChannel: 'headless.gui-mutation' });
   });
 
-  it('documents the planning-chat invoke channels with no follower translation case', () => {
+  it('forwards every planning-chat invoke channel to the owner', () => {
     const routed = routedPlanningChatChannels();
     const missing = planningChatInvokeChannels().filter((channel) => !routed.has(channel));
-    expect(missing.sort()).toEqual([...MISSING_PLANNING_CHAT_CHANNELS].sort());
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -966,6 +966,9 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:planning-chat-send':
       case 'invoker:planning-chat-submit':
       case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-set-terminal-mode':
+      case 'invoker:planning-chat-rebind-repo':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };


### PR DESCRIPTION
## Summary

A follower Invoker window can now bind a planning repo.

The leftover planning-chat actions go to the same owner GUI mutation handler as send.

Draft discard and terminal-mode changes use that path too, so a later sibling cannot ship silent.

## Review Claim

Follower planning-chat rebind, draft discard, and terminal-mode changes reach `headless.gui-mutation` instead of throwing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The follower still never runs these mutations locally. It only forwards them to the existing owner handler.

## Slice Rationale

The previous slice recorded the throw. This slice adds the three missing translator cases and flips the tests to expect an owner forward.

## Non-goals

Does not change `rebindPlanningChatRepo` itself, clone behavior, or the planning composer UI.

Does not fold the delete wrapper in `main.ts` into the inner translator.

Does not add owner forwards for test-only seed or inject channels.

## Architecture

### Before

```mermaid
graph TD
    A["follower repo field commit"] --> B["invoker:planning-chat-rebind-repo"]
    B --> C["translator default null"]
    C --> D["throw: no owner delegation"]
```

### After

```mermaid
graph TD
    A["follower repo field commit"] --> B["invoker:planning-chat-rebind-repo"]
    B --> C["translator headless.gui-mutation"]
    C --> D["owner rebindPlanningChatRepo"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/planning-chat-follower-delegation.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/ipc-registration.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>