### PR TITLE
[Auto-approve authors](1) Stop gating the immediate post-autofix approval on PR authorship

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -585,29 +585,6 @@ describe('finalizeAppliedFix', () => {
     expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
-
-  it('leaves the fix awaiting approval when the PR author is not allowlisted', async () => {
-    const orchestrator = {
-      setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn(),
-    };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    const result = await finalizeAppliedFix('task-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: true,
-      autoApproveAuthorGate: async () => ({ allowed: false, reason: 'author-not-allowlisted' }),
-    });
-
-    expect(result).toEqual({ autoApproved: false, started: [] });
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
-    expect(orchestrator.approve).not.toHaveBeenCalled();
-  });
 });
 
 describe('autoFixOnFailure', () => {

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -35,7 +35,6 @@ import {
   forkWorkflow as sharedForkWorkflow,
 } from './workflow-actions.js';
 import { parseHeadlessFixArgs } from './auto-fix-intents.js';
-import { buildPersistedAutoApproveAuthorGate } from './auto-approve-author-gate.js';
 import { resolveDefaultExecutionAgent, resolveConflictResolutionSettings } from './config.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -642,8 +641,6 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       taskExecutor: te,
       mutationTiming: deps.mutationTiming,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-      autoApproveAuthorGate: deps.autoApproveAuthorGate
-        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
     }, {
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
@@ -703,8 +700,6 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
       ...deps,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-      autoApproveAuthorGate: deps.autoApproveAuthorGate
-        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
     }, agentArg?.toLowerCase(), deps.signal, {
       pathDefaultAgent: resolveDefaultExecutionAgent(deps.invokerConfig),
     });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -26,10 +26,6 @@ import {
 } from '@invoker/execution-engine';
 import { loadConfig, resolveAutoFixExecutionModel, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { resolveAutoFixRetries } from './autofix-defaults.js';
-import {
-  buildPersistedAutoApproveAuthorGate,
-  type AutoApproveAuthorGateResult,
-} from './auto-approve-author-gate.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { trackWorkflow } from './headless-watch.js';
 import {
@@ -102,8 +98,6 @@ export interface HeadlessDeps {
    * only delegated here to run one command and exit).
    */
   getWorkerRuntimeController?: () => WorkerRuntimeController | null;
-  /** Fail-closed PR-author gate for auto-approve. Reads config.json autoApproveAuthors. */
-  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export const RESET = '\x1b[0m';
@@ -132,8 +126,6 @@ export function buildHeadlessApiServerDeps(
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
-      autoApproveAuthorGate: deps.autoApproveAuthorGate
-        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
       allowGraphMutation: deps.invokerConfig?.allowGraphMutation,
       defaultAutoFixRetries: deps.invokerConfig ? resolveAutoFixRetries(deps.invokerConfig) : undefined,
       getAutoFixAgent: () => deps.invokerConfig?.autoFixAgent,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -49,7 +49,6 @@ import {
   type InvokerConfig,
 } from '../config.js';
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
-import { buildPersistedAutoApproveAuthorGate } from '../auto-approve-author-gate.js';
 import { backupPlan } from '../plan-backup.js';
 import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
@@ -530,7 +529,6 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
         autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
-        autoApproveAuthorGate: buildPersistedAutoApproveAuthorGate(persistence),
       },
       {
         agentName,
@@ -2444,7 +2442,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         persistence,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
-        autoApproveAuthorGate: buildPersistedAutoApproveAuthorGate(persistence),
       }, agentName, activeMutationContext?.signal);
       await finalizeMutationWithGlobalTopup({
         orchestrator,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,7 +22,7 @@ import {
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, type AutoApproveAuthorGateResult, formatAgentFailureForTask } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, formatAgentFailureForTask } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
@@ -144,8 +144,6 @@ export interface ActionDeps {
   mutationTiming?: WorkflowMutationTiming;
   /** When true, successful AI-applied fixes are approved immediately. */
   autoApproveAIFixes?: boolean;
-  /** Fail-closed PR-author allowlist. Missing/denied means do not auto-approve. */
-  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
 }
 
 export interface CommandActionDeps extends ActionDeps {
@@ -840,7 +838,7 @@ export async function setTaskFixContext(
 
 export async function resolveConflictAction(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'autoApproveAuthorGate'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   agentName?: string,
   signal?: AbortSignal,
   options?: { pathDefaultAgent?: string },
@@ -884,7 +882,7 @@ function resolveTaskRunnerDefaultExecutionAgent(taskExecutor: TaskRunner): strin
 
 export async function fixWithAgentAction(
   taskId: string,
-  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'autoApproveAuthorGate' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
+  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
   options: {
     agentName?: string;
     recoveryRoute?: FailureRecoveryRoute;
@@ -992,7 +990,7 @@ export async function fixWithAgentAction(
 export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes' | 'autoApproveAuthorGate'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   signal?: AbortSignal,
   lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -1004,12 +1002,6 @@ export async function finalizeAppliedFix(
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
   if (!deps.autoApproveAIFixes) {
-    return { autoApproved: false, started: [] };
-  }
-  const authorGate = deps.autoApproveAuthorGate
-    ? await deps.autoApproveAuthorGate(taskId)
-    : { allowed: false as const, reason: 'allowlist-missing' as const };
-  if (!authorGate.allowed) {
     return { autoApproved: false, started: [] };
   }
 
@@ -1229,7 +1221,6 @@ export async function autoFixOnFailure(
     mutationTiming?: WorkflowMutationTiming;
     getAutoFixAgent?: () => string | undefined;
     getAutoApproveAIFixes?: () => boolean | undefined;
-    autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
     signal?: AbortSignal;
   },
   inlineRetryDepth = 0,
@@ -1367,7 +1358,6 @@ export async function autoFixOnFailure(
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-        autoApproveAuthorGate: deps.autoApproveAuthorGate,
       }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -20,8 +20,7 @@ import { makeEnvelope } from '@invoker/contracts';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { AutoApproveAuthorGateResult, TaskRunner } from '@invoker/execution-engine';
-import { buildPersistedAutoApproveAuthorGate } from './auto-approve-author-gate.js';
+import type { TaskRunner } from '@invoker/execution-engine';
 import {
   parseSpawnRepairWorkflowMutationArgs,
   submitRepairWorkflowFromCiFailure,
@@ -122,7 +121,6 @@ export interface WorkflowMutationFacadeDeps {
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
   autoApproveAIFixes?: boolean;
-  autoApproveAuthorGate?: (taskId: string) => Promise<AutoApproveAuthorGateResult>;
   allowGraphMutation?: boolean;
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
@@ -141,11 +139,7 @@ export class WorkflowMutationFacade {
   private readonly deps: WorkflowMutationFacadeDeps;
 
   constructor(deps: WorkflowMutationFacadeDeps) {
-    this.deps = {
-      ...deps,
-      autoApproveAuthorGate: deps.autoApproveAuthorGate
-        ?? buildPersistedAutoApproveAuthorGate(deps.persistence),
-    };
+    this.deps = deps;
   }
 
   // ── Task-scoped mutations ────────────────────────────────


### PR DESCRIPTION
## Summary

The auto-approve worker only approves an AI fix once it confirms the mapped GitHub PR's author is on `autoApproveAuthors`. That check runs right after an autofix succeeds, before the fix can be approved.

If no PR has been opened yet, there is nothing to check an author against. The fix then sits in `awaiting_approval` forever, even with `autoApproveAIFixes` and `autoApproveAuthors` both configured correctly.

This PR stops that check from running inside `finalizeAppliedFix`. A successful fix now auto-approves whenever `autoApproveAIFixes` is on, with no author lookup involved.

## Review Claim

Approve taking the `autoApproveAuthorGate` parameter, and its one call, out of `finalizeAppliedFix` and its five callers in `packages/app/src`, so a successful AI fix auto-approves without needing an already-open, author-resolvable PR.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Removing this check only changes whether a successfully-applied AI fix is auto-approved without a human clicking approve — it does not change what `approveTask` does once approval happens, and it can't approve a task in any state other than `awaiting_approval` with a pending fix error.

## Slice Rationale

This slice only touches `finalizeAppliedFix` and its five callers under `packages/app/src`. A second, separate check in `packages/execution-engine` still applies to the recovery worker that watches for stuck approvals; that one is addressed in the next PR in this stack, once this slice is live and its callers no longer need the shared helper module. Keeping the two apart lines up with how `scripts/review-unit-rules.mjs` classifies each file, and this slice stands on its own — it builds and behaves correctly by itself.

## Non-goals

Does not touch the background `autoapprove` worker in `packages/execution-engine` (still gated after this slice — see (2)).

Does not delete the underlying gate module (`auto-approve-author-allowlist.ts` / `auto-approve-author-gate.ts`) — still used by (2) until that slice removes its last caller.

Does not change `autoApproveAuthors` config storage or the `invoker_auto_approve_authors` CLI/MCP tool.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/workflow-actions.test.ts` (87 passed)
- [x] `pnpm --filter @invoker/app build` (verify-workspace-imports, verify-noexternal-completeness, tsup, verify-surfaces-bundled all pass)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
