### PR TITLE
Re-sync vendored review-unit-rules.mjs with its source

### DIFF
--- a/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
@@ -279,7 +279,8 @@ export function classifyReviewUnitsForPath(filePath) {
   if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
   if (
     path === 'skills/make-pr/SKILL.md'
-    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path.startsWith('skills/chat-submit/')
+    || path.startsWith('skills/plan-to-invoker/')
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'


### PR DESCRIPTION
## Summary

`skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs` is a vendored,
byte-identical copy of `scripts/review-unit-rules.mjs`, used so the skill
still works from a standalone npm install outside a git checkout.

The source file picked up a `skills/chat-submit/` match and a
`startsWith('skills/plan-to-invoker/')` match, but the vendored copy was
never re-synced.

`required-fast / Vitest Workspace` has a byte-identical drift check for
this pair, and it has been failing before any real vitest tests even run
(CI run 33069605015, job 98516884433).

This re-runs `scripts/vendor-plan-doctor-deps.sh` to bring the vendored copy
back in sync. No logic changes — just closing the drift.

## Review Claim

That the vendored copy is now byte-identical to its source again, restoring
the drift check `required-fast / Vitest Workspace` runs on every PR.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Vendored copy stays byte-identical to its source; no runtime logic changes,
only re-syncs a stale copy.

## Slice Rationale

Single mechanical file, single fix, no other changes bundled in.

## Non-goals

unchanged behavior. Does not address the separately-tracked "Vitest Workspace
is red on master (worker-registry + SSH executor drift)" condition documented
in `.mergify.yml` — that's a distinct, pre-existing, already-known-non-blocking
issue, not something this PR touches.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `diff -q scripts/review-unit-rules.mjs skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs` — exit 1 before this change, exit 0 after (reproduced directly, the exact check `scripts/test-plan-to-invoker-skill.sh` runs at the point CI failed)
- [ ] `bash scripts/test-plan-to-invoker-skill.sh` (full suite; needs `pnpm install` to resolve the `yaml` runtime dependency for its other checks, not run standalone in this worktree)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Review classification now consistently applies tooling-policy checks to all files under the chat submission and plan invocation skill areas.
  * This improves review routing and ensures policy-focused changes are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->