### PR TITLE
[cross-repo-research lenses effectiveness and handoff scrub](1) Fan out five research lenses before synthesis

### DIFF
--- a/scripts/cross-repo-research-watch.mjs
+++ b/scripts/cross-repo-research-watch.mjs
@@ -175,26 +175,95 @@ function selectCandidates(activity, { maxCandidates, ledger }) {
   return selected;
 }
 
-function researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+const RESEARCH_LENSES = [
+  {
+    id: 'fit',
+    label: 'Fit',
+    ask: 'Assess product/architectural fit: does the target repo already solve this, partially solve it, or genuinely need it? Grep the target checkout for existing coverage.',
+    field: 'fitAnalysis',
+  },
+  {
+    id: 'peers',
+    label: 'Peers',
+    ask: 'Survey peer/competitor repos and prior art for this idea beyond the source repo. Record entries as peerLandscape: [{ repo, approach, outcome }].',
+    field: 'peerLandscape',
+  },
+  {
+    id: 'implementations',
+    label: 'Implementations',
+    ask: 'Enumerate at least two alternate implementation approaches for this idea inside the target repo, with tradeoffs. Record entries as alternateImplementations: [{ approach, tradeoffs }].',
+    field: 'alternateImplementations',
+  },
+  {
+    id: 'adversarial',
+    label: 'Adversarial',
+    ask: 'Argue against stealing this idea: redundancy, maintenance cost, safety risk, scope creep. Record entries as adversarialAnalysis: [{ objection, strength }].',
+    field: 'adversarialAnalysis',
+  },
+  {
+    id: 'effectiveness',
+    label: 'Effectiveness',
+    ask: 'Define effectivenessMeasurement: { leadingSignals: [...], laggingSignals: [...] } — concrete, observable signals beyond the fixture e2e test that show the idea worked once implemented. Leading signals are fast proxies; lagging signals are slower outcome measures.',
+    field: 'effectivenessMeasurement',
+  },
+];
+
+function lensArtifactPath(artifactDir, slotIndex, lensId) {
+  return `${artifactDir}/lens-${slotIndex}-${lensId}.json`;
+}
+
+function lensTaskId(slotIndex, lensId) {
+  return `research-${slotIndex}-${lensId}`;
+}
+
+function synthesisTaskId(slotIndex) {
+  return `research-${slotIndex}-synthesis`;
+}
+
+function lensPrompt(lens, slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
   const candidate = slot.candidate;
   const noop = !candidate;
   return [
-    'You are researching whether a source-repo idea should be stolen into the target repo.',
+    `You are the ${lens.label} lens in a parallel research swarm evaluating whether a source-repo idea should be stolen into the target repo.`,
+    'Do not implement product code. Do not open PRs. Do not label Linear tickets invoker-ready.',
+    noop
+      ? 'No candidate was assigned to this slot. Write a JSON artifact with lensId, verdict "skip", and an empty findings field, then exit.'
+      : `Candidate: ${candidate.title}`,
+    `Source: ${sourceRepoUrl}`,
+    `Target checkout: ${targetRepoUrl}`,
+    candidate ? `Evidence URL: ${candidate.url}` : '',
+    candidate ? `Source snippet: ${String(candidate.body).slice(0, 800)}` : '',
+    `Lens task: ${lens.ask}`,
+    `Write artifact JSON to ${lensArtifactPath(artifactDir, slot.index, lens.id)} with fields: lensId ("${lens.id}"), ${lens.field}.`,
+    'This lens only writes its own artifact file; do not write research-N.json.',
+  ].filter(Boolean).join('\n');
+}
+
+function synthesisPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+  const candidate = slot.candidate;
+  const noop = !candidate;
+  const lensPaths = RESEARCH_LENSES
+    .map((lens) => `${lens.field} from ${lensArtifactPath(artifactDir, slot.index, lens.id)}`)
+    .join(', ');
+  return [
+    'You are synthesizing five parallel research lenses (Fit, Peers, Implementations, Adversarial, Effectiveness) into one verdict.',
     'Do not implement product code. Do not open PRs. Do not label Linear tickets invoker-ready.',
     noop
       ? 'No candidate was assigned to this slot. Write a JSON artifact with verdict skip and title "noop-slot", then exit.'
       : `Candidate: ${candidate.title}`,
     `Source: ${sourceRepoUrl}`,
     `Target checkout: ${targetRepoUrl}`,
-    candidate ? `Evidence URL: ${candidate.url}` : '',
-    candidate ? `Source snippet: ${String(candidate.body).slice(0, 800)}` : '',
+    `Read each lens artifact and fold in its field: ${lensPaths}.`,
     `Write artifact JSON to ${artifactDir}/research-${slot.index}.json with fields:`,
     'title, verdict (steal|skip), repo, goal, motivation, safetyInvariant, verify,',
     'reviewClaim, reviewLane, sliceRationale, architecturalEffect, alternatives,',
     'implementationDetails, nonGoals, files, changeTypes, acceptanceCriteria,',
-    'layer, featureState, evidence.',
+    'layer, featureState, evidence,',
+    'peerLandscape, adversarialAnalysis, alternateImplementations, effectivenessMeasurement.',
+    'effectivenessMeasurement is required and must include leadingSignals and laggingSignals',
+    'beyond the fixture e2e test alone.',
     'repo must be the target repo URL. verify must be a runnable command.',
-    'Justify good vs bad with target greps. Skip ideas the target already owns.',
+    'Justify good vs bad with target greps and the adversarial lens objections. Skip ideas the target already owns.',
   ].filter(Boolean).join('\n');
 }
 
@@ -216,6 +285,62 @@ tasks:
 `;
 }
 
+function buildLensTask(lens, slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+  const id = lensTaskId(slot.index, lens.id);
+  const artifactPath = lensArtifactPath(artifactDir, slot.index, lens.id);
+  return `  - id: ${id}
+    description: |
+      ${lens.label} lens for research candidate slot ${slot.index}.
+      Goal: Produce ${lens.field} for candidate slot ${slot.index} via the ${lens.label} lens.
+      Motivation: Peer, adversarial, and effectiveness analysis must run in parallel before synthesis.
+      Safety invariant: No product commits; artifact write only under ${artifactDir}.
+      Review claim: The lens artifact records ${lens.field} for this candidate.
+      Review lane: docs
+      Slice rationale: One lens per parallel research task; five lenses per candidate.
+      Architectural effect: None; research-only.
+      Alternative considerations: A single combined research prompt was rejected in favor of parallel lenses.
+      Implementation details: Grep the target checkout; write the lens artifact JSON.
+      Non-goals: No Linear create here; no product implementation; no research-N.json write.
+      Files: ${artifactPath}
+      Change types: docs
+      Acceptance criteria:
+      - Artifact JSON exists at ${artifactPath} with lensId and ${lens.field}
+      Layer: docs
+      Feature state: active
+    prompt: |
+${lensPrompt(lens, slot, targetRepoUrl, sourceRepoUrl, artifactDir).split('\n').map((l) => `      ${l}`).join('\n')}
+    dependencies: []
+`;
+}
+
+function buildSynthesisTask(slot, targetRepoUrl, sourceRepoUrl, artifactDir) {
+  const deps = RESEARCH_LENSES.map((lens) => lensTaskId(slot.index, lens.id));
+  return `  - id: ${synthesisTaskId(slot.index)}
+    description: |
+      Synthesize the five research lenses for candidate slot ${slot.index} into a steal/skip verdict.
+      Goal: Produce research-${slot.index}.json with plan-to-invoker fields plus lens findings.
+      Motivation: Human triage needs full Goal/Motivation/Safety/Verify before invoker-ready.
+      Safety invariant: No product commits; artifact write only under ${artifactDir}.
+      Review claim: The artifact records a justified steal or skip verdict backed by all five lenses.
+      Review lane: docs
+      Slice rationale: One synthesis task per candidate, gated on its five lens tasks.
+      Architectural effect: None; research-only.
+      Alternative considerations: In-process classification was rejected; swarm research is required.
+      Implementation details: Read each lens artifact; write the synthesized research artifact JSON.
+      Non-goals: No Linear create here; no product implementation.
+      Files: ${artifactDir}/research-${slot.index}.json
+      Change types: docs
+      Acceptance criteria:
+      - Artifact JSON exists with Goal, Motivation, Safety invariant, Verify, Verdict
+      - Artifact JSON includes peerLandscape, adversarialAnalysis, alternateImplementations, effectivenessMeasurement
+      Layer: docs
+      Feature state: active
+    prompt: |
+${synthesisPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir).split('\n').map((l) => `      ${l}`).join('\n')}
+    dependencies: ${JSON.stringify(deps)}
+`;
+}
+
 function buildResearchWorkflow({
   targetRepoUrl,
   sourceRepoUrl,
@@ -223,32 +348,10 @@ function buildResearchWorkflow({
   slots,
   upstreamToken,
 }) {
-  const tasks = slots.map((slot) => {
-    const deps = [];
-    return `  - id: research-${slot.index}
-    description: |
-      Research candidate slot ${slot.index} for steal vs skip.
-      Goal: Produce research-${slot.index}.json with plan-to-invoker fields.
-      Motivation: Human triage needs full Goal/Motivation/Safety/Verify before invoker-ready.
-      Safety invariant: No product commits; artifact write only under ${artifactDir}.
-      Review claim: The artifact records a justified steal or skip verdict for this candidate.
-      Review lane: docs
-      Slice rationale: One candidate per parallel research slot.
-      Architectural effect: None; research-only.
-      Alternative considerations: In-process classification was rejected; swarm research is required.
-      Implementation details: Grep the target checkout; write the artifact JSON.
-      Non-goals: No Linear create here; no product implementation.
-      Files: ${artifactDir}/research-${slot.index}.json
-      Change types: docs
-      Acceptance criteria:
-      - Artifact JSON exists with Goal, Motivation, Safety invariant, Verify, Verdict
-      Layer: docs
-      Feature state: active
-    prompt: |
-${researchPrompt(slot, targetRepoUrl, sourceRepoUrl, artifactDir).split('\n').map((l) => `      ${l}`).join('\n')}
-    dependencies: ${JSON.stringify(deps)}
-`;
-  }).join('\n');
+  const tasks = slots.map((slot) => [
+    ...RESEARCH_LENSES.map((lens) => buildLensTask(lens, slot, targetRepoUrl, sourceRepoUrl, artifactDir)),
+    buildSynthesisTask(slot, targetRepoUrl, sourceRepoUrl, artifactDir),
+  ].join('\n')).join('\n');
 
   return `name: "cross-repo-research research ${slugify(sourceOwnerRepo(sourceRepoUrl) ?? sourceRepoUrl)}"
 onFinish: none
@@ -300,6 +403,30 @@ tasks:
       Safety invariant: Never adds invoker-ready; Linear key stays in env/secrets only.
     command: ${yamlQuote(command)}
     dependencies: []
+  - id: scrub-handoff-artifacts
+    description: |
+      Remove ephemeral inter-task handoff files (candidates.json, research-*.json,
+      lens-*.json) from the git worktree before merge.
+      Goal: Leave no worktree-leaked handoff JSON tracked or untracked after filing.
+      Motivation: Steal-candidate handoff files must never ship in a PR diff.
+      Safety invariant: Only touches worktree handoff paths; never alters the home
+        invoker runDir or ~/.invoker/cross-repo-research/ledger.json.
+      Review claim: Worktree has no candidates.json/research-*.json/lens-*.json left.
+      Review lane: cleanup
+      Slice rationale: Required leaf after file-linear-tickets, before merge.
+      Architectural effect: None; deletion only.
+      Alternative considerations: Shipping handoff JSON in the PR was rejected.
+      Implementation details: Run scripts/scrub-handoff-artifacts.sh.
+      Non-goals: No feature edits; no ledger.json changes.
+      Files: (handoff paths only)
+      Change types: delete
+      Acceptance criteria:
+      - \`bash scripts/scrub-handoff-artifacts.sh\` exits 0 with no handoff paths remaining
+      Layer: e2e_regression
+      Feature state: active
+    command: "bash scripts/scrub-handoff-artifacts.sh"
+    dependencies:
+      - file-linear-tickets
 `;
 }
 

--- a/scripts/scrub-handoff-artifacts.sh
+++ b/scripts/scrub-handoff-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Scrub ephemeral inter-task handoff files from the git worktree before merge.
+# Keeps ~/.invoker ledgers and checked-in scripts/fixtures untouched.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+find . -maxdepth 4 \( -name candidates.json -o -name 'research-*.json' -o -name 'lens-*.json' \) \
+  ! -path './.git/*' ! -path './node_modules/*' ! -path './scripts/*' ! -path './packages/*' \
+  -print0 2>/dev/null | xargs -0 rm -f
+
+for p in plans/invoker-handoff.md plans/invoker-handoff.yaml; do
+  if [[ -e "$p" ]]; then
+    rm -f "$p"
+  fi
+done
+
+if git status --porcelain | grep -E '(candidates\.json|research-[0-9]+\.json|lens-.*\.json|plans/invoker-handoff\.(md|yaml))' >/tmp/handoff-dirty 2>/dev/null; then
+  git add -A -- plans/invoker-handoff.md plans/invoker-handoff.yaml 2>/dev/null || true
+  git add -u
+  if [[ -s /tmp/handoff-dirty ]]; then
+    git commit -m "chore: scrub inter-task handoff artifacts before merge" || true
+  fi
+fi
+
+if find . -maxdepth 4 \( -name candidates.json -o -name 'research-*.json' -o -name 'lens-*.json' \) \
+  ! -path './.git/*' ! -path './node_modules/*' ! -path './scripts/*' ! -path './packages/*' | grep -q .; then
+  echo "handoff files remain in worktree" >&2
+  exit 1
+fi
+
+echo "scrub-handoff-artifacts-ok"

--- a/scripts/test-cross-repo-research-watch.sh
+++ b/scripts/test-cross-repo-research-watch.sh
@@ -94,9 +94,16 @@ test -n "$research" || fail "B: missing research template" "$log"
 grep -q "id: research-1" "$research" || fail "B: missing research-1" "$research"
 grep -q "id: research-3" "$research" || fail "B: expected K=3 slots" "$research"
 grep -q "onFinish: none" "$research" || fail "B: research must be onFinish none" "$research"
+for lens in fit peers implementations adversarial effectiveness; do
+  grep -q "id: research-1-${lens}" "$research" || fail "B: missing lens id research-1-${lens}" "$research"
+done
+grep -q "id: research-1-synthesis" "$research" || fail "B: missing synthesis task for slot 1" "$research"
+grep -q "effectivenessMeasurement" "$research" || fail "B: synthesis must require effectivenessMeasurement" "$research"
 file_lin="$(find "$sb/work/runs" -name '03-file-linear.template.yaml' | head -1)"
 grep -q "linear-issue-create.mjs" "$file_lin" || fail "B: file-linear must call create script" "$file_lin"
 grep -vq "invoker-ready" "$file_lin" || fail "B: must not mention invoker-ready" "$file_lin"
+grep -q "id: scrub-handoff-artifacts" "$file_lin" || fail "B: file-linear chain missing scrub-handoff-artifacts" "$file_lin"
+grep -q "scrub-handoff-artifacts.sh" "$file_lin" || fail "B: scrub task must run scrub-handoff-artifacts.sh" "$file_lin"
 echo "PASS B: feat activity → chain with K slots"
 
 # ── C. Duplicate fingerprint → skip ──────────────────────────────────────────

--- a/scripts/test-plan-effectiveness-gate.sh
+++ b/scripts/test-plan-effectiveness-gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Prove plan-to-invoker completeness hard-requires Effectiveness measurement.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/eff-gate.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+miss="$tmp/miss.yaml"
+ok="$tmp/ok.yaml"
+
+cat > "$miss" <<'YAML'
+name: "effectiveness-gate-miss"
+onFinish: none
+mergeMode: no_op
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+tasks:
+  - id: t1
+    description: |
+      Goal: x
+      Motivation: y
+      Safety invariant: z
+      Review claim: c
+      Review lane: docs
+      Slice rationale: s
+      Architectural effect: none
+      Alternative considerations: none
+      Implementation details: n
+      Non-goals: n
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `true`
+    command: "true"
+    dependencies: []
+YAML
+
+cat > "$ok" <<'YAML'
+name: "effectiveness-gate-ok"
+onFinish: none
+mergeMode: no_op
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+tasks:
+  - id: t1
+    description: |
+      Goal: x
+      Motivation: y
+      Safety invariant: z
+      Effectiveness measurement: leading signal A; lagging signal B beyond fixture e2e
+      Review claim: c
+      Review lane: docs
+      Slice rationale: s
+      Architectural effect: none
+      Alternative considerations: none
+      Implementation details: n
+      Non-goals: n
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `true`
+    command: "true"
+    dependencies: []
+YAML
+
+set +e
+bash "$ROOT/skills/plan-to-invoker/scripts/check-planning-completeness.sh" "$miss"
+miss_ec=$?
+bash "$ROOT/skills/plan-to-invoker/scripts/check-planning-completeness.sh" "$ok"
+ok_ec=$?
+set -e
+
+if [[ "$miss_ec" -ne 1 ]]; then
+  echo "expected miss plan exit 1, got $miss_ec" >&2
+  exit 1
+fi
+if [[ "$ok_ec" -ne 0 ]]; then
+  echo "expected ok plan exit 0, got $ok_ec" >&2
+  exit 1
+fi
+echo "effectiveness-gate-ok"

--- a/scripts/test-plan-handoff-scrub-gate.sh
+++ b/scripts/test-plan-handoff-scrub-gate.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Prove plan-to-invoker hard-requires scrub-handoff-artifacts on PR-bound plans.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/handoff-scrub-gate.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+miss="$tmp/miss.yaml"
+ok="$tmp/ok.yaml"
+
+# Minimal PR-bound plan missing scrub-handoff-artifacts (other headings present).
+cat > "$miss" <<'YAML'
+name: "handoff-scrub-gate-miss"
+description: |
+  Goal: g
+  Motivation: m
+  Safety invariant: s
+  Effectiveness measurement: leading a; lagging b beyond fixture e2e
+  Verify: true
+onFinish: pull_request
+mergeMode: manual
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+tasks:
+  - id: implement-thing
+    description: |
+      Goal: g
+      Motivation: m
+      Safety invariant: s
+      Effectiveness measurement: leading a; lagging b beyond fixture e2e
+      Review claim: c
+      Review lane: behavior
+      Slice rationale: s
+      Architectural effect: none
+      Alternative considerations: none
+      Implementation details: n
+      Non-goals: n
+      Files: packages/app/src/main.ts
+      Change types: modify
+      Acceptance criteria:
+      - `true`
+      Layer: app_bridge
+      Feature state: active
+    prompt: |
+      Assume no prior context. You are given only this task.
+      Goal: g
+      Motivation: m
+      Safety invariant: s
+      Effectiveness measurement: leading a; lagging b beyond fixture e2e
+      Review claim: c
+      Review lane: behavior
+      Alternative considerations: none
+      Implementation details: touch nothing harmful
+      Non-goals: none
+      Acceptance criteria:
+      - `true`
+    dependencies: []
+YAML
+
+# Same plan with required scrub-handoff-artifacts leaf.
+cat > "$ok" <<'YAML'
+name: "handoff-scrub-gate-ok"
+description: |
+  Goal: g
+  Motivation: m
+  Safety invariant: s
+  Effectiveness measurement: leading a; lagging b beyond fixture e2e
+  Verify: true
+onFinish: pull_request
+mergeMode: manual
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+tasks:
+  - id: implement-thing
+    description: |
+      Goal: g
+      Motivation: m
+      Safety invariant: s
+      Effectiveness measurement: leading a; lagging b beyond fixture e2e
+      Review claim: c
+      Review lane: behavior
+      Slice rationale: s
+      Architectural effect: none
+      Alternative considerations: none
+      Implementation details: n
+      Non-goals: n
+      Files: packages/app/src/main.ts
+      Change types: modify
+      Acceptance criteria:
+      - `true`
+      Layer: app_bridge
+      Feature state: active
+    prompt: |
+      Assume no prior context. You are given only this task.
+      Goal: g
+      Motivation: m
+      Safety invariant: s
+      Effectiveness measurement: leading a; lagging b beyond fixture e2e
+      Review claim: c
+      Review lane: behavior
+      Alternative considerations: none
+      Implementation details: touch nothing harmful
+      Non-goals: none
+      Acceptance criteria:
+      - `true`
+    dependencies: []
+  - id: scrub-handoff-artifacts
+    description: |
+      Goal: Remove ephemeral inter-task handoff files before merge.
+      Motivation: Handoff must not ship in the PR.
+      Safety invariant: Do not delete ledger.json under home invoker dir.
+      Effectiveness measurement: Exit 0 only when handoff patterns are absent.
+      Review claim: Worktree has no handoff JSON left for the PR.
+      Review lane: cleanup
+      Slice rationale: Required leaf before merge.
+      Architectural effect: None.
+      Alternative considerations: Shipping handoff files rejected.
+      Implementation details: Run scripts/scrub-handoff-artifacts.sh
+      Non-goals: No feature edits.
+      Files: (handoff paths only)
+      Change types: delete
+      Acceptance criteria:
+      - `bash scripts/scrub-handoff-artifacts.sh` exits 0
+      Layer: e2e_regression
+      Feature state: active
+    command: "bash scripts/scrub-handoff-artifacts.sh"
+    dependencies:
+      - implement-thing
+YAML
+
+set +e
+# Prefer atomicity lint once the gate exists; fall back to skill-doctor first-failed.
+bash "$ROOT/skills/plan-to-invoker/scripts/lint-task-atomicity.sh" "$miss" >/tmp/miss-out 2>&1
+miss_ec=$?
+bash "$ROOT/skills/plan-to-invoker/scripts/lint-task-atomicity.sh" "$ok" >/tmp/ok-out 2>&1
+ok_ec=$?
+set -e
+
+if [[ "$miss_ec" -eq 0 ]]; then
+  echo "expected miss plan atomicity fail, got 0" >&2
+  cat /tmp/miss-out >&2
+  exit 1
+fi
+if [[ "$ok_ec" -ne 0 ]]; then
+  echo "expected ok plan atomicity pass, got $ok_ec" >&2
+  cat /tmp/ok-out >&2
+  exit 1
+fi
+echo "handoff-scrub-gate-ok"


### PR DESCRIPTION
## Summary

Cross-repo research now evaluates each candidate through Fit, Peers, Implementations, Adversarial, and Effectiveness tasks before synthesis.

Synthesis requires an effectiveness measurement. Filing is followed by an explicit handoff-artifact scrub without touching the home ledger.

## Review Claim

Generated research workflows fan out five named lenses, require measured synthesis, and scrub ephemeral handoff artifacts after ticket filing.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Research chains remain `onFinish: none`, never apply `invoker-ready`, preserve generate-only and empty-map no-ops, and never alter the home `ledger.json`.

## Slice Rationale

This establishes the research artifact contract before later slices consume its fields in Linear tickets and planning gates.

## Non-goals

No Linear body changes, plan-completeness rules, worker registration changes, live API calls, or home-ledger cleanup.

## Architecture

### Before

```mermaid
graph LR
    A["Candidate"] --> B["Single research prompt"] --> C["Linear filing"]
```

### After

```mermaid
graph LR
    A["Candidate"] --> B["Five parallel lenses"] --> C["Effectiveness-gated synthesis"] --> D["Linear filing"] --> E["Handoff scrub"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-cross-repo-research-watch.sh`
- Runner result: `All cross-repo-research fixture tests passed.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting dependent stack slices.
- Revert command: `git revert 67da34a38abba3284fd263ef7954e57bf0382581`
- Post-revert steps: Re-run the cross-repo research fixture suite.
- Data migration? No.

</details>
