### PR TITLE
[Source development isolation (5) detached owner activation](1) Preserve selected-profile identity in detached owner children

### DIFF
--- a/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
+++ b/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
@@ -10,9 +10,23 @@ vi.mock('node:timers/promises', () => ({
   setTimeout: vi.fn(async () => undefined),
 }));
 
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => ({ unref: vi.fn() })),
+  };
+});
+
 import { readdir, readFile } from 'node:fs/promises';
 import { setTimeout as delay } from 'node:timers/promises';
+import { spawn } from 'node:child_process';
 import { cleanupStandaloneOwnersForTestDir } from '../../e2e/fixtures/headless-client.js';
+import {
+  OwnerChildProfileError,
+  resolveOwnerChildProfileEnv,
+  spawnDetachedStandaloneOwner,
+} from '../headless-owner-bootstrap.js';
 
 describe('cleanupStandaloneOwnersForTestDir', () => {
   const linuxIt = process.platform === 'linux' ? it : it.skip;
@@ -70,5 +84,70 @@ describe('cleanupStandaloneOwnersForTestDir', () => {
     expect(kill).toHaveBeenCalledWith(123, 'SIGTERM');
     expect(kill).not.toHaveBeenCalledWith(123, 0);
     expect(kill).not.toHaveBeenCalledWith(123, 'SIGKILL');
+  });
+});
+
+describe('detached owner child profile identity', () => {
+  const sourceDevelopmentEnv = {
+    INVOKER_RUNTIME_KIND: 'source-development',
+    INVOKER_DEVELOPMENT_PROFILE: '1',
+    INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1',
+    INVOKER_SOURCE_ROOT: '/repo/checkout',
+    INVOKER_PROFILE_ID: 'abc1234567',
+    INVOKER_DB_DIR: '/Users/dev/.invoker/dev/abc1234567',
+    INVOKER_USER_DATA_DIR: '/Users/dev/.invoker/dev/abc1234567/electron',
+    INVOKER_IPC_SOCKET: '/Users/dev/.invoker/dev/abc1234567/ipc-transport.sock',
+    INVOKER_REPO_CONFIG_PATH: '/Users/dev/.invoker/dev/abc1234567/config.json',
+    INVOKER_ENV_PATH: '/Users/dev/.invoker/dev/abc1234567/.env',
+    INVOKER_LOG_PATH: '/Users/dev/.invoker/dev/abc1234567/invoker.log',
+    INVOKER_API_PORT: '41123',
+    INVOKER_WEB_PORT: '42123',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes production identity from a packaged parent to the child', () => {
+    const childEnv = resolveOwnerChildProfileEnv({});
+
+    expect(childEnv).toEqual({ INVOKER_RUNTIME_KIND: 'packaged' });
+  });
+
+  it('passes the same source profile and disjoint locations from a source-development parent to the child', () => {
+    const childEnv = resolveOwnerChildProfileEnv(sourceDevelopmentEnv);
+
+    expect(childEnv).toEqual({ INVOKER_RUNTIME_KIND: 'source-development', ...sourceDevelopmentEnv });
+    expect(childEnv.INVOKER_DB_DIR).not.toBe('/Users/dev/.invoker');
+    expect(childEnv.INVOKER_IPC_SOCKET).not.toBe('/Users/dev/.invoker/ipc-transport.sock');
+  });
+
+  it('fails before spawn when a source-development parent has a partial profile', () => {
+    const { INVOKER_DB_DIR: _drop, ...partialEnv } = sourceDevelopmentEnv;
+
+    expect(() => resolveOwnerChildProfileEnv(partialEnv)).toThrow(OwnerChildProfileError);
+  });
+
+  it('fails before spawn when settings declare contradictory profiles', () => {
+    const contradictoryEnv = { ...sourceDevelopmentEnv, INVOKER_RUNTIME_KIND: 'packaged' };
+
+    expect(() => resolveOwnerChildProfileEnv(contradictoryEnv)).toThrow(OwnerChildProfileError);
+  });
+
+  it('spawnDetachedStandaloneOwner does not spawn a child when the profile is contradictory', () => {
+    const previousEnv = { ...process.env };
+    Object.assign(process.env, { ...sourceDevelopmentEnv, INVOKER_RUNTIME_KIND: 'packaged' });
+
+    try {
+      expect(() => spawnDetachedStandaloneOwner('/repo/checkout')).toThrow(OwnerChildProfileError);
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      for (const key of Object.keys(sourceDevelopmentEnv)) delete process.env[key];
+      Object.assign(process.env, previousEnv);
+    }
   });
 });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -551,7 +551,14 @@ export async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promis
   try {
     if (bootstrapLock) {
       delegationClientLog('bootstrap spawning detached standalone owner');
-      spawnDetachedStandaloneOwner(repoRoot);
+      try {
+        spawnDetachedStandaloneOwner(repoRoot);
+      } catch (err) {
+        delegationClientLog(
+          `bootstrap refused to spawn detached standalone owner: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
+      }
     }
     const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     let attempts = 0;

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -4,6 +4,96 @@ import { join, resolve } from 'node:path';
 
 export const OWNER_BOOTSTRAP_LOCK_DIR = 'headless-owner-bootstrap.lock';
 
+export type OwnerRuntimeKind = 'packaged' | 'source-development';
+
+const PACKAGED_KIND: OwnerRuntimeKind = 'packaged';
+const SOURCE_DEVELOPMENT_KIND: OwnerRuntimeKind = 'source-development';
+
+/**
+ * Every environment variable that carries the parent's selected-profile
+ * identity (database/config/log/socket locations and ports) for a
+ * source-development run. This list must stay complete: a detached child
+ * that inherits only part of it would silently bind some resources to the
+ * source-development profile and others to production defaults.
+ */
+const SOURCE_DEVELOPMENT_PROFILE_KEYS = [
+  'INVOKER_DEVELOPMENT_PROFILE',
+  'INVOKER_DEVELOPMENT_PROFILE_ACTIVE',
+  'INVOKER_SOURCE_ROOT',
+  'INVOKER_PROFILE_ID',
+  'INVOKER_DB_DIR',
+  'INVOKER_USER_DATA_DIR',
+  'INVOKER_IPC_SOCKET',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_ENV_PATH',
+  'INVOKER_LOG_PATH',
+  'INVOKER_API_PORT',
+  'INVOKER_WEB_PORT',
+] as const;
+
+export class OwnerChildProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OwnerChildProfileError';
+  }
+}
+
+function determineOwnerParentRuntimeKind(parentEnv: NodeJS.ProcessEnv): OwnerRuntimeKind {
+  const declaredKind = parentEnv.INVOKER_RUNTIME_KIND;
+  if (declaredKind !== undefined && declaredKind !== PACKAGED_KIND && declaredKind !== SOURCE_DEVELOPMENT_KIND) {
+    throw new OwnerChildProfileError(`Unknown Invoker runtime kind "${declaredKind}".`);
+  }
+
+  const developmentProfileActive = parentEnv.INVOKER_DEVELOPMENT_PROFILE === '1';
+  if (declaredKind === PACKAGED_KIND && developmentProfileActive) {
+    throw new OwnerChildProfileError(
+      'INVOKER_RUNTIME_KIND=packaged contradicts INVOKER_DEVELOPMENT_PROFILE=1; refusing to spawn an owner child with a contradictory profile.',
+    );
+  }
+  if (declaredKind === SOURCE_DEVELOPMENT_KIND && !developmentProfileActive) {
+    throw new OwnerChildProfileError(
+      'INVOKER_RUNTIME_KIND=source-development requires INVOKER_DEVELOPMENT_PROFILE=1; refusing to spawn an owner child with a contradictory profile.',
+    );
+  }
+
+  return declaredKind === SOURCE_DEVELOPMENT_KIND || developmentProfileActive ? SOURCE_DEVELOPMENT_KIND : PACKAGED_KIND;
+}
+
+/**
+ * Build the explicit, complete set of profile-identity environment
+ * variables a detached owner child must receive from its parent. Throws
+ * before the caller spawns anything when the parent's own settings are
+ * partial or contradictory, rather than letting an incomplete inherited
+ * `process.env` silently hand the child a mixed production/source-development
+ * identity.
+ */
+export function resolveOwnerChildProfileEnv(parentEnv: NodeJS.ProcessEnv): Record<string, string> {
+  const kind = determineOwnerParentRuntimeKind(parentEnv);
+
+  if (kind === PACKAGED_KIND) {
+    const stray = SOURCE_DEVELOPMENT_PROFILE_KEYS.filter((key) => Boolean(parentEnv[key]));
+    if (stray.length > 0) {
+      throw new OwnerChildProfileError(
+        `Packaged parent has source-development settings set (${stray.join(', ')}); refusing to spawn an owner child with a contradictory profile.`,
+      );
+    }
+    return { INVOKER_RUNTIME_KIND: PACKAGED_KIND };
+  }
+
+  const missing = SOURCE_DEVELOPMENT_PROFILE_KEYS.filter((key) => !parentEnv[key]);
+  if (missing.length > 0) {
+    throw new OwnerChildProfileError(
+      `Source-development parent is missing required profile settings (${missing.join(', ')}); refusing to spawn an owner child with a partial profile.`,
+    );
+  }
+
+  const childEnv: Record<string, string> = { INVOKER_RUNTIME_KIND: SOURCE_DEVELOPMENT_KIND };
+  for (const key of SOURCE_DEVELOPMENT_PROFILE_KEYS) {
+    childEnv[key] = parentEnv[key] as string;
+  }
+  return childEnv;
+}
+
 export type OwnerBootstrapLock = {
   lockDir: string;
   release: () => void;
@@ -53,6 +143,7 @@ export function spawnDetachedStandaloneOwner(
   repoRoot: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): void {
+  const profileEnv = resolveOwnerChildProfileEnv(process.env);
   const electronLauncher = resolve(repoRoot, 'scripts', 'electron.cjs');
   const mainJs = resolve(repoRoot, 'packages', 'app', 'dist', 'main.js');
   const args = [
@@ -69,6 +160,7 @@ export function spawnDetachedStandaloneOwner(
     env: {
       ...process.env,
       ...extraEnv,
+      ...profileEnv,
       INVOKER_HEADLESS_STANDALONE: '1',
       LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
     },


### PR DESCRIPTION
## Summary

Detached owner children now receive the parent's selected runtime profile as explicit process state.

Packaged parents retain production defaults. Source-development children inherit the parent's isolated database, socket, configuration, logs, and network settings.

Partial or contradictory profile settings fail before a child process starts.

## Review Claim

A packaged parent spawns a production owner child, and a source-development parent spawns a child in the same isolated profile.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Child creation cannot silently change between production and source profiles. Profile validation completes before `spawn`, and invalid parent state raises `OwnerChildProfileError` without starting a child.

## Slice Rationale

Detached child activation is a separate lifecycle boundary from CLI and API surfaces. This slice keeps child-process identity propagation with its direct bootstrap caller.

## Non-goals

No generic app startup selection, CLI, launch script, documentation, or global installation changes.

## Architecture

### Before

```mermaid
graph LR
    A["Parent process environment"] --> B["Detached owner spawn"]
    B --> C["Child infers profile from ambient variables"]
```

### After

```mermaid
graph LR
    A["Parent process environment"] --> B["Validate complete profile identity"]
    B --> C["Detached owner spawn receives explicit profile state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-client-fixture-cleanup.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4025bdf7615fcabfe0fcd20106b9ddb488c83eff`
- Post-revert steps: None
- Data migration? No

</details>
