### PR TITLE
[Release version stamping] Wire nightly patch bump + release minor guard

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       tag: ${{ steps.decide.outputs.tag }}
       previous_tag: ${{ steps.decide.outputs.previous_tag }}
-      sha: ${{ steps.decide.outputs.sha }}
+      sha: ${{ steps.bump.outputs.sha }}
       should_run: ${{ steps.decide.outputs.should_run }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
 
@@ -33,6 +33,19 @@ jobs:
       - name: Decide daily cut
         id: decide
         run: bash scripts/daily-release-decide.sh --tip HEAD --out "$GITHUB_OUTPUT"
+
+      - name: Bump nightly patch version
+        if: steps.decide.outputs.should_run == 'true'
+        run: |
+          node scripts/bump-release-version.mjs --type patch
+          git config user.name "invoker-release-bot"
+          git config user.email "invoker-release-bot@users.noreply.github.com"
+          git commit -am "chore(release): bump patch version for ${{ steps.decide.outputs.tag }}"
+          git push origin HEAD:master
+
+      - name: Resolve build sha
+        id: bump
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Skip summary
         if: steps.decide.outputs.should_run != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,34 @@ env:
   NODE_VERSION: '26'
 
 jobs:
+  guard-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Guard release is exactly a minor bump
+        run: |
+          CURRENT_REF="${{ github.sha }}"
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged "$CURRENT_REF^" | head -1)
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "No previous v* release tag found; skipping guard for the first release."
+            exit 0
+          fi
+          PREVIOUS_VERSION=$(git show "$PREVIOUS_TAG:package.json" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).version)")
+          EXPECTED_VERSION=$(node scripts/bump-release-version.mjs --type minor --dry-run --from "$PREVIOUS_VERSION")
+          CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
+          if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "Release version guard failed: expected a minor bump from $PREVIOUS_VERSION ($EXPECTED_VERSION), but package.json has $CURRENT_VERSION." >&2
+            exit 1
+          fi
+          echo "Release version guard passed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+
   build:
+    needs: guard-version
     uses: ./.github/workflows/reusable-release-build.yml
 
   publish-release:

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export function computeNextVersion(current, kind) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+  if (!match) {
+    throw new Error(`invalid version: ${JSON.stringify(current)}`);
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+
+  if (kind === 'patch') {
+    return `${major}.${minor}.${patch + 1}`;
+  }
+  if (kind === 'minor') {
+    return `${major}.${minor + 1}.0`;
+  }
+  throw new Error(`invalid kind: ${JSON.stringify(kind)}`);
+}
+
+// Mirrors scripts/check-version-sync.mjs's own `sources` array so the two
+// scripts cannot disagree about which files carry the release version.
+const JSON_TARGETS = [
+  'package.json',
+  'packages/app/package.json',
+  'packages/cli/package.json',
+  'packages/slack-manager/package.json',
+  'packages/watcher/package.json',
+  'packages/npm-cli/package.json',
+  'packages/npm-ui/package.json',
+  'packages/npm-slack/package.json',
+  'packages/npm-watcher/package.json',
+];
+
+const CONST_TARGETS = ['packages/cli/src/index.ts', 'packages/slack-manager/src/index.ts'];
+
+const JSON_VERSION_RE = /"version":\s*"([^"]+)"/;
+const CONST_VERSION_RE = /^const VERSION = '([^']+)';$/m;
+
+function loadTargets() {
+  const jsonTargets = JSON_TARGETS.map((relPath) => {
+    const text = readFileSync(join(root, relPath), 'utf8');
+    return { relPath, kind: 'json', text, current: text.match(JSON_VERSION_RE)?.[1] };
+  });
+  const constTargets = CONST_TARGETS.map((relPath) => {
+    const text = readFileSync(join(root, relPath), 'utf8');
+    return { relPath, kind: 'const', text, current: text.match(CONST_VERSION_RE)?.[1] };
+  });
+  return [...jsonTargets, ...constTargets];
+}
+
+function writeTarget(target, nextVersion) {
+  const re = target.kind === 'json' ? JSON_VERSION_RE : CONST_VERSION_RE;
+  const replacement =
+    target.kind === 'json' ? `"version": "${nextVersion}"` : `const VERSION = '${nextVersion}';`;
+  writeFileSync(join(root, target.relPath), target.text.replace(re, replacement));
+}
+
+function parseArgs(argv) {
+  let type;
+  let dryRun = false;
+  let from;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--type') {
+      type = argv[++i];
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--from') {
+      from = argv[++i];
+    }
+  }
+  return { type, dryRun, from };
+}
+
+function main() {
+  const { type, dryRun, from } = parseArgs(process.argv.slice(2));
+
+  if (type !== 'patch' && type !== 'minor') {
+    console.error(`--type must be "patch" or "minor" (got ${JSON.stringify(type)})`);
+    process.exit(1);
+  }
+
+  const current = from ?? JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+
+  let next;
+  try {
+    next = computeNextVersion(current, type);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log(next);
+    process.exit(0);
+  }
+
+  const targets = loadTargets();
+  const mismatches = targets.filter((target) => target.current !== current);
+  if (mismatches.length > 0) {
+    console.error(`Cannot bump: expected all targets at version ${current}, found mismatches:`);
+    for (const target of mismatches) {
+      console.error(`  ${target.relPath}: expected ${current}, found ${target.current ?? 'NOT FOUND'}`);
+    }
+    process.exit(1);
+  }
+
+  for (const target of targets) {
+    writeTarget(target, next);
+  }
+
+  console.log(next);
+  process.exit(0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/test-bump-release-version.mjs
+++ b/scripts/test-bump-release-version.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeNextVersion } from './bump-release-version.mjs';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (err) {
+    console.error(`not ok - ${name}`);
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+test('patch bump keeps major/minor and increments patch', () => {
+  assert.equal(computeNextVersion('0.0.13', 'patch'), '0.0.14');
+  assert.equal(computeNextVersion('1.2.3', 'patch'), '1.2.4');
+});
+
+test('minor bump increments minor and resets patch to 0', () => {
+  assert.equal(computeNextVersion('0.0.13', 'minor'), '0.1.0');
+  assert.equal(computeNextVersion('1.2.3', 'minor'), '1.3.0');
+});
+
+test('invalid version string throws', () => {
+  assert.throws(() => computeNextVersion('not-a-version', 'patch'));
+  assert.throws(() => computeNextVersion('1.2', 'patch'));
+});
+
+test('invalid kind throws', () => {
+  assert.throws(() => computeNextVersion('1.2.3', 'major'));
+});
+
+test('--dry-run prints the computed version and writes nothing', () => {
+  const before = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
+  const output = execFileSync(
+    process.execPath,
+    [join(root, 'scripts/bump-release-version.mjs'), '--type', 'patch', '--dry-run', '--from', '0.0.13'],
+    { encoding: 'utf8' },
+  ).trim();
+  assert.equal(output, '0.0.14');
+  const after = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
+  assert.equal(after, before);
+});
+
+console.log('all tests passed');
+process.exit(0);

--- a/scripts/test-ci-workflow-release-version-bump.mjs
+++ b/scripts/test-ci-workflow-release-version-bump.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exitCode = 1;
+}
+
+const dailyRelease = readFileSync(join(root, '.github/workflows/daily-release.yml'), 'utf8');
+const release = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+
+const decideJobMatch = dailyRelease.match(/\n {2}decide:\n([\s\S]*?)\n {2}\S/);
+const decideJob = decideJobMatch ? decideJobMatch[1] : '';
+
+if (!/Bump nightly patch version/.test(decideJob)) {
+  fail('daily-release.yml decide job is missing a "Bump nightly patch version" step');
+} else {
+  const bumpStepMatch = decideJob.match(/Bump nightly patch version[\s\S]*?(?=\n {6}- name:|$)/);
+  const bumpStep = bumpStepMatch ? bumpStepMatch[0] : '';
+  if (!/should_run == 'true'/.test(bumpStep)) {
+    fail('the patch-bump step must be gated on should_run == \'true\'');
+  }
+  if (!/bump-release-version\.mjs --type patch/.test(bumpStep)) {
+    fail('the patch-bump step must invoke bump-release-version.mjs --type patch');
+  }
+  const decideIndex = decideJob.indexOf('Decide daily cut');
+  const bumpIndex = decideJob.indexOf('Bump nightly patch version');
+  if (decideIndex === -1 || bumpIndex === -1 || bumpIndex < decideIndex) {
+    fail('the patch-bump step must come after the "Decide daily cut" step');
+  }
+}
+
+if (!/guard-version:/.test(release)) {
+  fail('release.yml is missing a guard-version job');
+} else {
+  const guardJobMatch = release.match(/\n {2}guard-version:\n([\s\S]*?)\n {2}\S/);
+  const guardJob = guardJobMatch ? guardJobMatch[1] : '';
+  if (!/bump-release-version\.mjs --type minor/.test(guardJob)) {
+    fail('guard-version job must invoke bump-release-version.mjs --type minor');
+  }
+  const buildJobMatch = release.match(/\n {2}build:\n([\s\S]*?)\n {2}\S/);
+  const buildJob = buildJobMatch ? buildJobMatch[1] : '';
+  if (!/needs:\s*guard-version/.test(buildJob)) {
+    fail('build job must declare "needs: guard-version"');
+  }
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+
+console.log('PASS: daily-release.yml bumps the patch version on a real cut, release.yml guards for a minor-only bump');


### PR DESCRIPTION
## Summary

Nightly builds and stale local installs used to print the identical version number, so there was no way to tell which build you were actually running.

This wires the version-bump helper from the prior slice into both release pipelines. A nightly cut now bumps the patch number for real.

A tagged release is checked against the previous release to confirm it moved by a minor number.

## Review Claim

The nightly pipeline commits a real patch bump only on a day it actually cuts a release, and the tagged-release pipeline fails loudly if the shipped version is not exactly a minor bump over the prior release.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The patch bump step only runs when the existing daily-cut decision already said a cut should happen — a day with nothing new stays a no-op, with no commit. The release-side check only reads and compares versions; it never writes, commits, or pushes anything.

## Slice Rationale

The bump math and file-writing tool landed as its own reviewable slice already. This slice is the wiring — hooking that tool into the two pipelines — so a reviewer here only has to check the wiring, not the arithmetic.

## Non-goals

Does not change which days a nightly cut runs or is skipped. Does not automate the existing manual release-tagging step; a human still tags a release the same way as before, this only checks the number they land on.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-release-version-bump.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4f4e937e0b`
- Post-revert steps: None
- Data migration? No

</details>
