### PR TITLE
[Source development isolation](3) app activation surfaces

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -1361,3 +1361,70 @@ describe('Unknown routes', () => {
     expect(res.body.error).toBe('Not found');
   });
 });
+
+describe('API port selection by runtime profile', () => {
+  const envKeys = ['INVOKER_API_PORT', 'INVOKER_RUNTIME_KIND', 'INVOKER_SOURCE_ROOT'] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of envKeys) saved[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  function startIsolated() {
+    const localMocks = createMocks();
+    return startApiServer({
+      orchestrator: localMocks.orchestrator as any,
+      persistence: localMocks.persistence as any,
+      executorRegistry: localMocks.executorRegistry as any,
+      mutations: buildFacade(localMocks),
+      deleteWorkflow: localMocks.deleteWorkflow,
+      detachWorkflow: localMocks.detachWorkflow,
+    });
+  }
+
+  it('packaged case retains the existing production port when no override is set', async () => {
+    delete process.env.INVOKER_API_PORT;
+    delete process.env.INVOKER_RUNTIME_KIND;
+    delete process.env.INVOKER_SOURCE_ROOT;
+    const localApi = startIsolated();
+    try {
+      expect(localApi.port).toBe(4100);
+    } finally {
+      await localApi.close();
+    }
+  });
+
+  it('source case derives a port disjoint from the production default', async () => {
+    delete process.env.INVOKER_API_PORT;
+    process.env.INVOKER_RUNTIME_KIND = 'source-development';
+    process.env.INVOKER_SOURCE_ROOT = '/tmp/invoker-api-server-test-source-root';
+    const localApi = startIsolated();
+    try {
+      expect(localApi.port).not.toBe(4100);
+      expect(localApi.port).toBeGreaterThanOrEqual(41000);
+      expect(localApi.port).toBeLessThan(41900);
+    } finally {
+      await localApi.close();
+    }
+  });
+
+  it('an explicit synthetic override wins over the selected profile', async () => {
+    process.env.INVOKER_API_PORT = '0';
+    process.env.INVOKER_RUNTIME_KIND = 'source-development';
+    process.env.INVOKER_SOURCE_ROOT = '/tmp/invoker-api-server-test-source-root';
+    const localApi = startIsolated();
+    try {
+      expect(localApi.port).toBe(0);
+    } finally {
+      await localApi.close();
+    }
+  });
+});

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -44,6 +44,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { Logger } from '@invoker/contracts';
+import { resolveInvokerInstanceProfile } from '@invoker/contracts';
 import {
   OrchestratorError,
   OrchestratorErrorCode,
@@ -210,6 +211,21 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// An explicit INVOKER_API_PORT is a synthetic override and always wins; otherwise the
+// selected profile decides, so a source-development launch never falls back to the
+// production port.
+function resolveApiPort(): number {
+  if (process.env.INVOKER_API_PORT !== undefined) {
+    return parseInt(process.env.INVOKER_API_PORT, 10);
+  }
+  const profile = resolveInvokerInstanceProfile({
+    kind: process.env.INVOKER_RUNTIME_KIND ?? 'packaged',
+    sourceRoot: process.env.INVOKER_SOURCE_ROOT,
+    env: process.env,
+  });
+  return profile.ports.apiPort;
+}
+
 export function startApiServer(deps: ApiServerDeps): ApiServer {
   const {
     logger: apiLogger,
@@ -219,7 +235,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     deleteWorkflow,
     detachWorkflow,
   } = deps;
-  const port = parseInt(process.env.INVOKER_API_PORT ?? '4100', 10);
+  const port = resolveApiPort();
 
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     try {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1,10 +1,9 @@
 import type { App, BrowserWindow, IpcMain } from 'electron';
 import { appendFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { Orchestrator, CommandService, OrchestratorErrorCode, normalizeWorkflowBaseBranch } from '@invoker/workflow-core';
 import type { TaskDelta, TaskReplacementDef, TaskState, TaskStateChanges } from '@invoker/workflow-core';
-import { CommandError, IpcChannels, makeEnvelope } from '@invoker/contracts';
+import { CommandError, IpcChannels, makeEnvelope, resolveInvokerInstanceProfile } from '@invoker/contracts';
 import type {
   BundledSkillsInstallMode,
   InAppPlanRequest,
@@ -2006,8 +2005,17 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   });
 
+  // An explicit INVOKER_DB_DIR is a synthetic override and always wins; otherwise the
+  // selected profile decides, so a source-development launch never traces into the
+  // production home directory.
+  const invokerHomeRoot = process.env.INVOKER_DB_DIR ?? resolveInvokerInstanceProfile({
+    kind: process.env.INVOKER_RUNTIME_KIND ?? 'packaged',
+    sourceRoot: process.env.INVOKER_SOURCE_ROOT,
+    env: process.env,
+  }).homeRoot;
+
   const traceRendererTaskGraphEvents = process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1';
-  const rendererTaskGraphTracePath = join(homedir(), '.invoker', 'ui-task-graph-events.jsonl');
+  const rendererTaskGraphTracePath = join(invokerHomeRoot, 'ui-task-graph-events.jsonl');
   let rendererTaskGraphTraceWriteFailed = false;
   ipcMain.handle('invoker:trace-renderer-task-graph-event', (_event, event: TaskGraphEvent) => {
     if (!traceRendererTaskGraphEvents) return;
@@ -2033,7 +2041,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
 
   const traceRendererWorkflowEvents = process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS === '1';
-  const rendererWorkflowTracePath = join(homedir(), '.invoker', 'ui-workflow-events.jsonl');
+  const rendererWorkflowTracePath = join(invokerHomeRoot, 'ui-workflow-events.jsonl');
   let rendererWorkflowTraceWriteFailed = false;
   ipcMain.handle('invoker:trace-renderer-workflow-event', (_event, workflows: unknown[]) => {
     if (!traceRendererWorkflowEvents) return;


### PR DESCRIPTION
## Summary

Apply the selected runtime profile to API and IPC-facing app surfaces without changing packaged production exposure.

Source development now uses disjoint API bindings and trace destinations while explicit synthetic overrides keep precedence.

## Review Claim

API and IPC-facing app surfaces use the selected profile's bindings and trace locations.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Packaged exposure stays production-compatible; source exposure remains disjoint and local.

## Slice Rationale

Externally exposed app files form one activation-surface unit separate from main-process work.

## Non-goals

No generic main-process, CLI, launcher, documentation, or UI work.

No changes to packaged values or explicit synthetic overrides.

## Architecture

### Before

API and IPC-facing app surfaces rebuilt packaged defaults even after an upstream runtime profile was selected.

### After

Those surfaces consume the selected profile while preserving packaged values and explicit synthetic overrides.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- api-server`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 617994628d53fb9e5ef1462951993e1e45ac6127`
- Post-revert steps: None
- Data migration? No

</details>
