### PR TITLE
[Source development isolation](3) add the fail-closed profile launcher

### DIFF
--- a/packages/app/src/__tests__/plan-backup.test.ts
+++ b/packages/app/src/__tests__/plan-backup.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
 import { mkdirSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import { backupPlan } from '../plan-backup.js';
 import type { PlanDefinition } from '@invoker/workflow-core';
 
-const backupDir = join(homedir(), '.invoker', 'plans');
+const backupDir = join(resolveInvokerHomeRoot(), 'plans');
 
 function cleanupBackups(): void {
   if (existsSync(backupDir)) {
@@ -29,7 +29,7 @@ describe('backupPlan', () => {
     ],
   };
 
-  it('creates a YAML file in ~/.invoker/plans/', () => {
+  it('creates a YAML file in the active Invoker profile', () => {
     const filepath = backupPlan(plan);
     expect(existsSync(filepath)).toBe(true);
     expect(filepath).toContain(backupDir);

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
 import type { Logger } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 
-const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
+const LOG_PATH = process.env.INVOKER_LOG_PATH ?? path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -30,11 +30,10 @@ const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E
 const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.includes('--install-skills')
   || process.argv.slice(2).includes('install-skills');
+const sourceDevelopmentProfile = process.env.INVOKER_DEVELOPMENT_PROFILE === '1';
 
 configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
 
-// Isolate userData (and with it the single-instance lock) for e2e runs so a
-// test instance can launch alongside a normally running Invoker.
 if (process.env.INVOKER_USER_DATA_DIR) {
   app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
 }
@@ -610,10 +609,9 @@ process.on('unhandledRejection', (reason) => {
 const repoRoot = resolveRepoRoot(__dirname, { fallback: process.resourcesPath });
 const planDoctorScriptPath = path.join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh');
 
-// Load secrets from ~/.invoker/.env (canonical) then the repo .env BEFORE any startup guard
-// reads process.env. dotenv never overrides vars already set in the real environment.
 function loadInvokerEnvFiles(): void {
-  for (const envPath of [path.join(homedir(), '.invoker', '.env'), path.resolve(repoRoot, '.env')]) {
+  const profileEnvPath = process.env.INVOKER_ENV_PATH ?? path.join(homedir(), '.invoker', '.env');
+  for (const envPath of [profileEnvPath, path.resolve(repoRoot, '.env')]) {
     if (existsSync(envPath)) loadDotenv({ path: envPath });
   }
 }
@@ -2082,7 +2080,7 @@ function startHeadlessMode(): void {
             planningCommandBuilder,
             agentRegistry,
           ),
-          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+          autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -2096,7 +2094,7 @@ function startHeadlessMode(): void {
             );
           }
         }
-        workerRuntimeController.startAutoStartedWorkers();
+        if (!sourceDevelopmentProfile) workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
           standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
@@ -2104,7 +2102,7 @@ function startHeadlessMode(): void {
             ownerId: workflowMutationOwnerId,
             createTaskExecutor: createStandaloneTaskExecutor,
             setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
-            topUpReadyLaunchesEnabled: () => !invokerConfig.disableAutoRunOnStartup,
+            topUpReadyLaunchesEnabled: () => !sourceDevelopmentProfile && !invokerConfig.disableAutoRunOnStartup,
           });
         }
         if (command === 'owner-serve') {
@@ -2690,7 +2688,7 @@ startMainProcessBootstrap({
     recordStartupMark('deferred-startup.begin');
     if (ownerMode && workerRuntimeController) {
       setTimeout(() => {
-        workerRuntimeController?.startAutoStartedWorkers();
+        if (!sourceDevelopmentProfile) workerRuntimeController?.startAutoStartedWorkers();
         recordStartupMark('workers.auto-started');
       }, 0);
     }
@@ -3265,7 +3263,7 @@ startMainProcessBootstrap({
           planningCommandBuilder,
           agentRegistry,
         ),
-        autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+        autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -3297,7 +3295,7 @@ startMainProcessBootstrap({
               { module: 'init', taskIds: orphaned.map((task) => task.id) },
             );
           }
-          if (invokerConfig.disableAutoRunOnStartup) {
+          if (sourceDevelopmentProfile || invokerConfig.disableAutoRunOnStartup) {
             logger.info('auto-run on startup disabled by config', { module: 'init' });
           } else {
             orchestrator.startExecution();

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -2,10 +2,9 @@
  * Shared logic for opening an external OS terminal for a persisted task.
  */
 
-import type { Logger, OpenTerminalResponse } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, type Logger, type OpenTerminalResponse } from '@invoker/contracts';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
-import { homedir } from 'node:os';
 import {
   DEFAULT_EXECUTION_AGENT,
   DockerExecutor,
@@ -242,7 +241,7 @@ export function resolveTaskTerminalSpec(
       executorRegistry.register('docker', docker);
       executor = docker;
     } else if (repairedMeta.runnerKind === 'worktree') {
-      const invokerHome = path.resolve(homedir(), '.invoker');
+      const invokerHome = resolveInvokerHomeRoot();
       const maxWorktrees = resolveEffectiveMaxConcurrency(loadConfig().maxConcurrency);
       const worktree = new WorktreeExecutor({
         worktreeBaseDir: path.resolve(invokerHome, 'worktrees'),

--- a/packages/app/src/plan-backup.ts
+++ b/packages/app/src/plan-backup.ts
@@ -4,9 +4,8 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { stringify as stringifyYaml } from 'yaml';
-import type { Logger } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import type { PlanDefinition } from '@invoker/workflow-core';
 
 let backupCounter = 0;
@@ -27,7 +26,7 @@ function slugify(name: string): string {
  * @returns The absolute path of the backup file.
  */
 export function backupPlan(plan: PlanDefinition, yamlSource?: string, planLogger?: Logger): string {
-  const dir = join(homedir(), '.invoker', 'plans');
+  const dir = join(resolveInvokerHomeRoot(), 'plans');
   mkdirSync(dir, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');

--- a/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
+++ b/packages/contracts/src/__tests__/invoker-instance-profile.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import {
+  InvokerInstanceProfileError,
+  resolveInvokerInstanceProfile,
+} from '../invoker-instance-profile.js';
+
+const HOME = '/home/user';
+
+describe('resolveInvokerInstanceProfile', () => {
+  it('resolves the existing production home and production-compatible defaults for packaged', () => {
+    const profile = resolveInvokerInstanceProfile({ kind: 'packaged', homeDir: HOME, platform: 'linux' });
+
+    expect(profile.homeRoot).toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.ipcSocketPath).toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.logPath).toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ports).toEqual({ apiPort: 4100, webPort: 4200 });
+    expect(profile.isProductionAccessExplicit).toBe(true);
+    expect(profile.developmentId).toBeNull();
+  });
+
+  it('resolves every resource outside production for a source-development profile', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/feature-a',
+      homeDir: HOME,
+      platform: 'linux',
+    });
+
+    expect(profile.homeRoot).not.toBe(join(HOME, '.invoker'));
+    expect(profile.configPath).not.toBe(join(HOME, '.invoker', 'config.json'));
+    expect(profile.envPath).not.toBe(join(HOME, '.invoker', 'env.sh'));
+    expect(profile.logPath).not.toBe(join(HOME, '.invoker', 'invoker.log'));
+    expect(profile.ipcSocketPath).not.toBe(join(HOME, '.invoker', 'ipc-transport.sock'));
+    expect(profile.electronUserDataDir).not.toBe(join(HOME, '.invoker'));
+    expect(profile.ports.apiPort).not.toBe(4100);
+    expect(profile.ports.webPort).not.toBe(4200);
+    expect(profile.isProductionAccessExplicit).toBe(false);
+    expect(profile.developmentId).toMatch(/^[0-9a-f]{10}$/);
+
+    // Every resource stays under the derived, isolated home root.
+    expect(profile.configPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.envPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.logPath.startsWith(profile.homeRoot)).toBe(true);
+    expect(profile.ipcSocketPath.startsWith(profile.homeRoot)).toBe(true);
+
+    // Unix domain socket paths must stay well within the platform limit (~104-108 bytes).
+    expect(profile.ipcSocketPath.length).toBeLessThan(100);
+  });
+
+  it('resolves two distinct worktree roots to distinct, stable development profiles', () => {
+    const a1 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const a2 = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/a', homeDir: HOME });
+    const b = resolveInvokerInstanceProfile({ kind: 'source-development', sourceRoot: '/Users/dev/worktrees/b', homeDir: HOME });
+
+    expect(a1).toEqual(a2);
+
+    expect(a1.developmentId).not.toBe(b.developmentId);
+    expect(a1.homeRoot).not.toBe(b.homeRoot);
+    expect(a1.ipcSocketPath).not.toBe(b.ipcSocketPath);
+    expect(a1.configPath).not.toBe(b.configPath);
+    expect(a1.envPath).not.toBe(b.envPath);
+    expect(a1.logPath).not.toBe(b.logPath);
+    expect(a1.electronUserDataDir).not.toBe(b.electronUserDataDir);
+    expect(a1.ports).not.toEqual(b.ports);
+  });
+
+  it('preserves explicit overrides regardless of profile kind', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'test',
+      homeDir: HOME,
+      env: {
+        INVOKER_DB_DIR: '/tmp/invoker-explicit',
+        INVOKER_IPC_SOCKET: '/tmp/custom.sock',
+        INVOKER_REPO_CONFIG_PATH: '/tmp/custom-config.json',
+        INVOKER_ENV_PATH: '/tmp/custom.env',
+        INVOKER_LOG_PATH: '/tmp/custom.log',
+      },
+    });
+
+    expect(profile.homeRoot).toBe('/tmp/invoker-explicit');
+    expect(profile.ipcSocketPath).toBe('/tmp/custom.sock');
+    expect(profile.configPath).toBe('/tmp/custom-config.json');
+    expect(profile.envPath).toBe('/tmp/custom.env');
+    expect(profile.logPath).toBe('/tmp/custom.log');
+  });
+
+  it('produces a deterministic error for a malformed profile name', () => {
+    const attempt = () => resolveInvokerInstanceProfile({ kind: 'production' });
+
+    expect(attempt).toThrow(InvokerInstanceProfileError);
+    expect(attempt).toThrow(
+      'Unknown Invoker runtime profile "production". Expected one of: packaged, source-development, test.',
+    );
+
+    // Same malformed input always produces the same error message.
+    let firstMessage = '';
+    let secondMessage = '';
+    try {
+      attempt();
+    } catch (error) {
+      firstMessage = (error as Error).message;
+    }
+    try {
+      attempt();
+    } catch (error) {
+      secondMessage = (error as Error).message;
+    }
+    expect(firstMessage).toBe(secondMessage);
+  });
+
+  it('requires a sourceRoot for source-development profiles', () => {
+    expect(() => resolveInvokerInstanceProfile({ kind: 'source-development' })).toThrow(
+      InvokerInstanceProfileError,
+    );
+  });
+
+  it('keeps a profile\'s own resource paths disjoint from one another', () => {
+    const profile = resolveInvokerInstanceProfile({
+      kind: 'source-development',
+      sourceRoot: '/Users/dev/worktrees/c',
+      homeDir: HOME,
+    });
+
+    const paths = [profile.ipcSocketPath, profile.configPath, profile.envPath, profile.logPath];
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './invoker-instance-profile.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';

--- a/packages/contracts/src/invoker-instance-profile.ts
+++ b/packages/contracts/src/invoker-instance-profile.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+import { homedir, platform as osPlatform } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export type InvokerRuntimeKind = 'packaged' | 'source-development' | 'test';
+
+const INVOKER_RUNTIME_KINDS: readonly InvokerRuntimeKind[] = ['packaged', 'source-development', 'test'];
+
+export interface InvokerInstanceProfileEnv {
+  INVOKER_DB_DIR?: string;
+  INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
+  INVOKER_USER_DATA_DIR?: string;
+  INVOKER_ENV_PATH?: string;
+  INVOKER_LOG_PATH?: string;
+  INVOKER_API_PORT?: string;
+  INVOKER_WEB_PORT?: string;
+  APPDATA?: string;
+  XDG_CONFIG_HOME?: string;
+}
+
+export interface InvokerInstanceProfileInput {
+  kind: string;
+  sourceRoot?: string;
+  env?: InvokerInstanceProfileEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+export interface InvokerInstancePortPolicy {
+  apiPort: number;
+  webPort: number;
+}
+
+export interface InvokerInstanceProfile {
+  kind: InvokerRuntimeKind;
+  developmentId: string | null;
+  isProductionAccessExplicit: boolean;
+  homeRoot: string;
+  electronUserDataDir: string;
+  ipcSocketPath: string;
+  configPath: string;
+  envPath: string;
+  logPath: string;
+  ports: InvokerInstancePortPolicy;
+}
+
+export class InvokerInstanceProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvokerInstanceProfileError';
+  }
+}
+
+const PRODUCTION_API_PORT = 4100;
+const PRODUCTION_WEB_PORT = 4200;
+const DEVELOPMENT_API_PORT_BASE = 41000;
+const DEVELOPMENT_PORT_SPAN = 900;
+const DEVELOPMENT_WEB_PORT_OFFSET = 1000;
+
+function isInvokerRuntimeKind(value: string): value is InvokerRuntimeKind {
+  return (INVOKER_RUNTIME_KINDS as readonly string[]).includes(value);
+}
+
+function hashSourceRoot(sourceRoot: string): string {
+  return createHash('sha256').update(resolve(sourceRoot)).digest('hex').slice(0, 10);
+}
+
+function derivePortFromDevelopmentId(developmentId: string): number {
+  const numeric = parseInt(developmentId.slice(0, 8), 16);
+  return DEVELOPMENT_API_PORT_BASE + (numeric % DEVELOPMENT_PORT_SPAN);
+}
+
+function defaultElectronUserDataDir(
+  platformName: NodeJS.Platform,
+  homeDir: string,
+  env: InvokerInstanceProfileEnv,
+): string {
+  const productName = 'Invoker';
+  if (platformName === 'darwin') {
+    return join(homeDir, 'Library', 'Application Support', productName);
+  }
+  if (platformName === 'win32') {
+    return join(env.APPDATA ?? join(homeDir, 'AppData', 'Roaming'), productName);
+  }
+  return join(env.XDG_CONFIG_HOME ?? join(homeDir, '.config'), productName);
+}
+
+export function resolveInvokerInstanceProfile(input: InvokerInstanceProfileInput): InvokerInstanceProfile {
+  const {
+    kind: rawKind,
+    sourceRoot,
+    env = {},
+    platform: platformName = osPlatform(),
+    homeDir = homedir(),
+  } = input;
+
+  if (!isInvokerRuntimeKind(rawKind)) {
+    throw new InvokerInstanceProfileError(
+      `Unknown Invoker runtime profile "${rawKind}". Expected one of: ${INVOKER_RUNTIME_KINDS.join(', ')}.`,
+    );
+  }
+  const kind = rawKind;
+
+  if (kind === 'source-development' && !sourceRoot?.trim()) {
+    throw new InvokerInstanceProfileError('A source-development profile requires a non-empty sourceRoot.');
+  }
+
+  const developmentId = kind === 'source-development' ? hashSourceRoot(sourceRoot!) : null;
+
+  const homeRoot = env.INVOKER_DB_DIR
+    ?? (kind === 'test'
+      ? join(homeDir, '.invoker', 'test')
+      : kind === 'source-development'
+        ? join(homeDir, '.invoker', 'dev', developmentId!)
+        : join(homeDir, '.invoker'));
+
+  const ipcSocketPath = env.INVOKER_IPC_SOCKET ?? join(homeRoot, 'ipc-transport.sock');
+  const configPath = env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homeRoot, 'config.json');
+  const envPath = env.INVOKER_ENV_PATH ?? join(homeRoot, '.env');
+  const logPath = env.INVOKER_LOG_PATH ?? join(homeRoot, 'invoker.log');
+
+  const electronUserDataDir = env.INVOKER_USER_DATA_DIR
+    ?? (kind === 'packaged'
+      ? defaultElectronUserDataDir(platformName, homeDir, env)
+      : join(homeRoot, 'electron'));
+
+  const ports: InvokerInstancePortPolicy = kind === 'packaged'
+    ? {
+      apiPort: env.INVOKER_API_PORT ? parseInt(env.INVOKER_API_PORT, 10) : PRODUCTION_API_PORT,
+      webPort: env.INVOKER_WEB_PORT ? parseInt(env.INVOKER_WEB_PORT, 10) : PRODUCTION_WEB_PORT,
+    }
+    : kind === 'test'
+      ? { apiPort: 0, webPort: 0 }
+      : (() => {
+        const apiPort = derivePortFromDevelopmentId(developmentId!);
+        return { apiPort, webPort: apiPort + DEVELOPMENT_WEB_PORT_OFFSET };
+      })();
+
+  return {
+    kind,
+    developmentId,
+    isProductionAccessExplicit: kind === 'packaged',
+    homeRoot,
+    electronUserDataDir,
+    ipcSocketPath,
+    configPath,
+    envPath,
+    logPath,
+    ports,
+  };
+}

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,10 @@ set -e
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
 
+if [ "${INVOKER_DEVELOPMENT_PROFILE_ACTIVE:-0}" != "1" ]; then
+  exec node "$REPO_ROOT/scripts/with-invoker-development-profile.mjs" -- bash "$0" "$@"
+fi
+
 # Workspaces are durable task/attempt artifacts. Disable destructive cleanup
 # from this launcher even if the caller's environment opts into it.
 export INVOKER_ENABLE_WORKSPACE_CLEANUP=0

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -5,6 +5,13 @@ const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
+if (process.argv[2] !== '--install-only' && process.env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE !== '1') {
+  const launcher = path.join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
+  const result = spawnSync(process.execPath, [launcher, '--', process.execPath, __filename, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+  });
+  process.exit(result.status ?? 1);
+}
 const ELECTRON_INSTALL_ATTEMPTS = 3;
 const MISSING_ELECTRON_MESSAGE =
   'Electron is not installed. Provision this machine before running Invoker: ' +

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { realpathSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultSourceRoot = realpathSync(resolve(scriptDir, '..'));
+
+function fail(message) {
+  process.stderr.write(`[invoker-development-profile] ${message}\n`);
+  process.exit(2);
+}
+
+function productionUserDataDir(homeDir) {
+  if (platform() === 'darwin') return join(homeDir, 'Library', 'Application Support', 'Invoker');
+  if (platform() === 'win32') return join(process.env.APPDATA ?? join(homeDir, 'AppData', 'Roaming'), 'Invoker');
+  return join(process.env.XDG_CONFIG_HOME ?? join(homeDir, '.config'), 'Invoker');
+}
+
+function developmentEnvironment(sourceRoot) {
+  const canonicalRoot = realpathSync(resolve(sourceRoot));
+  const id = createHash('sha256').update(canonicalRoot).digest('hex').slice(0, 10);
+  const homeRoot = join(homedir(), '.invoker', 'dev', id);
+  const apiPort = 41000 + (Number.parseInt(id.slice(0, 8), 16) % 900);
+  return {
+    INVOKER_DEVELOPMENT_PROFILE: '1',
+    INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1',
+    INVOKER_RUNTIME_KIND: 'source-development',
+    INVOKER_SOURCE_ROOT: canonicalRoot,
+    INVOKER_PROFILE_ID: id,
+    INVOKER_DB_DIR: homeRoot,
+    INVOKER_USER_DATA_DIR: join(homeRoot, 'electron'),
+    INVOKER_IPC_SOCKET: join(homeRoot, 'ipc-transport.sock'),
+    INVOKER_REPO_CONFIG_PATH: join(homeRoot, 'config.json'),
+    INVOKER_ENV_PATH: join(homeRoot, '.env'),
+    INVOKER_LOG_PATH: join(homeRoot, 'invoker.log'),
+    INVOKER_API_PORT: String(apiPort),
+    INVOKER_WEB_PORT: String(apiPort + 1000),
+    INVOKER_DISABLE_AUTONOMOUS_WORKERS: '1',
+    INVOKER_DISABLE_AUTO_RUN_ON_STARTUP: '1',
+  };
+}
+
+function resolveValue(name, value) {
+  return name.endsWith('_PORT') ? String(value) : resolve(String(value));
+}
+
+function assertNoProductionCollision(env) {
+  const homeDir = homedir();
+  const productionHome = join(homeDir, '.invoker');
+  const forbidden = new Map([
+    ['INVOKER_DB_DIR', productionHome],
+    ['INVOKER_USER_DATA_DIR', productionUserDataDir(homeDir)],
+    ['INVOKER_IPC_SOCKET', join(productionHome, 'ipc-transport.sock')],
+    ['INVOKER_REPO_CONFIG_PATH', join(productionHome, 'config.json')],
+    ['INVOKER_ENV_PATH', join(productionHome, '.env')],
+    ['INVOKER_LOG_PATH', join(productionHome, 'invoker.log')],
+    ['INVOKER_API_PORT', '4100'],
+    ['INVOKER_WEB_PORT', '4200'],
+  ]);
+  for (const [name, productionValue] of forbidden) {
+    if (env[name] && resolveValue(name, env[name]) === resolveValue(name, productionValue)) {
+      fail(`${name} points at the production profile (${productionValue}); refusing to start source development.`);
+    }
+  }
+}
+
+let args = process.argv.slice(2);
+let sourceRoot = defaultSourceRoot;
+let shell = false;
+let printEnv = false;
+let productionOwnerService = false;
+
+while (args.length > 0) {
+  if (args[0] === '--') {
+    args = args.slice(1);
+    break;
+  }
+  if (args[0] === '--source-root') {
+    if (!args[1]) fail('--source-root requires a path');
+    sourceRoot = args[1];
+    args = args.slice(2);
+    continue;
+  }
+  if (args[0] === '--shell') {
+    shell = true;
+    args = args.slice(1);
+    break;
+  }
+  if (args[0] === '--print-env') {
+    printEnv = true;
+    args = args.slice(1);
+    continue;
+  }
+  if (args[0] === '--production-owner-service') {
+    productionOwnerService = true;
+    args = args.slice(1);
+    continue;
+  }
+  fail(`unknown option: ${args[0]}`);
+}
+
+if (productionOwnerService) {
+  if (printEnv && args.length === 0) {
+    process.stdout.write(`${JSON.stringify({ INVOKER_RUNTIME_KIND: 'packaged', INVOKER_PRODUCTION_OWNER_SERVICE: '1' })}\n`);
+    process.exit(0);
+  }
+  if (args.length !== 3 || basename(args[0]) !== 'invoker-cli' || args[1] !== 'owner' || args[2] !== 'serve') {
+    fail('the production exception accepts exactly: invoker-cli owner serve');
+  }
+  const result = spawnSync(args[0], args.slice(1), {
+    stdio: 'inherit',
+    env: { ...process.env, INVOKER_RUNTIME_KIND: 'packaged', INVOKER_PRODUCTION_OWNER_SERVICE: '1' },
+  });
+  process.exit(result.status ?? 1);
+}
+
+assertNoProductionCollision(process.env);
+const profile = developmentEnvironment(sourceRoot);
+const childEnv = { ...process.env, ...profile };
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+if (printEnv) {
+  process.stdout.write(`${JSON.stringify(profile)}\n`);
+  if (args.length === 0) process.exit(0);
+}
+if (args.length === 0) fail('missing command after --');
+
+const shellArgs = args[1] === '--' ? args.slice(2) : args.slice(1);
+const result = shell
+  ? spawnSync(args[0], shellArgs, { stdio: 'inherit', env: childEnv, shell: true })
+  : spawnSync(args[0], args.slice(1), { stdio: 'inherit', env: childEnv });
+if (result.error) fail(result.error.message);
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Add one shared fail-closed profile launcher and wrap the direct `run.sh` and Electron bootstrap entry points.

The launcher derives worktree-specific resource locations, prevents production collisions, and permits one exact production owner-service exception.

Package-script entry points adopt the launcher in the next slice.

## Review Claim

Direct source entry points enter one shared fail-closed development-profile launcher.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Production resource matches stop before process spawn, while the explicit exception accepts only the designated owner-service form.

## Slice Rationale

The shared launcher must exist before package scripts can safely make it their default entry path.

## Non-goals

Do not change package scripts, application runtime logic, documentation, or production storage.

## Architecture

### Before

```mermaid
graph TD
    A["Direct source entry points"] --> B["Invoker process with inherited environment"]
```

### After

```mermaid
graph TD
    A["Direct source entry points"] --> B["Shared development-profile launcher"]
    B --> C["Collision guard"]
    C --> D["Isolated Invoker process"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/with-invoker-development-profile.mjs --print-env`
- [x] `sh -c 'INVOKER_DB_DIR="$HOME/.invoker" node scripts/with-invoker-development-profile.mjs --print-env >/tmp/invoker-profile-collision.log 2>&1; status=$?; printf "COLLISION_EXIT=%s\n" "$status"; test "$status" -eq 2'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after dependent stack slices
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent stack slices first
- Data migration? No

</details>
