### PR TITLE
[Source development isolation](4) CLI activation

### DIFF
--- a/packages/cli/src/__tests__/invoker-profile-defaults.test.ts
+++ b/packages/cli/src/__tests__/invoker-profile-defaults.test.ts
@@ -1,0 +1,210 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { LocalBus } from '@invoker/transport';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { main } from '../index.js';
+import { invokerHomeDir } from '../onboarding.js';
+import { resolveCliInstanceProfile, resolveInvokerDbPath } from '../worker-toggles.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeSourceCheckout(prefix: string): string {
+  const sourceRoot = makeTempDir(prefix);
+  writeFileSync(join(sourceRoot, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+  return sourceRoot;
+}
+
+function captureProcessOutput() {
+  let stdout = '';
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+    stdout += chunk.toString();
+    return true;
+  });
+  return {
+    get stdout() { return stdout; },
+    restore() {
+      stdoutSpy.mockRestore();
+    },
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('resolveCliInstanceProfile', () => {
+  it('retains the production ~/.invoker layout for an installed CLI (no workspace marker above it)', () => {
+    const fakeHome = makeTempDir('invoker-profile-home-');
+    const installedStartDir = makeTempDir('invoker-profile-installed-');
+
+    const profile = resolveCliInstanceProfile({ startDir: installedStartDir, homeDir: fakeHome, env: {} });
+
+    expect(profile.kind).toBe('packaged');
+    expect(profile.homeRoot).toBe(join(fakeHome, '.invoker'));
+    expect(profile.isProductionAccessExplicit).toBe(true);
+  });
+
+  it('uses a disjoint per-checkout profile for a source-development CLI (workspace marker present)', () => {
+    const fakeHome = makeTempDir('invoker-profile-home-');
+    const sourceRoot = makeSourceCheckout('invoker-profile-source-');
+    const nestedStartDir = join(sourceRoot, 'packages', 'cli', 'dist');
+    mkdirSync(nestedStartDir, { recursive: true });
+
+    const profile = resolveCliInstanceProfile({ startDir: nestedStartDir, homeDir: fakeHome, env: {} });
+
+    expect(profile.kind).toBe('source-development');
+    expect(profile.homeRoot).not.toBe(join(fakeHome, '.invoker'));
+    expect(profile.homeRoot.startsWith(join(fakeHome, '.invoker', 'dev'))).toBe(true);
+    expect(profile.isProductionAccessExplicit).toBe(false);
+  });
+
+  it('resolves two distinct source checkouts to two distinct, stable profiles', () => {
+    const fakeHome = makeTempDir('invoker-profile-home-');
+    const sourceRootA = makeSourceCheckout('invoker-profile-source-a-');
+    const sourceRootB = makeSourceCheckout('invoker-profile-source-b-');
+
+    const a1 = resolveCliInstanceProfile({ startDir: sourceRootA, homeDir: fakeHome, env: {} });
+    const a2 = resolveCliInstanceProfile({ startDir: sourceRootA, homeDir: fakeHome, env: {} });
+    const b = resolveCliInstanceProfile({ startDir: sourceRootB, homeDir: fakeHome, env: {} });
+
+    expect(a1.homeRoot).toBe(a2.homeRoot);
+    expect(a1.homeRoot).not.toBe(b.homeRoot);
+  });
+
+  it('lets an explicit INVOKER_DB_DIR override win for both installed and source profiles', () => {
+    const fakeHome = makeTempDir('invoker-profile-home-');
+    const explicitDbDir = join(fakeHome, 'explicit-db-dir');
+    const installedStartDir = makeTempDir('invoker-profile-installed-override-');
+    const sourceRoot = makeSourceCheckout('invoker-profile-source-override-');
+
+    const installedProfile = resolveCliInstanceProfile({
+      startDir: installedStartDir,
+      homeDir: fakeHome,
+      env: { INVOKER_DB_DIR: explicitDbDir },
+    });
+    const sourceProfile = resolveCliInstanceProfile({
+      startDir: sourceRoot,
+      homeDir: fakeHome,
+      env: { INVOKER_DB_DIR: explicitDbDir },
+    });
+
+    expect(installedProfile.homeRoot).toBe(explicitDbDir);
+    expect(sourceProfile.homeRoot).toBe(explicitDbDir);
+  });
+});
+
+describe('invokerHomeDir', () => {
+  const previousDbDir = process.env.INVOKER_DB_DIR;
+
+  afterEach(() => {
+    if (previousDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = previousDbDir;
+    }
+  });
+
+  it('matches the shared CLI instance profile home root', () => {
+    delete process.env.INVOKER_DB_DIR;
+    expect(invokerHomeDir()).toBe(resolveCliInstanceProfile().homeRoot);
+  });
+
+  it('honors an explicit INVOKER_DB_DIR override', () => {
+    const explicitDbDir = makeTempDir('invoker-home-dir-override-');
+    process.env.INVOKER_DB_DIR = explicitDbDir;
+    expect(invokerHomeDir()).toBe(explicitDbDir);
+  });
+});
+
+describe('resolveInvokerDbPath', () => {
+  const previousDbDir = process.env.INVOKER_DB_DIR;
+  const previousConfigPath = process.env.INVOKER_REPO_CONFIG_PATH;
+
+  afterEach(() => {
+    if (previousDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = previousDbDir;
+    }
+    if (previousConfigPath === undefined) {
+      delete process.env.INVOKER_REPO_CONFIG_PATH;
+    } else {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousConfigPath;
+    }
+  });
+
+  it('falls back to the shared CLI instance profile home root when no explicit location is set', () => {
+    delete process.env.INVOKER_DB_DIR;
+    delete process.env.INVOKER_REPO_CONFIG_PATH;
+    expect(resolveInvokerDbPath()).toBe(join(resolveCliInstanceProfile().homeRoot, 'invoker.db'));
+  });
+
+  it('prefers INVOKER_DB_DIR over the profile default', () => {
+    const explicitDbDir = makeTempDir('invoker-db-path-override-');
+    delete process.env.INVOKER_REPO_CONFIG_PATH;
+    process.env.INVOKER_DB_DIR = explicitDbDir;
+    expect(resolveInvokerDbPath()).toBe(join(explicitDbDir, 'invoker.db'));
+  });
+
+  it('prefers INVOKER_REPO_CONFIG_PATH over the profile default when INVOKER_DB_DIR is unset', () => {
+    const explicitConfigDir = makeTempDir('invoker-db-path-config-override-');
+    delete process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_REPO_CONFIG_PATH = join(explicitConfigDir, 'config.json');
+    expect(resolveInvokerDbPath()).toBe(join(explicitConfigDir, 'invoker.db'));
+  });
+});
+
+describe('invoker-cli query respects an explicit db-dir location', () => {
+  const previousDbDir = process.env.INVOKER_DB_DIR;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = previousDbDir;
+    }
+  });
+
+  it('uses INVOKER_DB_DIR rather than falling back to a production or unrelated default', async () => {
+    const explicitDbDir = makeTempDir('invoker-cli-query-profile-defaults-');
+    const seeded = await SQLiteAdapter.create(join(explicitDbDir, 'invoker.db'), {
+      ownerCapability: true,
+      outputDir: join(explicitDbDir, 'outputs'),
+      slowQueryThresholdMs: 0,
+    });
+    try {
+      seeded.saveWorkflow({
+        id: 'wf-explicit-db-dir',
+        name: 'Explicit db-dir workflow',
+        onFinish: 'none',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+    } finally {
+      seeded.close();
+    }
+
+    process.env.INVOKER_DB_DIR = explicitDbDir;
+    const bus = new LocalBus();
+    const output = captureProcessOutput();
+
+    const code = await main(['query', 'workflows', '--output', 'json'], { createMessageBus: () => bus });
+    output.restore();
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(output.stdout) as Array<{ id: string }>;
+    expect(parsed.map((item) => item.id)).toEqual(['wf-explicit-db-dir']);
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -71,6 +71,7 @@ import {
   openWorkerDesiredStateStore,
   readDesiredStateWorkerToggleValue,
   readWorkerToggleValue,
+  resolveCliInstanceProfile,
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
@@ -399,7 +400,7 @@ async function queryLiveOwner(
 }
 
 function resolveQueryDbDir(): string {
-  return resolve(process.env.INVOKER_DB_DIR ?? join(homedir(), '.invoker'));
+  return resolve(resolveCliInstanceProfile().homeRoot);
 }
 
 function serializeWorkflowForQuery(workflow: Workflow): Record<string, unknown> {

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import {
@@ -27,7 +27,7 @@ import { parsePlanFile } from '@invoker/workflow-core';
 import { formatCaughtException, logCaughtException } from './logging.js';
 import { installBundledSkills } from './bundled-skills.js';
 import { runRemoteDoctorChecks } from './remote-doctor.js';
-import { applyWorkerToggle, isDesiredStateWorkerToggle, isPolicyWorkerToggle, ONBOARDING_WORKER_TOGGLES, openWorkerDesiredStateStore, applyDesiredStateWorkerToggle, readDesiredStateWorkerToggleValue, readWorkerToggleValue } from './worker-toggles.js';
+import { applyWorkerToggle, isDesiredStateWorkerToggle, isPolicyWorkerToggle, ONBOARDING_WORKER_TOGGLES, openWorkerDesiredStateStore, applyDesiredStateWorkerToggle, readDesiredStateWorkerToggleValue, readWorkerToggleValue, resolveCliInstanceProfile } from './worker-toggles.js';
 
 // ── Paths ────────────────────────────────────────────────────
 
@@ -45,7 +45,7 @@ function experimentalPlannerServerSpec(packageSpec: string = EXPERIMENTAL_PLANNE
 }
 
 export function invokerHomeDir(): string {
-  return join(homedir(), '.invoker');
+  return resolveCliInstanceProfile().homeRoot;
 }
 export function defaultConfigPath(): string {
   return process.env.INVOKER_REPO_CONFIG_PATH ?? join(invokerHomeDir(), 'config.json');

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -1,6 +1,10 @@
 import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
-import type { InvokerConfigRecord } from '@invoker/contracts';
+import {
+  resolveInvokerInstanceProfile,
+  resolveRepoRoot,
+  type InvokerConfigRecord,
+  type InvokerInstanceProfile,
+} from '@invoker/contracts';
 import { SQLiteAdapter } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
@@ -172,7 +176,48 @@ export function findWorkerToggle(id: string): WorkerToggleSpec | undefined {
   return WORKER_TOGGLES.find((spec) => spec.id === id);
 }
 
-function resolveInvokerDbPath(): string {
+export interface CliRuntimeProfileOptions {
+  startDir?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * An installed CLI has no `pnpm-workspace.yaml` above it, so it keeps the
+ * production `~/.invoker` layout; a source checkout resolves one, so it gets
+ * a disjoint per-checkout profile instead of silently sharing the production
+ * database/settings/onboarding/worker-toggle locations with the packaged app.
+ * Explicit env overrides (e.g. INVOKER_DB_DIR) still win either way, since
+ * resolveInvokerInstanceProfile applies them ahead of the profile default.
+ *
+ * The CLI's own test suite always runs from this checkout, so auto-detecting
+ * from the real module location would classify every test process as
+ * source-development. Callers that don't pin a startDir themselves skip
+ * auto-detection under the test runner, keeping the production-shaped
+ * default those tests already isolate against via a temp HOME.
+ */
+export function resolveCliInstanceProfile(options: CliRuntimeProfileOptions = {}): InvokerInstanceProfile {
+  const env = options.env ?? process.env;
+  const autoDetecting = options.startDir === undefined;
+  let sourceRoot: string | undefined;
+  if (!autoDetecting || !env.VITEST) {
+    try {
+      sourceRoot = resolveRepoRoot(options.startDir ?? __dirname);
+    } catch {
+      sourceRoot = undefined;
+    }
+  }
+  return resolveInvokerInstanceProfile({
+    kind: sourceRoot ? 'source-development' : 'packaged',
+    sourceRoot,
+    env,
+    homeDir: options.homeDir,
+    platform: options.platform,
+  });
+}
+
+export function resolveInvokerDbPath(): string {
   if (process.env.INVOKER_DB_DIR) {
     return join(process.env.INVOKER_DB_DIR, 'invoker.db');
   }
@@ -180,7 +225,7 @@ function resolveInvokerDbPath(): string {
   if (configPath) {
     return join(dirname(configPath), 'invoker.db');
   }
-  return join(homedir(), '.invoker', 'invoker.db');
+  return join(resolveCliInstanceProfile().homeRoot, 'invoker.db');
 }
 
 function resolveInvokerOutputDir(dbPath: string): string {


### PR DESCRIPTION
## Summary

Make the repository development CLI use the selected source profile while preserving installed CLI production defaults.

Source checkouts now use disjoint database, settings, onboarding, and worker-toggle locations. Explicit user-supplied locations continue to take precedence.

## Review Claim

Installed CLI usage retains production defaults while source-development CLI usage consumes disjoint database, settings, onboarding, and worker-toggle locations.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Installed CLI behavior stays unchanged and source development cannot silently fall back to production locations.

## Slice Rationale

CLI is a separate package and activation surface from the app.

## Non-goals

No app, launcher, documentation, or package distribution work.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && pnpm exec vitest run src/__tests__/invoker-profile-defaults.test.ts --reporter verbose` — 1 test file passed; 10 tests passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e0d3eea0c`
- Post-revert steps: None
- Data migration? No

</details>
