### PR TITLE
[Release version stamping](2) Wire nightly patch bump and release minor-version guard into CI

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       tag: ${{ steps.decide.outputs.tag }}
       previous_tag: ${{ steps.decide.outputs.previous_tag }}
-      sha: ${{ steps.decide.outputs.sha }}
+      sha: ${{ steps.bump.outputs.sha }}
       should_run: ${{ steps.decide.outputs.should_run }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
 
@@ -33,6 +33,19 @@ jobs:
       - name: Decide daily cut
         id: decide
         run: bash scripts/daily-release-decide.sh --tip HEAD --out "$GITHUB_OUTPUT"
+
+      - name: Bump nightly patch version
+        if: steps.decide.outputs.should_run == 'true'
+        run: |
+          node scripts/bump-release-version.mjs --type patch
+          git config user.name "invoker-release-bot"
+          git config user.email "invoker-release-bot@users.noreply.github.com"
+          git commit -am "chore(release): bump patch version for ${{ steps.decide.outputs.tag }}"
+          git push origin HEAD:master
+
+      - name: Resolve build sha
+        id: bump
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Skip summary
         if: steps.decide.outputs.should_run != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,34 @@ env:
   NODE_VERSION: '26'
 
 jobs:
+  guard-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Guard release is exactly a minor bump
+        run: |
+          CURRENT_REF="${{ github.sha }}"
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged "$CURRENT_REF^" | head -1)
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "No previous v* release tag found; skipping guard for the first release."
+            exit 0
+          fi
+          PREVIOUS_VERSION=$(git show "$PREVIOUS_TAG:package.json" | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).version)")
+          EXPECTED_VERSION=$(node scripts/bump-release-version.mjs --type minor --dry-run --from "$PREVIOUS_VERSION")
+          CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
+          if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "Release version guard failed: expected a minor bump from $PREVIOUS_VERSION ($EXPECTED_VERSION), but package.json has $CURRENT_VERSION." >&2
+            exit 1
+          fi
+          echo "Release version guard passed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+
   build:
+    needs: guard-version
     uses: ./.github/workflows/reusable-release-build.yml
 
   publish-release:

--- a/scripts/test-ci-workflow-release-version-bump.mjs
+++ b/scripts/test-ci-workflow-release-version-bump.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exitCode = 1;
+}
+
+const dailyRelease = readFileSync(join(root, '.github/workflows/daily-release.yml'), 'utf8');
+const release = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+
+const decideJobMatch = dailyRelease.match(/\n {2}decide:\n([\s\S]*?)\n {2}\S/);
+const decideJob = decideJobMatch ? decideJobMatch[1] : '';
+
+if (!/Bump nightly patch version/.test(decideJob)) {
+  fail('daily-release.yml decide job is missing a "Bump nightly patch version" step');
+} else {
+  const bumpStepMatch = decideJob.match(/Bump nightly patch version[\s\S]*?(?=\n {6}- name:|$)/);
+  const bumpStep = bumpStepMatch ? bumpStepMatch[0] : '';
+  if (!/should_run == 'true'/.test(bumpStep)) {
+    fail('the patch-bump step must be gated on should_run == \'true\'');
+  }
+  if (!/bump-release-version\.mjs --type patch/.test(bumpStep)) {
+    fail('the patch-bump step must invoke bump-release-version.mjs --type patch');
+  }
+  const decideIndex = decideJob.indexOf('Decide daily cut');
+  const bumpIndex = decideJob.indexOf('Bump nightly patch version');
+  if (decideIndex === -1 || bumpIndex === -1 || bumpIndex < decideIndex) {
+    fail('the patch-bump step must come after the "Decide daily cut" step');
+  }
+}
+
+if (!/guard-version:/.test(release)) {
+  fail('release.yml is missing a guard-version job');
+} else {
+  const guardJobMatch = release.match(/\n {2}guard-version:\n([\s\S]*?)\n {2}\S/);
+  const guardJob = guardJobMatch ? guardJobMatch[1] : '';
+  if (!/bump-release-version\.mjs --type minor/.test(guardJob)) {
+    fail('guard-version job must invoke bump-release-version.mjs --type minor');
+  }
+  const buildJobMatch = release.match(/\n {2}build:\n([\s\S]*?)\n {2}\S/);
+  const buildJob = buildJobMatch ? buildJobMatch[1] : '';
+  if (!/needs:\s*guard-version/.test(buildJob)) {
+    fail('build job must declare "needs: guard-version"');
+  }
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+
+console.log('PASS: daily-release.yml bumps the patch version on a real cut, release.yml guards for a minor-only bump');


### PR DESCRIPTION
## Summary

The version printed at startup is the same number for an old install and a fresh nightly build, because nothing bumps the version between releases.

This wires the already-merged bump script into both release pipelines. Nightly builds now get a real, unique patch version.

Tagged releases now fail loudly if the version wasn't bumped by exactly one minor step.

## Review Claim

daily-release.yml commits a real patch-version bump before every nightly build, and release.yml fails the release if the tagged version isn't exactly a minor bump over the last release.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The patch bump only runs when the existing "Decide daily cut" step already decided `should_run == 'true'`. A skip day stays a no-op, with no bump commit. The release guard job only reads and compares versions; it never writes, commits, or pushes.

## Slice Rationale

This is the only slice that touches CI-pipeline behavior. The bump-version script it calls already landed and was proven separately, so this reviewer only has to check the wiring, not the bump math.

## Non-goals

No change to the daily should_run/skip decision logic itself. No auto-tagging or auto-committing inside release.yml — the guard only rejects, it never bumps or commits. No change to what daily-release.yml or release.yml publish beyond which commit/version they're built from.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-release-version-bump.mjs` — fails against unwired master, passes on this branch
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/daily-release.yml')); yaml.safe_load(open('.github/workflows/release.yml'))"` — both files parse as valid YAML
- [x] `pnpm run check:comments` — no disallowed comments added

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e580a36`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process Improvements**
  * Nightly releases now automatically increment the patch version before building and publishing.
  * Release workflows verify that package versions follow the expected minor-version progression.
  * Builds now use the commit created by the version update.

* **Tests**
  * Added automated checks to validate nightly version bumps and release version safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->