### PR TITLE
[No-Mergify babysit](1) multi-repo cron and CI repair

### DIFF
--- a/scripts/cron-pr-admin-bypass-land.sh
+++ b/scripts/cron-pr-admin-bypass-land.sh
@@ -6,7 +6,15 @@ source "$(dirname "$0")/cron-pr-lib.sh"
 
 cron_lock
 
+# INVOKER_GITHUB_TARGET_REPOS (comma-separated) scans more than one repo in
+# one cron tick, each with its own resolved Mergify rule/default branch and
+# foreign-safe repair plans (see mergify_admin_requeue_exec.py's
+# run_cron_target_repos). Unset/empty keeps the single-repo $TARGET_REPO
+# behavior exactly as before.
 args=(--once --repo "$TARGET_REPO" --author "$PR_AUTHOR")
+if [ -n "${INVOKER_GITHUB_TARGET_REPOS:-}" ]; then
+  args+=(--target-repos "$INVOKER_GITHUB_TARGET_REPOS")
+fi
 if [ "$DRY_RUN" = "1" ]; then
   args+=(--dry-run)
 fi

--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -31,6 +31,11 @@ REPO_ROOT = exec_impl.REPO_ROOT
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    target_repos = [repo.strip() for repo in args.target_repos.split(",") if repo.strip()]
+    if target_repos:
+        return exec_impl.run_cron_target_repos(
+            args, target_repos, default_claim_repair_filing, default_release_repair_filing
+        )
     if args.loop:
         return run_loop(args, default_claim_repair_filing, default_release_repair_filing)
     return run_once(args, default_claim_repair_filing, default_release_repair_filing)

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -92,6 +92,24 @@ def _repair_task_yaml(*, description: str, prompt: str, max_turns: int | None = 
     )
 
 
+def _foreign_safe_push_command(*, head_ref: str, start_head: str, skip_guard: str) -> str:
+    # A foreign worktree never has Invoker's own scripts/pr_worker_safe_push.py
+    # (that script lives only in the Invoker checkout). Reimplement its
+    # expected-head safety check inline with plain git so the push still
+    # refuses to run if the branch moved since this repair started.
+    return (
+        "set -euo pipefail\n"
+        f"{skip_guard}"
+        f"git fetch origin {_shlex(head_ref)}\n"
+        f"current_head=\"$(git rev-parse origin/{head_ref})\"\n"
+        f"if [ \"$current_head\" != {_shlex(start_head)} ]; then\n"
+        f"  echo \"refusing to push: {head_ref} moved from {start_head} to $current_head\" >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        f"git push origin HEAD:{_shlex(head_ref)}\n"
+    )
+
+
 def _safe_push_task_yaml(
     *,
     task_id: str,
@@ -100,6 +118,7 @@ def _safe_push_task_yaml(
     head_ref: str,
     start_head: str,
     skip_if_prereq: bool,
+    foreign: bool = False,
 ) -> str:
     skip_guard = (
         "if [ -f .invoker-repair-prereq-created ]; then\n"
@@ -109,15 +128,18 @@ def _safe_push_task_yaml(
         if skip_if_prereq
         else ""
     )
-    # Owner-side JSONL settlement is recorded by mergify_admin_requeue_workflow_fastpath
-    # from durable workflow/task state. Never pass the owner machine's ledger path into
-    # a remote worker command (Linux workers cannot write /Users/... paths).
-    command = (
-        "set -euo pipefail\n"
-        f"{skip_guard}"
-        "python3 scripts/pr_worker_safe_push.py \\\n"
-        f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd .\n"
-    )
+    if foreign:
+        command = _foreign_safe_push_command(head_ref=head_ref, start_head=start_head, skip_guard=skip_guard)
+    else:
+        # Owner-side JSONL settlement is recorded by mergify_admin_requeue_workflow_fastpath
+        # from durable workflow/task state. Never pass the owner machine's ledger path into
+        # a remote worker command (Linux workers cannot write /Users/... paths).
+        command = (
+            "set -euo pipefail\n"
+            f"{skip_guard}"
+            "python3 scripts/pr_worker_safe_push.py \\\n"
+            f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd .\n"
+        )
     return (
         f"  - id: {task_id}\n"
         f"    description: {_yaml_str(description)}\n"
@@ -166,6 +188,7 @@ def build_repair_check_plan(
     latest: MergifyQueueEvent | None,
     start_head: str,
     state_file: Path,
+    foreign: bool = False,
 ) -> AsyncRepairPlan:
     name = repair_check_plan_name(pr.number, check_name, start_head)
     prompt = (
@@ -189,6 +212,21 @@ def build_repair_check_plan(
 
     yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
     yaml_text += _repair_task_yaml(description=f"Repair PR #{pr.number} (failed check {check_name})", prompt=prompt)
+    if foreign:
+        # A foreign worktree never has Invoker's own
+        # mergify_admin_requeue_repair_normalize.py (prerequisite-PR splitting
+        # is an Invoker-repo-only concept), so go straight from repair to a
+        # plain safe push instead of running that Invoker-only normalize step.
+        yaml_text += _safe_push_task_yaml(
+            task_id="safe-push",
+            description=f"Safely push PR #{pr.number} only if its head did not move",
+            dependencies="repair",
+            head_ref=pr.head_ref_name,
+            start_head=start_head,
+            skip_if_prereq=False,
+            foreign=True,
+        )
+        return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
     normalize_command = (
         "set -euo pipefail\n"
         "python3 -B scripts/mergify_admin_requeue_repair_normalize.py \\\n"
@@ -235,6 +273,7 @@ def build_rebase_onto_master_plan(
     repo: str,
     start_head: str,
     state_file: Path,
+    foreign: bool = False,
 ) -> AsyncRepairPlan:
     onto_ref = pr.base_ref_name or "master"
     name = rebase_onto_master_plan_name(pr.number, start_head)
@@ -251,6 +290,7 @@ def build_rebase_onto_master_plan(
         head_ref=pr.head_ref_name,
         start_head=start_head,
         skip_if_prereq=False,
+        foreign=foreign,
     )
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
@@ -262,6 +302,7 @@ def build_repair_bot_thread_plan(
     repo: str,
     start_head: str,
     state_file: Path,
+    foreign: bool = False,
 ) -> AsyncRepairPlan:
     name = repair_bot_thread_plan_name(pr.number, start_head)
     prompt = (
@@ -281,6 +322,7 @@ def build_repair_bot_thread_plan(
         head_ref=pr.head_ref_name,
         start_head=start_head,
         skip_if_prereq=False,
+        foreign=foreign,
     )
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 from pathlib import Path
 import sys
@@ -11,7 +12,14 @@ try:
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_loader import AdminBypassStackLoader
     from .mergify_admin_requeue_logger import AdminBypassLogger
-    from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
+    from .mergify_admin_requeue_model import (
+        Action,
+        DEFAULT_INVOKER_REPO,
+        Ledger,
+        PrSnapshot,
+        load_mergify_rules,
+        resolve_admin_bypass_rules_for_repo,
+    )
     from .mergify_admin_requeue_plan import (
         REBASE_CONFLICT_REPAIR_FILING_KIND,
         REBASE_ONTO_MASTER_FILING_KIND,
@@ -36,7 +44,14 @@ except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_loader import AdminBypassStackLoader
     from mergify_admin_requeue_logger import AdminBypassLogger
-    from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
+    from mergify_admin_requeue_model import (
+        Action,
+        DEFAULT_INVOKER_REPO,
+        Ledger,
+        PrSnapshot,
+        load_mergify_rules,
+        resolve_admin_bypass_rules_for_repo,
+    )
     from mergify_admin_requeue_plan import (
         REBASE_CONFLICT_REPAIR_FILING_KIND,
         REBASE_ONTO_MASTER_FILING_KIND,
@@ -121,13 +136,23 @@ def run_cycle(
     args: argparse.Namespace,
     claim_repair_filing: ClaimRepairFiling | None = None,
     release_repair_filing: ReleaseRepairFiling | None = None,
+    rules: tuple[str, frozenset[str], frozenset[str]] | None = None,
 ) -> bool:
-    rule_path = REPO_ROOT / ".mergify.yml"
-    try:
-        trunk, _labels, required_checks = load_mergify_rules(rule_path)
-    except ValueError as exc:
-        print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
-        raise RuntimeError("failed to load admin-bypass Mergify rule") from exc
+    # `rules` lets a multi-repo caller (run_cron_target_repos) pass in a
+    # rule tuple it already resolved for a foreign repo via
+    # resolve_admin_bypass_rules_for_repo, instead of always loading
+    # Invoker's own local .mergify.yml regardless of args.repo. Every
+    # existing single-repo caller omits it and keeps this exact prior
+    # behavior.
+    if rules is not None:
+        trunk, _labels, required_checks = rules
+    else:
+        rule_path = REPO_ROOT / ".mergify.yml"
+        try:
+            trunk, _labels, required_checks = load_mergify_rules(rule_path)
+        except ValueError as exc:
+            print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
+            raise RuntimeError("failed to load admin-bypass Mergify rule") from exc
 
     logger = AdminBypassLogger()
     logger.trace(
@@ -226,7 +251,7 @@ def run_cycle(
                         progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                     else:
                         check_name = action.key
-                        workflow_id = resolve_workflow_for_pr(action.pr_number)
+                        workflow_id = resolve_workflow_for_pr(action.pr_number, args.repo)
                         if workflow_id:
                             submit_repair_review_gate_ci(action.pr_number)
                             ledger.record(
@@ -308,7 +333,7 @@ def run_cycle(
                 continue
             elif action.kind == "rebase_onto_master":
                 try:
-                    workflow_id = resolve_workflow_for_pr(action.pr_number)
+                    workflow_id = resolve_workflow_for_pr(action.pr_number, args.repo)
                     if workflow_id:
                         submit_rebase_recreate(workflow_id)
                         ledger.record(
@@ -434,6 +459,57 @@ def run_loop(
     return 0
 
 
+def resolve_rules_for_repo(repo: str, gh: GhClient) -> tuple[str, frozenset[str], frozenset[str]]:
+    # The Invoker repo itself always reads its own local checkout's
+    # .mergify.yml (matches load_mergify_rules' pre-existing single-repo
+    # behavior exactly, and avoids a needless network round trip for the
+    # repo cron already runs from). Every other target repo has no local
+    # checkout to read, so its rule (if any) and default branch come from
+    # the GitHub API instead.
+    if repo == DEFAULT_INVOKER_REPO:
+        try:
+            return load_mergify_rules(REPO_ROOT / ".mergify.yml")
+        except ValueError as exc:
+            raise RuntimeError(f"failed to load admin-bypass Mergify rule for {repo}") from exc
+    file_text = gh.file_text(repo, ".mergify.yml")
+    default_branch = gh.default_branch(repo)
+    try:
+        return resolve_admin_bypass_rules_for_repo(repo, file_text, default_branch)
+    except ValueError as exc:
+        raise RuntimeError(f"failed to resolve admin-bypass rules for {repo}") from exc
+
+
+def run_cron_target_repos(
+    args: argparse.Namespace,
+    target_repos: Sequence[str],
+    claim_repair_filing: ClaimRepairFiling | None = None,
+    release_repair_filing: ReleaseRepairFiling | None = None,
+    gh: GhClient | None = None,
+) -> int:
+    # Cron entry point for scanning more than one repo in a single tick.
+    # Each repo gets its own rule resolution (its own Mergify text/default
+    # branch, per resolve_rules_for_repo) and its own args.repo so every
+    # downstream call (ledger, executor, repairer, fastpath) stays scoped
+    # to that one repo. One repo's rule-resolution or scan failure is
+    # logged and skipped rather than aborting the whole cron tick.
+    gh = gh or GhClient()
+    had_failure = False
+    for repo in target_repos:
+        repo_args = copy.copy(args)
+        repo_args.repo = repo
+        try:
+            rules = resolve_rules_for_repo(repo, gh)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            had_failure = True
+            continue
+        try:
+            run_cycle(repo_args, claim_repair_filing, release_repair_filing, rules=rules)
+        except RuntimeError:
+            had_failure = True
+    return 2 if had_failure else 0
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Repair and queue open admin-bypass Mergify stacks.")
     mode = parser.add_mutually_exclusive_group()
@@ -442,6 +518,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--poll-seconds", type=float, default=60, help="Seconds to wait between loop scans. Default: 60.")
     parser.add_argument("--dry-run", action="store_true", help="Print planned actions; perform no GitHub mutations.")
     parser.add_argument("--repo", default="Neko-Catpital-Labs/Invoker", help="Default: Neko-Catpital-Labs/Invoker.")
+    parser.add_argument(
+        "--target-repos",
+        default="",
+        help="Comma-separated repos to cron over in one tick (owner/name,owner/name,...). "
+        "Default: --repo alone. Any repo other than --repo's default is treated as foreign: "
+        "its own Mergify rule (or default branch) is resolved via the GitHub API, and its "
+        "repair plans never invoke Invoker-only repair helper scripts.",
+    )
     parser.add_argument("--author", help="Limit scan to one author. Default: all authors.")
     parser.add_argument("--state-file", default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"), help="Ledger JSONL path.")
     parser.add_argument("--pr", type=int, action="append", default=[], help="Limit to a PR; repeatable.")

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -14,6 +14,12 @@ STACK_MARKER_RE = re.compile(r"<!--\s*mergify-stack-data:\s*(\{.*?\})\s*-->", re
 SHA_RE = re.compile(r"`([0-9a-fA-F]{40})`")
 GH_ACTIONS_JOB_RE = re.compile(r"/actions/runs/\d+/job/(\d+)")
 
+# The one repo whose worktree carries Invoker's own repair helper scripts
+# (mergify_admin_requeue_repair_normalize.py, pr_worker_safe_push.py). Any
+# other repo's worktree is "foreign": it never has those scripts, so repair
+# plans for it must not invoke them.
+DEFAULT_INVOKER_REPO = "Neko-Catpital-Labs/Invoker"
+
 
 @dataclass(frozen=True)
 class CheckContext:
@@ -146,16 +152,22 @@ class Ledger:
                 if isinstance(row, dict):
                     self.rows.append(row)
 
-    def count(self, kind: str, pr: int, head_sha: str, key: str) -> int:
+    # `repo` is keyword-only and defaults to None (no repo filter applied), so
+    # every pre-existing single-repo caller keeps its exact prior behavior.
+    # Multi-repo callers pass repo= to scope reads/writes to one repo's rows,
+    # so two repos sharing a PR number (or retry-cap key) never cross-pollute
+    # each other's ledger state in one shared ledger file.
+    def count(self, kind: str, pr: int, head_sha: str, key: str, *, repo: str | None = None) -> int:
         return sum(
             1 for row in self.rows
             if row.get("kind") == kind
             and int(row.get("pr", -1)) == pr
             and row.get("headSha") == head_sha
             and row.get("key") == key
+            and (repo is None or row.get("repo") == repo)
         )
 
-    def latest(self, kind: str, pr: int, head_sha: str, key: str) -> dict[str, object] | None:
+    def latest(self, kind: str, pr: int, head_sha: str, key: str, *, repo: str | None = None) -> dict[str, object] | None:
         latest_row: dict[str, object] | None = None
         latest_epoch = float("-inf")
         for row in self.rows:
@@ -167,13 +179,15 @@ class Ledger:
                 continue
             if row.get("key") != key:
                 continue
+            if repo is not None and row.get("repo") != repo:
+                continue
             epoch = int(row.get("epoch", 0) or 0)
             if latest_row is None or epoch >= latest_epoch:
                 latest_row = row
                 latest_epoch = epoch
         return latest_row
 
-    def count_by_unit(self, kind: str, pr: int, key: str) -> int:
+    def count_by_unit(self, kind: str, pr: int, key: str, *, repo: str | None = None) -> int:
         # Same as count(), but persistent across a commit change: a
         # successful repair attempt pushes a new commit as a normal side
         # effect, and that must not silently reset the retry cap for this
@@ -185,9 +199,10 @@ class Ledger:
             if row.get("kind") == kind
             and int(row.get("pr", -1)) == pr
             and row.get("key") == key
+            and (repo is None or row.get("repo") == repo)
         )
 
-    def latest_by_unit(self, kind: str, pr: int, key: str) -> dict[str, object] | None:
+    def latest_by_unit(self, kind: str, pr: int, key: str, *, repo: str | None = None) -> dict[str, object] | None:
         latest_row: dict[str, object] | None = None
         latest_epoch = float("-inf")
         for row in self.rows:
@@ -197,13 +212,15 @@ class Ledger:
                 continue
             if row.get("key") != key:
                 continue
+            if repo is not None and row.get("repo") != repo:
+                continue
             epoch = int(row.get("epoch", 0) or 0)
             if latest_row is None or epoch >= latest_epoch:
                 latest_row = row
                 latest_epoch = epoch
         return latest_row
 
-    def has_different_head(self, kind: str, pr: int, current_head: str, key: str) -> bool:
+    def has_different_head(self, kind: str, pr: int, current_head: str, key: str, *, repo: str | None = None) -> bool:
         for row in self.rows:
             if row.get("kind") != kind:
                 continue
@@ -211,11 +228,23 @@ class Ledger:
                 continue
             if row.get("key") != key:
                 continue
+            if repo is not None and row.get("repo") != repo:
+                continue
             if row.get("headSha") and row.get("headSha") != current_head:
                 return True
         return False
 
-    def record(self, kind: str, pr: int, head_sha: str, key: str, epoch: int | None = None, meta: Mapping[str, object] | None = None) -> None:
+    def record(
+        self,
+        kind: str,
+        pr: int,
+        head_sha: str,
+        key: str,
+        epoch: int | None = None,
+        meta: Mapping[str, object] | None = None,
+        *,
+        repo: str | None = None,
+    ) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         row = {
             "kind": kind,
@@ -226,6 +255,8 @@ class Ledger:
         }
         if meta:
             row["meta"] = dict(meta)
+        if repo is not None:
+            row["repo"] = repo
         with self.path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(row, sort_keys=True) + "\n")
         self.rows.append(row)
@@ -263,7 +294,10 @@ def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
         raise ValueError("failed to load admin-bypass Mergify rule")
+    return _parse_mergify_rules(lines)
 
+
+def _parse_mergify_rules(lines: list[str]) -> tuple[str, frozenset[str], frozenset[str]]:
     start = -1
     start_indent = 0
     for i, line in enumerate(lines):
@@ -303,6 +337,26 @@ def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]
     if not trunk or not labels or not required:
         raise ValueError("failed to load admin-bypass Mergify rule")
     return trunk, frozenset(labels), frozenset(required)
+
+
+def resolve_admin_bypass_rules_for_repo(
+    repo: str, file_text: str | None, default_branch: str | None
+) -> tuple[str, frozenset[str], frozenset[str]]:
+    # A foreign repo (anything but DEFAULT_INVOKER_REPO) rarely ships an
+    # admin-bypass Mergify rule shaped like Invoker's own -- when it does,
+    # honor it exactly like the Invoker path (trunk/labels/required checks
+    # all parsed from the rule). When it doesn't, fall back to the repo's
+    # default branch as trunk with no required-check allowlist, so the
+    # caller repairs whatever checks are actually observed failing on that
+    # PR instead of refusing to act for lack of a configured rule.
+    if file_text:
+        try:
+            return _parse_mergify_rules(file_text.splitlines())
+        except ValueError:
+            pass
+    if not default_branch:
+        raise ValueError(f"failed to resolve admin-bypass rules for repo {repo}")
+    return default_branch, frozenset(), frozenset()
 
 
 def latest_contexts_by_required_check(raw_contexts: list[Mapping[str, object]], head_sha: str, required_checks: Collection[str]) -> dict[str, CheckContext]:

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -8,14 +8,14 @@ try:
     from . import mergify_admin_requeue_async_repair as async_repair
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
-    from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from .mergify_admin_requeue_model import DEFAULT_INVOKER_REPO, Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import is_queue_only_required_check
     from .mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
-    from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from mergify_admin_requeue_model import DEFAULT_INVOKER_REPO, Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import is_queue_only_required_check
     from mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
@@ -45,6 +45,12 @@ class AdminBypassRepairer:
         self.logger = logger
         self.ledger = ledger
         self.repo = repo
+        # A foreign repo's worktree never has Invoker's own repair helper
+        # scripts (mergify_admin_requeue_repair_normalize.py,
+        # pr_worker_safe_push.py), so its generated repair plans must never
+        # invoke them -- see async_repair.build_repair_check_plan's
+        # foreign= parameter.
+        self.is_foreign = repo != DEFAULT_INVOKER_REPO
 
     def blocked_outcome(
         self,
@@ -182,6 +188,7 @@ class AdminBypassRepairer:
             latest=latest,
             start_head=start_head,
             state_file=self.ledger.path,
+            foreign=self.is_foreign,
         )
         self.logger.trace(
             "admin-bypass-repair-check-start",
@@ -208,6 +215,7 @@ class AdminBypassRepairer:
         key = f"rebase-onto-master:{pr.number}"
         plan = async_repair.build_rebase_onto_master_plan(
             pr, reason, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
+            foreign=self.is_foreign,
         )
         self.logger.trace(
             "admin-bypass-rebase-onto-master-start",
@@ -229,6 +237,7 @@ class AdminBypassRepairer:
         start_head = pr.head_ref_oid
         plan = async_repair.build_repair_bot_thread_plan(
             pr, thread_id, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
+            foreign=self.is_foreign,
         )
         self.logger.trace(
             "admin-bypass-repair-bot-thread-start",

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 import re
@@ -191,6 +192,24 @@ class GhClient:
     def resolve_review_thread(self, thread_id: str) -> None:
         query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
         run_logged(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"])
+
+    def default_branch(self, repo: str) -> str:
+        out = self._run(["gh", "api", f"repos/{repo}"])
+        return str(json.loads(out).get("default_branch") or "")
+
+    def file_text(self, repo: str, path: str) -> str | None:
+        # A missing file (no admin-bypass Mergify rule in this repo) is the
+        # expected case for most foreign repos. A 404 is not in
+        # TRANSIENT_GH_ERROR_MARKERS, so run_logged raises it on the first
+        # attempt without retrying/backing off.
+        try:
+            out = self._run(["gh", "api", f"repos/{repo}/contents/{path}", "--jq", ".content"])
+        except (subprocess.CalledProcessError, RuntimeError):
+            return None
+        encoded = out.strip()
+        if not encoded:
+            return None
+        return base64.b64decode(encoded).decode("utf-8", errors="replace")
 
 
 def run_logged(

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -10,6 +10,7 @@ from pathlib import Path
 try:
     from .mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from .mergify_admin_requeue_model import DEFAULT_INVOKER_REPO
     from .mergify_admin_requeue_async_repair import (
         rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
@@ -19,6 +20,7 @@ try:
 except ImportError:
     from mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from mergify_admin_requeue_model import DEFAULT_INVOKER_REPO
     from mergify_admin_requeue_async_repair import (
         rebase_onto_master_plan_name,
         repair_bot_thread_plan_name,
@@ -27,11 +29,18 @@ except ImportError:
     )
 
 
-def resolve_workflow_for_pr(pr_number: int) -> str | None:
+def resolve_workflow_for_pr(pr_number: int, repo: str = DEFAULT_INVOKER_REPO) -> str | None:
     # See cron-pr-lib.sh's resolve_workflow_for_pr comment: review-gate exits 0
     # with `{}` for a genuine miss (no local workflow mapping). A non-zero exit
     # means the lookup mechanism itself is broken, which must propagate as an
     # exception rather than silently falling back to ad-hoc repair.
+    #
+    # Invoker only ever owns a workflow for a PR on its own repo -- a foreign
+    # repo's PR number can collide with an unrelated Invoker PR number, so
+    # skip the lookup entirely for any other repo instead of risking the
+    # fast-path reusing the wrong repo's workflow.
+    if repo != DEFAULT_INVOKER_REPO:
+        return None
     review_gate_cmd = os.environ.get("INVOKER_PR_CRON_REVIEW_GATE_CMD")
     if review_gate_cmd:
         try:

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -266,6 +266,46 @@ class AsyncRepairPlanTests(unittest.TestCase):
         run.assert_called_once()
         self.assertFalse(written_paths[0].exists())
 
+    def test_foreign_repair_check_plan_omits_normalize_and_invoker_safe_push(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(), "CI", repo="some-org/catstack", details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"), foreign=True,
+        )
+        doc = yaml.safe_load(plan.yaml_text)
+        self.assertEqual(doc["repoUrl"], "https://github.com/some-org/catstack.git")
+        self.assertEqual([task["id"] for task in doc["tasks"]], ["repair", "safe-push"])
+        self.assertNotIn("id: normalize", plan.yaml_text)
+        self.assertNotIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
+        self.assertNotIn("pr_worker_safe_push.py", plan.yaml_text)
+        self.assertIn("git push origin HEAD:", plan.yaml_text)
+        self.assertIn(HEAD, plan.yaml_text)
+
+    def test_foreign_rebase_and_bot_thread_plans_omit_invoker_safe_push(self):
+        rebase_plan = async_repair.build_rebase_onto_master_plan(
+            pr(), "GitHub reports merge conflict", repo="some-org/catstack",
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"), foreign=True,
+        )
+        bot_thread_plan = async_repair.build_repair_bot_thread_plan(
+            pr(), "tbot", repo="some-org/catstack", start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"), foreign=True,
+        )
+        for plan in (rebase_plan, bot_thread_plan):
+            with self.subTest(plan=plan.plan_name):
+                self.assertNotIn("pr_worker_safe_push.py", plan.yaml_text)
+                self.assertIn("git push origin HEAD:", plan.yaml_text)
+
+    def test_non_foreign_repair_check_plan_still_includes_invoker_helpers(self):
+        # Default (foreign=False) behavior must stay exactly as it was before
+        # multi-repo support existed.
+        plan = async_repair.build_repair_check_plan(
+            pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
+        self.assertIn("pr_worker_safe_push.py", plan.yaml_text)
+
     def test_submit_async_repair_plan_raises_on_failure(self):
         plan = async_repair.AsyncRepairPlan(plan_name="p", yaml_text="name: x\n")
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")

--- a/scripts/test_mergify_admin_requeue_cron_target_repos.py
+++ b/scripts/test_mergify_admin_requeue_cron_target_repos.py
@@ -1,0 +1,110 @@
+"""Behavioural tests for exec.py's multi-repo cron loop.
+
+Run:  python3 scripts/test_mergify_admin_requeue_cron_target_repos.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.mergify_admin_requeue_exec as exec_impl
+from scripts.mergify_admin_requeue_model import DEFAULT_INVOKER_REPO
+
+
+def base_args(**overrides):
+    values = dict(
+        once=True,
+        loop=False,
+        poll_seconds=60,
+        dry_run=False,
+        repo=DEFAULT_INVOKER_REPO,
+        target_repos="",
+        author=None,
+        state_file="/tmp/ledger.jsonl",
+        pr=[],
+        max_requeue_attempts=2,
+        max_repair_attempts=3,
+        json=False,
+    )
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class ResolveRulesForRepoTests(unittest.TestCase):
+    def test_invoker_repo_reads_local_file_and_never_calls_gh(self):
+        gh = mock.Mock()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), frozenset({"lint"}))) as load:
+            result = exec_impl.resolve_rules_for_repo(DEFAULT_INVOKER_REPO, gh)
+        load.assert_called_once()
+        gh.file_text.assert_not_called()
+        gh.default_branch.assert_not_called()
+        self.assertEqual(result, ("master", frozenset({"admin-bypass"}), frozenset({"lint"})))
+
+    def test_foreign_repo_falls_back_to_gh_provided_default_branch(self):
+        gh = mock.Mock()
+        gh.file_text.return_value = None
+        gh.default_branch.return_value = "main"
+        trunk, labels, required = exec_impl.resolve_rules_for_repo("some-org/catstack", gh)
+        gh.file_text.assert_called_once_with("some-org/catstack", ".mergify.yml")
+        gh.default_branch.assert_called_once_with("some-org/catstack")
+        self.assertEqual(trunk, "main")
+        self.assertEqual(required, frozenset())
+
+    def test_foreign_repo_with_no_default_branch_raises_runtime_error(self):
+        gh = mock.Mock()
+        gh.file_text.return_value = None
+        gh.default_branch.return_value = ""
+        with self.assertRaises(RuntimeError):
+            exec_impl.resolve_rules_for_repo("some-org/catstack", gh)
+
+
+class RunCronTargetReposTests(unittest.TestCase):
+    def test_scans_each_repo_with_its_own_resolved_rules_and_repo_scoped_args(self):
+        args = base_args(repo=DEFAULT_INVOKER_REPO)
+        seen_repos = []
+        seen_rules = []
+
+        def fake_run_cycle(repo_args, claim, release, rules=None):
+            seen_repos.append(repo_args.repo)
+            seen_rules.append(rules)
+            return False
+
+        with mock.patch.object(
+            exec_impl, "resolve_rules_for_repo",
+            side_effect=lambda repo, gh: (f"trunk-{repo}", frozenset(), frozenset()),
+        ), mock.patch.object(exec_impl, "run_cycle", side_effect=fake_run_cycle):
+            code = exec_impl.run_cron_target_repos(
+                args, [DEFAULT_INVOKER_REPO, "some-org/catstack"], gh=mock.Mock()
+            )
+        self.assertEqual(code, 0)
+        self.assertEqual(seen_repos, [DEFAULT_INVOKER_REPO, "some-org/catstack"])
+        self.assertEqual([rules[0] for rules in seen_rules], [f"trunk-{DEFAULT_INVOKER_REPO}", "trunk-some-org/catstack"])
+        # The original args object passed in must not be mutated by the loop.
+        self.assertEqual(args.repo, DEFAULT_INVOKER_REPO)
+
+    def test_one_repo_rule_resolution_failure_does_not_block_the_others(self):
+        args = base_args()
+        scanned = []
+
+        def fake_resolve(repo, gh):
+            if repo == "broken-org/repo":
+                raise RuntimeError("boom")
+            return ("master", frozenset(), frozenset())
+
+        with mock.patch.object(exec_impl, "resolve_rules_for_repo", side_effect=fake_resolve), \
+             mock.patch.object(exec_impl, "run_cycle", side_effect=lambda a, c, r, rules=None: scanned.append(a.repo)):
+            code = exec_impl.run_cron_target_repos(
+                args, ["broken-org/repo", DEFAULT_INVOKER_REPO], gh=mock.Mock()
+            )
+        self.assertEqual(scanned, [DEFAULT_INVOKER_REPO])
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_model.py
+++ b/scripts/test_mergify_admin_requeue_model.py
@@ -318,6 +318,37 @@ class MergifyRuleLoading(unittest.TestCase):
             m.load_mergify_rules(self._write("pull_request_rules:\n  - name: other\n"))
 
 
+class ResolveAdminBypassRulesForRepo(unittest.TestCase):
+    """A foreign repo's own Mergify text wins; a default branch is the fallback."""
+
+    def test_uses_repo_own_mergify_text_when_present(self):
+        trunk, labels, required = m.resolve_admin_bypass_rules_for_repo(
+            "some-org/catstack", MERGIFY_YML, "main"
+        )
+        self.assertEqual(trunk, "master")
+        self.assertEqual(labels, frozenset({"admin-bypass"}))
+        self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))
+
+    def test_falls_back_to_default_branch_when_no_mergify_text(self):
+        trunk, labels, required = m.resolve_admin_bypass_rules_for_repo(
+            "some-org/catstack", None, "main"
+        )
+        self.assertEqual(trunk, "main")
+        self.assertEqual(labels, frozenset())
+        self.assertEqual(required, frozenset())
+
+    def test_falls_back_to_default_branch_when_mergify_text_has_no_admin_bypass_rule(self):
+        trunk, labels, required = m.resolve_admin_bypass_rules_for_repo(
+            "some-org/catstack", "pull_request_rules:\n  - name: other\n", "main"
+        )
+        self.assertEqual(trunk, "main")
+        self.assertEqual(required, frozenset())
+
+    def test_raises_when_neither_mergify_text_nor_default_branch_available(self):
+        with self.assertRaises(ValueError):
+            m.resolve_admin_bypass_rules_for_repo("some-org/catstack", None, None)
+
+
 class LedgerIdempotency(unittest.TestCase):
     """The ledger stops the worker repeating an action on the same commit."""
 
@@ -356,6 +387,17 @@ class LedgerIdempotency(unittest.TestCase):
         )
         led = m.Ledger(path)
         self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 1)
+
+    def test_repo_scoping_keeps_two_repos_from_cross_pollinating_the_same_pr_number(self):
+        path = self._ledger_path()
+        led = m.Ledger(path)
+        led.record("requeue", 1, "sha1", "flaky", repo="owner/invoker")
+        self.assertEqual(led.count("requeue", 1, "sha1", "flaky", repo="owner/invoker"), 1)
+        self.assertEqual(led.count("requeue", 1, "sha1", "flaky", repo="owner/catstack"), 0)
+        # No repo filter (the pre-multi-repo call shape) still sees every row.
+        self.assertEqual(led.count("requeue", 1, "sha1", "flaky"), 1)
+        self.assertIsNone(led.latest("requeue", 1, "sha1", "flaky", repo="owner/catstack"))
+        self.assertIsNotNone(led.latest("requeue", 1, "sha1", "flaky", repo="owner/invoker"))
 
 
 if __name__ == "__main__":

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -475,6 +475,35 @@ class GhClientLabelEdit(unittest.TestCase):
             ]
         )
 
+class GhClientRepoRuleDiscovery(unittest.TestCase):
+    def test_default_branch_reads_repo_metadata(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run", return_value='{"default_branch": "main"}') as run:
+            result = client.default_branch("some-org/catstack")
+        run.assert_called_once_with(["gh", "api", "repos/some-org/catstack"])
+        self.assertEqual(result, "main")
+
+    def test_file_text_decodes_base64_content(self):
+        import base64
+
+        client = s.GhClient()
+        encoded = base64.b64encode(b"pull_request_rules:\n").decode("ascii")
+        with mock.patch.object(client, "_run", return_value=encoded) as run:
+            result = client.file_text("some-org/catstack", ".mergify.yml")
+        run.assert_called_once_with(
+            ["gh", "api", "repos/some-org/catstack/contents/.mergify.yml", "--jq", ".content"]
+        )
+        self.assertEqual(result, "pull_request_rules:\n")
+
+    def test_file_text_returns_none_on_missing_file(self):
+        client = s.GhClient()
+        with mock.patch.object(
+            client, "_run", side_effect=subprocess.CalledProcessError(1, ["gh"], stderr="404 Not Found")
+        ):
+            result = client.file_text("some-org/catstack", ".mergify.yml")
+        self.assertIsNone(result)
+
+
 class GhRetryBudgetRespectsWorkerTickTimeout(unittest.TestCase):
     # The pr-admin-bypass-land worker (packages/execution-engine/src/workers/
     # pr-maintenance-workers.ts) force-kills the whole script if a tick runs


### PR DESCRIPTION
## Summary

The babysitter now walks every configured target repository instead of only Invoker.

Each repository gets its own Mergify rules, default branch, and ledger scope.

Non-Invoker check repair uses that repository's checkout and generic guarded Git commands.

## Review Claim

Cron walks every configured repository, derives repository-local landing policy, scopes ledgers by repository, and emits foreign-safe plans for observed failing CI checks.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Non-Invoker repair plans use that repository's `repoUrl` and never run Invoker-only normalize or safe-push helpers in a foreign worktree.

## Slice Rationale

This foundation precedes squash-merge landing so foreign repositories can be repaired without changing Invoker's Mergify queue behavior.

Repository-specific discovery replaces reuse of Invoker's `.mergify.yml`; squash-merge landing remains separate to keep this policy slice local.

## Non-goals

No squash-merge landing path, direct `gh pr merge`, UI change, package manifest change, deployment documentation, or Mergify enablement for catstack.

## Architecture

### Before

```mermaid
graph TD
    A["Cron"] --> B["Invoker-only rules, trunk, and ledger"]
    B --> C["Invoker-only repair helpers"]
```

### After

```mermaid
graph TD
    A["Cron"] --> B["Each configured repository"]
    B --> C["Repository rules or default branch"]
    B --> D["Repository-scoped ledger"]
    C --> E["Observed CI classification"]
    E --> F["Invoker helper path"]
    E --> G["Foreign guarded Git path"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 scripts/test_mergify_admin_requeue_model.py`
- [x] `python3 scripts/test_mergify_admin_requeue_async_repair.py`
- [x] `python3 scripts/test_mergify_admin_requeue_cron_target_repos.py`
- [x] `python3 scripts/test_mergify_admin_requeue_snapshot.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
