### PR TITLE
[IPC Profile Gaps Step 1: fix scripts/headless-ipc.js](1) Bundle contracts into transport

### DIFF
--- a/packages/transport/tsup.config.ts
+++ b/packages/transport/tsup.config.ts
@@ -7,6 +7,7 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  noExternal: ['@invoker/contracts'],
   dts: {
     compilerOptions: {
       composite: false,


### PR DESCRIPTION
## Summary

The transport build now embeds its existing contracts dependency in the generated module.

This keeps the built transport entry point importable when a standalone script loads it outside package source resolution.

No transport API or runtime decision changes in this foundation slice.

## Review Claim

Approve one transport build-boundary change that embeds the existing contracts dependency in generated output without changing transport logic.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The build still exposes the same transport entry point, types, and runtime logic. Only dependency packaging changes, and the contracts package is already required by transport.

## Slice Rationale

This foundation lands before the headless client change because its focused check imports the built transport module without relying on workspace source links.

## Non-goals

- No change to transport APIs or message-bus behavior.
- No change to contracts source or exports.
- No change to any IPC client.

## Architecture

### Before

```mermaid
graph LR
    A["transport dist"] --> B["external workspace contracts module"]
```

### After

```mermaid
graph LR
    A["transport dist"] --> B["embedded contracts dependency"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/transport build` — `DTS ⚡️ Build success`, `TRANSPORT_BUILD_EXIT=0`
- [x] `pnpm run check:comments` — `[comments] Checked added source lines; no disallowed comments found.`, `COMMENT_CHECK_EXIT=0`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Rebuild `@invoker/transport`.
- Data migration? No

</details>
