### PR TITLE
[DO-1 owner sandbox fix](1) Add production-owner-service opt-out to electron.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "check:comments": "node scripts/check-added-comments.mjs",
     "check:versions": "node scripts/check-version-sync.mjs",
     "bump-version": "node scripts/bump-version.mjs",
-    "check:dev-isolation": "node scripts/test-development-profile-guard.mjs",
+    "check:dev-isolation": "node scripts/test-development-profile-guard.mjs && node scripts/test-electron-development-profile-guard.mjs",
     "check:all": "pnpm run check:dev-isolation && pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && pnpm run check:comments && pnpm run check:versions && bash scripts/check-owner-boundary.sh",
     "lint": "pnpm run check:all"
   },

--- a/scripts/electron-development-profile-guard.cjs
+++ b/scripts/electron-development-profile-guard.cjs
@@ -1,0 +1,8 @@
+function shouldWrapInDevelopmentProfile(argv2, env) {
+  if (argv2 === '--install-only') return false;
+  if (env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE === '1') return false;
+  if (env.INVOKER_PRODUCTION_OWNER_SERVICE === '1') return false;
+  return true;
+}
+
+module.exports = { shouldWrapInDevelopmentProfile };

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -4,8 +4,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
+const { shouldWrapInDevelopmentProfile } = require('./electron-development-profile-guard.cjs');
+
 const repoRoot = path.resolve(__dirname, '..');
-if (process.argv[2] !== '--install-only' && process.env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE !== '1') {
+if (shouldWrapInDevelopmentProfile(process.argv[2], process.env)) {
   const launcher = path.join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
   const result = spawnSync(process.execPath, [launcher, '--', process.execPath, __filename, ...process.argv.slice(2)], {
     stdio: 'inherit',

--- a/scripts/test-electron-development-profile-guard.mjs
+++ b/scripts/test-electron-development-profile-guard.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { shouldWrapInDevelopmentProfile } = require('./electron-development-profile-guard.cjs');
+
+// Regression: the production owner on a source-checkout host (no packaged
+// invoker-ui on PATH) launches via `electron.cjs ... --headless owner-serve`
+// with no INVOKER_DEVELOPMENT_PROFILE_ACTIVE set. Before this fix that always
+// redirected the real production owner into an isolated dev-profile sandbox
+// database (confirmed live on DigitalOcean 1: production invoker.db stopped
+// being written while a fresh ~/.invoker/dev/<hash>/ sandbox was actively
+// written instead). packages/slack-manager/src/invoker-launcher.ts now sets
+// INVOKER_PRODUCTION_OWNER_SERVICE=1 on that exact spawn.
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', { INVOKER_PRODUCTION_OWNER_SERVICE: '1' }),
+  false,
+  'the real production owner spawn must not be wrapped into a dev profile',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', {}),
+  true,
+  'an ordinary developer launch (no production flag) must still get an isolated dev profile',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--install-only', {}),
+  false,
+  'the postinstall electron-download step must never wrap',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', { INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1' }),
+  false,
+  'a re-exec that already carries the active-profile marker must not wrap again',
+);
+
+console.log('PASS: electron.cjs only wraps launches that are not the declared production owner service');


### PR DESCRIPTION
## Summary

`scripts/electron.cjs` wraps every launch into an isolated dev database unless the caller opts out.

Only the packaged `invoker-cli` path had an opt-out. A real owner service launched straight from a monorepo checkout had none at all.

This adds that missing opt-out. The actual production caller that needs it is a separate, stacked follow-up PR.

## Review Claim

Approve adding an `INVOKER_PRODUCTION_OWNER_SERVICE` opt-out to `scripts/electron.cjs`'s dev-profile wrap guard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new check only adds one more way to skip the wrap; it does not change the existing `--install-only` or `INVOKER_DEVELOPMENT_PROFILE_ACTIVE` exits. An ordinary developer launch (none of the three set) still gets wrapped into its isolated sandbox exactly as before.

## Slice Rationale

This guard is inert without a real caller setting the new flag; splitting it from that caller keeps this slice pure tooling policy, reviewable independent of any product behavior.

## Non-goals

Does not change who actually sets `INVOKER_PRODUCTION_OWNER_SERVICE`; that lands in the stacked follow-up PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-electron-development-profile-guard.mjs` — the un-fixed guard predicate returns `true` (would wrap) even with the new flag set; `false` after this change.
- [x] `pnpm run check:dev-isolation` — both guard scripts pass together.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6545773`
- Post-revert steps: None
- Data migration? No

</details>
