### PR TITLE
[Merge-gate skill visible](1) Echo invoker-make-pr on merge-gate task output

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -125,6 +125,57 @@ describe('MergeGateExecutor', () => {
     }
   });
 
+  it('emits skill=invoker-make-pr on the merge task-output channel for Invoker repos', async () => {
+    const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-skill-output-'));
+    tempDirs.push(invokerHome);
+    process.env.INVOKER_DB_DIR = invokerHome;
+
+    const task = makeMergeTask();
+    const blockedClone = createDeferred<string>();
+    const executor = new MergeGateExecutor({
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1782192502908-14',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+          onFinish: 'pull_request',
+          mergeMode: 'external_review',
+        })),
+        updateTask: vi.fn(),
+      },
+      orchestrator: {
+        getTask: vi.fn(() => task),
+        getAllTasks: vi.fn(() => [task]),
+      },
+      createMergeWorktree: vi.fn(() => blockedClone.promise),
+      detectDefaultBranch: vi.fn(async () => 'master'),
+      buildMergeSummary: vi.fn(async () => 'summary'),
+      callbacks: {},
+    } as any);
+
+    try {
+      const handle = await executor.start(makeRequest(task));
+      const chunks: string[] = [];
+      executor.onOutput(handle, (data) => {
+        chunks.push(data);
+      });
+
+      await vi.waitFor(() => {
+        expect(chunks.join('')).toContain('skill=invoker-make-pr');
+      });
+      const output = chunks.join('');
+      expect(output).toContain('[merge] Starting merge gate action');
+      expect(output).toContain('[merge] review-stack publisher skill=invoker-make-pr');
+      expect(output).not.toContain('/pr-skill');
+    } finally {
+      blockedClone.resolve('/tmp/unused-gate');
+      await executor.destroyAll();
+    }
+  });
+
   it('emits a terminal failure when destroyed while a merge action is in flight', async () => {
     const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-destroy-test-'));
     const gateWorkspace = mkdtempSync(join(tmpdir(), 'invoker-merge-gate-test-'));

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1434,6 +1434,73 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('publishReviewStackWithMakePrSkill writes skill=invoker-make-pr onto merge task output', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const agent = {
+          name: 'claude',
+          stdinMode: 'ignore' as const,
+          bundledSkills: ['make-pr'],
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.exit(1)'],
+            sessionId: 'skill-visible',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const appendTaskOutput = vi.fn();
+        const onOutput = vi.fn();
+        const executor = new TaskRunner({
+          orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+          persistence: { appendTaskOutput } as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: vi.fn().mockReturnValue(agent),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([agent]),
+          } as any,
+          cwd: '/tmp',
+          callbacks: { onOutput },
+          logger: createMockLogger(),
+        });
+
+        await expect((executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-1',
+          mergeNodeTaskId: '__merge__wf-1',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+        })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+
+        const output = [
+          ...onOutput.mock.calls.map((call) => String(call[1])),
+          ...appendTaskOutput.mock.calls.map((call) => String(call[1])),
+        ].join('\n');
+        expect(output).toContain('skill=invoker-make-pr');
+        expect(output).not.toContain('/pr-skill');
+        expect(onOutput).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          expect.stringContaining('skill=invoker-make-pr'),
+        );
+        expect(appendTaskOutput).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          expect.stringContaining('skill=invoker-make-pr'),
+        );
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
     it('publishReviewStackWithMakePrSkill throws when make-pr agents cannot publish valid JSON', async () => {
       const badAgent = {
         name: 'claude',

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -7,6 +7,7 @@ import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import type { MergeRunnerHost, MergeGateLineage } from './merge-runner.js';
 import { runMergeGateActionImpl, updateMergeGateMetadataIfCurrent } from './merge-runner.js';
+import { isInvokerRepoUrl } from './pr-authoring.js';
 
 interface MergeGateEntry extends BaseEntry {
   killed?: boolean;
@@ -51,7 +52,7 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     }, this.heartbeatIntervalMs);
 
     setImmediate(() => {
-      void this.run(handle, task, launchWorkspacePath);
+      void this.run(handle, task, launchWorkspacePath, workflow?.repoUrl);
     });
 
     return handle;
@@ -145,7 +146,7 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     }
   }
 
-  private async run(handle: ExecutorHandle, task: TaskState, launchWorkspacePath: string): Promise<void> {
+  private async run(handle: ExecutorHandle, task: TaskState, launchWorkspacePath: string, repoUrl?: string): Promise<void> {
     const entry = this.getEntry(handle);
     if (!entry || entry.completed || entry.killed) return;
 
@@ -158,6 +159,9 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
         handle.executionId,
         `[merge] Preparing gate workspace (cloning/provisioning; this can take a while on large repos)…\n`,
       );
+      if (isInvokerRepoUrl(repoUrl)) {
+        this.emitOutput(handle.executionId, `[merge] review-stack publisher skill=invoker-make-pr\n`);
+      }
       // Capture launch lineage so a stale (relaunched) run's direct metadata
       // write is suppressed.
       const lineage: MergeGateLineage = {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1608,10 +1608,22 @@ export class TaskRunner {
           agentName: agent.name,
           cwd: args.cwd,
         });
-        this.logger.info(
+        const skillLine =
           `[pr-authoring] review-stack publish starting agent=${agent.name} `
-            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
-        );
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`;
+        this.logger.info(skillLine);
+        if (args.mergeNodeTaskId) {
+          const outputLine = `${skillLine}\n`;
+          try {
+            this.callbacks.onOutput?.(args.mergeNodeTaskId, outputLine);
+            this.persistence.appendTaskOutput?.(args.mergeNodeTaskId, outputLine);
+          } catch (error) {
+            this.logger.warn('[pr-authoring] failed to persist task output', {
+              taskId: args.mergeNodeTaskId,
+              error,
+            });
+          }
+        }
         const repairPublicationEnv = args.recordedFixCommit
           ? {
             INVOKER_REPAIR_PUBLICATION: '1',


### PR DESCRIPTION
## Summary

Merge-gate task output looked skill-less because only Starting, Preparing, and finished lines were stored.

The owner logger already named skill=invoker-make-pr. This change copies that publisher name onto the merge output channel.

## Review Claim

Approve that Invoker merge-gate task output now includes skill=invoker-make-pr and does not treat /pr-skill as the publisher.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only adds a publisher name to merge-gate output for Invoker repos. It does not invoke Cursor /pr-skill or change how review stacks are published.

## Slice Rationale

The missing publisher name and the unit assertion that would have caught a skill-less merge output belong in one slice.

## Non-goals

Does not change the Invoker-on-Invoker publish path away from make-pr.

Does not add Cursor /pr-skill as a publisher.

Does not change review-stack publication, polling, or approval.

## Architecture

### Before

```mermaid
graph TD
    A["merge-gate emitOutput"] --> B["Starting Preparing finished"]
    C["owner logger"] --> D["skill=invoker-make-pr only"]
```

### After

```mermaid
graph TD
    A["merge-gate emitOutput"] --> B["Starting Preparing skill=invoker-make-pr finished"]
    C["publishReviewStackWithMakePrSkill"] --> D["same skill line on task output"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b0914fae66`
- Post-revert steps: None
- Data migration? No

</details>
