### PR TITLE
[CLAUDE.md operator policy](1) Stop prescribing ./run.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Concrete incidents that motivate the class-search rule above — each is a case 
 ## SQLite Command Policy
 
 - If you are considering direct SQLite commands, use the corresponding Invoker headless command first.
-- For normal local operations on workflows or tasks, prefer `./run.sh --headless ...` and `node scripts/headless-ipc.js ...` over SQLite reads or writes. Typical examples: `query workflows`, `query tasks`, `retry`, `retry-task`, `rebase-recreate`, `approve`, `reject`, `cancel`, and `cancel-workflow`.
+- For normal local operations on workflows or tasks, prefer Invoker MCP tools (`invoker_get_workflow`, `invoker_list_tasks`, submit/prepare) when they exist, else `invoker-ui --headless ...` or `invoker-cli` against the live owner. Typical examples: `query workflows`, `query tasks`, `retry`, `retry-task`, `rebase-recreate`, `approve`, `reject`, `cancel`, and `cancel-workflow`.
 - Verify operational changes with Invoker query commands (`query workflows`, `query tasks`, `query queue`, `query audit`) instead of SQLite inspection whenever the command surface exists.
 - If no corresponding headless command exists, stop and prompt the user with a concrete plan to add that headless command functionality before proceeding.
 


### PR DESCRIPTION
## Summary

This documentation change updates the operator SQLite policy in CLAUDE.md.

Agents were spawning checkout Electron because that file still named `./run.sh` as the default.

The paragraph now points at live MCP tools and the installed npm Invoker binary only.

## Review Claim

CLAUDE.md operator policy must not prescribe `./run.sh` or the checkout IPC helper.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Ops docs never prescribe ./run.sh; live npm invoker-ui / invoker-cli / MCP only.

## Slice Rationale

One documentation paragraph. Sibling always-on rules in this repo do not name the old binary as the default.

## Non-goals

Does not change product code, skills, or CI. Does not implement the refuse-when-owner-up backlog. Does not rewrite personal Cursor rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Read `CLAUDE.md` SQLite Command Policy after the edit and confirm the operator paragraph names MCP tools plus the installed npm Invoker binary only
- [x] `rg -n 'run\\.sh --headless|headless-ipc' CLAUDE.md` — no matches

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9f5b2bd555`
- Post-revert steps: None
- Data migration? No

</details>
