### PR TITLE
[Electron preprovision repro fixtures](1) Fix dev-profile wrap crash

### DIFF
--- a/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
+++ b/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
@@ -31,6 +31,7 @@ mkdir -p \
   "$TMP_DIR/repo/node_modules/extract-zip" \
   "$TMP_DIR/empty-path"
 cp "$ROOT_DIR/scripts/electron.cjs" "$TMP_DIR/repo/scripts/electron.cjs"
+cp "$ROOT_DIR/scripts/electron-development-profile-guard.cjs" "$TMP_DIR/repo/scripts/electron-development-profile-guard.cjs"
 
 cat >"$TMP_DIR/repo/node_modules/electron/package.json" <<'JSON'
 {
@@ -105,7 +106,7 @@ JS
 set +e
 (
   cd "$TMP_DIR/repo"
-  node scripts/electron.cjs --ensure-only
+  INVOKER_DEVELOPMENT_PROFILE_ACTIVE=1 node scripts/electron.cjs --ensure-only
 ) >"$TMP_DIR/stdout" 2>"$TMP_DIR/stderr"
 STATUS=$?
 set -e

--- a/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
+++ b/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
@@ -99,6 +99,7 @@ run_fake_headless() {
   rm -f "$PNPM_CALLS" "$RUN_STDOUT" "$RUN_STDERR"
   status=0
   HOME="$TMP_DIR/home" \
+    INVOKER_DEVELOPMENT_PROFILE_ACTIVE=1 \
     INVOKER_FORCE_BOOTSTRAP="$force_bootstrap" \
     INVOKER_DB_DIR="$TMP_DIR/db" \
     INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \


### PR DESCRIPTION
## Summary

CI job `e2e-proof / shard 1` (run 33160903007) fails on current master. The
`08-electron-preprovision-repro.sh` suite crashes with `MODULE_NOT_FOUND`
before it ever runs its real assertions.

`scripts/electron.cjs` and `run.sh` both now load a small isolation helper
file at startup.

Two repro scripts build a synthetic, stripped-down copy of the repo to
test these entrypoints. Neither synthetic copy included that new helper
or opted out of it.

This copies the missing helper file into one fixture and sets the existing
opt-out flag in the other, so both repros reach the behavior they were
written to test.

## Review Claim

Approve that both repro fixtures again reach their real assertions instead
of crashing on an unrelated missing-module error.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Both changes only affect throwaway temp fixtures these scripts build and
delete on every run; `scripts/electron.cjs` and `run.sh` themselves are
untouched.

## Slice Rationale

One CI-only fixture defect, fixed at both of its two call sites in the
same failing suite; splitting further would leave the suite red.

## Non-goals

Does not change `scripts/electron.cjs`, `run.sh`, or the isolation guard
itself. Does not address any other CI job.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/08-electron-preprovision-repro.sh` on a Linux host (matching the CI runner) — exit 0, both `remote-electron-provisioning fixed` lines and `repro: confirmed fixed behavior` printed.
- [x] Same command failed with `Cannot find module './electron-development-profile-guard.cjs'` before this change, confirming the fix addresses the actual failure.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 56b3296d3a`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reproduction scenarios to validate behavior when the development profile is active.
  * Improved coverage for remote Electron provisioning and preprovisioned bootstrap flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->