### PR TITLE
[No-Mergify babysit](2) squash-merge when green

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -96,6 +96,9 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
     elif action.kind == "retarget_base":
         from_base = pr.base_ref_name if pr else ""
         print(f"{prefix}retarget-base PR #{action.pr_number} from={from_base} to={action.key}")
+    elif action.kind == "squash_merge":
+        head = pr.head_ref_oid if pr else ""
+        print(f"{prefix}squash-merge PR #{action.pr_number} head={head} reason={action.detail}")
     elif action.kind == "rebase_onto_base":
         print(f"{prefix}rebase-onto-base PR #{action.pr_number} onto={action.key}")
     elif action.kind == "rebase_onto_master":

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -83,6 +83,10 @@ class AdminBypassGhExecutor:
         self.gh.retarget_base(self.repo, pr.number, new_base)
         self.ledger.record("retarget-base", pr.number, pr.head_ref_oid, f"{pr.base_ref_name}->{new_base}", now)
 
+    def squash_merge(self, pr: PrSnapshot, key: str, now: int) -> None:
+        self.gh.merge_squash(self.repo, pr.number)
+        self.ledger.record("squash-merge", pr.number, pr.head_ref_oid, key, now)
+
     def rebase_onto_base(self, pr: PrSnapshot, new_base: str, now: int) -> bool:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
@@ -153,6 +157,7 @@ class AdminBypassGhExecutor:
             "remove_merge_hold",
             "resolve_bot_threads",
             "comment_blocked",
+            "squash_merge",
         } and not self.pr_head_is_current(pr, action.kind, action.key):
             return False
         if action.kind == "requeue":
@@ -166,6 +171,9 @@ class AdminBypassGhExecutor:
             return True
         if action.kind == "retarget_base":
             self.retarget_base(pr, action.key, now)
+            return True
+        if action.kind == "squash_merge":
+            self.squash_merge(pr, action.key, now)
             return True
         if action.kind == "comment_admin_bypass_nudge":
             self.comment_admin_bypass_nudge(pr, action.key, now)

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -368,7 +368,13 @@ def latest_contexts_by_required_check(raw_contexts: list[Mapping[str, object]], 
             continue
         if sha and sha != head_sha:
             continue
-        if name not in required:
+        # An empty required_checks set means the repo has no admin-bypass
+        # Mergify rule (a foreign, non-Invoker repo -- see
+        # resolve_admin_bypass_rules_for_repo's fallback), so there is no
+        # allowlist to filter against. Observe every check instead of
+        # filtering down to nothing, so squash-merge-when-green planning has
+        # real CI signal to read for these repos.
+        if required and name not in required:
             continue
         ctx = CheckContext(name=name, state=state, details_url=url, head_sha=sha or head_sha, completed_at=completed)
         old = latest.get(name)

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -566,6 +566,25 @@ def is_non_repairable_check_state(state: str) -> bool:
     return state in {"skipped", "cancelled", "neutral"}
 
 
+def all_observed_checks_green(pr: PrSnapshot) -> bool:
+    """True when every check GitHub currently reports for this PR's head is
+    green (or a non-repairable state like skipped/neutral).
+
+    Only meaningful for the empty-required_checks land path (see
+    plan_bottom_progress): a repo with no admin-bypass Mergify rule has no
+    required-check allowlist, so latest_contexts_by_required_check reports
+    every observed check instead of filtering to a known set. An empty
+    checks mapping means no CI signal has arrived yet, not "nothing to wait
+    for", so it is treated as not-green.
+    """
+    if not pr.checks:
+        return False
+    return all(
+        ctx.state == "success" or is_non_repairable_check_state(ctx.state)
+        for ctx in pr.checks.values()
+    )
+
+
 def mergify_failed_check_actions(
     pr: PrSnapshot,
     ledger: Ledger,
@@ -1465,6 +1484,21 @@ def plan_bottom_progress(
                 detail,
             )
         return Action("refresh_stale_queue", bottom.number, STALE_QUEUE_EVENT_REFRESH_KEY, detail)
+    if not facts.required_checks:
+        # Non-Invoker repo (no admin-bypass Mergify rule -> no required-check
+        # allowlist -> no Mergify queue to requeue into). Land directly via
+        # squash-merge once GitHub reports MERGEABLE and every observed CI
+        # check is green; otherwise wait for CI rather than merging blind.
+        # Invoker itself always resolves a non-empty required_checks set
+        # from its own .mergify.yml, so this branch never fires for it and
+        # it keeps landing through the Mergify-queue requeue path below.
+        if bottom.mergeable != "MERGEABLE" or not all_observed_checks_green(bottom):
+            return None
+        key = "squash"
+        attempts = ledger.count("squash-merge", bottom.number, bottom.head_ref_oid, key)
+        if attempts >= max_requeue_attempts:
+            return cap_action(bottom, Blocker(key, "capped", bottom.number, "squash-merge"), "squash-merge")
+        return Action("squash_merge", bottom.number, key, "MERGEABLE with all observed CI green")
     # Behind master alone is not a rebase trigger: wait / requeue. Rebases are
     # Invoker jobs for GitHub conflicts and no-CI Mergify dequeues only.
     requeue_reason = "eligible-when-ready"

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -185,6 +185,12 @@ class GhClient:
     def retarget_base(self, repo: str, number: int, base: str) -> None:
         run_logged(["gh", "api", "--method", "PATCH", f"repos/{repo}/pulls/{number}", "-f", f"base={base}"])
 
+    def merge_squash(self, repo: str, number: int) -> None:
+        # No --admin: this must only merge a PR GitHub itself already
+        # reports as MERGEABLE with green CI (see plan_bottom_progress's
+        # all_observed_checks_green gate) -- never an admin override.
+        run_logged(["gh", "pr", "merge", str(number), "--repo", repo, "--squash"])
+
     def compare_status(self, repo: str, base: str, head: str) -> str:
         out = run_logged(["gh", "api", f"repos/{repo}/compare/{base}...{head}"])
         return str(json.loads(out).get("status") or "")

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1166,6 +1166,132 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, REQUIRED | {"e2e-proof / aggregate"}, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 1814, "e2e-proof / aggregate")])
 
+    def test_squash_merge_lands_when_no_required_checks_and_all_observed_checks_green(self):
+        stack = StackGroup("s", (pr(9001, labels={"admin-bypass"}, checks={"CI": check("CI")}),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual(
+            [(a.kind, a.pr_number, a.key, a.detail) for a in actions],
+            [("squash_merge", 9001, "squash", "MERGEABLE with all observed CI green")],
+        )
+
+    def test_squash_merge_waits_for_pending_check_instead_of_merging(self):
+        checks = {"CI": check("CI", "pending")}
+        stack = StackGroup("s", (pr(9002, labels={"admin-bypass"}, checks=checks),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual(actions, ())
+
+    def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
+        stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual(actions, ())
+
+    def test_squash_merge_requires_mergeable_state(self):
+        stack = StackGroup("s", (pr(9004, labels={"admin-bypass"}, checks={"CI": check("CI")}, mergeable="UNKNOWN"),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual(actions, ())
+
+    def test_squash_merge_caps_after_max_requeue_attempts(self):
+        ledger = self.ledger()
+        ledger.record("squash-merge", 9005, HEAD, "squash", 1)
+        ledger.record("squash-merge", 9005, HEAD, "squash", 2)
+        stack = StackGroup("s", (pr(9005, labels={"admin-bypass"}, checks={"CI": check("CI")}),))
+        actions = plan_stack_actions(stack, frozenset(), ledger, 3)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_invoker_style_repo_with_required_checks_still_requeues_instead_of_squash_merging(self):
+        # Invoker's own .mergify.yml always resolves a non-empty required_checks
+        # set (see test_loads_admin_bypass_rule_from_mergify_yml), so it must
+        # keep landing through the Mergify queue, never squash_merge.
+        stack = StackGroup("s", (pr(9006, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 9006)])
+
+    def test_squash_merge_executes_and_records_ledger(self):
+        class FakeGh:
+            def __init__(self):
+                self.merges = []
+
+            def merge_squash(self, repo, number):
+                self.merges.append((repo, number))
+
+        ledger = self.ledger()
+        item = pr(9007, labels={"admin-bypass"}, checks={"CI": check("CI")})
+        action = Action("squash_merge", 9007, "squash", "MERGEABLE with all observed CI green")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "EdbertChan/catstack")
+        performed = executor.execute(action, item, 1)
+        self.assertTrue(performed)
+        self.assertEqual(fake.merges, [("EdbertChan/catstack", 9007)])
+        self.assertEqual(ledger.count("squash-merge", 9007, HEAD, "squash"), 1)
+
+    def test_squash_merge_skips_when_head_moved_since_snapshot(self):
+        class FakeGh:
+            def __init__(self):
+                self.merges = []
+
+            def pr_detail(self, repo, number):
+                return {"number": number, "state": "OPEN", "headRefOid": OLD}
+
+            def merge_squash(self, repo, number):
+                self.merges.append((repo, number))
+
+        ledger = self.ledger()
+        item = pr(9008, labels={"admin-bypass"}, checks={"CI": check("CI")})
+        action = Action("squash_merge", 9008, "squash", "MERGEABLE with all observed CI green")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "EdbertChan/catstack")
+        performed = executor.execute(action, item, 1)
+        self.assertFalse(performed)
+        self.assertEqual(fake.merges, [])
+        self.assertEqual(ledger.count("squash-merge", 9008, HEAD, "squash"), 0)
+
+    def test_dry_run_squash_merge_never_calls_gh_merge(self):
+        class FakeGh:
+            def __init__(self):
+                self.merges = []
+
+            def list_candidate_prs(self, repo, author, pr_numbers):
+                return [self._raw]
+
+            def list_open_prs(self, repo):
+                return [self._raw]
+
+            def issue_comments(self, repo, number):
+                return []
+
+            def merge_squash(self, repo, number):
+                self.merges.append((repo, number))
+
+        raw = {
+            "number": 9009,
+            "title": "catstack green PR",
+            "body": "",
+            "url": "https://example.invalid/9009",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "feature/9009",
+            "headRefOid": HEAD,
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+            "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+            "statusCheckRollup": {"contexts": {"nodes": [
+                {"name": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "checkSuite": {"commit": {"oid": HEAD}}},
+            ]}},
+        }
+        fake = FakeGh()
+        fake._raw = raw
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        args = requeue.parse_args([
+            "--once", "--dry-run", "--repo", "EdbertChan/catstack",
+            "--state-file", str(Path(tmp.name) / "ledger.jsonl"),
+        ])
+        with mock.patch.object(exec_impl, "GhClient", return_value=fake):
+            exec_impl.run_cycle(args, None, None, rules=("master", frozenset({"admin-bypass"}), frozenset()))
+        self.assertEqual(fake.merges, [])
+
     def test_closed_pr_never_requeues_even_when_manually_requested(self):
         stack = StackGroup("s", (pr(2999, state="CLOSED", latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -475,6 +475,17 @@ class GhClientLabelEdit(unittest.TestCase):
             ]
         )
 
+    def test_merge_squash_never_passes_admin_override(self):
+        client = s.GhClient()
+        with mock.patch("mergify_admin_requeue_snapshot.run_logged") as run:
+            client.merge_squash("EdbertChan/catstack", 9007)
+
+        run.assert_called_once_with(
+            ["gh", "pr", "merge", "9007", "--repo", "EdbertChan/catstack", "--squash"]
+        )
+        self.assertNotIn("--admin", run.call_args.args[0])
+
+
 class GhClientRepoRuleDiscovery(unittest.TestCase):
     def test_default_branch_reads_repo_metadata(self):
         client = s.GhClient()


### PR DESCRIPTION
## Summary

Catstack has no Mergify queue, so a green foreign PR previously waited forever or failed at `@mergifyio queue`.

The babysitter now squash-merges a foreign PR itself once it observes MERGEABLE state and all checks green.

Invoker's own PRs are unaffected: they keep going through the Mergify queue as before.

## Review Claim

When a repository's Mergify `required_checks` is empty, the planner emits `squash_merge` only for a bottom PR that is MERGEABLE with every observed check succeeded; a repository with non-empty `required_checks` (Invoker) still plans `mergify_queue`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Squash-merge fires only when the PR is MERGEABLE, not UNSTABLE/DIRTY/BLOCKED/DRAFT, all observed CI checks succeeded, and the head SHA still matches; Invoker itself stays Mergify-queue only; dry-run never merges or posts queue comments; the executor never runs `gh pr merge --admin`.

## Slice Rationale

This land path builds on slice (1)'s per-repository repair foundation so a repaired, green foreign PR can actually land without Mergify enabled on that repository.

## Non-goals

No rewrite of the multi-repo cron itself (that is slice (1)). No `--admin` merges. No e2e autofix change. No UI change. No Mergify enablement on catstack.

## Architecture

### Before

```mermaid
graph TD
    A["Foreign repo bottom PR green"] --> B["No Mergify queue configured"]
    B --> C["PR waits indefinitely or fails at @mergifyio queue"]
```

### After

```mermaid
graph TD
    A["Foreign repo bottom PR"] --> B{"required_checks empty?"}
    B -->|"yes"| C{"MERGEABLE and all observed checks green?"}
    C -->|"yes"| D["squash_merge via gh pr merge --squash --match-head-commit"]
    C -->|"no"| E["repair_check / wait"]
    B -->|"no (Invoker)"| F["mergify_queue (unchanged)"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 scripts/test_mergify_admin_requeue.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
