### PR TITLE
[Experiment spawn pool inherit](2) Inherit pivot poolId on experiment variants

### DIFF
--- a/packages/workflow-core/src/__tests__/graph-mutation.test.ts
+++ b/packages/workflow-core/src/__tests__/graph-mutation.test.ts
@@ -329,4 +329,32 @@ describe('applyGraphMutation', () => {
     expect(cRemap).toBeLessThan(bStale);
     expect(bStale).toBeLessThan(fixCreated);
   });
+
+  it('rejects pool-routed runnerKind without poolId at graph mutation', () => {
+    orchestrator.loadPlan({
+      name: 'test',
+      tasks: [{ id: 'A', description: 'A', command: 'echo A' }],
+    });
+    orchestrator.startExecution();
+
+    const s = (l: string) => sid(orchestrator, 0, l);
+    const wfId = orchestrator.getTask(s('A'))!.config.workflowId!;
+
+    expect(() =>
+      applyMutation(orchestrator, {
+        sourceNodeId: s('A'),
+        sourceDisposition: 'complete',
+        newNodes: [
+          {
+            id: s('exp-bad'),
+            description: 'Pool stamp without poolId',
+            dependencies: [s('A')],
+            workflowId: wfId,
+            runnerKind: 'ssh',
+          },
+        ],
+        outputNodeId: s('exp-bad'),
+      }),
+    ).toThrow(/runnerKind=ssh but no poolId/);
+  });
 });

--- a/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
@@ -138,7 +138,7 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
     });
   });
 
-  it.fails('spawned experiment tasks keep the pivot poolId (and runnerKind)', () => {
+  it('spawned experiment tasks keep the pivot poolId (and runnerKind)', () => {
     const plan: PlanDefinition = {
       name: 'experiment-pool-inherit-repro',
       baseBranch: 'main',
@@ -173,5 +173,46 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
       expect(exp.config.runnerKind, `${local} runnerKind`).toBe(pivot.config.runnerKind);
       expect(exp.config.poolId, `${local} poolId`).toBe(pivot.config.poolId);
     }
+  });
+
+  it('spawn/graph-mutation throws when runnerKind=ssh without poolId', () => {
+    orchestrator.loadPlan({
+      name: 'experiment-pool-assert',
+      tasks: [{ id: 'pivot', description: 'Pivot', pivot: true, command: 'echo pivot' }],
+    });
+    orchestrator.startExecution();
+
+    const pivotId = sid(orchestrator, 0, 'pivot');
+    const wfId = orchestrator.getTask(pivotId)!.config.workflowId!;
+
+    expect(() =>
+      (orchestrator as unknown as {
+        applyGraphMutation(mutation: {
+          sourceNodeId: string;
+          sourceDisposition: 'complete';
+          newNodes: Array<{
+            id: string;
+            description: string;
+            dependencies: string[];
+            workflowId: string;
+            runnerKind: 'ssh';
+          }>;
+          outputNodeId: string;
+        }): unknown;
+      }).applyGraphMutation({
+        sourceNodeId: pivotId,
+        sourceDisposition: 'complete',
+        newNodes: [
+          {
+            id: sid(orchestrator, 0, 'bad-exp'),
+            description: 'Missing poolId',
+            dependencies: [pivotId],
+            workflowId: wfId,
+            runnerKind: 'ssh',
+          },
+        ],
+        outputNodeId: sid(orchestrator, 0, 'bad-exp'),
+      }),
+    ).toThrow(/runnerKind=ssh but no poolId/);
   });
 });

--- a/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
@@ -138,7 +138,7 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
     });
   });
 
-  it('spawned experiment tasks keep the pivot poolId (and runnerKind)', () => {
+  it('spawned experiment tasks keep the pivot poolId, runnerKind, and execution agent/model', () => {
     const plan: PlanDefinition = {
       name: 'experiment-pool-inherit-repro',
       baseBranch: 'main',
@@ -148,6 +148,8 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
           description: 'Pivot with pool',
           pivot: true,
           poolId: 'local-mac-only',
+          executionAgent: 'codex',
+          executionModel: 'o3',
           experimentVariants: [
             { id: 'mine-00', description: 'Mine 0', command: 'echo 0' },
             { id: 'mine-01', description: 'Mine 1', command: 'echo 1' },
@@ -165,6 +167,8 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
     // Plan pools are currently stamped runnerKind=ssh at load; selectExecutor
     // remaps via pool members when poolId is present.
     expect(pivot.config.runnerKind).toBe('ssh');
+    expect(pivot.config.executionAgent).toBe('codex');
+    expect(pivot.config.executionModel).toBe('o3');
 
     orchestrator.handleWorkerResponse(spawnResponse(pivotId, ['mine-00', 'mine-01']));
 
@@ -172,7 +176,13 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
       const exp = orchestrator.getTask(sid(orchestrator, 0, local))!;
       expect(exp.config.runnerKind, `${local} runnerKind`).toBe(pivot.config.runnerKind);
       expect(exp.config.poolId, `${local} poolId`).toBe(pivot.config.poolId);
+      expect(exp.config.executionAgent, `${local} executionAgent`).toBe(pivot.config.executionAgent);
+      expect(exp.config.executionModel, `${local} executionModel`).toBe(pivot.config.executionModel);
     }
+
+    const recon = orchestrator.getTask(`${pivotId}-reconciliation`)!;
+    expect(recon.config.executionAgent).toBe('codex');
+    expect(recon.config.executionModel).toBe('o3');
   });
 
   it('spawn/graph-mutation throws when runnerKind=ssh without poolId', () => {

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -11,12 +11,26 @@
  * the validity functions in @invoker/graph.
  */
 
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig } from '@invoker/workflow-graph';
-import type { GraphMutation, OrchestratorPersistence, OrchestratorMessageBus } from './orchestrator.js';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, RunnerKind } from '@invoker/workflow-graph';
+import type { GraphMutation, GraphMutationNodeDef, OrchestratorPersistence, OrchestratorMessageBus } from './orchestrator.js';
 import { createTaskState } from '@invoker/workflow-graph';
 import { findLeafTaskIds } from '@invoker/workflow-graph';
 
 const TASK_DELTA_CHANNEL = 'task.delta';
+
+const POOL_ROUTED_RUNNER_KINDS = new Set<RunnerKind>(['ssh']);
+
+export function assertPoolRoutedGraphNodeHasPoolId(nodeDef: GraphMutationNodeDef): void {
+  if (!nodeDef.runnerKind || !POOL_ROUTED_RUNNER_KINDS.has(nodeDef.runnerKind)) {
+    return;
+  }
+  if (nodeDef.poolId) {
+    return;
+  }
+  throw new Error(
+    `Graph mutation node "${nodeDef.id}" has runnerKind=${nodeDef.runnerKind} but no poolId`,
+  );
+}
 
 // ── Host Interface ──────────────────────────────────────────
 
@@ -190,6 +204,7 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
 
   // 3. Create new nodes
   for (const nodeDef of mutation.newNodes) {
+    assertPoolRoutedGraphNodeHasPoolId(nodeDef);
     const nodeBase = {
       workflowId: nodeDef.workflowId,
       parentTask: nodeDef.parentTask,
@@ -199,6 +214,7 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       isReconciliation: nodeDef.isReconciliation,
       requiresManualApproval: nodeDef.requiresManualApproval,
       isMergeNode: nodeDef.isMergeNode,
+      ...(nodeDef.poolId ? { poolId: nodeDef.poolId } : {}),
     } as const;
     let nodeConfig: TaskConfig;
     switch (nodeDef.runnerKind) {
@@ -206,7 +222,11 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
         nodeConfig = { ...nodeBase, runnerKind: 'merge' };
         break;
       case 'docker':
-        nodeConfig = { ...nodeBase, runnerKind: 'docker' };
+        nodeConfig = {
+          ...nodeBase,
+          runnerKind: 'docker',
+          ...(nodeDef.dockerImage ? { dockerImage: nodeDef.dockerImage } : {}),
+        };
         break;
       case 'ssh':
         nodeConfig = { ...nodeBase, runnerKind: 'ssh' };

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -215,6 +215,8 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       requiresManualApproval: nodeDef.requiresManualApproval,
       isMergeNode: nodeDef.isMergeNode,
       ...(nodeDef.poolId ? { poolId: nodeDef.poolId } : {}),
+      ...(nodeDef.executionAgent ? { executionAgent: nodeDef.executionAgent } : {}),
+      ...(nodeDef.executionModel ? { executionModel: nodeDef.executionModel } : {}),
     } as const;
     let nodeConfig: TaskConfig;
     switch (nodeDef.runnerKind) {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -550,6 +550,8 @@ export interface GraphMutationNodeDef {
   runnerKind?: RunnerKind;
   poolId?: string;
   dockerImage?: string;
+  executionAgent?: string;
+  executionModel?: string;
   isReconciliation?: boolean;
   requiresManualApproval?: boolean;
   isMergeNode?: boolean;

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -548,6 +548,8 @@ export interface GraphMutationNodeDef {
   prompt?: string;
   command?: string;
   runnerKind?: RunnerKind;
+  poolId?: string;
+  dockerImage?: string;
   isReconciliation?: boolean;
   requiresManualApproval?: boolean;
   isMergeNode?: boolean;

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -359,6 +359,8 @@ export function handleSpawnExperimentsImpl(
   const parentRunnerKind = parentTask?.config.runnerKind;
   const parentDockerImage =
     parentTask?.config.runnerKind === 'docker' ? parentTask.config.dockerImage : undefined;
+  const parentExecutionAgent = parentTask?.config.executionAgent;
+  const parentExecutionModel = parentTask?.config.executionModel;
 
   const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
     id: scopeLocal(v.id),
@@ -372,6 +374,8 @@ export function handleSpawnExperimentsImpl(
     runnerKind: parentRunnerKind,
     poolId: parentPoolId,
     dockerImage: parentDockerImage,
+    executionAgent: parentExecutionAgent,
+    executionModel: parentExecutionModel,
   }));
 
   const reconciliationId = `${taskId}-reconciliation`;
@@ -388,6 +392,8 @@ export function handleSpawnExperimentsImpl(
       runnerKind: parentRunnerKind,
       poolId: parentPoolId,
       dockerImage: parentDockerImage,
+      executionAgent: parentExecutionAgent,
+      executionModel: parentExecutionModel,
     },
   ];
 

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -355,6 +355,11 @@ export function handleSpawnExperimentsImpl(
   }
   const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
 
+  const parentPoolId = parentTask?.config.poolId;
+  const parentRunnerKind = parentTask?.config.runnerKind;
+  const parentDockerImage =
+    parentTask?.config.runnerKind === 'docker' ? parentTask.config.dockerImage : undefined;
+
   const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
     id: scopeLocal(v.id),
     description: v.description ?? `Experiment: ${v.id}`,
@@ -364,7 +369,9 @@ export function handleSpawnExperimentsImpl(
     experimentPrompt: v.prompt,
     prompt: v.prompt,
     command: v.command,
-    runnerKind: parentTask?.config.runnerKind,
+    runnerKind: parentRunnerKind,
+    poolId: parentPoolId,
+    dockerImage: parentDockerImage,
   }));
 
   const reconciliationId = `${taskId}-reconciliation`;
@@ -378,6 +385,9 @@ export function handleSpawnExperimentsImpl(
       parentTask: taskId,
       isReconciliation: true,
       requiresManualApproval: true,
+      runnerKind: parentRunnerKind,
+      poolId: parentPoolId,
+      dockerImage: parentDockerImage,
     },
   ];
 


### PR DESCRIPTION
## Summary

Spawned experiment variants now keep the pivot task's poolId, runnerKind, and execution agent/model.

selectExecutor can resolve pool members again instead of failing with runnerKind=ssh but no poolMemberId.

Graph mutation also rejects pool-routed nodes that stamp runnerKind=ssh without poolId, so the bug fails at spawn instead of executor selection.

## Review Claim

Approve inheriting pivot poolId, dockerImage, executionAgent, and executionModel onto experiment and reconciliation nodes, plus a spawn-time poolId assert for pool-routed runnerKind.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only graph-mutation spawn routing changes; no change to pool capacity math or SSH lease logic.

## Slice Rationale

Behavior fix after the repro slice that locked the missing poolId failure; follow-up also covers Claude/Codex agent and model inheritance.

## Non-goals

Does not stop plan load from labeling pooled tasks as runnerKind=ssh.

Does not change defaultPoolId selection or mixed SSH/worktree member picking.

## Architecture

### Before

```mermaid
graph TD
    P["pivot poolId set, runnerKind ssh"]
    E["exp runnerKind ssh, poolId missing"]
    X["selectExecutor throws"]
    P --> E --> X
```

### After

```mermaid
graph TD
    P["pivot poolId, agent, model set"]
    E["exp inherits poolId, agent, model"]
    M["selectExecutor remaps via pool member"]
    P --> E --> M
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/repro-experiment-spawn-pool-inherit.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
