### PR TITLE
[Bugfix: plan validator accepts a baseBranch that doesn't exist on the remote](1) Reject a baseBranch absent from repoUrl

### DIFF
--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -537,6 +537,19 @@ function validateReviewGate(reviewGate, errors) {
   });
 }
 
+function checkBaseBranchOnRemote(repoUrl, baseBranch) {
+  try {
+    const out = execFileSync('git', ['ls-remote', '--heads', repoUrl, baseBranch], {
+      timeout: 8000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    });
+    return out.trim() === '' ? 'absent' : 'present';
+  } catch {
+    return 'unknown';
+  }
+}
+
 function validatePlan(yamlContent, repoRoot) {
   const errors = [];
 
@@ -708,6 +721,20 @@ function validatePlan(yamlContent, repoRoot) {
       field: 'baseBranch',
       message: "Plan has externalDependencies but baseBranch is 'master'. For stacked workflows, set baseBranch to the upstream workflow's featureBranch, or use step-submit-stacked to auto-resolve.",
     });
+  }
+
+  // Check that an explicit baseBranch actually exists on the remote.
+  // Best-effort: network/auth failures are not validation errors.
+  if (typeof raw.baseBranch === 'string' && raw.baseBranch.trim() !== '' && raw.repoUrl) {
+    const remoteCheck = checkBaseBranchOnRemote(raw.repoUrl, raw.baseBranch);
+    if (remoteCheck === 'absent') {
+      errors.push({
+        errorType: 'basebranch_not_on_remote',
+        field: 'baseBranch',
+        message: `baseBranch '${raw.baseBranch}' was not found on ${raw.repoUrl} (git ls-remote returned no matching ref). Invoker's merge gate fetches this branch from origin and will fail with "required by the merge/gate step was not found on the remote" if submitted as-is. Push the branch first, or point baseBranch at a branch that exists (often 'master').`,
+        value: raw.baseBranch,
+      });
+    }
   }
 
   // Collect task IDs for dependency validation


### PR DESCRIPTION
## Summary

The plan validator used to accept a plan whose `baseBranch` was never pushed to `repoUrl`.

That plan would pass validation and continue on into Invoker. It only failed later, when Invoker's merge gate tried to fetch a branch that never existed on origin.

This exact gap hit workflow `wf-1787809244122-3`. Its plan pointed `baseBranch` at a local staging branch that was never pushed.

The merge gate retried that same dead config 5 times, unable to succeed.

The fix adds a best-effort `git ls-remote` check to `validate-plan.mjs`. When `repoUrl` and an explicit `baseBranch` are both set, it confirms the branch exists on the remote first.

Any network, auth, or timeout error is treated as "unknown," not a rejection. This keeps the validator from getting flaky offline.

## Review Claim

`validate-plan.mjs` must reject a plan whose explicit `baseBranch` is absent from `repoUrl`, since Invoker's merge gate always fetches `baseBranch` from origin and cannot succeed otherwise.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

All other validator behavior stays identical. The new check only adds an error when `repoUrl` is set and `baseBranch` was explicitly set by the plan author (not the implicit `master` default). It never fails closed on a network or auth error — an unreachable remote is treated as "unknown" and silently skipped, not as a rejection.

## Slice Rationale

One policy slice: a single new check inside the existing `validate-plan.mjs` skill script, added as a local helper function. No new module boundaries, no new YAML fields, no change to the Invoker app's own merge-gate runtime.

## Non-goals

No refactor of `validate-plan.mjs` beyond this check. No change to `validate-plan.ts` (a separate, unused mirror file — `validate-plan.sh` only ever invokes `validate-plan.mjs`). No change to the Invoker app's merge-gate code. No new script files.

## Test Plan

<details>
<summary>Test Plan</summary>

Repro built and run by hand against this branch: a local bare git repo stood in as a fake "remote" (no network dependency), with a throwaway plan whose `baseBranch` does not exist there.

- [ ] Before the fix (pre-fix `validate-plan.mjs` content swapped over the working file, then restored): `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan.yaml>` **accepts** the plan — no `basebranch_not_on_remote` error in the output.
- [ ] After the fix (current `validate-plan.mjs` on this branch): the same command **rejects** the same plan with `basebranch_not_on_remote`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
