### PR TITLE
No-Mergify observed CI repair (3) Tolerate wrapped publisher JSON

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -405,6 +405,17 @@ describe('make-pr stack publish body contract', () => {
     expect(parsed[0]?.id).toBe('a');
   });
 
+  it('extracts balanced JSON when surrounding commentary and quoted strings contain braces', () => {
+    const title = 'Keep } inside an escaped "quote" and { inside the string';
+    const payload = JSON.stringify({
+      artifacts: [{ id: 'a', url: 'https://x/1', title }],
+    });
+    const raw = `Preparing {draft} output.\n${payload}\nFinished with } commentary.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.title).toBe(title);
+  });
+
   it('still throws "must output JSON" for genuinely non-JSON output', () => {
     expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
       'make-pr stack publisher must output JSON',

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -426,6 +426,14 @@ describe('make-pr stack publish body contract', () => {
     expect(parsed[0]?.id).toBe('a');
   });
 
+  it('extracts nested artifact JSON from an invalid enclosing brace span', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = `Note: {payload follows: ${payload}}`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
   it('still throws "must output JSON" for genuinely non-JSON output', () => {
     expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
       'make-pr stack publisher must output JSON',

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -416,6 +416,16 @@ describe('make-pr stack publish body contract', () => {
     expect(parsed[0]?.title).toBe(title);
   });
 
+  it('does not let a valid-JSON decoy in leading commentary shadow the real artifacts payload', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    // "{}" is itself valid, parseable JSON -- a naive first-match scanner
+    // would stop here and never reach the real payload below it.
+    const raw = `Status: {}\nHere is the published review stack:\n${payload}`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
   it('still throws "must output JSON" for genuinely non-JSON output', () => {
     expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
       'make-pr stack publisher must output JSON',

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -380,6 +380,36 @@ describe('make-pr stack publish body contract', () => {
     // The caller validates this empty body and falls through to the next agent.
     expect(validateReviewStackPrBody(parsed[0]?.body ?? '').length).toBeGreaterThan(0);
   });
+
+  it('parses JSON wrapped in a ```json fenced code block despite the no-fences instruction', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```json\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('parses JSON wrapped in a bare ``` fenced code block', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts a JSON object surrounded by commentary the agent added despite instructions', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = `Here is the published review stack:\n${payload}\nLet me know if you need anything else.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('still throws "must output JSON" for genuinely non-JSON output', () => {
+    expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
+      'make-pr stack publisher must output JSON',
+    );
+  });
 });
 
 // ── resolveSkillPathViaAgent ─────────────────────────────

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -408,10 +408,6 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
 
 function extractJsonPayload(raw: string): string {
   const trimmed = raw.trim();
-  // Prefer the LAST balanced, parseable top-level JSON object rather than the
-  // first: agent output can contain leading commentary that happens to
-  // include its own valid JSON object (even just "{}"), which would
-  // otherwise shadow the real payload appearing later in the same output.
   let lastValid: string | undefined;
   for (let start = 0; start < trimmed.length; start += 1) {
     if (trimmed[start] !== '{') continue;
@@ -443,9 +439,7 @@ function extractJsonPayload(raw: string): string {
           try {
             JSON.parse(candidate);
             lastValid = candidate;
-          } catch {
-            // Not valid JSON; fall through and keep scanning from end + 1.
-          }
+          } catch {}
           start = end;
           break;
         }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -439,8 +439,8 @@ function extractJsonPayload(raw: string): string {
           try {
             JSON.parse(candidate);
             lastValid = candidate;
+            start = end;
           } catch {}
-          start = end;
           break;
         }
       }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -406,12 +406,29 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
   return providerId;
 }
 
+function extractJsonPayload(raw: string): string {
+  const trimmed = raw.trim();
+  const fenceMatch = /^```(?:json)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed);
+  if (fenceMatch) return fenceMatch[1].trim();
+
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return trimmed.slice(firstBrace, lastBrace + 1);
+  }
+  return trimmed;
+}
+
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.trim());
   } catch {
-    throw new Error('make-pr stack publisher must output JSON');
+    try {
+      parsed = JSON.parse(extractJsonPayload(raw));
+    } catch {
+      throw new Error('make-pr stack publisher must output JSON');
+    }
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -408,13 +408,42 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
 
 function extractJsonPayload(raw: string): string {
   const trimmed = raw.trim();
-  const fenceMatch = /^```(?:json)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed);
-  if (fenceMatch) return fenceMatch[1].trim();
+  for (let start = 0; start < trimmed.length; start += 1) {
+    if (trimmed[start] !== '{') continue;
 
-  const firstBrace = trimmed.indexOf('{');
-  const lastBrace = trimmed.lastIndexOf('}');
-  if (firstBrace !== -1 && lastBrace > firstBrace) {
-    return trimmed.slice(firstBrace, lastBrace + 1);
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let end = start; end < trimmed.length; end += 1) {
+      const character = trimmed[end];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === '{') {
+        depth += 1;
+      } else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = trimmed.slice(start, end + 1);
+          try {
+            JSON.parse(candidate);
+            return candidate;
+          } catch {
+            break;
+          }
+        }
+      }
+    }
   }
   return trimmed;
 }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -408,6 +408,11 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
 
 function extractJsonPayload(raw: string): string {
   const trimmed = raw.trim();
+  // Prefer the LAST balanced, parseable top-level JSON object rather than the
+  // first: agent output can contain leading commentary that happens to
+  // include its own valid JSON object (even just "{}"), which would
+  // otherwise shadow the real payload appearing later in the same output.
+  let lastValid: string | undefined;
   for (let start = 0; start < trimmed.length; start += 1) {
     if (trimmed[start] !== '{') continue;
 
@@ -437,15 +442,17 @@ function extractJsonPayload(raw: string): string {
           const candidate = trimmed.slice(start, end + 1);
           try {
             JSON.parse(candidate);
-            return candidate;
+            lastValid = candidate;
           } catch {
-            break;
+            // Not valid JSON; fall through and keep scanning from end + 1.
           }
+          start = end;
+          break;
         }
       }
     }
   }
-  return trimmed;
+  return lastValid ?? trimmed;
 }
 
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1312,26 +1312,6 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
         self.assertEqual(actions, ())
 
-    def test_empty_required_checks_failed_observed_catstack_ci_repairs_before_squash_or_requeue(self):
-        checks = {
-            "lint": check("lint"),
-            "test": check("test", "failure"),
-        }
-        stack = StackGroup("s", (pr(9003, base="master", labels={"admin-bypass"}, checks=checks, latest=None),))
-        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9003, "test")])
-        self.assertNotIn("squash_merge", {a.kind for a in actions})
-        self.assertNotIn("requeue", {a.kind for a in actions})
-
-    def test_catstack_failing_test_plans_repair_not_squash_or_queue(self):
-        checks = {
-            "lint": check("lint"),
-            "test": check("test", "failure"),
-        }
-        stack = StackGroup("s", (pr(9010, base="main", labels={"admin-bypass"}, checks=checks, latest=None),))
-        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9010, "test")])
-
     def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
         stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1312,6 +1312,26 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
         self.assertEqual(actions, ())
 
+    def test_empty_required_checks_failed_observed_catstack_ci_repairs_before_squash_or_requeue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9003, base="master", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9003, "test")])
+        self.assertNotIn("squash_merge", {a.kind for a in actions})
+        self.assertNotIn("requeue", {a.kind for a in actions})
+
+    def test_catstack_failing_test_plans_repair_not_squash_or_queue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9010, base="main", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9010, "test")])
+
     def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
         stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)


### PR DESCRIPTION
## Summary

Accept stack publisher JSON when an agent wraps it in a code fence or adds text around it.

Keep exact JSON handling and the same malformed-output error.

## Review Claim

Publisher output parsing accepts a single JSON object inside common agent wrappers while keeping artifact checks unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Artifact ordering, dependency checks, required body checks, provider IDs, branch fields, and genuinely malformed-output errors remain unchanged.

## Slice Rationale

This separate parser-boundary slice lets the review gate consume compliant artifact data even when an agent adds presentation text.

## Non-goals

No prompt schema, artifact shape, GitHub mutation, user interface, or unrelated changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-authoring.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f45e8fb6916aab61ce0325aeadd619e3a3b719a8`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parser-boundary change with downstream artifact validation unchanged; wrong JSON selection is mitigated by preferring the last valid object and new regression tests.
> 
> **Overview**
> **`parseMakePrStackPublishResult`** now accepts make-pr stack publisher output when agents ignore the “JSON only” instruction and wrap or pad the payload.
> 
> Parsing still tries a direct **`JSON.parse`** on trimmed input first. On failure it runs a new **`extractJsonPayload`** helper that walks balanced `{…}` spans (respecting strings and escapes), keeps the **last** successfully parseable object (so a leading `{}` decoy does not win), then parses that string. Artifact shape, ordering, dependency rules, body handling, and the **`make-pr stack publisher must output JSON`** error for truly non-JSON text are unchanged.
> 
> Tests cover ```json`/bare fences, surrounding prose, braces inside strings and commentary, decoy JSON, and nested payloads inside invalid outer brace spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797fc20a7b00ed6a8b7ff0f924830fe7f28b9d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of pull request publishing results when JSON is surrounded by commentary, formatting fences, or other text.
  - Correctly handles quoted strings, escaped characters, and multiple JSON objects while identifying the relevant result.
  - Continues to reject genuinely invalid non-JSON output with an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->