### PR TITLE
fix(ci): preserve explicit development resource overrides

### DIFF
--- a/scripts/test-development-profile-guard.mjs
+++ b/scripts/test-development-profile-guard.mjs
@@ -16,6 +16,14 @@ const doors = [
   ['app:start', appPackage.scripts.start],
   ['app:dev', appPackage.scripts.dev],
 ];
+const profileResourceKeys = [
+  'INVOKER_DB_DIR',
+  'INVOKER_USER_DATA_DIR',
+  'INVOKER_IPC_SOCKET',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_ENV_PATH',
+  'INVOKER_LOG_PATH',
+];
 
 const failures = [];
 for (const [name, command] of doors) {
@@ -24,7 +32,7 @@ for (const [name, command] of doors) {
 
 function profileFor(sourceRoot) {
   const env = { ...process.env };
-  delete env.INVOKER_DB_DIR;
+  for (const key of profileResourceKeys) delete env[key];
   const result = spawnSync(process.execPath, [launcher, '--source-root', sourceRoot, '--print-env'], {
     cwd: root,
     encoding: 'utf8',
@@ -37,7 +45,7 @@ function profileFor(sourceRoot) {
 const first = profileFor(root);
 const second = profileFor(resolve(root, '..'));
 const productionHome = join(homedir(), '.invoker');
-for (const key of ['INVOKER_DB_DIR', 'INVOKER_USER_DATA_DIR', 'INVOKER_IPC_SOCKET', 'INVOKER_REPO_CONFIG_PATH', 'INVOKER_ENV_PATH', 'INVOKER_LOG_PATH']) {
+for (const key of profileResourceKeys) {
   if (!first[key] || first[key] === productionHome || !first[key].startsWith(`${productionHome}/dev/`)) {
     failures.push(`${key} is missing or not contained by the isolated development namespace`);
   }
@@ -53,6 +61,24 @@ const collision = spawnSync(process.execPath, [launcher, '--print-env'], {
 });
 if (collision.status === 0 || !collision.stderr.includes('production profile')) failures.push('production collision did not fail closed');
 
+const explicitResourcePaths = Object.fromEntries(
+  profileResourceKeys.map((key) => [key, join('/tmp', 'invoker-development-profile-override', key.toLowerCase())]),
+);
+const explicitOverride = spawnSync(
+  process.execPath,
+  [launcher, '--', process.execPath, '-e', `process.stdout.write(JSON.stringify(Object.fromEntries(${JSON.stringify(profileResourceKeys)}.map((key) => [key, process.env[key]]))))`],
+  {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, ...explicitResourcePaths },
+  },
+);
+if (explicitOverride.status !== 0) {
+  failures.push(`explicit resource override probe failed: ${explicitOverride.stderr.trim()}`);
+} else if (JSON.stringify(JSON.parse(explicitOverride.stdout)) !== JSON.stringify(explicitResourcePaths)) {
+  failures.push('development profile replaced explicit non-production resource paths');
+}
+
 const exception = spawnSync(process.execPath, [launcher, '--production-owner-service', '--print-env'], { cwd: root, encoding: 'utf8' });
 if (exception.status !== 0 || JSON.parse(exception.stdout).INVOKER_PRODUCTION_OWNER_SERVICE !== '1') failures.push('exact production-owner service exception dry-run failed');
 
@@ -63,4 +89,4 @@ if (failures.length > 0) {
   for (const failure of failures) process.stderr.write(`FAIL: ${failure}\n`);
   process.exit(1);
 }
-process.stdout.write(`PASS: ${doors.length}/${doors.length} developer launchers use isolated worktree profiles; production collisions and broad exceptions are rejected\n`);
+process.stdout.write(`PASS: ${doors.length}/${doors.length} developer launchers use isolated worktree profiles; explicit non-production resource paths survive; production collisions and broad exceptions are rejected\n`);

--- a/scripts/test-suites/required/07-invalid-config-json.sh
+++ b/scripts/test-suites/required/07-invalid-config-json.sh
@@ -21,9 +21,13 @@ node - "$CONFIG_PATH" >"$OUT_FILE" 2>&1 <<'EOF'
 const { spawnSync } = require('node:child_process');
 
 const configPath = process.argv[2];
+const env = { ...process.env, INVOKER_REPO_CONFIG_PATH: configPath };
+// Exercise the clean-runner path even when this guard is invoked from an
+// already-active development profile.
+delete env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE;
 const result = spawnSync('./run.sh', ['--headless', 'query', 'workflows'], {
   cwd: process.cwd(),
-  env: { ...process.env, INVOKER_REPO_CONFIG_PATH: configPath },
+  env,
   encoding: 'utf8',
   timeout: 15000,
 });

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -121,8 +121,6 @@ if (productionOwnerService) {
 }
 
 assertNoProductionCollision(process.env);
-// Explicit non-production resource paths are test/CLI inputs, not profile
-// defaults. Preserve them after the collision guard has rejected production.
 const profile = developmentEnvironment(sourceRoot);
 const childEnv = { ...process.env, ...profile };
 delete childEnv.ELECTRON_RUN_AS_NODE;

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -21,10 +21,11 @@ function productionUserDataDir(homeDir) {
   return join(process.env.XDG_CONFIG_HOME ?? join(homeDir, '.config'), 'Invoker');
 }
 
-function developmentEnvironment(sourceRoot) {
+function developmentEnvironment(sourceRoot, env = process.env) {
   const canonicalRoot = realpathSync(resolve(sourceRoot));
   const id = createHash('sha256').update(canonicalRoot).digest('hex').slice(0, 10);
-  const homeRoot = join(homedir(), '.invoker', 'dev', id);
+  const defaultHomeRoot = join(homedir(), '.invoker', 'dev', id);
+  const homeRoot = env.INVOKER_DB_DIR?.trim() || defaultHomeRoot;
   const apiPort = 41000 + (Number.parseInt(id.slice(0, 8), 16) % 900);
   return {
     INVOKER_DEVELOPMENT_PROFILE: '1',
@@ -33,11 +34,11 @@ function developmentEnvironment(sourceRoot) {
     INVOKER_SOURCE_ROOT: canonicalRoot,
     INVOKER_PROFILE_ID: id,
     INVOKER_DB_DIR: homeRoot,
-    INVOKER_USER_DATA_DIR: join(homeRoot, 'electron'),
-    INVOKER_IPC_SOCKET: join(homeRoot, 'ipc-transport.sock'),
-    INVOKER_REPO_CONFIG_PATH: join(homeRoot, 'config.json'),
-    INVOKER_ENV_PATH: join(homeRoot, '.env'),
-    INVOKER_LOG_PATH: join(homeRoot, 'invoker.log'),
+    INVOKER_USER_DATA_DIR: env.INVOKER_USER_DATA_DIR?.trim() || join(homeRoot, 'electron'),
+    INVOKER_IPC_SOCKET: env.INVOKER_IPC_SOCKET?.trim() || join(homeRoot, 'ipc-transport.sock'),
+    INVOKER_REPO_CONFIG_PATH: env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homeRoot, 'config.json'),
+    INVOKER_ENV_PATH: env.INVOKER_ENV_PATH?.trim() || join(homeRoot, '.env'),
+    INVOKER_LOG_PATH: env.INVOKER_LOG_PATH?.trim() || join(homeRoot, 'invoker.log'),
     INVOKER_API_PORT: String(apiPort),
     INVOKER_WEB_PORT: String(apiPort + 1000),
     INVOKER_DISABLE_AUTONOMOUS_WORKERS: '1',
@@ -120,6 +121,8 @@ if (productionOwnerService) {
 }
 
 assertNoProductionCollision(process.env);
+// Explicit non-production resource paths are test/CLI inputs, not profile
+// defaults. Preserve them after the collision guard has rejected production.
 const profile = developmentEnvironment(sourceRoot);
 const childEnv = { ...process.env, ...profile };
 delete childEnv.ELECTRON_RUN_AS_NODE;


### PR DESCRIPTION
## Summary

The `required-fast / Guardrails` check has been failing on every master push since this morning.

The new source-development-profile launcher silently overwrote `INVOKER_REPO_CONFIG_PATH` (and four sibling env vars) with its own default path, even when a caller had explicitly set them.

That broke the `07-invalid-config-json.sh` guardrail. It injects a malformed config path to prove Invoker fails fast on bad config.

The launcher replaced that path with a real one before Invoker saw it, so the check silently passed a real config instead.

This PR makes the launcher preserve an explicit override instead of replacing it, restores the guardrail's intended behavior, and adds a regression test.

## Review Claim

Approve preserving explicit `INVOKER_DB_DIR` / `INVOKER_USER_DATA_DIR` / `INVOKER_IPC_SOCKET` / `INVOKER_REPO_CONFIG_PATH` / `INVOKER_ENV_PATH` overrides in `scripts/with-invoker-development-profile.mjs` instead of always replacing them with profile defaults.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The launcher still calls `assertNoProductionCollision` before honoring any override, so an explicit value that points at the real production `~/.invoker` namespace is still rejected. Only the profile-default fallback path changes; production-collision behavior is unchanged.

## Slice Rationale

This is one atomic fix: the behavior change, its regression test, and the guardrail fix that depends on it all describe the same bug and cannot be verified independently of each other.

## Non-goals

Does not update `docs/getting-started.md` to describe the override behavior; that lands as a follow-up docs-only slice.

Does not change the automated Mergify repair bot that produced an earlier, orphaned copy of this same fix on an unrelated PR's branch instead of master — that gap is being tracked separately.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/07-invalid-config-json.sh` — `FAIL: expected explicit invalid-config error` before this change, `PASS: malformed config JSON fails fast` after.
- [x] `node scripts/test-development-profile-guard.mjs` — `PASS: 5/5 developer launchers use isolated worktree profiles; explicit non-production resource paths survive; production collisions and broad exceptions are rejected`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 271d3a997d`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode isolation to prevent resource collisions and preserve explicitly configured non-production paths.
  * Ensured configuration validation runs correctly even when a development profile is already active.

* **Tests**
  * Expanded validation for launcher isolation, collision handling, override preservation, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->