### PR TITLE
[Invoker sleep/wake](1) Add invoker-cli wait that parks until settle then prints INVOKER_WAKE

### DIFF
--- a/packages/cli/src/__tests__/cli-wait.test.ts
+++ b/packages/cli/src/__tests__/cli-wait.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import { main, parseWaitArgs } from '../index.js';
+import {
+  assertInvokerWakeLineWithinBudget,
+  formatInvokerWakeLine,
+  INVOKER_WAKE_MAX_BYTES,
+  INVOKER_WAKE_PREFIX,
+} from '../invoker-wake.js';
+import {
+  waitForWorkflowTasks,
+  workflowTasksSettled,
+} from '../mcp-workflow-status.js';
+
+function captureProcessOutput() {
+  let stdout = '';
+  let stderr = '';
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+    stdout += chunk.toString();
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+    stderr += chunk.toString();
+    return true;
+  });
+  return {
+    get stdout() { return stdout; },
+    get stderr() { return stderr; },
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
+describe('invoker-wake payload', () => {
+  it('formats a compact INVOKER_WAKE line without tasks or descriptions', () => {
+    const line = formatInvokerWakeLine({
+      workflowId: 'wf-1',
+      settled: true,
+      timedOut: false,
+      status: {
+        total: 2,
+        completed: 1,
+        failed: 0,
+        closed: 0,
+        running: 0,
+        pending: 0,
+        awaitingApproval: 1,
+        blocked: 0,
+      },
+      reviewUrl: 'https://example.test/pr/1',
+    });
+    expect(line.startsWith(`${INVOKER_WAKE_PREFIX} `)).toBe(true);
+    const payload = JSON.parse(line.slice(INVOKER_WAKE_PREFIX.length + 1));
+    expect(payload).toEqual({
+      workflowId: 'wf-1',
+      settled: true,
+      timedOut: false,
+      status: {
+        total: 2,
+        completed: 1,
+        failed: 0,
+        closed: 0,
+        running: 0,
+        pending: 0,
+        awaitingApproval: 1,
+        blocked: 0,
+      },
+      reviewUrl: 'https://example.test/pr/1',
+    });
+    expect(line).not.toContain('"tasks"');
+    expect(line).not.toContain('"description"');
+    assertInvokerWakeLineWithinBudget(line);
+    expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(INVOKER_WAKE_MAX_BYTES);
+  });
+
+  it('rejects payloads that include task bodies', () => {
+    expect(() => assertInvokerWakeLineWithinBudget(
+      `${INVOKER_WAKE_PREFIX} ${JSON.stringify({ workflowId: 'wf', tasks: [{ id: 'a', description: 'x' }] })}`,
+    )).toThrow(/must not include tasks or descriptions/);
+  });
+});
+
+describe('waitForWorkflowTasks silence', () => {
+  it('does not emit before settle when stdout is unused by the waiter', async () => {
+    const output = captureProcessOutput();
+    let calls = 0;
+    const result = await waitForWorkflowTasks({
+      workflowId: 'wf-1',
+      maxWaitMs: 1000,
+      pollIntervalMs: 1,
+      sleep: async () => undefined,
+      loadTasks: async () => {
+        calls += 1;
+        if (calls === 1) return [{ id: 'a', status: 'running' }];
+        return [{ id: 'a', status: 'completed' }];
+      },
+    });
+    expect(result.settled).toBe(true);
+    expect(output.stdout).toBe('');
+    output.restore();
+  });
+
+  it('treats human-gate status as settled', () => {
+    expect(workflowTasksSettled([{ id: 'a', status: 'awaiting_approval' }])).toBe(true);
+  });
+});
+
+describe('invoker-cli wait', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses wait flags', () => {
+    expect(parseWaitArgs(['wf-9', '--max-wait-ms', '1000', '--poll-interval-ms', '50'])).toEqual({
+      workflowId: 'wf-9',
+      maxWaitMs: 1000,
+      pollIntervalMs: 50,
+    });
+  });
+
+  it('prints one INVOKER_WAKE line after settle and exits 0', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    let calls = 0;
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { output: JSON.stringify([{ id: 'a', status: 'running' }]) };
+      }
+      return { output: JSON.stringify([{ id: 'a', status: 'completed' }]) };
+    });
+
+    const code = await main(
+      ['wait', 'wf-1', '--max-wait-ms', '1000', '--poll-interval-ms', '1'],
+      { createMessageBus: () => bus },
+    );
+
+    expect(code).toBe(0);
+    const lines = output.stdout.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^INVOKER_WAKE /);
+    const payload = JSON.parse(lines[0].slice('INVOKER_WAKE '.length));
+    expect(payload.settled).toBe(true);
+    expect(payload.timedOut).toBe(false);
+    expect(payload.status.completed).toBe(1);
+    expect(payload.tasks).toBeUndefined();
+    output.restore();
+  });
+
+  it('exits 1 when no live owner is reachable', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => {
+      throw new Error('no owner');
+    });
+
+    const code = await main(['wait', 'wf-1'], { createMessageBus: () => bus });
+    expect(code).toBe(1);
+    expect(output.stderr).toMatch(/No running Invoker owner/);
+    expect(output.stdout).toBe('');
+    output.restore();
+  });
+
+  it('prints INVOKER_WAKE and exits 1 on timeout without settle', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async () => ({
+      output: JSON.stringify([{ id: 'a', status: 'running' }]),
+    }));
+
+    const code = await main(
+      ['wait', 'wf-1', '--max-wait-ms', '5', '--poll-interval-ms', '1'],
+      { createMessageBus: () => bus },
+    );
+
+    expect(code).toBe(1);
+    expect(output.stdout.trim().split('\n')).toHaveLength(1);
+    const payload = JSON.parse(output.stdout.trim().slice('INVOKER_WAKE '.length));
+    expect(payload.settled).toBe(false);
+    expect(payload.timedOut).toBe(true);
+    output.restore();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,7 +49,15 @@ import {
   withTimeout,
   type LiveOwnerInfo,
 } from './live-owner-bus.js';
+import {
+  assertInvokerWakeLineWithinBudget,
+  formatInvokerWakeLine,
+} from './invoker-wake.js';
 import { runMcpServer } from './mcp-server.js';
+import {
+  normalizeTaskSnapshots,
+  waitForWorkflowTasks,
+} from './mcp-workflow-status.js';
 import { defaultConfigPath, runDoctor, runSetup } from './onboarding.js';
 import { runInstall } from './quick-install.js';
 import {
@@ -182,6 +190,7 @@ function usage(): string {
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli query workflows [--status <status>] [--output text|json]',
     '  invoker-cli query tasks [--workflow <id>] [--status <status>] [--output text|json]',
+    '  invoker-cli wait <workflowId> [--max-wait-ms <ms>] [--poll-interval-ms <ms>]',
     '  invoker-cli retry-task <taskId>',
     '  invoker-cli retry <workflowId>',
     '  invoker-cli resume <workflowId>',
@@ -201,6 +210,7 @@ function usage(): string {
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker owner when available, otherwise run standalone.',
     '  query workflows|tasks  Read workflows or tasks from a live owner, or a read-only database view.',
+    '  wait <workflowId>  Park until a live-owner workflow settles, then print one INVOKER_WAKE line.',
     '  retry-task <taskId>  Ask a live Invoker owner to retry one task.',
     '  retry <workflowId>  Ask a live Invoker owner to retry a workflow.',
     '  resume <workflowId> Ask a live Invoker owner to resume a workflow.',
@@ -228,6 +238,8 @@ function usage(): string {
     '  --json           Emit only a machine-readable result summary on stdout.',
     '  --workflow <id>  Restrict `query tasks` to one workflow.',
     '  --status <status>  Restrict `query workflows` or `query tasks` to one status.',
+    '  --max-wait-ms <ms>  Maximum park time for `wait`. Defaults to 86400000 (24h).',
+    '  --poll-interval-ms <ms>  Query interval for `wait`. Defaults to 5000.',
     '  --parallel N    Maximum concurrent mutation requests for `retry-tasks`. Defaults to 8.',
     '  --dry-run       Print matching task IDs for `retry-tasks` without mutating.',
     '  --output <fmt>   Query output format. Supported values: text, json. Defaults to text.',
@@ -530,6 +542,89 @@ async function runQuery(options: QueryOptions, deps: CliDeps): Promise<number> {
 
   process.stdout.write(await queryStandaloneDatabase(options));
   return 0;
+}
+
+type WaitOptions = {
+  workflowId: string;
+  maxWaitMs: number;
+  pollIntervalMs: number;
+};
+
+const DEFAULT_WAIT_MAX_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_WAIT_POLL_MS = 5_000;
+
+function parsePositiveIntFlag(flag: string, value: string | undefined): number {
+  if (!value) throw new Error(`Missing value for ${flag}`);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== value) {
+    throw new Error(`Invalid ${flag} value. Expected a positive integer.`);
+  }
+  return parsed;
+}
+
+export function parseWaitArgs(argv: string[]): WaitOptions {
+  let workflowId: string | undefined;
+  let maxWaitMs = DEFAULT_WAIT_MAX_MS;
+  let pollIntervalMs = DEFAULT_WAIT_POLL_MS;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--max-wait-ms') {
+      maxWaitMs = parsePositiveIntFlag('--max-wait-ms', argv[++i]);
+    } else if (arg === '--poll-interval-ms') {
+      pollIntervalMs = parsePositiveIntFlag('--poll-interval-ms', argv[++i]);
+    } else if (arg === '--help' || arg === '-h') {
+      throw new Error('Usage: invoker-cli wait <workflowId> [--max-wait-ms <ms>] [--poll-interval-ms <ms>]');
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown wait option: ${arg}`);
+    } else if (!workflowId) {
+      workflowId = arg;
+    } else {
+      throw new Error(`Unexpected wait argument: ${arg}`);
+    }
+  }
+
+  if (!workflowId) {
+    throw new Error('Missing workflowId. Usage: invoker-cli wait <workflowId> [--max-wait-ms <ms>] [--poll-interval-ms <ms>]');
+  }
+
+  return { workflowId, maxWaitMs, pollIntervalMs };
+}
+
+async function runWait(options: WaitOptions, deps: CliDeps): Promise<number> {
+  let bus: MessageBus | undefined;
+  try {
+    bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
+    const owner = await discoverLiveOwner(bus);
+    if (!owner) {
+      throw new Error(REQUIRED_OWNER_MESSAGE);
+    }
+    const activeBus = bus;
+    const result = await waitForWorkflowTasks({
+      workflowId: options.workflowId,
+      maxWaitMs: options.maxWaitMs,
+      pollIntervalMs: options.pollIntervalMs,
+      loadTasks: async () => {
+        const raw = await withTimeout(
+          activeBus.request('headless.query', {
+            kind: 'cli-query',
+            args: ['query', 'tasks', '--workflow', options.workflowId, '--output', 'json'],
+          }),
+          15_000,
+        );
+        return normalizeTaskSnapshots(JSON.parse(validateLiveQueryResponse(raw)));
+      },
+    });
+    const line = formatInvokerWakeLine(result);
+    assertInvokerWakeLineWithinBudget(line);
+    process.stdout.write(`${line}\n`);
+    return result.settled ? 0 : 1;
+  } finally {
+    const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
+    if (disconnect) {
+      disconnect.call(bus);
+    }
+  }
 }
 
 const REQUIRED_OWNER_MESSAGE = 'No running Invoker owner is reachable; start the Invoker app or run `invoker-cli owner serve`.';
@@ -1170,6 +1265,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'query') {
       return await runQuery(parseQueryArgs(argv.slice(1)), deps);
+    }
+    if (argv[0] === 'wait') {
+      return await runWait(parseWaitArgs(argv.slice(1)), deps);
     }
     if (argv[0] === 'retry-task' || argv[0] === 'retry' || argv[0] === 'resume') {
       if (argv.length > 2) {

--- a/packages/cli/src/invoker-wake.ts
+++ b/packages/cli/src/invoker-wake.ts
@@ -1,0 +1,43 @@
+import type { WorkflowStatusSummary, WorkflowWaitResult } from './mcp-workflow-status.js';
+
+export const INVOKER_WAKE_PREFIX = 'INVOKER_WAKE';
+export const INVOKER_WAKE_MAX_BYTES = 2048;
+
+export type InvokerWakePayload = {
+  workflowId: string;
+  settled: boolean;
+  timedOut: boolean;
+  status: WorkflowStatusSummary;
+  reviewUrl?: string;
+};
+
+export function toInvokerWakePayload(
+  result: Pick<WorkflowWaitResult, 'workflowId' | 'settled' | 'timedOut' | 'status' | 'reviewUrl'>,
+): InvokerWakePayload {
+  const payload: InvokerWakePayload = {
+    workflowId: result.workflowId,
+    settled: result.settled,
+    timedOut: result.timedOut,
+    status: result.status,
+  };
+  if (result.reviewUrl) {
+    payload.reviewUrl = result.reviewUrl;
+  }
+  return payload;
+}
+
+export function formatInvokerWakeLine(
+  result: Pick<WorkflowWaitResult, 'workflowId' | 'settled' | 'timedOut' | 'status' | 'reviewUrl'>,
+): string {
+  return `${INVOKER_WAKE_PREFIX} ${JSON.stringify(toInvokerWakePayload(result))}`;
+}
+
+export function assertInvokerWakeLineWithinBudget(line: string): void {
+  const bytes = Buffer.byteLength(line, 'utf8');
+  if (bytes > INVOKER_WAKE_MAX_BYTES) {
+    throw new Error(`INVOKER_WAKE payload exceeds ${INVOKER_WAKE_MAX_BYTES} bytes (${bytes})`);
+  }
+  if (line.includes('"tasks"') || line.includes('"description"')) {
+    throw new Error('INVOKER_WAKE payload must not include tasks or descriptions');
+  }
+}

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -324,7 +324,7 @@ export function handoffPrompt(request: string): string {
     planFilePath: 'plans/invoker-handoff.yaml',
     reviewInstruction: 'Call `invoker_prepare_plan_review` with exactly one of `planPath` or `sessionId`, then show the returned ordered steps and confirmation text to the user. Keep the returned `reviewToken`.',
     shortReplyInstruction: 'Then keep the chat reply focused on the review summary and approval state. Never paste the YAML into chat.',
-    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Always pass the same source (`planPath` or `sessionId`) plus the `reviewToken`. Use mode `live` so the workflow appears in the running Invoker app. After submit, use `invoker_get_workflow`, `invoker_list_tasks`, or bounded `invoker_wait_for_workflow` to report status.',
+    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Always pass the same source (`planPath` or `sessionId`) plus the `reviewToken`. Use mode `live` so the workflow appears in the running Invoker app. After submit, optionally confirm the workflow exists, then arm `invoker-cli wait <workflowId>` with `notify_on_output` on `^INVOKER_WAKE`, end the turn, and continue the parent job on wake.',
   });
   return [
     `User request: ${request}`,

--- a/packages/shell/src/always-on/fragments.ts
+++ b/packages/shell/src/always-on/fragments.ts
@@ -12,7 +12,8 @@ When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or 
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
-Plain approval stops after workflow handoff; do not publish PRs unless the user asks.
+Plain approval authorizes workflow handoff only; do not publish PRs unless the user asks.
+After submit, arm \`invoker-cli wait <workflowId>\` with \`notify_on_output\` on \`^INVOKER_WAKE\`, end the turn, and continue the parent job on wake.
 `;
 
 export const CURSOR_RULE_CONTENTS = `---
@@ -34,7 +35,8 @@ When Invoker MCP (\`invoker_prepare_plan_review\` / \`invoker_submit_plan\`) or 
 - If MCP and CLI are both missing: stay local.
 
 Slash commands \`/invoker-plan-to-invoker\` and \`/plan-to-invoker\` always enter the skill.
-Plain approval stops after workflow handoff; do not publish PRs unless the user asks.
+Plain approval authorizes workflow handoff only; do not publish PRs unless the user asks.
+After submit, arm \`invoker-cli wait <workflowId>\` with \`notify_on_output\` on \`^INVOKER_WAKE\`, end the turn, and continue the parent job on wake.
 `;
 
 export const CLAUDE_HOOK_SCRIPT = `#!/usr/bin/env node


### PR DESCRIPTION
## Summary

Agents need a way to park after handing work to Invoker without holding the chat turn open.

This slice adds `invoker-cli wait`, a query-only command that stays quiet until the workflow settles.

When settle happens, it prints one `INVOKER_WAKE` line with compact status counts and exits.

The MCP handoff text and always-on fragments now point agents at that same park path.

## Review Claim

`invoker-cli wait <workflowId>` parks on live-owner queries until settled (including human gates), then prints exactly one compact `INVOKER_WAKE` line with no task bodies.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Waiter only queries a live owner. It does not retry, cancel, approve, restart owner-serve, write chat messages, or publish PRs.

## Slice Rationale

CLI waiter, MCP handoff pointer, and always-on fragments are the activation surface. Follow-on skill and spend-bench wording land in the next slice.

## Non-goals

Does not change chat-submit or plan-to-invoker skill steps.
Does not add spend e2e wording beyond the always-on park line.
Does not restart owner-serve or publish PRs.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant Chat
    participant Owner as InvokerOwner
    Chat->>Owner: handoff
    Note over Chat: poll in turn or stop
```

### After

```mermaid
sequenceDiagram
    participant Chat
    participant Waiter as invoker_cli_wait
    participant Owner as InvokerOwner
    Chat->>Owner: handoff
    Chat->>Waiter: park until settle
    Waiter->>Owner: query only
    Waiter-->>Chat: INVOKER_WAKE json
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && pnpm exec vitest run src/__tests__/cli-wait.test.ts`
- [x] `cd packages/cli && pnpm exec vitest run src/__tests__/mcp-review-and-status.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8fb1183f37`
- Post-revert steps: None
- Data migration? No

</details>
