### PR TITLE
[admin-bypass-repair-bot-thread-pr-10712-916aa1d](2) Redact repoUrl credentials from plan validator error output

### DIFF
--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -537,6 +537,21 @@ function validateReviewGate(reviewGate, errors) {
   });
 }
 
+// Credentials in a repoUrl must never reach validator output — errors are printed to stderr and logged.
+function redactRepoUrlUserInfo(repoUrl) {
+  if (typeof repoUrl !== 'string') return repoUrl;
+  try {
+    const parsed = new URL(repoUrl);
+    if (parsed.username === '' && parsed.password === '') return repoUrl;
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    // `new URL` rejects some URLs git still accepts (e.g. file://user:pass@/path).
+    return repoUrl.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/@]*@/, '$1');
+  }
+}
+
 // A base ref may be remote-qualified (`origin/master`, `upstream/main`,
 // `refs/remotes/upstream/release`), and repoUrl is only one remote, so a leading segment
 // that could name a different remote yields a second candidate. Reporting `absent` only
@@ -622,7 +637,7 @@ function validatePlan(yamlContent, repoRoot) {
       errorType: 'conflicting_fields',
       field: 'repoUrl',
       message: 'Plan cannot set both "scratch: true" and "repoUrl" — scratch plans run with no git repo',
-      value: raw.repoUrl,
+      value: redactRepoUrlUserInfo(raw.repoUrl),
     });
   } else if (!isScratch && !hasRepoUrl) {
     errors.push({
@@ -761,7 +776,7 @@ function validatePlan(yamlContent, repoRoot) {
       errors.push({
         errorType: 'basebranch_not_on_remote',
         field: 'baseBranch',
-        message: `baseBranch '${raw.baseBranch}' was not found on ${raw.repoUrl} (git ls-remote returned no matching ref). Invoker's merge gate fetches this branch from origin and will fail with "required by the merge/gate step was not found on the remote" if submitted as-is. Push the branch first, or point baseBranch at a branch that exists (often 'master').`,
+        message: `baseBranch '${raw.baseBranch}' was not found on ${redactRepoUrlUserInfo(raw.repoUrl)} (git ls-remote returned no matching ref). Invoker's merge gate fetches this branch from origin and will fail with "required by the merge/gate step was not found on the remote" if submitted as-is. Push the branch first, or point baseBranch at a branch that exists (often 'master').`,
         value: raw.baseBranch,
       });
     }


### PR DESCRIPTION
## Summary

Plans may carry a `repoUrl` with embedded credentials, such as a token in the URL userinfo segment. The plan validator echoed that URL verbatim into error messages and error values.

Validator errors are printed to stderr and logged, so an invalid plan could leak a live token into logs and transcripts.

The validator now strips the userinfo segment from `repoUrl` before it appears in any error output.

URLs that `new URL` rejects but git accepts fall back to a regex strip of the userinfo segment.

URLs without credentials pass through unchanged.

## Review Claim

`repoUrl` credentials never appear in plan validator error messages or error values.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes how `skills/plan-to-invoker/scripts/validate-plan.mjs` renders `repoUrl` inside error output; validation decisions, error types, and fields are untouched. Redaction failure degrades to returning the input string, which is exactly the pre-existing behavior.

## Slice Rationale

Credential redaction is a separate claim from the `baseBranch` ref-matching fix in the previous slice, even though both touch the same file. The regression test proving redaction lands with the test suite in the next slice.

## Non-goals

- No change to which plans validate or fail.
- No new tests (next slice).
- No redaction elsewhere in Invoker; only the plan validator's error output.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --check skills/plan-to-invoker/scripts/validate-plan.mjs`
- [x] `bash skills/plan-to-invoker/scripts/validate-plan.sh plans/plan-to-invoker-deterministic-step-1-validator.yaml`
- [x] `bash skills/plan-to-invoker/scripts/test-validate-plan.sh` (27/27 passing at the top of this stack, including "repoUrl credentials must be redacted from validator output")

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
