### PR TITLE
[invoker-ui --help](1) Fix invoker-ui --help launching the GUI instead of printing usage

### DIFF
--- a/packages/npm-ui/bin/invoker-ui.js
+++ b/packages/npm-ui/bin/invoker-ui.js
@@ -25,8 +25,24 @@ function doctor() {
   return ok ? 0 : 1;
 }
 
+function printHelp() {
+  console.log(`Usage: invoker-ui [command]
+
+Commands:
+  doctor       Check that required tools and the desktop artifact are present
+  --headless   Launch the Invoker desktop app in headless mode
+  --help, -h   Show this help message
+
+With no command, launches the Invoker desktop GUI.`);
+}
+
 if (process.argv[2] === 'doctor') {
   process.exit(doctor());
+}
+
+if (process.argv[2] === '--help' || process.argv[2] === '-h') {
+  printHelp();
+  process.exit(0);
 }
 
 if (process.platform === 'darwin') {

--- a/packages/npm-ui/scripts/test-wrapper.mjs
+++ b/packages/npm-ui/scripts/test-wrapper.mjs
@@ -58,3 +58,16 @@ try {
 } finally {
   rmSync(scratch, { recursive: true, force: true });
 }
+
+// invoker-ui --help must print usage and exit 0 without touching the
+// vendor Invoker.app (regression: it used to fall through to `open -a
+// Invoker.app --args --help`, launching a real second GUI instance).
+{
+  const invokerUiBin = join(packageRoot, 'bin', 'invoker-ui.js');
+  for (const flag of ['--help', '-h']) {
+    const output = execFileSync(process.execPath, [invokerUiBin, flag], { encoding: 'utf8' });
+    assert.match(output, /^Usage: invoker-ui/);
+    assert.doesNotMatch(output, /Invoker\.app is missing/);
+  }
+  console.log('ok invoker-ui --help prints usage without launching the GUI');
+}


### PR DESCRIPTION
## Summary

`invoker-ui --help` used to launch the real desktop GUI instead of printing usage text.

On macOS it fell through to `open -a Invoker.app --args --help`, which starts a full second app instance.

If another Invoker window was already open, that second instance lost the single-instance lock and popped an "Only one Invoker GUI can run" error dialog.

Any automated `--help`-style probe against `invoker-ui` was visibly disruptive on a machine with a GUI already running.

Now the entrypoint exposes a `--help`/`-h` command that prints a short usage block and exits, before it ever reaches the branch that opens the app.

## Review Claim

Approve exposing an explicit `--help`/`-h` command in `packages/npm-ui/bin/invoker-ui.js`, checked ahead of the branch that opens the app.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new branch only handles the exact literal argv values `--help` and `-h`; every other argv (including no args, `doctor`, and other flag combinations) falls through to the existing, unchanged dispatch. No existing invocation's behavior changes.

## Slice Rationale

Single-file fix to this entrypoint's argv handling, plus its regression test; nothing else in the npm-ui package needed to change.

## Non-goals

Does not change `doctor`, the branch that opens the app for other flags, the Linux AppImage path, or the globally-installed npm package on any machine (that only picks this up on the next `@neko-catpital-labs/invoker-ui` release/reinstall).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node packages/npm-ui/bin/invoker-ui.js --help` — prints usage, exits 0, does not spawn `open -a Invoker.app`
- [x] `node packages/npm-ui/scripts/test-wrapper.mjs` — added regression assertions for `--help` and `-h`, full script passes
- [x] `pnpm run check:comments` — passes, no disallowed comments

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert aa1fdec6b0`
- Post-revert steps: None
- Data migration? No

</details>
