### PR TITLE
Bugfix: electron.cjs unzip-preference-with-fallback has no regression test (1) Export unzip helpers

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -7,7 +7,7 @@ const { spawn, spawnSync } = require('node:child_process');
 const { shouldWrapInDevelopmentProfile } = require('./electron-development-profile-guard.cjs');
 
 const repoRoot = path.resolve(__dirname, '..');
-if (shouldWrapInDevelopmentProfile(process.argv[2], process.env)) {
+if (require.main === module && shouldWrapInDevelopmentProfile(process.argv[2], process.env)) {
   const launcher = path.join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');
   const result = spawnSync(process.execPath, [launcher, '--', process.execPath, __filename, ...process.argv.slice(2)], {
     stdio: 'inherit',
@@ -291,7 +291,11 @@ async function main() {
   });
 }
 
+module.exports = { systemUnzipIsAvailable, extractZipWithSystemUnzip };
+
+if (require.main === module) {
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 });
+}


### PR DESCRIPTION
## Summary

Make the existing system-unzip helpers importable without running Electron installation as a module-load side effect.

Direct invocation still runs `main()` once through the same error handler.

This creates the narrow seam required by the next stack slice.

## Review Claim

Approve making `systemUnzipIsAvailable` and `extractZipWithSystemUnzip` importable while preserving direct `scripts/electron.cjs` execution.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Direct execution still calls `main()` exactly once with unchanged argv, exit-code, spawn, and error-handler behavior. Requiring the module does not call `main()`.

## Slice Rationale

This slice only adds the import seam and direct-execution guard. The dependent stack slice adds the regression coverage separately.

## Non-goals

No extractor preference change. No repair-flow change. No new flags, dependency changes, network behavior, or documentation edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -e "const m = require('./scripts/electron.cjs'); process.exit((typeof m.systemUnzipIsAvailable === 'function' && typeof m.extractZipWithSystemUnzip === 'function') ? 0 : 1)"` — `IMPORT_CHECK_EXIT=0`.
- [x] `pnpm run check:comments` — `[comments] Checked added source lines; no disallowed comments found.` and `COMMENTS_EXIT=0`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before reverting the dependent regression-coverage PR.
- Revert command: Revert this PR through GitHub, or run `git revert <merge-commit>`.
- Post-revert steps: Revert the dependent regression-coverage PR first if it has landed.
- Data migration? No.

</details>
