### PR TITLE
[Source development isolation](2) make the app profile-aware

### DIFF
--- a/packages/app/src/__tests__/plan-backup.test.ts
+++ b/packages/app/src/__tests__/plan-backup.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
 import { mkdirSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import { backupPlan } from '../plan-backup.js';
 import type { PlanDefinition } from '@invoker/workflow-core';
 
-const backupDir = join(homedir(), '.invoker', 'plans');
+const backupDir = join(resolveInvokerHomeRoot(), 'plans');
 
 function cleanupBackups(): void {
   if (existsSync(backupDir)) {
@@ -29,7 +29,7 @@ describe('backupPlan', () => {
     ],
   };
 
-  it('creates a YAML file in ~/.invoker/plans/', () => {
+  it('creates a YAML file in the active Invoker profile', () => {
     const filepath = backupPlan(plan);
     expect(existsSync(filepath)).toBe(true);
     expect(filepath).toContain(backupDir);

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
 import type { Logger } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 
-const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
+const LOG_PATH = process.env.INVOKER_LOG_PATH ?? path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -30,11 +30,10 @@ const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E
 const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.includes('--install-skills')
   || process.argv.slice(2).includes('install-skills');
+const sourceDevelopmentProfile = process.env.INVOKER_DEVELOPMENT_PROFILE === '1';
 
 configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
 
-// Isolate userData (and with it the single-instance lock) for e2e runs so a
-// test instance can launch alongside a normally running Invoker.
 if (process.env.INVOKER_USER_DATA_DIR) {
   app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
 }
@@ -610,10 +609,9 @@ process.on('unhandledRejection', (reason) => {
 const repoRoot = resolveRepoRoot(__dirname, { fallback: process.resourcesPath });
 const planDoctorScriptPath = path.join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh');
 
-// Load secrets from ~/.invoker/.env (canonical) then the repo .env BEFORE any startup guard
-// reads process.env. dotenv never overrides vars already set in the real environment.
 function loadInvokerEnvFiles(): void {
-  for (const envPath of [path.join(homedir(), '.invoker', '.env'), path.resolve(repoRoot, '.env')]) {
+  const profileEnvPath = process.env.INVOKER_ENV_PATH ?? path.join(homedir(), '.invoker', '.env');
+  for (const envPath of [profileEnvPath, path.resolve(repoRoot, '.env')]) {
     if (existsSync(envPath)) loadDotenv({ path: envPath });
   }
 }
@@ -2082,7 +2080,7 @@ function startHeadlessMode(): void {
             planningCommandBuilder,
             agentRegistry,
           ),
-          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+          autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -2096,7 +2094,7 @@ function startHeadlessMode(): void {
             );
           }
         }
-        workerRuntimeController.startAutoStartedWorkers();
+        if (!sourceDevelopmentProfile) workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
           standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
@@ -2104,7 +2102,7 @@ function startHeadlessMode(): void {
             ownerId: workflowMutationOwnerId,
             createTaskExecutor: createStandaloneTaskExecutor,
             setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
-            topUpReadyLaunchesEnabled: () => !invokerConfig.disableAutoRunOnStartup,
+            topUpReadyLaunchesEnabled: () => !sourceDevelopmentProfile && !invokerConfig.disableAutoRunOnStartup,
           });
         }
         if (command === 'owner-serve') {
@@ -2690,7 +2688,7 @@ startMainProcessBootstrap({
     recordStartupMark('deferred-startup.begin');
     if (ownerMode && workerRuntimeController) {
       setTimeout(() => {
-        workerRuntimeController?.startAutoStartedWorkers();
+        if (!sourceDevelopmentProfile) workerRuntimeController?.startAutoStartedWorkers();
         recordStartupMark('workers.auto-started');
       }, 0);
     }
@@ -3265,7 +3263,7 @@ startMainProcessBootstrap({
           planningCommandBuilder,
           agentRegistry,
         ),
-        autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+        autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -3297,7 +3295,7 @@ startMainProcessBootstrap({
               { module: 'init', taskIds: orphaned.map((task) => task.id) },
             );
           }
-          if (invokerConfig.disableAutoRunOnStartup) {
+          if (sourceDevelopmentProfile || invokerConfig.disableAutoRunOnStartup) {
             logger.info('auto-run on startup disabled by config', { module: 'init' });
           } else {
             orchestrator.startExecution();

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -2,10 +2,9 @@
  * Shared logic for opening an external OS terminal for a persisted task.
  */
 
-import type { Logger, OpenTerminalResponse } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, type Logger, type OpenTerminalResponse } from '@invoker/contracts';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
-import { homedir } from 'node:os';
 import {
   DEFAULT_EXECUTION_AGENT,
   DockerExecutor,
@@ -242,7 +241,7 @@ export function resolveTaskTerminalSpec(
       executorRegistry.register('docker', docker);
       executor = docker;
     } else if (repairedMeta.runnerKind === 'worktree') {
-      const invokerHome = path.resolve(homedir(), '.invoker');
+      const invokerHome = resolveInvokerHomeRoot();
       const maxWorktrees = resolveEffectiveMaxConcurrency(loadConfig().maxConcurrency);
       const worktree = new WorktreeExecutor({
         worktreeBaseDir: path.resolve(invokerHome, 'worktrees'),

--- a/packages/app/src/plan-backup.ts
+++ b/packages/app/src/plan-backup.ts
@@ -4,9 +4,8 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { stringify as stringifyYaml } from 'yaml';
-import type { Logger } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import type { PlanDefinition } from '@invoker/workflow-core';
 
 let backupCounter = 0;
@@ -27,7 +26,7 @@ function slugify(name: string): string {
  * @returns The absolute path of the backup file.
  */
 export function backupPlan(plan: PlanDefinition, yamlSource?: string, planLogger?: Logger): string {
-  const dir = join(homedir(), '.invoker', 'plans');
+  const dir = join(resolveInvokerHomeRoot(), 'plans');
   mkdirSync(dir, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');

--- a/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
+++ b/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import {
+  InvokerInstanceProfileError,
+  resolveInvokerInstanceProfile,
+} from '../invoker-instance-profile.js';
+
+const HOME = '/home/user';
+
+describe('resolveInvokerInstanceProfile', () => {
+  it('resolves the existing production home and production-compatible defaults for packaged', () => {
+    const profile = resolveInvokerInstanceProfile({ kind: 'packaged', homeDir: HOME, platform: 'linux' });
+
+    expect(profile.homeRoot).toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.ipcSocketPath).toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.logPath).toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ports).toEqual({ apiPort: 4100, webPort: 4200 });
+    expect(profile.isProductionAccessExplicit).toBe(true);
+    expect(profile.developmentId).toBeNull();
+  });
+
+  it('resolves every resource outside production for a source-development profile', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/feature-a',
+      homeDir: HOME,
+      platform: 'linux',
+    });
+
+    expect(profile.homeRoot).not.toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).not.toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.envPath).not.toBe(join(HOME, '.invoker', 'env.sh'));
+    expect(profile.logPath).not.toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ipcSocketPath).not.toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.electronUserDataDir).not.toBe(join(HOME, '.invoker'));
+    expect(profile.ports.apiPort).not.toBe(4100);
+    expect(profile.ports.webPort).not.toBe(4200);
+    expect(profile.isProductionAccessExplicit).toBe(false);
+    expect(profile.developmentId).toMatch(/^[0-9a-f]{10}$/);
+
+    // Every resource stays under the derived, isolated home root.
+    expect(profile.configPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.envPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.logPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.ipcSocketPath.startsWith(profile.homeRoot)).toBe(true);
+
+    // Unix domain socket paths must stay well within the platform limit (~104-108 bytes).
+    expect(profile.ipcSocketPath.length).toBeLessThan(100);
+  });
+
+  it('resolves two distinct worktree roots to distinct, stable development profiles', () => {
+    const a1 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const a2 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const b = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/b', homeDir: HOME });
+
+    expect(a1).toEqual(a2);
+
+    expect(a1.developmentId).not.toBe(b.developmentId);
+    expect(a1.homeRoot).not.toBe(b.homeRoot);
+    expect(a1.ipcSocketPath).not.toBe(b.ipcSocketPath);
+    expect(a1.configPath).not.toBe(b.configPath);
+    expect(a1.envPath).not.toBe(b.envPath);
+    expect(a1.logPath).not.toBe(b.logPath);
+    expect(a1.electronUserDataDir).not.toBe(b.electronUserDataDir);
+    expect(a1.ports).not.toEqual(b.ports);
+  });
+
+  it('preserves explicit overrides regardless of profile kind', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'test',
+      homeDir: HOME,
+      env: {
+        INVOKER_DB_DIR: '/tmp/invoker-explicit',
+        INVOKER_IPC_SOCKET: '/tmp/custom.sock',
+        INVOKER_REPO_CONFIG_PATH: '/tmp/custom-config.json',
+        INVOKER_ENV_PATH: '/tmp/custom.env',
+        INVOKER_LOG_PATH: '/tmp/custom.log',
+      },
+    });
+
+    expect(profile.homeRoot).toBe('/tmp/invoker-explicit');
+    expect(profile.ipcSocketPath).toBe('/tmp/custom.sock');
+    expect(profile.configPath).toBe('/tmp/custom-config.json');
+    expect(profile.envPath).toBe('/tmp/custom.env');
+    expect(profile.logPath).toBe('/tmp/custom.log');
+  });
+
+  it('produces a deterministic error for a malformed profile name', () => {
+    const attempt = () => resolveInvokerInstanceProfile({ kind: 'production' });
+
+    expect(attempt).toThrow(InvokerInstanceProfileError);
+    expect(attempt).toThrow(
+      'Unknown Invoker runtime profile "production". Expected one of: packaged, source-development, test.',
+    );
+
+    // Same malformed input always produces the same error message.
+    let firstMessage = '';
+    let secondMessage = '';
+    try {
+      attempt();
+    } catch (error) {
+      firstMessage = (error as Error).message;
+    }
+    try {
+      attempt();
+    } catch (error) {
+      secondMessage = (error as Error).message;
+    }
+    expect(firstMessage).toBe(secondMessage);
+  });
+
+  it('requires a sourceRoot for source-development profiles', () => {
+    expect(() => resolveInvokerInstanceProfile({ kind: 'source-development' })).toThrow(
+      InvokerInstanceProfileError,
+    );
+  });
+
+  it('keeps a profile\'s own resource paths disjoint from one another', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/c',
+      homeDir: HOME,
+    });
+
+    const paths = [profile.ipcSocketPath, profile.configPath, profile.envPath, profile.logPath];
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './invoker-instance-profile.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';

--- a/packages/contracts/src/invoker-instance-profile.ts
+++ b/packages/contracts/src/invoker-instance-profile.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+import { homedir, platform as osPlatform } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export type InvokerRuntimeKind = 'packaged' | 'source-development' | 'test';
+
+const INVOKER_RUNTIME_KINDS: readonly InvokerRuntimeKind[] = ['packaged', 'source-development', 'test'];
+
+export interface InvokerInstanceProfileEnv {
+  INVOKER_DB_DIR?: string;
+  INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
+  INVOKER_USER_DATA_DIR?: string;
+  INVOKER_ENV_PATH?: string;
+  INVOKER_LOG_PATH?: string;
+  INVOKER_API_PORT?: string;
+  INVOKER_WEB_PORT?: string;
+  APPDATA?: string;
+  XDG_CONFIG_HOME?: string;
+}
+
+export interface InvokerInstanceProfileInput {
+  kind: string;
+  sourceRoot?: string;
+  env?: InvokerInstanceProfileEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+export interface InvokerInstancePortPolicy {
+  apiPort: number;
+  webPort: number;
+}
+
+export interface InvokerInstanceProfile {
+  kind: InvokerRuntimeKind;
+  developmentId: string | null;
+  isProductionAccessExplicit: boolean;
+  homeRoot: string;
+  electronUserDataDir: string;
+  ipcSocketPath: string;
+  configPath: string;
+  envPath: string;
+  logPath: string;
+  ports: InvokerInstancePortPolicy;
+}
+
+export class InvokerInstanceProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvokerInstanceProfileError';
+  }
+}
+
+const PRODUCTION_API_PORT = 4100;
+const PRODUCTION_WEB_PORT = 4200;
+const DEVELOPMENT_API_PORT_BASE = 41000;
+const DEVELOPMENT_PORT_SPAN = 900;
+const DEVELOPMENT_WEB_PORT_OFFSET = 1000;
+
+function isInvokerRuntimeKind(value: string): value is InvokerRuntimeKind {
+  return (INVOKER_RUNTIME_KINDS as readonly string[]).includes(value);
+}
+
+function hashSourceRoot(sourceRoot: string): string {
+  return createHash('sha256').update(resolve(sourceRoot)).digest('hex').slice(0, 10);
+}
+
+function derivePortFromDevelopmentId(developmentId: string): number {
+  const numeric = parseInt(developmentId.slice(0, 8), 16);
+  return DEVELOPMENT_API_PORT_BASE + (numeric % DEVELOPMENT_PORT_SPAN);
+}
+
+function defaultElectronUserDataDir(
+  platformName: NodeJS.Platform,
+  homeDir: string,
+  env: InvokerInstanceProfileEnv,
+): string {
+  const productName = 'Invoker';
+  if (platformName === 'darwin') {
+    return join(homeDir, 'Library', 'Application Support', productName);
+  }
+  if (platformName === 'win32') {
+    return join(env.APPDATA ?? join(homeDir, 'AppData', 'Roaming'), productName);
+  }
+  return join(env.XDG_CONFIG_HOME ?? join(homeDir, '.config'), productName);
+}
+
+export function resolveInvokerInstanceProfile(input: InvokerInstanceProfileInput): InvokerInstanceProfile {
+  const {
+    kind: rawKind,
+    sourceRoot,
+    env = {},
+    platform: platformName = osPlatform(),
+    homeDir = homedir(),
+  } = input;
+
+  if (!isInvokerRuntimeKind(rawKind)) {
+    throw new InvokerInstanceProfileError(
+      `Unknown Invoker runtime profile "${rawKind}". Expected one of: ${INVOKER_RUNTIME_KINDS.join(', ')}.`,
+    );
+  }
+  const kind = rawKind;
+
+  if (kind === 'source-development' && !sourceRoot?.trim()) {
+    throw new InvokerInstanceProfileError('A source-development profile requires a non-empty sourceRoot.');
+  }
+
+  const developmentId = kind === 'source-development' ? hashSourceRoot(sourceRoot!) : null;
+
+  const homeRoot = env.INVOKER_DB_DIR
+    ?? (kind === 'test'
+      ? join(homeDir, '.invoker', 'test')
+      : kind === 'source-development'
+        ? join(homeDir, '.invoker', 'dev', developmentId!)
+        : join(homeDir, '.invoker'));
+
+  const ipcSocketPath = env.INVOKER_IPC_SOCKET ?? join(homeRoot, 'ipc-transport.sock');
+  const configPath = env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homeRoot, 'config.json');
+  const envPath = env.INVOKER_ENV_PATH ?? join(homeRoot, '.env');
+  const logPath = env.INVOKER_LOG_PATH ?? join(homeRoot, 'invoker.log');
+
+  const electronUserDataDir = env.INVOKER_USER_DATA_DIR
+    ?? (kind === 'packaged'
+      ? defaultElectronUserDataDir(platformName, homeDir, env)
+      : join(homeRoot, 'electron'));
+
+  const ports: InvokerInstancePortPolicy = kind === 'packaged'
+    ? {
+      apiPort: env.INVOKER_API_PORT ? parseInt(env.INVOKER_API_PORT, 10) : PRODUCTION_API_PORT,
+      webPort: env.INVOKER_WEB_PORT ? parseInt(env.INVOKER_WEB_PORT, 10) : PRODUCTION_WEB_PORT,
+    }
+    : kind === 'test'
+      ? { apiPort: 0, webPort: 0 }
+      : (() => {
+        const apiPort = derivePortFromDevelopmentId(developmentId!);
+        return { apiPort, webPort: apiPort + DEVELOPMENT_WEB_PORT_OFFSET };
+      })();
+
+  return {
+    kind,
+    developmentId,
+    isProductionAccessExplicit: kind === 'packaged',
+    homeRoot,
+    electronUserDataDir,
+    ipcSocketPath,
+    configPath,
+    envPath,
+    logPath,
+    ports,
+  };
+}


### PR DESCRIPTION
## Summary

Teach the Electron app to honor development-profile paths and leave autonomous startup off when the source profile marker is present.

Packaged launches retain their existing paths, workers, and startup behavior because they do not set that marker.

## Review Claim

The Electron app consumes one development profile for mutable resources and autonomous startup safeguards.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Packaged launches do not set the development marker, so their existing paths, workers, and startup behavior remain unchanged.

## Slice Rationale

This slice contains the application-side profile consumer; environment injection follows separately.

## Non-goals

Do not change launch scripts, package commands, documentation, or production defaults.

## Architecture

### Before

```mermaid
graph TD
    A["Application startup"] --> B["Production-compatible paths"]
    A --> C["Configured autonomous work"]
```

### After

```mermaid
graph TD
    A["Application startup"] --> B["Profile-provided paths"]
    A --> C["Development marker check"]
    C --> D["Autonomous work stays off for source profiles"]
```

## Visual Proof

![Isolated source-development Invoker window with an empty plan graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260827-5c2cee/invoker-source-development-window-only.png)

Manually inspected: I opened this exact capture; it shows the source Invoker window with “No plan yet” and all workflow counters at zero.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-backup.test.ts src/__tests__/open-terminal.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before the later launcher slice
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent stack slices first
- Data migration? No

</details>
