### PR TITLE
[cross-repo-research lenses and effectiveness measurement](2) Add research lens fields to Linear tickets

### DIFF
--- a/scripts/linear-issue-create.mjs
+++ b/scripts/linear-issue-create.mjs
@@ -70,6 +70,24 @@ function heading(name, value) {
   return text ? `${name}: ${text}` : '';
 }
 
+function formatComplex(value) {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map((v) => `- ${formatComplex(v)}`).join('\n');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value)
+      .map(([k, v]) => {
+        const formatted = formatComplex(v);
+        return formatted.includes('\n') ? `${k}:\n${formatted}` : `${k}: ${formatted}`;
+      })
+      .join('\n');
+  }
+  return String(value);
+}
+
 function buildBodyFromArtifact(artifact) {
   const lines = [
     heading('Repo', artifact.repo ?? artifact.repoUrl),
@@ -81,6 +99,10 @@ function buildBodyFromArtifact(artifact) {
     heading('Review lane', artifact.reviewLane),
     heading('Slice rationale', artifact.sliceRationale),
     heading('Architectural effect', artifact.architecturalEffect),
+    heading('Peer landscape', formatComplex(artifact.peerLandscape)),
+    heading('Adversarial analysis', formatComplex(artifact.adversarialAnalysis)),
+    heading('Alternate implementations', formatComplex(artifact.alternateImplementations)),
+    heading('Effectiveness measurement', formatComplex(artifact.effectivenessMeasurement)),
     heading('Alternative considerations', artifact.alternatives ?? artifact.alternativeConsiderations),
     heading('Implementation details', artifact.implementationDetails ?? artifact.implementation),
     heading('Non-goals', artifact.nonGoals),
@@ -105,7 +127,7 @@ function requireField(body, name) {
 }
 
 function validateBody(body) {
-  for (const field of ['Repo', 'Goal', 'Motivation', 'Safety invariant', 'Verify']) {
+  for (const field of ['Repo', 'Goal', 'Motivation', 'Safety invariant', 'Verify', 'Effectiveness measurement']) {
     requireField(body, field);
   }
   if (/\binvoker-ready\b/i.test(body)) {

--- a/scripts/test-cross-repo-research-watch.sh
+++ b/scripts/test-cross-repo-research-watch.sh
@@ -166,7 +166,14 @@ cat > "$sb/steal.json" <<'JSON'
   "verify": "cd packages/ui && pnpm test -- workflow-progress-surfaces",
   "reviewClaim": "needs_input ranks above failed in attention entries",
   "reviewLane": "behavior",
-  "evidence": "orca #15551"
+  "evidence": "orca #15551",
+  "peerLandscape": "Orca and Linear both surface needs_input above failed.",
+  "adversarialAnalysis": "Sort thrash could hide steady-state agents if resort runs too often.",
+  "alternateImplementations": ["Client-side sort comparator", "Server-side ordered query"],
+  "effectivenessMeasurement": {
+    "leadingSignals": ["needs_input entries clicked within 5s of render"],
+    "laggingSignals": ["operator-reported time-to-respond drops week over week"]
+  }
 }
 JSON
 cat > "$sb/skip.json" <<'JSON'
@@ -178,7 +185,11 @@ cat > "$sb/skip.json" <<'JSON'
   "motivation": "Invoker already orchestrates stacked PRs",
   "safetyInvariant": "No product change; documentation of skip only",
   "verify": "test -f skills/land-stack/SKILL.md",
-  "evidence": "land-stack skill exists"
+  "evidence": "land-stack skill exists",
+  "effectivenessMeasurement": {
+    "leadingSignals": ["no duplicate skip-idea tickets filed for this fingerprint"],
+    "laggingSignals": ["no stacked-PR rebuild proposal reopens within a quarter"]
+  }
 }
 JSON
 cat > "$sb/bin/create-stub" <<STUB
@@ -200,6 +211,10 @@ grep -q "Goal:" "$sb/creates.jsonl" || fail "D-steal: body missing Goal" "$sb/cr
 grep -q "Motivation:" "$sb/creates.jsonl" || fail "D-steal: body missing Motivation" "$sb/creates.jsonl"
 grep -q "Safety invariant:" "$sb/creates.jsonl" || fail "D-steal: body missing Safety" "$sb/creates.jsonl"
 grep -q "Verify:" "$sb/creates.jsonl" || fail "D-steal: body missing Verify" "$sb/creates.jsonl"
+grep -q "Peer landscape:" "$sb/creates.jsonl" || fail "D-steal: body missing Peer landscape" "$sb/creates.jsonl"
+grep -q "Adversarial analysis:" "$sb/creates.jsonl" || fail "D-steal: body missing Adversarial analysis" "$sb/creates.jsonl"
+grep -q "Alternate implementations:" "$sb/creates.jsonl" || fail "D-steal: body missing Alternate implementations" "$sb/creates.jsonl"
+grep -q "Effectiveness measurement:" "$sb/creates.jsonl" || fail "D-steal: body missing Effectiveness measurement" "$sb/creates.jsonl"
 grep -vq "invoker-ready" "$sb/creates.jsonl" || fail "D-steal: must not include invoker-ready" "$sb/creates.jsonl"
 
 : > "$sb/creates.jsonl"
@@ -236,5 +251,26 @@ if env INVOKER_LINEAR_LABEL_NAMES=invoker-ready INVOKER_LINEAR_DRY_RUN=1 \
 fi
 grep -qi "Refusing\|invoker-ready" "$log" || fail "E: expected refusal message" "$log"
 echo "PASS E: refuses invoker-ready"
+
+# ── F. Fail closed without effectivenessMeasurement ──────────────────────────
+mk_sb
+cat > "$sb/no-measurement.json" <<'JSON'
+{
+  "title": "Missing effectiveness measurement",
+  "verdict": "steal",
+  "repo": "https://github.com/Neko-Catpital-Labs/Invoker.git",
+  "goal": "g",
+  "motivation": "m",
+  "safetyInvariant": "s",
+  "verify": "true"
+}
+JSON
+log="$sb/f.log"
+if env INVOKER_LINEAR_DRY_RUN=1 \
+  node "$REPO_ROOT/scripts/linear-issue-create.mjs" --artifact "$sb/no-measurement.json" > "$log" 2>&1; then
+  fail "F: must refuse create without effectivenessMeasurement" "$log"
+fi
+grep -qi "Effectiveness measurement" "$log" || fail "F: expected missing-effectiveness message" "$log"
+echo "PASS F: fails closed without effectivenessMeasurement"
 
 echo "All cross-repo-research fixture tests passed."


### PR DESCRIPTION
## Summary

Linear ticket bodies now carry the competitive, adversarial, alternate-implementation, and effectiveness context produced by research.

Filing stops when effectiveness measurement is absent, keeping incomplete research out of triage.

## Review Claim

Linear filing emits all four lens-derived sections and stops before GraphQL creation when effectiveness measurement is missing.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Steal tickets remain unlabeled, skip tickets use only `idea-skip`, `invoker-ready` remains forbidden, and bodies contain no secrets.

## Slice Rationale

Ticket formatting follows the research artifact contract established by the preceding slice.

## Non-goals

No Linear UI changes, label policy changes, or live API calls in fixtures.

## Architecture

### Before

```mermaid
graph TD
    A["Research artifact"] --> B["Basic Linear body"]
    B --> C["GraphQL create"]
```

### After

```mermaid
graph TD
    A["Research artifact"] --> B["Required effectiveness check"]
    B --> C["Lens-complete Linear body"]
    C --> D["GraphQL create"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-cross-repo-research-watch.sh`
- [x] `git diff --check origin/pr/cross-repo-research-lenses...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8543b1e98270b76278880b554661e9dd13c36e31`
- Post-revert steps: Re-run `bash scripts/test-cross-repo-research-watch.sh`.
- Data migration? No

</details>
