### PR TITLE
Release version stamping (1) bump-version script

### DIFF
--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export function computeNextVersion(current, kind) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+  if (!match) {
+    throw new Error(`invalid version: ${JSON.stringify(current)}`);
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+
+  if (kind === 'patch') {
+    return `${major}.${minor}.${patch + 1}`;
+  }
+  if (kind === 'minor') {
+    return `${major}.${minor + 1}.0`;
+  }
+  throw new Error(`invalid kind: ${JSON.stringify(kind)}`);
+}
+
+const JSON_TARGETS = [
+  'package.json',
+  'packages/app/package.json',
+  'packages/cli/package.json',
+  'packages/slack-manager/package.json',
+  'packages/watcher/package.json',
+  'packages/npm-cli/package.json',
+  'packages/npm-ui/package.json',
+  'packages/npm-slack/package.json',
+  'packages/npm-watcher/package.json',
+];
+
+const CONST_TARGETS = ['packages/cli/src/index.ts', 'packages/slack-manager/src/index.ts'];
+
+const JSON_VERSION_RE = /"version":\s*"([^"]+)"/;
+const CONST_VERSION_RE = /^const VERSION = '([^']+)';$/m;
+
+function loadTargets() {
+  const jsonTargets = JSON_TARGETS.map((relPath) => {
+    const text = readFileSync(join(root, relPath), 'utf8');
+    return { relPath, kind: 'json', text, current: text.match(JSON_VERSION_RE)?.[1] };
+  });
+  const constTargets = CONST_TARGETS.map((relPath) => {
+    const text = readFileSync(join(root, relPath), 'utf8');
+    return { relPath, kind: 'const', text, current: text.match(CONST_VERSION_RE)?.[1] };
+  });
+  return [...jsonTargets, ...constTargets];
+}
+
+function writeTarget(target, nextVersion) {
+  const re = target.kind === 'json' ? JSON_VERSION_RE : CONST_VERSION_RE;
+  const replacement =
+    target.kind === 'json' ? `"version": "${nextVersion}"` : `const VERSION = '${nextVersion}';`;
+  writeFileSync(join(root, target.relPath), target.text.replace(re, replacement));
+}
+
+function parseArgs(argv) {
+  let type;
+  let dryRun = false;
+  let from;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--type') {
+      type = argv[++i];
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--from') {
+      from = argv[++i];
+    }
+  }
+  return { type, dryRun, from };
+}
+
+function main() {
+  const { type, dryRun, from } = parseArgs(process.argv.slice(2));
+
+  if (type !== 'patch' && type !== 'minor') {
+    console.error(`--type must be "patch" or "minor" (got ${JSON.stringify(type)})`);
+    process.exit(1);
+  }
+
+  const current = from ?? JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+
+  let next;
+  try {
+    next = computeNextVersion(current, type);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log(next);
+    process.exit(0);
+  }
+
+  const targets = loadTargets();
+  const mismatches = targets.filter((target) => target.current !== current);
+  if (mismatches.length > 0) {
+    console.error(`Cannot bump: expected all targets at version ${current}, found mismatches:`);
+    for (const target of mismatches) {
+      console.error(`  ${target.relPath}: expected ${current}, found ${target.current ?? 'NOT FOUND'}`);
+    }
+    process.exit(1);
+  }
+
+  for (const target of targets) {
+    writeTarget(target, next);
+  }
+
+  console.log(next);
+  process.exit(0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/test-bump-release-version.mjs
+++ b/scripts/test-bump-release-version.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeNextVersion } from './bump-release-version.mjs';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (err) {
+    console.error(`not ok - ${name}`);
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+test('patch bump keeps major/minor and increments patch', () => {
+  assert.equal(computeNextVersion('0.0.13', 'patch'), '0.0.14');
+  assert.equal(computeNextVersion('1.2.3', 'patch'), '1.2.4');
+});
+
+test('minor bump increments minor and resets patch to 0', () => {
+  assert.equal(computeNextVersion('0.0.13', 'minor'), '0.1.0');
+  assert.equal(computeNextVersion('1.2.3', 'minor'), '1.3.0');
+});
+
+test('invalid version string throws', () => {
+  assert.throws(() => computeNextVersion('not-a-version', 'patch'));
+  assert.throws(() => computeNextVersion('1.2', 'patch'));
+});
+
+test('invalid kind throws', () => {
+  assert.throws(() => computeNextVersion('1.2.3', 'major'));
+});
+
+test('--dry-run prints the computed version and writes nothing', () => {
+  const before = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
+  const output = execFileSync(
+    process.execPath,
+    [join(root, 'scripts/bump-release-version.mjs'), '--type', 'patch', '--dry-run', '--from', '0.0.13'],
+    { encoding: 'utf8' },
+  ).trim();
+  assert.equal(output, '0.0.14');
+  const after = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
+  assert.equal(after, before);
+});
+
+console.log('all tests passed');
+process.exit(0);


### PR DESCRIPTION
## Summary

Add a release-version tool that computes patch and minor bumps and prints the result for pipeline capture.

Dry runs only calculate the next version. Real runs update every tracked release-version source after an all-target drift check.

This slice provides the dormant tool and focused coverage. Release workflow wiring remains in the next stack workflow.

## Review Claim

Approve one release-tooling script that computes patch or minor versions and updates all tracked sources only after every prior value matches.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`--dry-run` never writes. A real run checks every target before writing any target, so version drift stops the operation without a partial bump.

## Slice Rationale

The version calculation and guarded file update form one tooling unit. Pipeline activation belongs in the next workflow so callers are reviewed separately.

## Non-goals

No GitHub Actions changes. No commit, push, or git orchestration. No changes to `scripts/check-version-sync.mjs`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/bump-release-version.mjs --type patch --dry-run --from 0.0.13` — printed `0.0.14`; exit `0`.
- [x] `node scripts/bump-release-version.mjs --type minor --dry-run --from 0.0.13` — printed `0.1.0`; exit `0`.
- [x] `node scripts/test-bump-release-version.mjs` — final line `all tests passed`; exit `0`.
- [x] `pnpm run check:comments` — `[comments] Checked added source lines; no disallowed comments found.`; exit `0`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. No release workflow calls this script in this slice.
- Revert command: Revert this PR through GitHub, or run `git revert <merge-commit>`.
- Post-revert steps: None.
- Data migration? No.

</details>
