### PR TITLE
[Plan draft click diagnostics](1) Log Slack outbound messages and rejection reasons

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -470,6 +470,28 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(commands).toHaveLength(1);
   });
 
+  it('lets the requester approve the current draft after a conversational (non-/plan) re-draft supersedes an older one', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands, { conversationalPlanning: true });
+    await start(slack, commands);
+
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'draft the first pass', 'conv-turn-1', 'thread-conversational');
+    const stale = slackPlanDrafts.getReady('C_LOBBY', 'thread-conversational')!;
+    expect(stale).toBeTruthy();
+
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'please try again', 'conv-turn-2', 'thread-conversational');
+    const current = slackPlanDrafts.getReady('C_LOBBY', 'thread-conversational')!;
+    expect(current).toBeTruthy();
+    expect(current.version).toBe(stale.version + 1);
+    expect(slackPlanDrafts.get(stale.draftId, stale.version)?.status).toBe('superseded');
+
+    const { respond } = await approveDraft(slack, current, 'current-ts');
+    expect(respond).not.toHaveBeenCalledWith(expect.objectContaining({ text: 'This plan review is no longer available.' }));
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
   it('reacquires an external repository checkout before restoring its thread', async () => {
     const commands: SurfaceCommand[] = [];
     const firstCheckout = vi.fn().mockResolvedValue('/planning-clones/proof-first');

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1621,8 +1621,21 @@ export class SlackSurface implements Surface {
     return parsed;
   }
 
+  private describeOutboundActions(blocks: unknown[] | undefined): string {
+    if (!blocks?.length) return 'none';
+    const pairs: string[] = [];
+    for (const block of blocks as Array<{ elements?: Array<{ action_id?: string; value?: string }> }>) {
+      for (const el of block.elements ?? []) {
+        if (el.action_id) pairs.push(`${el.action_id}=${el.value ?? ''}`);
+      }
+    }
+    return pairs.length > 0 ? pairs.join(',') : 'none';
+  }
+
   private async replacePlanDraftMessage(draft: SlackPlanDraft, text: string, blocks: unknown[]): Promise<void> {
     if (!draft.messageTs) return;
+    this.log('slack', 'info',
+      `[OUTBOUND_MESSAGE] chat.update channel=${draft.channelId} thread_ts=${draft.threadTs} ts=${draft.messageTs} draft=${draft.draftId}:${draft.version} textPreview="${text.slice(0, 100).replace(/\n/g, '\\n')}" actions=${this.describeOutboundActions(blocks)}`);
     await this.app.client.chat.update({
       channel: draft.channelId,
       ts: draft.messageTs,
@@ -1676,6 +1689,26 @@ export class SlackSurface implements Surface {
     }
   }
 
+  private logDraftActionUnavailable(
+    actionName: string,
+    value: string,
+    key: { draftId: string; version: number } | undefined,
+    context: { channel?: string; threadTs?: string; userId?: string },
+    draft: SlackPlanDraft | undefined,
+  ): void {
+    const reasons: string[] = [];
+    if (!key) reasons.push('unparseable_button_value');
+    if (key && !draft) reasons.push('draft_row_not_found');
+    if (!context.channel) reasons.push('missing_context_channel');
+    if (!context.threadTs) reasons.push('missing_context_threadTs');
+    if (!context.userId) reasons.push('missing_context_userId');
+    if (draft && context.channel && draft.channelId !== context.channel) reasons.push(`channel_mismatch(draft=${draft.channelId},click=${context.channel})`);
+    if (draft && context.threadTs && draft.threadTs !== context.threadTs) reasons.push(`threadTs_mismatch(draft=${draft.threadTs},click=${context.threadTs})`);
+    if (draft && context.userId && draft.requestedBy !== context.userId) reasons.push(`requestedBy_mismatch(draft=${draft.requestedBy},click=${context.userId})`);
+    this.log('slack', 'warn',
+      `[PLAN_DRAFT_ACTION_UNAVAILABLE] action=${actionName} value="${value}" draft=${draft ? `${draft.draftId}:${draft.version}(status=${draft.status})` : 'none'} click_channel=${context.channel ?? 'none'} click_threadTs=${context.threadTs ?? 'none'} click_userId=${context.userId ?? 'none'} reasons=${reasons.join('|') || 'unknown'}`);
+  }
+
   private async approveSlackPlanDraft(value: string, body: unknown, respond?: RespondFn): Promise<void> {
     const key = this.parseDraftAction(value);
     const context = this.draftActionContext(body);
@@ -1683,6 +1716,7 @@ export class SlackSurface implements Surface {
     if (!draft || !context.channel || !context.threadTs || !context.userId
       || draft.channelId !== context.channel || draft.threadTs !== context.threadTs
       || draft.requestedBy !== context.userId) {
+      this.logDraftActionUnavailable('approve', value, key, context, draft);
       await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
       return;
     }
@@ -1700,6 +1734,7 @@ export class SlackSurface implements Surface {
     if (!draft || !context.channel || !context.threadTs || !context.userId
       || draft.channelId !== context.channel || draft.threadTs !== context.threadTs
       || draft.requestedBy !== context.userId) {
+      this.logDraftActionUnavailable('cancel', value, key, context, draft);
       await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
       return;
     }
@@ -1722,6 +1757,7 @@ export class SlackSurface implements Surface {
     if (!draft || !context.channel || !context.threadTs || !context.userId
       || draft.channelId !== context.channel || draft.threadTs !== context.threadTs
       || draft.requestedBy !== context.userId) {
+      this.logDraftActionUnavailable('discard', value, key, context, draft);
       await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
       return;
     }
@@ -3253,15 +3289,25 @@ ${text}`;
     say: SayFn,
     msg: { text: string; thread_ts: string; blocks?: unknown[] },
   ): Promise<any> {
+    const textPreview = (msg.text ?? '').slice(0, 100).replace(/\n/g, '\\n');
+    const actions = this.describeOutboundActions(msg.blocks);
+    let result: any;
     try {
-      return await say(msg);
+      result = await say(msg);
     } catch (err) {
       const retryAfterMs = this.getRetryAfterMs(err);
-      if (retryAfterMs === null) throw err;
+      if (retryAfterMs === null) {
+        this.log('slack', 'error',
+          `[OUTBOUND_MESSAGE] say FAILED thread_ts=${msg.thread_ts} textPreview="${textPreview}" actions=${actions} error=${err instanceof Error ? err.message : String(err)}`);
+        throw err;
+      }
       this.log('slack', 'warn', `[RATE_LIMIT] Delaying retry for ${retryAfterMs}ms (thread_ts=${msg.thread_ts})`);
       await this.sleep(retryAfterMs + 100);
-      return await say(msg);
+      result = await say(msg);
     }
+    this.log('slack', 'info',
+      `[OUTBOUND_MESSAGE] say thread_ts=${msg.thread_ts} ts=${result?.ts ?? 'unknown'} textPreview="${textPreview}" actions=${actions}`);
+    return result;
   }
 
   private isCursorCliMissingError(err: unknown): boolean {


### PR DESCRIPTION
## Summary

The Slack bot's plan-review card can silently fail an Approve, Cancel, or Discard click with "This plan review is no longer available." Nothing was logged when this happened.

This adds two log lines: one for every outbound Slack message the bot sends, and one that records the exact reason a plan-draft click was refused.

No approval, cancellation, or submission behavior changes. This only adds observability so the next occurrence can be diagnosed from logs instead of a live database query.

## Review Claim

Approve that these two added log statements are accurate, low-noise, and do not change any existing control flow in `slack-surface.ts`.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Every new line is a `this.log(...)` call placed around existing return paths; no branch, return value, or persisted state is touched. The added test only asserts existing behavior and does not change production code paths.

## Slice Rationale

This is instrumentation for a still-unreproduced production bug. It is kept apart from any eventual behavior fix so that fix can be reviewed on its own, backed by the evidence this logging produces.

## Non-goals

Does not resolve the "no longer available" failure itself — the root cause was not reproduced locally and remains open. Does not change plan-draft approval, cancellation, or discard semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e4298d7a59`
- Post-revert steps: None
- Data migration? No

</details>
