### PR TITLE
Camera thrash hardening (1) selection never moves camera — proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1663,6 +1663,63 @@ test.describe('Visual proof capture', () => {
     expect(afterClick, 'camera viewport should stay exactly where it was after clicking empty background').toBe(afterSelect);
   });
 
+  test('graph-selection-camera-stable — main graph viewport is unchanged across workflow selection and background deselection', async ({ page }) => {
+    const beforeIds = await page.evaluate(async () => {
+      const workflows = await window.invoker.listWorkflows();
+      return workflows.map((workflow: { id: string }) => workflow.id);
+    });
+    await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(MENU_PROOF_PLAN));
+    const findNewWorkflowId = async (): Promise<string | null> => page.evaluate(async (knownIds) => {
+      const workflows = await window.invoker.listWorkflows();
+      return workflows.find((candidate: { id: string }) => !knownIds.includes(candidate.id))?.id ?? null;
+    }, beforeIds);
+    await expect.poll(findNewWorkflowId, { timeout: 10000 }).not.toBeNull();
+    const workflowId = await findNewWorkflowId();
+    expect(workflowId).toBeTruthy();
+
+    await openPlanGraph(page);
+    await page.getByTestId('rail-refresh').click();
+    await page.waitForTimeout(300);
+    await page.getByTestId(`workflow-node-${workflowId}`).first().waitFor({ state: 'visible', timeout: 15000 });
+
+    const surface = page.getByTestId('workflow-graph-surface');
+    const mainViewport = surface.getByTestId('workflow-graph-content').locator('.react-flow__viewport').first();
+    const beforeSelect = await waitForStableViewportTransform(page, mainViewport);
+    await captureScreenshot(page, 'graph-selection-camera-stable-before-select');
+
+    await selectWorkflowNode(page, workflowId!, 'Menu Proof Workflow');
+    const miniDag = page.getByTestId('selected-workflow-mini-dag');
+    await expect(miniDag).toBeVisible();
+    const afterSelect = await waitForStableViewportTransform(page, mainViewport);
+    await captureScreenshot(page, 'graph-selection-camera-stable-after-select');
+
+    const pane = surface.locator('.react-flow__pane').first();
+    const paneBox = await pane.boundingBox();
+    if (!paneBox) throw new Error('workflow graph pane has no bounding box');
+    const workflowNodeBox = await surface.locator('[data-testid^="workflow-node-"]').first().boundingBox();
+    const miniDagBox = await miniDag.boundingBox();
+    const isInsideBox = (x: number, y: number, box: { x: number; y: number; width: number; height: number } | null) =>
+      !!box && x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height;
+    const candidates = [
+      { x: paneBox.x + 24, y: paneBox.y + paneBox.height - 24 },
+      { x: paneBox.x + paneBox.width - 24, y: paneBox.y + paneBox.height - 24 },
+      { x: paneBox.x + 24, y: paneBox.y + 24 },
+    ];
+    const clickPoint = candidates.find(
+      (point) => !isInsideBox(point.x, point.y, workflowNodeBox) && !isInsideBox(point.x, point.y, miniDagBox),
+    );
+    if (!clickPoint) throw new Error('could not find an empty background point to click');
+    await page.mouse.click(clickPoint.x, clickPoint.y);
+    await page.waitForTimeout(200);
+
+    const afterBackground = await waitForStableViewportTransform(page, mainViewport);
+    await captureScreenshot(page, 'graph-selection-camera-stable-after-background');
+
+    console.log(`[graph-selection-camera-stable] main graph viewport: initial="${beforeSelect}" after-select="${afterSelect}" after-background="${afterBackground}"`);
+    expect(afterSelect, 'camera viewport should stay exactly where it was after selecting a workflow').toBe(beforeSelect);
+    expect(afterBackground, 'camera viewport should stay exactly where it was after clicking empty background').toBe(afterSelect);
+  });
+
   test('graph-camera-lock-navigation — task graph remains usable after keyboard and manual camera moves', async ({ page }) => {
     await loadPlanAndSelectWorkflow(page, DAG_DETERMINISM_PLAN);
     await minimizeInspectorIfVisible(page);


### PR DESCRIPTION
## Summary

Adds an Electron regression and reviewable media for selection camera stability.

## Review Claim

Approve exact viewport-transform equality coverage for workflow selection and background deselection.

## Review Lane

- proof

## Review Unit

- proof

## Safety Invariant

This slice observes `selection-camera-inert`; it does not alter UI runtime behavior.

## Slice Rationale

The end-to-end verification and its captured media form one reviewable evidence unit.

## Non-goals

- Do not change runtime UI source.
- Do not broaden the Electron suite beyond the named selection flow.

## Visual Proof

- [Recorded walkthrough](https://github.com/Neko-Catpital-Labs/Invoker/blob/2c344e3e2a/packages/app/e2e/visual-proof/after/graph-selection-camera-stable-walkthrough.webm?raw=1)
- [Initial graph state](https://github.com/Neko-Catpital-Labs/Invoker/blob/2c344e3e2a/packages/app/e2e/visual-proof/after/graph-selection-camera-stable-before-select.png?raw=1)
- [Selected graph state](https://github.com/Neko-Catpital-Labs/Invoker/blob/2c344e3e2a/packages/app/e2e/visual-proof/after/graph-selection-camera-stable-after-select.png?raw=1)
- [Deselected graph state](https://github.com/Neko-Catpital-Labs/Invoker/blob/2c344e3e2a/packages/app/e2e/visual-proof/after/graph-selection-camera-stable-after-background.png?raw=1)

Manually inspected: I opened all three exact screenshots and a dense contact sheet extracted from the 11.04-second WebM. The workflow node stays at the same canvas coordinates while only its selected fill changes and then clears.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `CAPTURE_MODE=after CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- visual-proof.spec.ts --grep graph-selection-camera-stable` — 1 passed.
- [x] Transform log: initial, selected, and deselected were all `translate(-84.5294px, 42.0574px) scale(1.84412)`.
- [x] Opened all three PNGs and inspected frames from the committed WebM.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 022489343c`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #11190