### PR TITLE
[admin-bypass-repair-bot-thread-pr-10712-b99f44e](1) Match baseBranch against the literal remote ref

### DIFF
--- a/skills/plan-to-invoker/scripts/test-validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/test-validate-plan.sh
@@ -897,6 +897,93 @@ test_error_field_structure() {
   return 0
 }
  
+# Test: baseBranch must match the literal remote ref, not a git ls-remote glob tail
+# `git ls-remote --heads <repo> feature/foo` also matches refs/heads/release/feature/foo,
+# so a pattern match is not proof that refs/heads/feature/foo exists.
+test_basebranch_remote_ref_is_matched_literally() {
+  local remote_dir
+  remote_dir=$(mktemp -d)
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -rf $remote_dir $temp_plan" RETURN
+
+  git init -q --bare "$remote_dir/origin.git" || return 1
+  git init -q "$remote_dir/work" || return 1
+  (
+    cd "$remote_dir/work" &&
+    git config user.email test@example.com &&
+    git config user.name test &&
+    git commit -q --allow-empty -m init &&
+    git branch -M master &&
+    git checkout -q -b release/feature/foo &&
+    git remote add origin "$remote_dir/origin.git" &&
+    git push -q origin master release/feature/foo
+  ) || return 1
+
+  emit_plan() {
+    cat > "$temp_plan" <<EOF
+name: basebranch-remote-literal-match
+onFinish: none
+mergeMode: manual
+repoUrl: file://$remote_dir/origin.git
+baseBranch: $1
+tasks:
+  - id: t1
+    description: Smoke
+    command: "true"
+EOF
+  }
+
+  local output
+
+  # refs/heads/feature/foo does not exist; only refs/heads/release/feature/foo does.
+  emit_plan "feature/foo"
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  set -e
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "basebranch_not_on_remote")] | length > 0' &>/dev/null; then
+    echo "Expected basebranch_not_on_remote for a glob-only tail match" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  # The branch that really exists must still validate.
+  emit_plan "release/feature/foo"
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected an existing baseBranch to validate, got exit $exit_code" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  # An unreachable remote must stay fail-open, not fail-closed.
+  cat > "$temp_plan" <<EOF
+name: basebranch-remote-unreachable
+onFinish: none
+mergeMode: manual
+repoUrl: file://$remote_dir/absent.git
+baseBranch: whatever
+tasks:
+  - id: t1
+    description: Smoke
+    command: "true"
+EOF
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  exit_code=$?
+  set -e
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected an unreachable remote to fail open, got exit $exit_code" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # Check dependencies
 if ! command -v jq &>/dev/null; then
   fail "jq is required for JSON parsing tests"
@@ -939,6 +1026,7 @@ run_test "Upward relative paths should be rejected" test_upward_relative_path_fa
 run_test "Experiment variant missing command scripts should be rejected" test_experiment_variant_missing_command_script_fails
 run_test "Branched review gate artifacts should be rejected" test_branched_review_gate_rejected
 run_test "Error objects should have correct field structure" test_error_field_structure
+run_test "baseBranch must match the literal remote ref" test_basebranch_remote_ref_is_matched_literally
 
 echo ""
 echo "========================================="

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -538,13 +538,19 @@ function validateReviewGate(reviewGate, errors) {
 }
 
 function checkBaseBranchOnRemote(repoUrl, baseBranch) {
+  const shortName = baseBranch.replace(/^refs\/heads\//, '');
+  const wantRef = `refs/heads/${shortName}`;
   try {
-    const out = execFileSync('git', ['ls-remote', '--heads', repoUrl, baseBranch], {
+    const out = execFileSync('git', ['ls-remote', '--heads', repoUrl, '--', wantRef], {
       timeout: 8000,
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf8',
     });
-    return out.trim() === '' ? 'absent' : 'present';
+    const matched = out
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/))
+      .some((parts) => parts[1] === wantRef);
+    return matched ? 'present' : 'absent';
   } catch {
     return 'unknown';
   }


### PR DESCRIPTION
## Summary

The plan validator's remote base-branch check passed `baseBranch` straight to `git ls-remote` as a pattern. ls-remote patterns are globs matched from the tail of a refname.

So `feature/foo` matched `refs/heads/release/feature/foo`, and the check reported a branch as present even when `refs/heads/feature/foo` did not exist on the remote.

The check now queries the fully qualified `refs/heads/<branch>` and requires the returned ref column to equal it exactly. An already-qualified `baseBranch` is stripped first to avoid double-prefixing.

Lookup failures on unreachable or unauthenticated remotes stay fail-open, exactly as before.

## Review Claim

Approve exact-ref matching in Plan-to-Invoker's remote base-branch existence check, replacing ls-remote glob matching.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only tightens string matching inside `checkBaseBranchOnRemote`. Lookup errors still return `unknown` and fail open, and plans whose explicit base genuinely exists still validate — proven by the 25-case validator test script, including the new literal-ref case.

## Slice Rationale

One validator matching rule plus its regression coverage. It is kept apart from the already-landed absent-branch check (#10708) because this repairs that check's false positives, and it is the exact defect a bot review thread flagged on PR #10712.

## Non-goals

- No change to the implicit `master` default, which still skips the remote lookup.
- No fail-closed behavior when a remote cannot be queried.
- No change to other validator rules or the `validate-plan.sh` wrapper.
- No change to app code or the merge gate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `INVOKER_REPO_ROOT=/home/invoker/Invoker bash skills/plan-to-invoker/scripts/test-validate-plan.sh` — 25/25 passed, including the new `baseBranch must match the literal remote ref` case.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's commit>`
- Post-revert steps: None
- Data migration? No

</details>
