### PR TITLE
[Headless Query Owner Guard](1) Guard query action-graph against a slow-but-live owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1065,6 +1065,78 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'action-graph', '--output', 'json']);
   }, 30_000);
 
+  it('keeps delegating query action-graph when the ping misses but a live owner marker exists', async () => {
+    // A live owner holds the DB (marker names this process, sidecars present) but is
+    // too busy to answer the fast discovery ping. Regression for a real repro: bursts
+    // of `query action-graph`/`query queue` each independently spun up their own
+    // standalone Electron process (visible dock-icon flashes / focus steal) instead of
+    // retrying against the owner that was actually already running.
+    const dbPath = join(dbDir, 'invoker.db');
+    writeFileSync(dbPath, '');
+    writeFileSync(`${dbPath}-wal`, '');
+    writeFileSync(`${dbPath}.owner`, String(process.pid), 'utf-8');
+
+    const graph = {
+      generatedAt: '2026-05-14T12:00:00.000Z',
+      stallThresholdMs: 60_000,
+      nodes: [],
+      edges: [],
+    };
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    // No owner-ping handler on either bus → discovery misses; cli-query still succeeds.
+    secondBus.onRequest('headless.query', async (payload: { kind: string }) => {
+      expect(payload).toEqual({ kind: 'action-graph' });
+      return graph;
+    });
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus: vi.fn().mockResolvedValue(secondBus),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(`${JSON.stringify(graph)}\n`);
+    stdout.mockRestore();
+  });
+
+  it('keeps delegating query queue when the ping misses but a live owner marker exists', async () => {
+    const dbPath = join(dbDir, 'invoker.db');
+    writeFileSync(dbPath, '');
+    writeFileSync(`${dbPath}-wal`, '');
+    writeFileSync(`${dbPath}.owner`, String(process.pid), 'utf-8');
+
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    secondBus.onRequest('headless.query', async () => ({
+      maxConcurrency: 4,
+      runningCount: 1,
+      running: [{ taskId: 'wf-1/root', description: 'root task' }],
+      queued: [],
+    }));
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'queue', '--output', 'json'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus: vi.fn().mockResolvedValue(secondBus),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith('{"maxConcurrency":4,"runningCount":1,"running":[{"taskId":"wf-1/root","description":"root task"}],"queued":[]}\n');
+    stdout.mockRestore();
+  });
+
   it('falls back to direct Electron headless for query queue when no owner endpoint is reachable', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
     const exitCode = await runHeadlessClientCommand(['query', 'queue', '--output', 'json'], {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -361,7 +361,7 @@ async function delegateReadOnlyQuery(
   if (ownerResult.resolved) {
     messageBus = ownerResult.bus;
   } else if (
-    !isQueue ||
+    (!isQueue && !isActionGraph) ||
     !hasLiveWritableOwner(resolve(resolveInvokerHomeRoot(), 'invoker.db'))
   ) {
     if (isQueue || isActionGraph) return false;


### PR DESCRIPTION
## Summary

Headless `query action-graph` gave up after a 2-second discovery ping and
spawned its own throwaway Electron process, even when a live owner was
already running — it just hadn't answered yet.

`query queue` already checked a live-writable-owner marker before giving
up this way; `query action-graph` never had that check.

Any repeated polling of it (a monitor loop, or normal headless usage)
could spawn a new Electron process on every miss. Each one briefly
registers with macOS Launch Services before its accessory activation
policy takes effect.

That shows up as icons flashing in the Dock, and can steal keyboard
focus from whatever the user was doing.

## Review Claim

Approve making `query action-graph`'s owner-discovery fallback check the
live-writable-owner marker before giving up, the same way `query queue`
already does — so a briefly-slow owner still gets a second chance instead
of an extra Electron process being spawned.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This changes only how a read-only query *discovers* an owner to delegate
to. It does not change what any query returns, does not touch a mutating
code path (`submit`/`retry`/`approve`/etc.), and the final fallback (spawn
standalone) still happens if the owner genuinely doesn't respond after
retrying — so the command can never hang or fail where it previously
returned a result.

## Slice Rationale

One-line asymmetry fix in the existing `delegateReadOnlyQuery` branch,
scoped to a single condition plus its regression tests. Small enough to
land standalone rather than bundled with anything else.

## Non-goals

- Does not fix the underlying reason discovery can be briefly slow (owner
  load, IPC latency) — only stops that slowness from causing a duplicate
  process.
- Does not change `query workflows`/`query tasks` (the generic delegatable
  read path), which already had this marker check.
- Not a UI change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx vitest run src/__tests__/headless-client.test.ts` — 49/49 pass, including the two new regression tests (`keeps delegating query action-graph when the ping misses but a live owner marker exists`, `keeps delegating query queue when the ping misses but a live owner marker exists`).
- [x] Fail-before/pass-after: reverted the one-line fix locally and reran the new `query action-graph` test — it failed (`expected 23 to be +0`, i.e. the mocked `runElectronHeadless` fired). Reapplied the fix and reran — passed.
- [x] `bash scripts/repro/repro-headless-thundering-herd.sh` — unrelated known-good regression guard, confirmed still passing (0 duplicate owner-serve/retry processes) to rule out overlap with this change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fe361e8dfb`
- Post-revert steps: None
- Data migration? No

</details>
