### PR TITLE
[DO-1 owner sandbox fix](2) Declare the real production owner spawn exempt

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "check:comments": "node scripts/check-added-comments.mjs",
     "check:versions": "node scripts/check-version-sync.mjs",
     "bump-version": "node scripts/bump-version.mjs",
-    "check:dev-isolation": "node scripts/test-development-profile-guard.mjs",
+    "check:dev-isolation": "node scripts/test-development-profile-guard.mjs && node scripts/test-electron-development-profile-guard.mjs",
     "check:all": "pnpm run check:dev-isolation && pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && pnpm run check:comments && pnpm run check:versions && bash scripts/check-owner-boundary.sh",
     "lint": "pnpm run check:all"
   },

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { LINUX_HEADLESS_ELECTRON_FLAGS } from '@invoker/contracts';
 
-import { resolveOwnerLaunch, withoutMissingPathEntries } from '../invoker-launcher.js';
+import { buildOwnerSpawnEnv, resolveOwnerLaunch, withoutMissingPathEntries } from '../invoker-launcher.js';
 
 describe('withoutMissingPathEntries', () => {
   const exists = (path: string) => path !== '/snap/bin' && path !== '/gone';
@@ -100,5 +100,28 @@ describe('resolveOwnerLaunch', () => {
         existsSync: () => false,
       }),
     ).toThrow(/Cannot launch Invoker headless owner/);
+  });
+});
+
+describe('buildOwnerSpawnEnv', () => {
+  it('declares the spawn as the real production owner service', () => {
+    // Regression: scripts/electron.cjs wraps every launch into an isolated
+    // source-development database unless this flag says otherwise. Confirmed
+    // live on DigitalOcean 1 (a source-checkout host with no packaged
+    // invoker-ui on PATH): production's invoker.db stopped being written
+    // while a fresh ~/.invoker/dev/<hash>/ sandbox was written instead.
+    const env = buildOwnerSpawnEnv({}, 'linux');
+    expect(env.INVOKER_PRODUCTION_OWNER_SERVICE).toBe('1');
+  });
+
+  it('still strips Slack credentials and normalizes PATH/LIBGL as before', () => {
+    const env = buildOwnerSpawnEnv(
+      { SLACK_BOT_TOKEN: 'xoxb-test', PATH: '/usr/bin:/snap/bin' },
+      'linux',
+      (path) => path !== '/snap/bin',
+    );
+    expect(env.SLACK_BOT_TOKEN).toBeUndefined();
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.LIBGL_ALWAYS_SOFTWARE).toBe('1');
   });
 });

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -60,6 +60,21 @@ export interface InvokerLauncher {
 export type OwnerLaunchSpec = HeadlessOwnerLaunchSpec;
 export { resolveHeadlessOwnerLaunchSpec as resolveOwnerLaunch };
 
+export function buildOwnerSpawnEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+  directoryExists: (path: string) => boolean = existsSync,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    LIBGL_ALWAYS_SOFTWARE: platform === 'linux' ? '1' : baseEnv.LIBGL_ALWAYS_SOFTWARE,
+    PATH: withoutMissingPathEntries(baseEnv.PATH, directoryExists),
+    INVOKER_PRODUCTION_OWNER_SERVICE: '1',
+  };
+  for (const key of SLACK_ENV_VARS) delete env[key];
+  return env;
+}
+
 export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerLauncher {
   let child: ChildProcess | undefined;
 
@@ -74,12 +89,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
         }
       }
 
-      const env: NodeJS.ProcessEnv = {
-        ...process.env,
-        LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
-        PATH: withoutMissingPathEntries(process.env.PATH),
-      };
-      for (const key of SLACK_ENV_VARS) delete env[key];
+      const env = buildOwnerSpawnEnv(process.env);
 
       const spec = resolveHeadlessOwnerLaunchSpec({ repoRoot: options.repoRoot });
       const out = openSync(options.logPath, 'a');

--- a/scripts/electron-development-profile-guard.cjs
+++ b/scripts/electron-development-profile-guard.cjs
@@ -1,0 +1,8 @@
+function shouldWrapInDevelopmentProfile(argv2, env) {
+  if (argv2 === '--install-only') return false;
+  if (env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE === '1') return false;
+  if (env.INVOKER_PRODUCTION_OWNER_SERVICE === '1') return false;
+  return true;
+}
+
+module.exports = { shouldWrapInDevelopmentProfile };

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -4,8 +4,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
+const { shouldWrapInDevelopmentProfile } = require('./electron-development-profile-guard.cjs');
+
 const repoRoot = path.resolve(__dirname, '..');
-if (process.argv[2] !== '--install-only' && process.env.INVOKER_DEVELOPMENT_PROFILE_ACTIVE !== '1') {
+if (shouldWrapInDevelopmentProfile(process.argv[2], process.env)) {
   const launcher = path.join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
   const result = spawnSync(process.execPath, [launcher, '--', process.execPath, __filename, ...process.argv.slice(2)], {
     stdio: 'inherit',

--- a/scripts/test-electron-development-profile-guard.mjs
+++ b/scripts/test-electron-development-profile-guard.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { shouldWrapInDevelopmentProfile } = require('./electron-development-profile-guard.cjs');
+
+// Regression: the production owner on a source-checkout host (no packaged
+// invoker-ui on PATH) launches via `electron.cjs ... --headless owner-serve`
+// with no INVOKER_DEVELOPMENT_PROFILE_ACTIVE set. Before this fix that always
+// redirected the real production owner into an isolated dev-profile sandbox
+// database (confirmed live on DigitalOcean 1: production invoker.db stopped
+// being written while a fresh ~/.invoker/dev/<hash>/ sandbox was actively
+// written instead). packages/slack-manager/src/invoker-launcher.ts now sets
+// INVOKER_PRODUCTION_OWNER_SERVICE=1 on that exact spawn.
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', { INVOKER_PRODUCTION_OWNER_SERVICE: '1' }),
+  false,
+  'the real production owner spawn must not be wrapped into a dev profile',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', {}),
+  true,
+  'an ordinary developer launch (no production flag) must still get an isolated dev profile',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--install-only', {}),
+  false,
+  'the postinstall electron-download step must never wrap',
+);
+
+assert.equal(
+  shouldWrapInDevelopmentProfile('--no-sandbox', { INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1' }),
+  false,
+  'a re-exec that already carries the active-profile marker must not wrap again',
+);
+
+console.log('PASS: electron.cjs only wraps launches that are not the declared production owner service');


### PR DESCRIPTION
## Summary

DigitalOcean 1's real production owner has been silently running on a throwaway sandbox database.

`scripts/electron.cjs` wraps every launch into an isolated dev database unless the caller opts out. The real production launcher never opted out.

Live evidence: production's own database stopped being written at 00:12 UTC.

A brand-new sandbox database was actively written by the same process afterward instead, and the real production socket no longer existed at all.

This makes the one launcher that actually starts production declare itself exempt, using the opt-out added in #11131.

## Review Claim

Approve setting `INVOKER_PRODUCTION_OWNER_SERVICE=1` on the real owner spawn in `packages/slack-manager/src/invoker-launcher.ts`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only adds one env var to the spawned child; every other value in that env object (PATH normalization, `LIBGL_ALWAYS_SOFTWARE`, stripped Slack credentials) is unchanged and covered by existing and new tests.

## Slice Rationale

This is the one real caller of the opt-out added in #11131; reviewing it separately keeps the mechanical guard change distinct from the actual product-behavior fix.

## Non-goals

Does not restart the live DigitalOcean 1 process; that is a separate, explicit action once this lands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test` — 71 passed, including 2 new tests: the spawn sets the flag, and PATH/Slack/LIBGL handling is unchanged.
- [x] `pnpm run check:types` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5c5e903`
- Post-revert steps: None
- Data migration? No

</details>
