### PR TITLE
[Planning chat follower delegation](3) Fail CI when a GUI mutation has no follower translator.

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -158,4 +158,65 @@ describe('GUI mutation translation', () => {
     expect(retryTaskSource).not.toContain('preemptTaskSubgraph(taskId)');
     expect(retryTaskSource).toContain('commandService.retryTask(envelope)');
   });
+
+  it('gives every production GUI mutation registration a follower translator case', () => {
+    const testOnlyBlock = extractBalancedBlock(
+      guiMutationHandlersSource,
+      "if (process.env.NODE_ENV === 'test')",
+    );
+    const productionHandlersSource = testOnlyBlock
+      ? guiMutationHandlersSource.replace(testOnlyBlock, '')
+      : guiMutationHandlersSource;
+    const registered = new Set([
+      ...channelRegistrations(productionHandlersSource),
+      ...channelRegistrations(mainSource),
+    ]);
+    const routed = new Set([
+      ...casesIn(getTranslatorSource()),
+      ...wrapperChannels(getMainTranslatorWrapperSource()),
+    ]);
+    if (/case SPAWN_REPAIR_WORKFLOW_CHANNEL:/.test(getTranslatorSource())) {
+      routed.add('invoker:spawn-repair-workflow');
+    }
+    const missing = [...registered].filter((channel) => !routed.has(channel)).sort();
+    expect(missing).toEqual([]);
+  });
 });
+
+function extractBalancedBlock(source: string, marker: string): string {
+  const markerIdx = source.indexOf(marker);
+  if (markerIdx < 0) return '';
+  const openIdx = source.indexOf('{', markerIdx);
+  let depth = 0;
+  for (let idx = openIdx; idx < source.length; idx += 1) {
+    if (source[idx] === '{') depth += 1;
+    else if (source[idx] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIdx, idx + 1);
+    }
+  }
+  return '';
+}
+
+function channelRegistrations(source: string): string[] {
+  return [
+    ...source.matchAll(/register(?:WorkflowScoped)?GuiMutationHandler\(\s*'([^']+)'/g),
+    ...source.matchAll(/registrars\.registerGuiMutationHandler\(\s*'([^']+)'/g),
+  ].map((match) => match[1]);
+}
+
+function casesIn(block: string): string[] {
+  return [...block.matchAll(/case '([^']+)':/g)].map((match) => match[1]);
+}
+
+function wrapperChannels(block: string): string[] {
+  return [...block.matchAll(/payload\.channel === '([^']+)'/g)].map((match) => match[1]);
+}
+
+function getMainTranslatorWrapperSource(): string {
+  const start = mainSource.indexOf('translateGuiMutationToHeadless: (payload) => {');
+  const end = mainSource.indexOf('guiMutationHandlers,', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}

--- a/packages/app/src/__tests__/planning-chat-follower-delegation.test.ts
+++ b/packages/app/src/__tests__/planning-chat-follower-delegation.test.ts
@@ -7,7 +7,7 @@ import { registerGuiMutationHandler } from '../ipc/ipc-registration.js';
 
 const CHANNEL = 'invoker:planning-chat-rebind-repo';
 const REPORTED_URL = 'https://github.com/Neko-Catpital-Labs/Invoker';
-const MISSING_PLANNING_CHAT_CHANNELS = [
+const PREVIOUSLY_UNWIRED_PLANNING_CHAT_CHANNELS = [
   'invoker:planning-chat-discard-draft',
   'invoker:planning-chat-rebind-repo',
   'invoker:planning-chat-set-terminal-mode',
@@ -90,18 +90,23 @@ async function invokeFollower(channel: string, args: unknown[]) {
 }
 
 describe('planning-chat follower owner delegation', () => {
-  it('reproduces the reported repo-field error for a follower GUI', async () => {
+  it('forwards the reported repo-field rebind to the owner instead of throwing', async () => {
     await expect(
       invokeFollower(CHANNEL, [{ sessionId: 'session-1', repoUrl: REPORTED_URL }]),
-    ).rejects.toThrow(`No owner delegation route is available for ${CHANNEL}`);
+    ).resolves.toMatchObject({
+      delegated: true,
+      translatedChannel: 'headless.gui-mutation',
+      payload: { channel: CHANNEL, args: [{ sessionId: 'session-1', repoUrl: REPORTED_URL }] },
+    });
   });
 
-  it.each([...MISSING_PLANNING_CHAT_CHANNELS])(
-    'throws the missing-delegation error for follower %s',
+  it.each([...PREVIOUSLY_UNWIRED_PLANNING_CHAT_CHANNELS])(
+    'forwards follower %s to the owner GUI mutation handler',
     async (channel) => {
-      await expect(invokeFollower(channel, [{ sessionId: 'session-1' }])).rejects.toThrow(
-        `No owner delegation route is available for ${channel}`,
-      );
+      await expect(invokeFollower(channel, [{ sessionId: 'session-1' }])).resolves.toMatchObject({
+        delegated: true,
+        translatedChannel: 'headless.gui-mutation',
+      });
     },
   );
 
@@ -111,9 +116,9 @@ describe('planning-chat follower owner delegation', () => {
     ).resolves.toMatchObject({ delegated: true, translatedChannel: 'headless.gui-mutation' });
   });
 
-  it('documents the planning-chat invoke channels with no follower translation case', () => {
+  it('forwards every planning-chat invoke channel to the owner', () => {
     const routed = routedPlanningChatChannels();
     const missing = planningChatInvokeChannels().filter((channel) => !routed.has(channel));
-    expect(missing.sort()).toEqual([...MISSING_PLANNING_CHAT_CHANNELS].sort());
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -966,6 +966,9 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:planning-chat-send':
       case 'invoker:planning-chat-submit':
       case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-set-terminal-mode':
+      case 'invoker:planning-chat-rebind-repo':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };


### PR DESCRIPTION
## Summary

A new GUI mutation can still ship without a follower translator case.

The planning-chat prefix check would not see that gap.

This closed-world proof compares every production registration to the translator.

## Review Claim

CI fails when a production `registerGuiMutationHandler` or workflow-scoped GUI mutation channel has no follower translator case.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only. No product handler or translator changes in this slice.

## Slice Rationale

The earlier slices wired three missing planning-chat cases. This slice is the gate that fails if a fourth sibling is registered without a translator case.

## Non-goals

Does not add translator cases for test-only seed or inject channels.

Does not fold the delete wrapper in `main.ts` into the inner translator.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/gui-mutation-translation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10664