### PR TITLE
[IPC Profile Gaps Step 0: shared profile-env resolver](1)

### DIFF
--- a/packages/contracts/src/__tests__/resolve-active-profile-env.test.ts
+++ b/packages/contracts/src/__tests__/resolve-active-profile-env.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveActiveInvokerProfileEnv, resolveRepoRoot } from '../index.js';
+
+const tempDirs: string[] = [];
+
+function makeRepoWithProfileScript(source: string): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'invoker-profile-env-'));
+  tempDirs.push(repoRoot);
+  const scriptsDir = join(repoRoot, 'scripts');
+  mkdirSync(scriptsDir);
+  writeFileSync(join(scriptsDir, 'with-invoker-development-profile.mjs'), source, 'utf8');
+  return repoRoot;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('resolveActiveInvokerProfileEnv', () => {
+  it('matches the development profile script for this repository', () => {
+    const repoRoot = resolveRepoRoot(process.cwd());
+    const scriptPath = join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
+    const direct = spawnSync(
+      process.execPath,
+      [scriptPath, '--source-root', repoRoot, '--print-env'],
+      { encoding: 'utf8', timeout: 5_000 },
+    );
+
+    expect(direct.error).toBeUndefined();
+    expect(direct.status).toBe(0);
+
+    const expected = JSON.parse(direct.stdout) as Record<string, string>;
+    const actual = resolveActiveInvokerProfileEnv({ repoRoot });
+
+    expect(actual).toEqual(expected);
+    expect(actual.INVOKER_DB_DIR).toBeTruthy();
+    expect(actual.INVOKER_IPC_SOCKET).toBeTruthy();
+  });
+
+  it('returns an empty object when the profile script is absent', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'invoker-profile-env-missing-'));
+    tempDirs.push(repoRoot);
+
+    expect(() => resolveActiveInvokerProfileEnv({ repoRoot })).not.toThrow();
+    expect(resolveActiveInvokerProfileEnv({ repoRoot })).toEqual({});
+  });
+
+  it.each([
+    ['a non-zero exit', 'process.exit(2);'],
+    ['empty output', ''],
+    ['malformed JSON', "process.stdout.write('not-json');"],
+    ['a non-object JSON value', "process.stdout.write('[]');"],
+  ])('returns an empty object for %s', (_name, source) => {
+    const repoRoot = makeRepoWithProfileScript(source);
+
+    expect(resolveActiveInvokerProfileEnv({ repoRoot })).toEqual({});
+  });
+
+  it('returns an empty object when the subprocess times out', () => {
+    const repoRoot = makeRepoWithProfileScript(
+      "setTimeout(() => process.stdout.write('{}'), 1_000);",
+    );
+
+    expect(() => resolveActiveInvokerProfileEnv({ repoRoot, timeoutMs: 10 })).not.toThrow();
+    expect(resolveActiveInvokerProfileEnv({ repoRoot, timeoutMs: 10 })).toEqual({});
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './resolve-active-profile-env.ts';
 export * from './invoker-instance-profile.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';

--- a/packages/contracts/src/resolve-active-profile-env.ts
+++ b/packages/contracts/src/resolve-active-profile-env.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { resolveRepoRoot } from './repo-root.js';
+
+export interface ResolveActiveInvokerProfileEnvOptions {
+  repoRoot?: string;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+function isEnvironmentOverrides(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && Object.values(value).every((entry) => typeof entry === 'string')
+  );
+}
+
+export function resolveActiveInvokerProfileEnv(
+  options: ResolveActiveInvokerProfileEnvOptions = {},
+): Record<string, string> {
+  try {
+    const repoRoot = resolve(options.repoRoot ?? resolveRepoRoot(process.cwd()));
+    const scriptPath = resolve(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--source-root', repoRoot, '--print-env'],
+      { encoding: 'utf8', timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS },
+    );
+
+    if (result.error || result.status !== 0) return {};
+
+    const stdout = result.stdout.trim();
+    if (!stdout) return {};
+
+    const parsed: unknown = JSON.parse(stdout);
+    return isEnvironmentOverrides(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

Adds one shared contracts helper that returns the development profile environment used for Invoker’s isolated home and IPC socket.

The helper calls the existing profile script’s print-only mode and returns an empty object when the script cannot provide valid overrides.

No client calls this helper yet. Later slices can adopt it independently without duplicating profile resolution.

## Review Claim

Approve one exported contracts resolver that returns the active Invoker profile environment and fails open without changing existing callers.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The helper never throws or hangs indefinitely. Missing scripts, spawn failures, non-zero exits, timeouts, empty output, and invalid output all return an empty object, preserving existing caller behavior.

## Slice Rationale

This slice isolates the reusable contracts capability. Each standalone client can adopt it in a separate follow-up reviewed against that client’s own connection path.

## Non-goals

- Does not change the development-profile script.
- Does not change any existing client or owner process.
- Does not cache resolved environment values.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts test`
- [x] `pnpm --filter @invoker/contracts build`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
