### PR TITLE
[Source development isolation](1) runtime profile contract

### DIFF
--- a/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
+++ b/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import {
+  InvokerInstanceProfileError,
+  resolveInvokerInstanceProfile,
+} from '../invoker-instance-profile.js';
+
+const HOME = '/home/user';
+
+describe('resolveInvokerInstanceProfile', () => {
+  it('resolves the existing production home and production-compatible defaults for packaged', () => {
+    const profile = resolveInvokerInstanceProfile({ kind: 'packaged', homeDir: HOME, platform: 'linux' });
+
+    expect(profile.homeRoot).toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.ipcSocketPath).toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.logPath).toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ports).toEqual({ apiPort: 4100, webPort: 4200 });
+    expect(profile.isProductionAccessExplicit).toBe(true);
+    expect(profile.developmentId).toBeNull();
+  });
+
+  it('resolves every resource outside production for a source-development profile', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/feature-a',
+      homeDir: HOME,
+      platform: 'linux',
+    });
+
+    expect(profile.homeRoot).not.toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).not.toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.envPath).not.toBe(join(HOME, '.invoker', 'env.sh'));
+    expect(profile.logPath).not.toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ipcSocketPath).not.toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.electronUserDataDir).not.toBe(join(HOME, '.invoker'));
+    expect(profile.ports.apiPort).not.toBe(4100);
+    expect(profile.ports.webPort).not.toBe(4200);
+    expect(profile.isProductionAccessExplicit).toBe(false);
+    expect(profile.developmentId).toMatch(/^[0-9a-f]{10}$/);
+
+    // Every resource stays under the derived, isolated home root.
+    expect(profile.configPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.envPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.logPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.ipcSocketPath.startsWith(profile.homeRoot)).toBe(true);
+
+    // Unix domain socket paths must stay well within the platform limit (~104-108 bytes).
+    expect(profile.ipcSocketPath.length).toBeLessThan(100);
+  });
+
+  it('resolves two distinct worktree roots to distinct, stable development profiles', () => {
+    const a1 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const a2 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const b = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/b', homeDir: HOME });
+
+    expect(a1).toEqual(a2);
+
+    expect(a1.developmentId).not.toBe(b.developmentId);
+    expect(a1.homeRoot).not.toBe(b.homeRoot);
+    expect(a1.ipcSocketPath).not.toBe(b.ipcSocketPath);
+    expect(a1.configPath).not.toBe(b.configPath);
+    expect(a1.envPath).not.toBe(b.envPath);
+    expect(a1.logPath).not.toBe(b.logPath);
+    expect(a1.electronUserDataDir).not.toBe(b.electronUserDataDir);
+    expect(a1.ports).not.toEqual(b.ports);
+  });
+
+  it('preserves explicit overrides regardless of profile kind', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'test',
+      homeDir: HOME,
+      env: {
+        INVOKER_DB_DIR: '/tmp/invoker-explicit',
+        INVOKER_IPC_SOCKET: '/tmp/custom.sock',
+        INVOKER_REPO_CONFIG_PATH: '/tmp/custom-config.json',
+        INVOKER_ENV_PATH: '/tmp/custom.env',
+        INVOKER_LOG_PATH: '/tmp/custom.log',
+      },
+    });
+
+    expect(profile.homeRoot).toBe('/tmp/invoker-explicit');
+    expect(profile.ipcSocketPath).toBe('/tmp/custom.sock');
+    expect(profile.configPath).toBe('/tmp/custom-config.json');
+    expect(profile.envPath).toBe('/tmp/custom.env');
+    expect(profile.logPath).toBe('/tmp/custom.log');
+  });
+
+  it('produces a deterministic error for a malformed profile name', () => {
+    const attempt = () => resolveInvokerInstanceProfile({ kind: 'production' });
+
+    expect(attempt).toThrow(InvokerInstanceProfileError);
+    expect(attempt).toThrow(
+      'Unknown Invoker runtime profile "production". Expected one of: packaged, source-development, test.',
+    );
+
+    // Same malformed input always produces the same error message.
+    let firstMessage = '';
+    let secondMessage = '';
+    try {
+      attempt();
+    } catch (error) {
+      firstMessage = (error as Error).message;
+    }
+    try {
+      attempt();
+    } catch (error) {
+      secondMessage = (error as Error).message;
+    }
+    expect(firstMessage).toBe(secondMessage);
+  });
+
+  it('requires a sourceRoot for source-development profiles', () => {
+    expect(() => resolveInvokerInstanceProfile({ kind: 'source-development' })).toThrow(
+      InvokerInstanceProfileError,
+    );
+  });
+
+  it('keeps a profile\'s own resource paths disjoint from one another', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/c',
+      homeDir: HOME,
+    });
+
+    const paths = [profile.ipcSocketPath, profile.configPath, profile.envPath, profile.logPath];
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './invoker-instance-profile.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';

--- a/packages/contracts/src/invoker-instance-profile.ts
+++ b/packages/contracts/src/invoker-instance-profile.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+import { homedir, platform as osPlatform } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export type InvokerRuntimeKind = 'packaged' | 'source-development' | 'test';
+
+const INVOKER_RUNTIME_KINDS: readonly InvokerRuntimeKind[] = ['packaged', 'source-development', 'test'];
+
+export interface InvokerInstanceProfileEnv {
+  INVOKER_DB_DIR?: string;
+  INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
+  INVOKER_USER_DATA_DIR?: string;
+  INVOKER_ENV_PATH?: string;
+  INVOKER_LOG_PATH?: string;
+  INVOKER_API_PORT?: string;
+  INVOKER_WEB_PORT?: string;
+  APPDATA?: string;
+  XDG_CONFIG_HOME?: string;
+}
+
+export interface InvokerInstanceProfileInput {
+  kind: string;
+  sourceRoot?: string;
+  env?: InvokerInstanceProfileEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+export interface InvokerInstancePortPolicy {
+  apiPort: number;
+  webPort: number;
+}
+
+export interface InvokerInstanceProfile {
+  kind: InvokerRuntimeKind;
+  developmentId: string | null;
+  isProductionAccessExplicit: boolean;
+  homeRoot: string;
+  electronUserDataDir: string;
+  ipcSocketPath: string;
+  configPath: string;
+  envPath: string;
+  logPath: string;
+  ports: InvokerInstancePortPolicy;
+}
+
+export class InvokerInstanceProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvokerInstanceProfileError';
+  }
+}
+
+const PRODUCTION_API_PORT = 4100;
+const PRODUCTION_WEB_PORT = 4200;
+const DEVELOPMENT_API_PORT_BASE = 41000;
+const DEVELOPMENT_PORT_SPAN = 900;
+const DEVELOPMENT_WEB_PORT_OFFSET = 1000;
+
+function isInvokerRuntimeKind(value: string): value is InvokerRuntimeKind {
+  return (INVOKER_RUNTIME_KINDS as readonly string[]).includes(value);
+}
+
+function hashSourceRoot(sourceRoot: string): string {
+  return createHash('sha256').update(resolve(sourceRoot)).digest('hex').slice(0, 10);
+}
+
+function derivePortFromDevelopmentId(developmentId: string): number {
+  const numeric = parseInt(developmentId.slice(0, 8), 16);
+  return DEVELOPMENT_API_PORT_BASE + (numeric % DEVELOPMENT_PORT_SPAN);
+}
+
+function defaultElectronUserDataDir(
+  platformName: NodeJS.Platform,
+  homeDir: string,
+  env: InvokerInstanceProfileEnv,
+): string {
+  const productName = 'Invoker';
+  if (platformName === 'darwin') {
+    return join(homeDir, 'Library', 'Application Support', productName);
+  }
+  if (platformName === 'win32') {
+    return join(env.APPDATA ?? join(homeDir, 'AppData', 'Roaming'), productName);
+  }
+  return join(env.XDG_CONFIG_HOME ?? join(homeDir, '.config'), productName);
+}
+
+export function resolveInvokerInstanceProfile(input: InvokerInstanceProfileInput): InvokerInstanceProfile {
+  const {
+    kind: rawKind,
+    sourceRoot,
+    env = {},
+    platform: platformName = osPlatform(),
+    homeDir = homedir(),
+  } = input;
+
+  if (!isInvokerRuntimeKind(rawKind)) {
+    throw new InvokerInstanceProfileError(
+      `Unknown Invoker runtime profile "${rawKind}". Expected one of: ${INVOKER_RUNTIME_KINDS.join(', ')}.`,
+    );
+  }
+  const kind = rawKind;
+
+  if (kind === 'source-development' && !sourceRoot?.trim()) {
+    throw new InvokerInstanceProfileError('A source-development profile requires a non-empty sourceRoot.');
+  }
+
+  const developmentId = kind === 'source-development' ? hashSourceRoot(sourceRoot!) : null;
+
+  const homeRoot = env.INVOKER_DB_DIR
+    ?? (kind === 'test'
+      ? join(homeDir, '.invoker', 'test')
+      : kind === 'source-development'
+        ? join(homeDir, '.invoker', 'dev', developmentId!)
+        : join(homeDir, '.invoker'));
+
+  const ipcSocketPath = env.INVOKER_IPC_SOCKET ?? join(homeRoot, 'ipc-transport.sock');
+  const configPath = env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homeRoot, 'config.json');
+  const envPath = env.INVOKER_ENV_PATH ?? join(homeRoot, '.env');
+  const logPath = env.INVOKER_LOG_PATH ?? join(homeRoot, 'invoker.log');
+
+  const electronUserDataDir = env.INVOKER_USER_DATA_DIR
+    ?? (kind === 'packaged'
+      ? defaultElectronUserDataDir(platformName, homeDir, env)
+      : join(homeRoot, 'electron'));
+
+  const ports: InvokerInstancePortPolicy = kind === 'packaged'
+    ? {
+      apiPort: env.INVOKER_API_PORT ? parseInt(env.INVOKER_API_PORT, 10) : PRODUCTION_API_PORT,
+      webPort: env.INVOKER_WEB_PORT ? parseInt(env.INVOKER_WEB_PORT, 10) : PRODUCTION_WEB_PORT,
+    }
+    : kind === 'test'
+      ? { apiPort: 0, webPort: 0 }
+      : (() => {
+        const apiPort = derivePortFromDevelopmentId(developmentId!);
+        return { apiPort, webPort: apiPort + DEVELOPMENT_WEB_PORT_OFFSET };
+      })();
+
+  return {
+    kind,
+    developmentId,
+    isProductionAccessExplicit: kind === 'packaged',
+    homeRoot,
+    electronUserDataDir,
+    ipcSocketPath,
+    configPath,
+    envPath,
+    logPath,
+    ports,
+  };
+}


### PR DESCRIPTION
## Summary

Introduce one typed runtime profile that derives every mutable Invoker resource from its runtime identity.

Packaged, source-development, and test identities receive deterministic storage, socket, configuration, log, and network values.

Existing production consumers keep their current behavior until later stack slices adopt the profile.

## Review Claim

A single contract deterministically derives Invoker home, Electron user data, IPC socket, config, env, log, and port policy for each runtime identity.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice is dormant; existing callers keep using their current resolvers, and packaged production behavior does not change.

## Slice Rationale

The shared data shape must land before application and launcher consumers can adopt it without duplicating profile policy.

## Non-goals

Do not activate the profile in application code, change launch scripts, start processes, or alter production data.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/invoker-instance-profile.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
