### PR TITLE
No-Mergify observed CI repair (2) Repair failed observed checks

### DIFF
--- a/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+const repro = String.raw`
+import json
+
+from scripts.mergify_admin_requeue import CheckContext, PrSnapshot, classify_pr
+
+head_sha = "0123456789abcdef0123456789abcdef01234567"
+checks = {
+    "lint": CheckContext(
+        name="lint",
+        state="success",
+        details_url="https://example.invalid/lint",
+        head_sha=head_sha,
+        completed_at="2026-08-27T00:00:00Z",
+    ),
+    "test": CheckContext(
+        name="test",
+        state="failure",
+        details_url="https://example.invalid/test",
+        head_sha=head_sha,
+        completed_at="2026-08-27T00:00:00Z",
+    ),
+}
+pr = PrSnapshot(
+    number=1,
+    title="Observed failed CI without Mergify configuration",
+    body="",
+    url="https://example.invalid/pull/1",
+    state="OPEN",
+    is_draft=False,
+    base_ref_name="main",
+    head_ref_name="admin-bypass/no-mergify-repair",
+    head_ref_oid=head_sha,
+    merge_state_status="CLEAN",
+    mergeable="MERGEABLE",
+    labels=frozenset({"admin-bypass"}),
+    checks=checks,
+    review_threads=(),
+    latest_mergify=None,
+)
+
+blockers = classify_pr(pr, required_checks=(), trunk="main")
+print(json.dumps([[blocker.kind, blocker.key] for blocker in blockers]))
+`;
+
+describe('admin-bypass observed CI without Mergify configuration', () => {
+  it.fails('classifies an observed failed check when required_checks is empty', () => {
+    const result = spawnSync('python3', ['-c', repro], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const diagnostics = [
+      `python3 exit status: ${String(result.status)}`,
+      `python3 error: ${result.error?.message ?? '<none>'}`,
+      `python3 stderr:\n${result.stderr || '<empty>'}`,
+    ].join('\n');
+
+    expect(result.status, diagnostics).toBe(0);
+
+    let blockers: unknown;
+    try {
+      blockers = JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(`Could not parse Python stdout as JSON: ${String(error)}\n${diagnostics}`);
+    }
+    expect(blockers, diagnostics).toEqual([['failed_check', 'test']]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-no-mergify-repair.test.ts
@@ -51,7 +51,7 @@ print(json.dumps([[blocker.kind, blocker.key] for blocker in blockers]))
 `;
 
 describe('admin-bypass observed CI without Mergify configuration', () => {
-  it.fails('classifies an observed failed check when required_checks is empty', () => {
+  it('classifies an observed failed check when required_checks is empty', () => {
     const result = spawnSync('python3', ['-c', repro], {
       cwd: repoRoot,
       encoding: 'utf8',

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -292,18 +292,21 @@ def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) ->
     if pr.merge_state_status == "DIRTY" or pr.mergeable == "CONFLICTING":
         blockers.append(Blocker("conflict", "conflict", pr.number, "GitHub reports merge conflict"))
 
-    for name in sorted(required_checks):
+    configured_check_names = sorted(required_checks)
+    check_names = configured_check_names or sorted(pr.checks)
+    check_label = "required check" if configured_check_names else "CI check"
+    for name in check_names:
         ctx = pr.checks.get(name)
         if ctx is None:
-            if pr.base_ref_name == trunk and not is_queue_only_required_check(name):
+            if configured_check_names and pr.base_ref_name == trunk and not is_queue_only_required_check(name):
                 blockers.append(Blocker(name, "missing_check", pr.number, f"missing required check {name}"))
             continue
         if ctx.state == "success":
             continue
         if ctx.state == "failure":
-            blockers.append(Blocker(name, "failed_check", pr.number, f"required check failed: {name}"))
+            blockers.append(Blocker(name, "failed_check", pr.number, f"{check_label} failed: {name}"))
         elif ctx.state in {"pending", "unknown"}:
-            blockers.append(Blocker(name, "pending_check", pr.number, f"required check not green: {name}={ctx.state}"))
+            blockers.append(Blocker(name, "pending_check", pr.number, f"{check_label} not green: {name}={ctx.state}"))
     return tuple(blockers)
 
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1180,6 +1180,26 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
         self.assertEqual(actions, ())
 
+    def test_empty_required_checks_failed_observed_catstack_ci_repairs_before_squash_or_requeue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9003, base="master", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9003, "test")])
+        self.assertNotIn("squash_merge", {a.kind for a in actions})
+        self.assertNotIn("requeue", {a.kind for a in actions})
+
+    def test_catstack_failing_test_plans_repair_not_squash_or_queue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9010, base="main", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9010, "test")])
+
     def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
         stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)


### PR DESCRIPTION
## Summary

Use observed CI check names when Mergify provides no configured required checks, so failed checks schedule repair.

Preserve configured-check selection and missing-check behavior.

## Review Claim

When required checks are unconfigured, the planner evaluates observed checks and repairs failures without changing configured-Mergify behavior or merge safety gates.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Configured-Mergify check selection, missing configured checks, human-thread blockers, mergeability, draft and base guards, queue and squash decisions, and the ban on `--admin` remain unchanged.

## Slice Rationale

This slice combines the narrow classifier policy change with its direct Vitest and native planner regressions; the earlier stack slice independently proves the pre-fix behavior.

## Non-goals

No Mergify configuration, generic autofix, authentication, human-review bypass, queue or squash policy, admin merge override, UI, documentation, or broad refactor changes.

## Architecture

### Before

The classifier iterates only configured required-check names, so an empty configuration leaves observed CI checks unevaluated.

### After

The classifier uses configured names when present and observed names otherwise. Downstream blocker classification and action planning remain in place.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/admin-bypass-no-mergify-repair.test.ts`
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue.MergifyAdminRequeueTests.test_catstack_failing_test_plans_repair_not_squash_or_queue`
- [ ] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` (local rerun exited 1 during temporary fixture cleanup after its test suites passed)
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bfc6c3af2e3d6479d8a5911a0e72ae9e1071a50f`
- Post-revert steps: None
- Data migration? No

</details>
