### PR TITLE
[Mergify repair prereq split](1) Auto-split trunk repairs that only add tooling-policy/docs

### DIFF
--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -223,8 +223,33 @@ def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
     return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
 
 
+def is_incidental_tooling_docs_addition(value: Mapping[str, object]) -> bool:
+    """True when the only reason PR-body validation failed is that the repair
+    commit introduced tooling-policy and/or docs files beyond the PR's own
+    declared review unit -- regardless of that PR's own review lane/unit.
+    Generalizes is_proof_tooling_policy_validation (which only covers a
+    proof-lane PR picking up tooling-policy files) to any lane, as long as
+    the only extra unit(s) are ones a repair incidentally produces (a script
+    fix plus its own test/doc update), not a genuinely separate feature."""
+    errors = value.get("errors")
+    review_units = value.get("reviewUnits")
+    if not isinstance(errors, list) or not errors:
+        return False
+    if not isinstance(review_units, list):
+        return False
+    review_unit_set = {str(unit) for unit in review_units}
+    own_unit = str(value.get("reviewUnit") or "")
+    extra_units = review_unit_set - {own_unit}
+    if not extra_units or not extra_units.issubset({"tooling-policy", "docs"}):
+        return False
+    joined = "\n".join(str(error) for error in errors)
+    return "Split this into one Review Unit per PR." in joined
+
+
 def is_prereq_split_validation(value: Mapping[str, object], base_ref_name: str) -> bool:
-    return base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+    if base_ref_name != TRUNK:
+        return False
+    return is_proof_tooling_policy_validation(value) or is_incidental_tooling_docs_addition(value)
 
 
 def is_manual_split_validation(value: Mapping[str, object]) -> bool:

--- a/scripts/test_mergify_admin_requeue_repair_body.py
+++ b/scripts/test_mergify_admin_requeue_repair_body.py
@@ -122,5 +122,55 @@ class RebaseOntoBaseTests(unittest.TestCase):
         self.assertEqual(status, "")
 
 
+PR_10742_LIVE_VALIDATION = {
+    # Captured verbatim from the real wf-1787861446614-2/normalize task
+    # failure on PR #10742 (2026-08-27): a "routing"-lane repair that fixed
+    # scripts/with-invoker-development-profile.mjs (tooling-policy) plus its
+    # test and docs/getting-started.md (docs). See
+    # docs/incidents/2026-08-16-mergify-admin-bypass-thrash-review-followups.md
+    # for the review context this class of failure belongs to.
+    "valid": False,
+    "errors": [
+        "Review lane behavior cannot ship with docs, policy files in the same "
+        "PR. Split behavior or cleanup from docs, policy, repro, and "
+        "benchmark slices.",
+        'PR body Review Unit "routing" cannot ship with tooling-policy, docs '
+        "files in the same PR. Split this into one Review Unit per PR.",
+    ],
+    "reviewLane": "behavior",
+    "reviewUnit": "routing",
+    "reviewUnits": ["routing", "tooling-policy", "docs"],
+    "scopeKinds": ["docs", "policy"],
+}
+
+
+class PrereqSplitValidationTests(unittest.TestCase):
+    def test_live_pr_10742_shape_is_prereq_splittable_on_trunk(self) -> None:
+        self.assertTrue(
+            repair_body.is_incidental_tooling_docs_addition(PR_10742_LIVE_VALIDATION)
+        )
+        self.assertTrue(
+            repair_body.is_prereq_split_validation(PR_10742_LIVE_VALIDATION, "master")
+        )
+
+    def test_non_trunk_base_still_blocks_for_human_split(self) -> None:
+        self.assertFalse(
+            repair_body.is_prereq_split_validation(PR_10742_LIVE_VALIDATION, "stack/base")
+        )
+
+    def test_extra_unit_outside_tooling_or_docs_is_not_auto_splittable(self) -> None:
+        genuinely_mixed = {
+            **PR_10742_LIVE_VALIDATION,
+            "reviewUnits": ["routing", "tooling-policy", "write-path"],
+        }
+        self.assertFalse(repair_body.is_incidental_tooling_docs_addition(genuinely_mixed))
+        self.assertFalse(repair_body.is_prereq_split_validation(genuinely_mixed, "master"))
+
+    def test_valid_body_is_never_prereq_splittable(self) -> None:
+        self.assertFalse(
+            repair_body.is_incidental_tooling_docs_addition({"valid": True, "errors": []})
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -297,6 +297,48 @@ class RepairNormalizeTests(unittest.TestCase):
         create_prereq.assert_called_once()
         self.assertTrue(normalize.PREREQ_SENTINEL.exists())
 
+    def test_non_proof_lane_tooling_docs_addition_on_trunk_auto_splits(self):
+        # Regression for wf-1787861446614-2/normalize (PR #10742, 2026-08-27):
+        # a "routing"-lane repair that fixed a tooling-policy file plus its
+        # test and docs was discarded (hard_reset_work_root + exit 1) instead
+        # of being auto-split, because only proof-lane PRs triggered
+        # create_repair_prerequisite. This must now split instead of block.
+        live_pr_10742_shape = {
+            "valid": False,
+            "errors": [
+                "Review lane behavior cannot ship with docs, policy files in "
+                "the same PR. Split behavior or cleanup from docs, policy, "
+                "repro, and benchmark slices.",
+                'PR body Review Unit "routing" cannot ship with '
+                "tooling-policy, docs files in the same PR. Split this into "
+                "one Review Unit per PR.",
+            ],
+            "reviewLane": "behavior",
+            "reviewUnit": "routing",
+            "reviewUnits": ["routing", "tooling-policy", "docs"],
+            "scopeKinds": ["docs", "policy"],
+        }
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("commit-a",)) as git_lines:
+            git_lines.side_effect = lambda cwd, *args: ("commit-a",) if args[:1] == ("rev-list",) else ()
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nrouting fix\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value=live_pr_10742_shape,
+                        ):
+                            with mock.patch(
+                                "scripts.mergify_admin_requeue_repair_normalize.create_repair_prerequisite",
+                                return_value={"prNumber": 11050, "branch": "stack/pr-babysit-prereq-10742-c2532d2"},
+                            ) as create_prereq:
+                                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                                    code = normalize.main(self.argv(**{"--pr": "10742"}))
+        self.addCleanup(lambda: normalize.PREREQ_SENTINEL.unlink(missing_ok=True))
+        self.assertEqual(code, 0)
+        create_prereq.assert_called_once()
+        self.assertTrue(normalize.PREREQ_SENTINEL.exists())
+
     def test_invalid_non_trunk_blocks_human_split(self):
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
             with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):


### PR DESCRIPTION
## Summary

The admin-bypass repair bot correctly diagnosed and fixed the master-side bug behind PR #11049, but the fix never reached a real PR.

The bot has a safety valve. It carves a repair into its own small prerequisite PR when the repair does not fit the original PR's own category.

That valve covered only one narrow combination.

Our real case used a different combination, so the valve was silently thrown away instead of carved out, and the fix never landed anywhere.

This widens the valve to cover the combination we actually hit, while every other combination keeps falling through to the existing human-review path, unchanged.

## Review Claim

Approve widening the repair bot's carve-out valve so this newly observed category combination also gets carved into its own small prerequisite PR, instead of being thrown away.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new check still requires every "extra" review unit beyond the PR's own declared unit to be exactly `tooling-policy` and/or `docs`. Any other extra unit (a genuine second feature mixed into the repair) still falls through to the existing human-split path unchanged — verified by `test_extra_unit_outside_tooling_or_docs_is_not_auto_splittable`.

## Slice Rationale

The behavior change and its two new test files describe one bug and one fix; keeping them together is the only way either half stays provably correct.

## Non-goals

Does not change `is_proof_tooling_policy_validation` or the non-trunk-base behavior (still blocks for a human, per `test_non_trunk_base_still_blocks_for_human_split`).

Does not add cross-PR awareness of shared trunk failures; that is a separate, larger change under discussion.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue_repair_normalize.py` — new regression test reproduces the exact real failure (`blocked_invalid: ...` from workflow wf-1787861446614-2) before this change, passes after.
- [x] `python3 -m unittest scripts/test_mergify_admin_requeue_repair_body.py` — 4 new focused tests for the widened predicate, all pass.
- [x] Full `scripts/test_mergify_admin_requeue*.py` suite still passes (no regressions).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b044591f98`
- Post-revert steps: None
- Data migration? No

</details>
