### PR TITLE
No-Mergify observed CI repair (1) Reproduce dropped failures

### DIFF
--- a/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+const repro = String.raw`
+import json
+
+from scripts.mergify_admin_requeue import CheckContext, PrSnapshot, classify_pr
+
+head_sha = "0123456789abcdef0123456789abcdef01234567"
+checks = {
+    "lint": CheckContext(
+        name="lint",
+        state="success",
+        details_url="https://example.invalid/lint",
+        head_sha=head_sha,
+        completed_at="2026-08-27T00:00:00Z",
+    ),
+    "test": CheckContext(
+        name="test",
+        state="failure",
+        details_url="https://example.invalid/test",
+        head_sha=head_sha,
+        completed_at="2026-08-27T00:00:00Z",
+    ),
+}
+pr = PrSnapshot(
+    number=1,
+    title="Observed failed CI without Mergify configuration",
+    body="",
+    url="https://example.invalid/pull/1",
+    state="OPEN",
+    is_draft=False,
+    base_ref_name="main",
+    head_ref_name="admin-bypass/no-mergify-repair",
+    head_ref_oid=head_sha,
+    merge_state_status="CLEAN",
+    mergeable="MERGEABLE",
+    labels=frozenset({"admin-bypass"}),
+    checks=checks,
+    review_threads=(),
+    latest_mergify=None,
+)
+
+blockers = classify_pr(pr, required_checks=(), trunk="main")
+print(json.dumps([[blocker.kind, blocker.key] for blocker in blockers]))
+`;
+
+describe('admin-bypass observed CI without Mergify configuration', () => {
+  it.fails('classifies an observed failed check when required_checks is empty', () => {
+    const result = spawnSync('python3', ['-c', repro], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const diagnostics = [
+      `python3 exit status: ${String(result.status)}`,
+      `python3 error: ${result.error?.message ?? '<none>'}`,
+      `python3 stderr:\n${result.stderr || '<empty>'}`,
+    ].join('\n');
+
+    expect(result.status, diagnostics).toBe(0);
+
+    let blockers: unknown;
+    try {
+      blockers = JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(`Could not parse Python stdout as JSON: ${String(error)}\n${diagnostics}`);
+    }
+    expect(blockers, diagnostics).toEqual([['failed_check', 'test']]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a hermetic expected-failure regression for observed failed CI when Mergify has no configured required-check list.

The proof records the current mismatch without changing runtime behavior.

## Review Claim

A focused expected-failure test reproduces the classifier dropping Catstack-shaped observed failed CI when Mergify supplies no required-check allowlist.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Runtime files are untouched and existing runtime behavior is unchanged; the new test remains marked `it.fails` because master does not yet meet the desired assertion.

## Slice Rationale

This first PR contains only the red-before proof, so reviewers can inspect the behavioral contract independently from the later runtime repair.

## Non-goals

No planner or runtime edits, Mergify configuration, generic autofix edits, merge policy edits, OAuth changes, or deployment.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/admin-bypass-no-mergify-repair.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2da32ac57f911dc9bc808ec40329196d6f3d4e7e`
- Post-revert steps: None
- Data migration? No

</details>
