### PR TITLE
[Plan Turn Reminder](2) Repeat the plan-draft-file reminder on every resumed plan-mode turn

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1256,10 +1256,7 @@ describe('PlanConversation harness session driver', () => {
   // the plan to the sidecar file and keep chat short was never repeated. The
   // model drifted to pasting the full YAML inline, which a downstream
   // word-count guard then truncated, and the plan was never captured.
-  // BUG (see fix in the next stack slice): the reminder is not repeated yet,
-  // so this currently fails. it.fails asserts that "still broken" state as
-  // the proof; the fix slice flips this back to a plain `it`.
-  it.fails('repeats the plan-draft-file reminder on a resumed plan-mode turn, not just turn one', async () => {
+  it('repeats the plan-draft-file reminder on a resumed plan-mode turn, not just turn one', async () => {
     const driver = createMockDriver({ supportsSessionContinuity: true });
     const conv = new PlanConversation({
       mode: 'plan',

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -481,6 +481,13 @@ function removeStandaloneSubmitInstruction(message: string): string {
   return filtered.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
 }
 
+/** Repeated on every resumed continuity-harness plan-mode turn — see buildTurnPrompt. */
+function buildPlanDraftReminder(planFilePath: string | null): string {
+  return planFilePath
+    ? `Reminder: when the final YAML plan is ready, write the COMPLETE YAML to \`${planFilePath}\` using your file-writing tool, then reply with only a short summary. Never paste the YAML into chat.`
+    : 'Reminder: when the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block, then keep the rest of your reply short.';
+}
+
 // ── PlanConversation ────────────────────────────────────────
 
 export class PlanConversation {
@@ -1030,9 +1037,16 @@ export class PlanConversation {
   private buildTurnPrompt(): string {
     if (this.harnessSessionDriver?.supportsSessionContinuity && this._harnessSessionId) {
       const latestMessage = this.messages[this.messages.length - 1]?.content ?? '';
-      return this.conversationalPlanning && this.planningSurface
-        ? formatPlanningHostedTurn(this.planningSurface, latestMessage)
-        : latestMessage;
+      if (!this.conversationalPlanning || !this.planningSurface) return latestMessage;
+      const hosted = formatPlanningHostedTurn(this.planningSurface, latestMessage);
+      // Turn 1 gets the plan-draft-file instruction via the full system prompt
+      // (buildCursorPrompt, below). A resumed continuity-harness turn skips
+      // that system prompt entirely, so on a long conversation the model can
+      // drift back to pasting YAML inline instead of writing the sidecar
+      // file — repeat the instruction here so it doesn't decay out of view.
+      return this.mode === 'plan'
+        ? `${hosted}\n\n${buildPlanDraftReminder(this.planDraftFilePath())}`
+        : hosted;
     }
     return this.buildCursorPrompt();
   }


### PR DESCRIPTION
## Summary

`buildTurnPrompt` only sent the plan-draft-file/short-reply instruction in the turn-1 system prompt.

Once a continuity harness (`claude`, `codex`) resumes an existing session, later turns dropped straight to `formatPlanningHostedTurn` with no reminder.

A long conversation could drift back to pasting the full YAML plan inline, which a downstream word-count guard then truncates, losing the draft before Invoker ever captures it.

## Review Claim

Confirm the reminder is scoped correctly: it repeats only on resumed, continuity-harness, plan-mode turns, and does not affect turn 1 or agent-mode turns.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Turn 1 is unaffected — it already gets this instruction via the full system prompt through `buildCursorPrompt`, a separate code path this change doesn't touch. Agent-mode and non-conversational-planning turns are unaffected: the call site is gated on `conversationalPlanning && planningSurface`, and the reminder itself is further gated on `this.mode === 'plan'`.

## Slice Rationale

Second half of the stack: flips the previous slice's regression test to the corrected expectation and lands the actual behavior change.

## Non-goals

Does not change `formatPlanningHostedTurn`'s signature or the lower-level `@invoker/contracts` package. Does not change turn-1 behavior. Does not address the separate, already-merged "raw YAML dump in chat" fix (#10242) — this fixes plan-draft *capture*, not display.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts` — 132/132 pass, including the flipped regression test and a new guard test confirming agent-mode turns are unaffected.
- [x] `pnpm --filter @invoker/surfaces test` — 602/602 pass (full package suite, no regressions).
- [x] `pnpm --filter @invoker/surfaces build` — clean `tsup` build.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2c2e74554a`
- Post-revert steps: None
- Data migration? No

</details>
