### PR TITLE
[Headless query live owner](1) Stop spawning checkout Electron for queries

### DIFF
--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -13,9 +13,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ELECTRON="$REPO_ROOT/scripts/electron.cjs"
-MAIN="$REPO_ROOT/packages/app/dist/main.js"
-IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+# shellcheck source=headless-lib.sh
+source "$REPO_ROOT/scripts/headless-lib.sh"
 
 # Parse args
 DRY_RUN=false
@@ -29,36 +28,6 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
 done
-
-# Electron sandbox detection (same as submit-plan.sh)
-unset ELECTRON_RUN_AS_NODE
-SANDBOX_FLAG=""
-if [ "$(uname)" = "Linux" ]; then
-  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
-  # shellcheck disable=SC2086
-  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
-    SANDBOX_FLAG="--no-sandbox"
-  fi
-  export LIBGL_ALWAYS_SOFTWARE=1
-fi
-
-# Helper: read-only query command (stderr hidden to keep parsing clean).
-# Bounded so a dead/unresponsive owner can't hang this script forever; safe
-# to kill since query subcommands never write to the DB.
-headless_query() {
-  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
-  local status=0
-  # shellcheck disable=SC2086
-  if command -v timeout >/dev/null 2>&1; then
-    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
-  else
-    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
-  fi
-  if [ "$status" -eq 124 ]; then
-    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
-  fi
-  return "$status"
-}
 
 # Helper: mutating command (stderr preserved for debugging real failures)
 headless_mutation() {

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -50,20 +50,46 @@ fi
 # Core transport helpers
 # ---------------------------------------------------------------------------
 
-# Read-only Electron query (stderr suppressed for clean parsing).
+# Safety invariant: a live owner is the only Invoker process. Query through
+# that owner (invoker-ui / headless-client IPC). Spawn checkout Electron only
+# for isolated STANDALONE tests. Do not boot a second Invoker to read state.
 #
 # Bounded by INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS (default 60; 0 disables).
 # Safe to kill on timeout: this only runs `query` subcommands, which never
 # write to the DB, so there is no stuck-row risk the way there is for
 # headless_mutation (see run_with_optional_timeout's use in rebase-retry-all.sh
 # for that different, deliberately-timeout-free case).
+_headless_query_invoke() {
+  local seconds="$1"
+  shift
+  local use_electron=0
+  if [ "$FORCE_OWNER_IPC" = "1" ]; then
+    use_electron=0
+  elif [ -n "${INVOKER_HEADLESS_ELECTRON_BIN:-}" ] || [ "$STANDALONE_MODE" = "1" ]; then
+    use_electron=1
+  fi
+  if [ "$use_electron" = "1" ]; then
+    # shellcheck disable=SC2086
+    run_with_optional_timeout "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+    return $?
+  fi
+  if [ -n "${INVOKER_HEADLESS_CLIENT_BIN:-}" ]; then
+    run_with_optional_timeout "$seconds" "$INVOKER_HEADLESS_CLIENT_BIN" "$@"
+    return $?
+  fi
+  if command -v invoker-ui >/dev/null 2>&1; then
+    run_with_optional_timeout "$seconds" invoker-ui --headless "$@"
+    return $?
+  fi
+  run_with_optional_timeout "$seconds" node "$REPO_ROOT/packages/app/dist/headless-client.js" "$@"
+}
+
 headless_query() {
   local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
   local status=0
   local stderr_file
   stderr_file="$(mktemp)"
-  # shellcheck disable=SC2086
-  run_with_optional_timeout "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>"$stderr_file" || status=$?
+  _headless_query_invoke "$seconds" "$@" 2>"$stderr_file" || status=$?
   case "$status" in
     0)
       ;;

--- a/scripts/recreate-failed-tasks.sh
+++ b/scripts/recreate-failed-tasks.sh
@@ -18,9 +18,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ELECTRON="$REPO_ROOT/scripts/electron.cjs"
-MAIN="$REPO_ROOT/packages/app/dist/main.js"
-IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+# shellcheck source=headless-lib.sh
+source "$REPO_ROOT/scripts/headless-lib.sh"
 
 DRY_RUN=false
 STATUS_FILTER=""
@@ -74,34 +73,6 @@ if [[ -n "$PARALLELISM" ]] && ! [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
   echo "Invalid --parallel value: $PARALLELISM (expected integer >= 1)" >&2
   exit 1
 fi
-
-unset ELECTRON_RUN_AS_NODE
-SANDBOX_FLAG=""
-if [ "$(uname)" = "Linux" ]; then
-  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
-  # shellcheck disable=SC2086
-  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
-    SANDBOX_FLAG="--no-sandbox"
-  fi
-  export LIBGL_ALWAYS_SOFTWARE=1
-fi
-
-# Bounded so a dead/unresponsive owner can't hang this script forever; safe
-# to kill since query subcommands never write to the DB.
-headless_query() {
-  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
-  local status=0
-  # shellcheck disable=SC2086
-  if command -v timeout >/dev/null 2>&1; then
-    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
-  else
-    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
-  fi
-  if [ "$status" -eq 124 ]; then
-    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
-  fi
-  return "$status"
-}
 
 headless_mutation() {
   # --no-track is an option to the IPC helper's `exec` subcommand and MUST come

--- a/scripts/test-suites/required/31-headless-query-live-owner-no-electron.sh
+++ b/scripts/test-suites/required/31-headless-query-live-owner-no-electron.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: default headless_query must not spawn checkout Electron.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+TMP_ROOT="$(mktemp -d -t invoker-headless-query-no-electron.XXXXXX)"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_ELECTRON="$TMP_ROOT/electron-must-not-run.sh"
+FAKE_CLIENT="$TMP_ROOT/fake-owner-client.sh"
+MARKER="$TMP_ROOT/electron-ran"
+
+cat > "$FAKE_ELECTRON" <<SH
+#!/usr/bin/env bash
+echo ran > "$MARKER"
+exit 1
+SH
+chmod +x "$FAKE_ELECTRON"
+
+cat > "$FAKE_CLIENT" <<'SH'
+#!/usr/bin/env bash
+printf '[]\n'
+SH
+chmod +x "$FAKE_CLIENT"
+
+unset INVOKER_HEADLESS_STANDALONE || true
+unset INVOKER_HEADLESS_ELECTRON_BIN || true
+export INVOKER_HEADLESS_CLIENT_BIN="$FAKE_CLIENT"
+
+# shellcheck source=../../scripts/headless-lib.sh
+source "$ROOT/scripts/headless-lib.sh"
+ELECTRON="$FAKE_ELECTRON"
+MAIN="$TMP_ROOT/missing-main.js"
+
+OUT="$TMP_ROOT/out.json"
+headless_query query workflows --output json >"$OUT"
+
+if [[ -f "$MARKER" ]]; then
+  echo "FAIL: headless_query spawned checkout Electron while not in STANDALONE mode" >&2
+  exit 1
+fi
+if ! grep -Fxq '[]' "$OUT"; then
+  echo "FAIL: expected fake owner client stdout" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+echo "PASS: default headless_query used the owner client, not checkout Electron"


### PR DESCRIPTION
## Summary

Worktree agents were booting a second Invoker just to run `query workflows`.

`headless_query` always launched checkout Electron. Mutations already talked to the live owner. Queries now do the same via `invoker-ui` or the Node client.

## Review Claim

Default `headless_query` does not spawn checkout Electron; it queries the live owner.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

When a live owner exists, query must not start a second Invoker process. Isolated STANDALONE tests may still spawn Electron.

## Slice Rationale

This is the transport worktree agents actually call. A CLAUDE note cannot stop `source headless-lib.sh; headless_query`.

## Non-goals

No agent prompt rewrites. No mutation-path changes. Does not cancel the currently looping squash-merge task.

## Architecture

### Before

```mermaid
graph TD
    A["headless_query"] --> B["checkout Electron"]
    C["live invoker-ui owner"]
```

### After

```mermaid
graph TD
    A["headless_query"] --> B["invoker-ui or headless-client"]
    B --> C["live invoker-ui owner"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/31-headless-query-live-owner-no-electron.sh`
- [x] `bash scripts/test-suites/required/30-headless-query-timeout-guard.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit. `headless_query` will spawn checkout Electron again.

</details>
