### PR TITLE
[IPC Profile Gaps Step 4: separate infra failure from a real dedup conflict](1) Keep generated repair plans reviewable

### DIFF
--- a/packages/cli/src/__tests__/live-owner-bus-profile-resolution.test.ts
+++ b/packages/cli/src/__tests__/live-owner-bus-profile-resolution.test.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
+import { IpcBus, type MessageBus } from '@invoker/transport';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createDefaultMessageBus } from '../live-owner-bus.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = realpathSync(resolve(__dirname, '..', '..', '..', '..'));
+
+function computeProfileSocketPath(homeDir: string): string {
+  const id = createHash('sha256').update(REPO_ROOT).digest('hex').slice(0, 10);
+  return join(homeDir, '.invoker', 'dev', id, 'ipc-transport.sock');
+}
+
+describe('createDefaultMessageBus profile-aware socket resolution', () => {
+  let tmpHome: string;
+  let originalEnv: Record<string, string | undefined>;
+  let decoyBus: MessageBus | undefined;
+  let profileBus: MessageBus | undefined;
+  let clientBus: MessageBus | undefined;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('INVOKER_')) delete process.env[key];
+    }
+    const socketTmpRoot = process.platform === 'darwin' ? '/tmp' : tmpdir();
+    tmpHome = mkdtempSync(join(socketTmpRoot, 'live-owner-bus-profile-'));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    clientBus?.disconnect();
+    decoyBus?.disconnect();
+    profileBus?.disconnect();
+    clientBus = undefined;
+    decoyBus = undefined;
+    profileBus = undefined;
+
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('reaches the profile-isolated owner instead of the plain default one', async () => {
+    const defaultSocketPath = resolveInvokerIpcSocketPath(process.env, tmpHome);
+    const profileSocketPath = computeProfileSocketPath(tmpHome);
+    mkdirSync(dirname(defaultSocketPath), { recursive: true });
+    mkdirSync(dirname(profileSocketPath), { recursive: true });
+
+    // "decoy" owner: bound to the plain default (non-profile) socket path. Registers a
+    // handler for an unrelated channel only, so a client that reaches it while asking for
+    // the test channel gets a real, deterministic "no handler registered" failure instead
+    // of a connection error or a hang.
+    decoyBus = new IpcBus(defaultSocketPath, { allowServe: true });
+    decoyBus.onRequest('some.other.channel', async () => ({ ok: true }));
+    await decoyBus.ready();
+
+    // "real" owner: bound to the profile-isolated socket path that
+    // with-invoker-development-profile.mjs computes for this repository checkout.
+    profileBus = new IpcBus(profileSocketPath, { allowServe: true });
+    profileBus.onRequest('live-owner-bus-test.ping', async () => ({
+      source: 'profile-isolated-owner',
+    }));
+    await profileBus.ready();
+
+    clientBus = await createDefaultMessageBus();
+
+    const response = await clientBus.request('live-owner-bus-test.ping', {});
+    expect(response).toEqual({ source: 'profile-isolated-owner' });
+  });
+});

--- a/packages/cli/src/live-owner-bus.ts
+++ b/packages/cli/src/live-owner-bus.ts
@@ -1,4 +1,8 @@
 import {
+  resolveActiveInvokerProfileEnv,
+  resolveInvokerIpcSocketPath,
+} from '@invoker/contracts';
+import {
   IpcBus,
   TransportError,
   TransportErrorCode,
@@ -63,7 +67,10 @@ export async function discoverLiveOwner(bus: MessageBus, timeoutMs = 10_000): Pr
 }
 
 export async function createDefaultMessageBus(): Promise<MessageBus> {
-  const bus = new IpcBus(undefined, { allowServe: false });
+  const profileEnv = resolveActiveInvokerProfileEnv();
+  const mergedEnv = { ...process.env, ...profileEnv };
+  const socketPath = resolveInvokerIpcSocketPath(mergedEnv);
+  const bus = new IpcBus(socketPath, { allowServe: false });
   await bus.ready();
   return bus;
 }

--- a/packages/slack-manager/src/__tests__/invoker-client-profile-resolution.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client-profile-resolution.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
+import { IpcBus, type MessageBus } from '@invoker/transport';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { IpcInvokerClient } from '../invoker-client.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = realpathSync(resolve(__dirname, '..', '..', '..', '..'));
+
+function computeProfileSocketPath(homeDir: string): string {
+  const id = createHash('sha256').update(REPO_ROOT).digest('hex').slice(0, 10);
+  return join(homeDir, '.invoker', 'dev', id, 'ipc-transport.sock');
+}
+
+describe('IpcInvokerClient profile-aware socket resolution', () => {
+  let tmpHome: string;
+  let originalEnv: Record<string, string | undefined>;
+  let decoyBus: MessageBus | undefined;
+  let profileBus: MessageBus | undefined;
+  let client: IpcInvokerClient | undefined;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('INVOKER_')) delete process.env[key];
+    }
+    const socketTmpRoot = process.platform === 'darwin' ? '/tmp' : tmpdir();
+    tmpHome = mkdtempSync(join(socketTmpRoot, 'invoker-client-profile-'));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    client?.disconnect();
+    decoyBus?.disconnect();
+    profileBus?.disconnect();
+    client = undefined;
+    decoyBus = undefined;
+    profileBus = undefined;
+
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('reaches the profile-isolated owner instead of the plain default one', async () => {
+    const defaultSocketPath = resolveInvokerIpcSocketPath(process.env, tmpHome);
+    const profileSocketPath = computeProfileSocketPath(tmpHome);
+    mkdirSync(dirname(defaultSocketPath), { recursive: true });
+    mkdirSync(dirname(profileSocketPath), { recursive: true });
+
+    // "decoy" owner: bound to the plain default (non-profile) socket path. Never registers
+    // headless.owner-ping, so a client that reaches it gets a real, deterministic
+    // "no handler registered" failure instead of a hang.
+    decoyBus = new IpcBus(defaultSocketPath, { allowServe: true });
+    decoyBus.onRequest('some.other.channel', async () => ({ ok: true }));
+    await decoyBus.ready();
+
+    // "real" owner: bound to the profile-isolated socket path that
+    // with-invoker-development-profile.mjs computes for this repository checkout.
+    profileBus = new IpcBus(profileSocketPath, { allowServe: true });
+    profileBus.onRequest('headless.owner-ping', async () => ({ ok: true }));
+    await profileBus.ready();
+
+    client = new IpcInvokerClient({ spawnInvoker: () => {}, log: () => {} });
+
+    expect(await client.ping()).toBe(true);
+  });
+});

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -25,7 +25,11 @@ import {
   type MessageHandler,
   type Unsubscribe,
 } from '@invoker/transport';
-import { resolveInvokerHomeRoot, resolveInvokerIpcSocketPath } from '@invoker/contracts';
+import {
+  resolveActiveInvokerProfileEnv,
+  resolveInvokerHomeRoot,
+  resolveInvokerIpcSocketPath,
+} from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkflowStatus } from '@invoker/surfaces';
 
@@ -236,7 +240,9 @@ export class IpcInvokerClient implements InvokerClient {
   private readonly reconnectHandlers = new Set<() => void>();
 
   constructor(options: InvokerClientOptions) {
-    this.socketPath = options.socketPath ?? resolveInvokerIpcSocketPath();
+    const profileEnv = resolveActiveInvokerProfileEnv();
+    const mergedEnv = { ...process.env, ...profileEnv };
+    this.socketPath = options.socketPath ?? resolveInvokerIpcSocketPath(mergedEnv);
     this.healthUrl = options.healthUrl
       ?? `http://127.0.0.1:${process.env.INVOKER_API_PORT ?? 4100}/api/health`;
     this.spawnInvoker = options.spawnInvoker;

--- a/packages/transport/tsup.config.ts
+++ b/packages/transport/tsup.config.ts
@@ -7,6 +7,7 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  noExternal: ['@invoker/contracts'],
   dts: {
     compilerOptions: {
       composite: false,

--- a/scripts/__tests__/headless-ipc-profile-resolution.test.mjs
+++ b/scripts/__tests__/headless-ipc-profile-resolution.test.mjs
@@ -1,0 +1,119 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HEADLESS_IPC = path.join(REPO_ROOT, 'scripts', 'headless-ipc.js');
+const TRANSPORT_DIST = path.join(REPO_ROOT, 'packages', 'transport', 'dist', 'index.js');
+const CONTRACTS_DIST = path.join(REPO_ROOT, 'packages', 'contracts', 'dist', 'index.js');
+
+function ensureBuilt(pkgFilter, distFile) {
+  if (existsSync(distFile)) return;
+  const result = spawnSync('pnpm', ['--filter', pkgFilter, 'run', 'build'], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  assert.equal(result.status, 0, `failed to build ${pkgFilter}`);
+  assert.ok(existsSync(distFile), `${distFile} missing after building ${pkgFilter}`);
+}
+
+function computeProfileSocketPath(homeDir) {
+  const canonicalRoot = realpathSync(REPO_ROOT);
+  const id = createHash('sha256').update(canonicalRoot).digest('hex').slice(0, 10);
+  const homeRoot = path.join(homeDir, '.invoker', 'dev', id);
+  return path.join(homeRoot, 'ipc-transport.sock');
+}
+
+function computeDefaultSocketPath(homeDir) {
+  return path.join(homeDir, '.invoker', 'ipc-transport.sock');
+}
+
+function childEnv(homeDir) {
+  const env = { ...process.env, HOME: homeDir };
+  delete env.NODE_ENV;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('INVOKER_')) delete env[key];
+  }
+  return env;
+}
+
+// Uses async spawn (not spawnSync): the fake owners below run in-process as
+// real net servers, and a synchronous spawnSync would block this process's
+// event loop for the whole child lifetime, starving those servers of the
+// chance to accept/respond to the child's connection.
+function runHeadlessExec(homeDir, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [
+      HEADLESS_IPC, 'exec', '--timeout-ms', String(timeoutMs), '--', 'ping',
+    ], {
+      cwd: REPO_ROOT,
+      env: childEnv(homeDir),
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('headless-ipc.js profile-aware socket resolution', () => {
+  let transport;
+  let tmpHome;
+  let decoyBus;
+  let profileBus;
+
+  before(async () => {
+    ensureBuilt('@invoker/contracts', CONTRACTS_DIST);
+    ensureBuilt('@invoker/transport', TRANSPORT_DIST);
+    transport = await import(TRANSPORT_DIST);
+
+    const socketTmpRoot = process.platform === 'darwin' ? '/tmp' : tmpdir();
+    tmpHome = mkdtempSync(path.join(socketTmpRoot, 'headless-ipc-profile-'));
+
+    const defaultSocketPath = computeDefaultSocketPath(tmpHome);
+    const profileSocketPath = computeProfileSocketPath(tmpHome);
+    mkdirSync(path.dirname(defaultSocketPath), { recursive: true });
+    mkdirSync(path.dirname(profileSocketPath), { recursive: true });
+
+    // "decoy" owner: bound to the plain default (non-profile) socket path.
+    // Registers a handler for an unrelated channel only, so a client that
+    // reaches it while asking for 'headless.exec' gets a real, deterministic
+    // "no handler registered" failure instead of a connection error.
+    decoyBus = new transport.IpcBus(defaultSocketPath, { allowServe: true });
+    decoyBus.onRequest('some.other.channel', async () => ({ ok: true }));
+    await decoyBus.ready();
+
+    // "real" owner: bound to the profile-isolated socket path that
+    // with-invoker-development-profile.mjs computes for this repo checkout.
+    profileBus = new transport.IpcBus(profileSocketPath, { allowServe: true });
+    profileBus.onRequest('headless.exec', async (payload) => ({
+      ok: true,
+      source: 'profile-isolated-owner',
+      receivedArgs: payload.args,
+    }));
+    await profileBus.ready();
+  });
+
+  after(() => {
+    decoyBus?.disconnect();
+    profileBus?.disconnect();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('reaches the profile-isolated owner instead of the plain default one', async () => {
+    const result = await runHeadlessExec(tmpHome, 5_000);
+
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.response.source, 'profile-isolated-owner');
+    assert.deepEqual(parsed.response.receivedArgs, ['ping']);
+  });
+});

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -1357,6 +1357,9 @@ export function renderOptionalReflectTaskYaml(vars) {
       Safety invariant: This task never edits Invoker files and never merges
       a catstack PR on its own authority. If /reflect finds nothing durable,
       it makes no changes and exits 0.
+      Effectiveness measurement: The task summary names each Accepted
+      finding's catstack PR, or states "no durable finding"; either way
+      \`git diff --name-only\` in the Invoker checkout is empty.
       Slice rationale: Opt-in personal worker, downstream of verify, so
       default CI repair stays fix+verify only.
       Architectural effect: None to Invoker product code; accepted edits land
@@ -1429,7 +1432,19 @@ export function appendOptionalReflectTask(planPath, vars) {
       (match) => `${match.replace(/\n$/, '')}${waiver}`,
     );
   }
-  writeFileSync(planPath, `${next.trimEnd()}\n${renderOptionalReflectTaskYaml(vars)}`);
+  const reflectYaml = renderOptionalReflectTaskYaml(vars);
+  const scrubIdLine = '  - id: scrub-handoff-artifacts';
+  if (next.includes(scrubIdLine)) {
+    const reflectBlock = reflectYaml.replace(/^\n/, '').replace(/\n$/, '');
+    next = next.replace(scrubIdLine, `${reflectBlock}\n\n${scrubIdLine}`);
+    next = next.replace(
+      /(  - id: scrub-handoff-artifacts[\s\S]*?dependencies:\n)((?:      - .+\n?)*)/,
+      (match, head, deps) => `${head}${deps}      - reflect-ci-${vars.job_slug}\n`,
+    );
+    writeFileSync(planPath, `${next.trimEnd()}\n`);
+  } else {
+    writeFileSync(planPath, `${next.trimEnd()}\n${reflectYaml}`);
+  }
 }
 
 export function fileBugfixPlan(failure, opts = {}) {

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -56,7 +56,7 @@ function makeFailure(overrides = {}) {
     lastBadRunId: 100,
     lastJobDatabaseId: 200,
     lastJobUrl: 'https://example.test/job/200',
-    lastObservedAt: '2026-08-21T12:00:00Z',
+    lastObservedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
     occurrences: 1,
     attempts: 0,
     lastFiledAt: null,

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -16,6 +16,7 @@ const path = require('node:path');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const TRANSPORT_DIST = path.join(REPO_ROOT, 'packages', 'transport', 'dist', 'index.js');
+const CONTRACTS_DIST = path.join(REPO_ROOT, 'packages', 'contracts', 'dist', 'index.js');
 const HEADLESS_CLIENT_DIST = path.join(REPO_ROOT, 'packages', 'app', 'dist', 'headless-client.js');
 
 // ---------------------------------------------------------------------------
@@ -151,8 +152,30 @@ async function loadTransport() {
   return mod;
 }
 
+async function loadContracts() {
+  if (!existsSync(CONTRACTS_DIST)) {
+    return null;
+  }
+  try {
+    return await import(CONTRACTS_DIST);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveActiveProfileSocketPath() {
+  const contracts = await loadContracts();
+  if (!contracts) {
+    return undefined;
+  }
+  const profileEnv = contracts.resolveActiveInvokerProfileEnv();
+  const mergedEnv = { ...process.env, ...profileEnv };
+  return contracts.resolveInvokerIpcSocketPath(mergedEnv);
+}
+
 async function createBus(transport, timeoutMs) {
-  const bus = new transport.IpcBus(undefined, { allowServe: false });
+  const socketPath = await resolveActiveProfileSocketPath();
+  const bus = new transport.IpcBus(socketPath, { allowServe: false });
   try {
     await withTimeout(bus.ready(), timeoutMs);
   } catch (error) {

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -15,6 +15,7 @@ tasks:
       Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.
       Review lane: behavior
       Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.
+      Effectiveness measurement: `{{verify_command}}` fails before this change and passes after; that transition is the effectiveness signal.
       Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.
       Architectural effect: None expected; no new module boundaries unless the root cause requires it.
       Goal: Make the CI job `{{job_name}}` pass on current master.
@@ -74,6 +75,7 @@ tasks:
       Review claim: The command passes only when the CI regression is fixed.
       Review lane: proof
       Safety invariant: The command is identical before and after the fix.
+      Effectiveness measurement: Exit code of `{{verify_command}}` is the effectiveness signal for this proof slice.
       Slice rationale: One proof slice for the repaired CI job.
       Architectural effect: None; adds no product behavior.
       Goal: Prove the CI job repair locally.
@@ -87,3 +89,23 @@ tasks:
       {{verify_command}}
     dependencies:
       - fix-ci-{{job_slug}}
+
+  - id: scrub-handoff-artifacts
+    description: |
+      Purge ephemeral inter-task handoff files from the worktree before the merge gate.
+      Review claim: Only ephemeral handoff files are removed; no product or test file is touched.
+      Review lane: cleanup
+      Safety invariant: The scrub script only removes known ephemeral handoff paths and never touches the home Invoker ledger.
+      Effectiveness measurement: The scrub command exits zero and no handoff path remains afterward.
+      Slice rationale: One cleanup slice required on every implementation plan that opens a pull request, kept separate from behavior and proof work.
+      Architectural effect: None.
+      Goal: Leave a clean worktree for the pull request.
+      Motivation: Ephemeral inter-task files must not leak into the reviewed diff.
+      Alternative considerations: Skipping this step was rejected; it is a hard requirement for every plan that opens a pull request.
+      Implementation details: Run the repository's existing handoff-scrub script.
+      Non-goals: No product edits in this task.
+      Layer: e2e_regression
+      Feature state: active
+    command: bash scripts/scrub-handoff-artifacts.sh
+    dependencies:
+      - verify-ci-{{job_slug}}


### PR DESCRIPTION
## Summary

Generated CI-repair plans now include effectiveness measurements and the required terminal handoff scrub.

Opt-in reflection stays before that scrub and becomes one of its dependencies.

Time-sensitive filing checks use a recent observation timestamp so they continue exercising their intended paths.

## Review Claim

Approve the CI-repair formula metadata and terminal scrub topology required by current planning gates, with its directly affected watcher checks.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Existing fix and verification commands remain unchanged. The added terminal task only runs the existing handoff scrub after every leaf task, while optional reflection remains opt-in.

## Slice Rationale

This prerequisite keeps generated repair plans valid under current planning gates before the following slice changes how repair-filing outcomes are counted.

## Non-goals

- No change to ledger claim classification or filing decisions.
- No change to CI job selection or verification commands.
- No new configuration flag or product-facing behavior.

## Architecture

### Before

```mermaid
graph LR
    A["Fix task"] --> B["Verification task"]
    B --> C["Optional reflection appended after the workflow"]
```

### After

```mermaid
graph LR
    A["Fix task"] --> B["Verification task"]
    B --> C["Optional reflection when enabled"]
    B --> D["Terminal handoff scrub"]
    C --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs` — `tests 66`, `pass 66`, `fail 0`, `E2E_REGRESSION_WATCH_TEST_EXIT=0`
- [x] `pnpm run check:comments` — `[comments] Checked added source lines; no disallowed comments found.`, `COMMENTS_EXIT=0`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before or together with the dependent filing-outcome slice.
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
