### PR TITLE
[Plan poolId honored](2) Honor plan-level poolId over default

### DIFF
--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -102,6 +102,7 @@ export interface RawPlan {
   reviewProvider?: string;
   repoUrl?: string;
   scratch?: boolean;
+  poolId?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -436,6 +437,16 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
   }
 
+  if (scratch && raw.poolId) {
+    throw new PlanParseError(
+      `${ownerLabel} sets "poolId" but has "scratch: true" — scratch plans never use execution pools.`,
+    );
+  }
+  if (raw.poolId !== undefined && (typeof raw.poolId !== 'string' || raw.poolId.trim() === '')) {
+    throw new PlanParseError(`${ownerLabel} "poolId" must be a non-empty string when provided.`);
+  }
+  const planPoolId = typeof raw.poolId === 'string' ? raw.poolId.trim() : undefined;
+
   const topLevelExternalDependencies = parseExternalDependencies(ownerLabel, raw.externalDependencies);
 
   const rawTasks = raw.tasks;
@@ -531,6 +542,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     reviewProvider,
     repoUrl: raw.repoUrl,
     scratch: scratch || undefined,
+    poolId: planPoolId,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,
@@ -561,6 +573,7 @@ function inheritStackWorkflowDefaults(stack: RawPlanBundle, workflow: RawPlan): 
     ...workflow,
     repoUrl: workflow.repoUrl ?? stack.repoUrl,
     scratch: workflow.scratch ?? stack.scratch,
+    poolId: workflow.poolId ?? stack.poolId,
     intermediateRepoUrl: workflow.intermediateRepoUrl ?? stack.intermediateRepoUrl,
     onFinish: workflow.onFinish ?? stack.onFinish,
     baseBranch: workflow.baseBranch ?? stack.baseBranch,

--- a/packages/workflow-core/src/__tests__/repro-plan-poolid-honored.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-plan-poolid-honored.test.ts
@@ -90,7 +90,7 @@ class InMemoryBus implements OrchestratorMessageBus {
 }
 
 describe('repro: plan-level poolId honored over defaultPoolId', () => {
-  it.fails('parsePlan + loadPlan keep plan poolId when defaultPoolId differs', () => {
+  it('parsePlan + loadPlan keep plan poolId when defaultPoolId differs', () => {
     const plan = parsePlan(`
 name: Plan Pool Wins
 repoUrl: git@github.com:test/repo.git

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -428,6 +428,7 @@ export interface PlanDefinition {
   repoUrl?: string;
   /** No-repo mode: every task runs in a plain temp directory, no git involved. Mutually exclusive with repoUrl. */
   scratch?: boolean;
+  poolId?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId: string;
@@ -1451,7 +1452,7 @@ export class Orchestrator {
         : resolveExecutorRouting(
             taskDef.id,
             taskDef.command,
-            taskDef.poolId,
+            taskDef.poolId ?? plan.poolId,
             this.defaultPoolId,
             this.executorRoutingRules,
             this.availablePoolIds,

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -50,6 +50,7 @@ export interface RawPlan {
   reviewProvider?: string;
   repoUrl?: string;
   scratch?: boolean;
+  poolId?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -206,6 +207,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
   }
 
+  if (scratch && raw.poolId) {
+    throw new PlanParseError('Plan sets "poolId" but has "scratch: true" — scratch plans never use execution pools.');
+  }
+  if (raw.poolId !== undefined && (typeof raw.poolId !== 'string' || raw.poolId.trim() === '')) {
+    throw new PlanParseError('Plan "poolId" must be a non-empty string when provided.');
+  }
+  const planPoolId = typeof raw.poolId === 'string' ? raw.poolId.trim() : undefined;
+
   const topLevelExternalDependencies = parseExternalDependencies('Plan', raw.externalDependencies);
   const seenTaskIds = new Set<string>();
   const tasks = raw.tasks.map((task, index) => {
@@ -284,6 +293,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     reviewProvider,
     repoUrl: raw.repoUrl,
     scratch: scratch || undefined,
+    poolId: planPoolId,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,


### PR DESCRIPTION
## Summary

Plan-level poolId is now kept on PlanDefinition and used at load time.

Tasks resolve pool as task poolId, then plan poolId, then defaultPoolId.

Declared local-mac-only no longer loses to mixed-local-ssh from config.

## Review Claim

Approve that declared plan or task poolId wins over Orchestrator defaultPoolId without breaking scratch plans or existing routing rules.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Local unit tests only. Changes only affect pool resolution precedence; no live executor dispatch in this slice.

## Slice Rationale

Fix follows the it.fails repro so CI stays green on each stack step.

## Non-goals

- Does not change experiment spawn pool inherit
- Does not change catstack plan-to-invoker skill docs
- Does not add new routing rule strategies

## Architecture

### Before

```mermaid
graph TD
    A["YAML plan.poolId local-mac-only"] --> B["parsePlan drops field"]
    B --> C["loadPlan uses task.poolId only"]
    C --> D["defaultPoolId mixed-local-ssh wins"]
```

### After

```mermaid
graph TD
    A["YAML plan.poolId local-mac-only"] --> B["parsePlan keeps plan.poolId"]
    B --> C["loadPlan uses task then plan then default"]
    C --> D["config.poolId is local-mac-only"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/repro-plan-poolid-honored.test.ts`
- [x] `pnpm run check:comments`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator.test.ts -t defaultPoolId`
- [x] Pass-after: both repro assertions green after flip from it.fails

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes executor pool resolution at plan load, which affects where tasks run, but scope is limited to precedence and validation with unit test coverage and no change to routing rule strategies.
> 
> **Overview**
> **Plan YAML `poolId` at workflow scope is now preserved and applied** when tasks do not declare their own pool. Previously parsing dropped the field, so `loadPlan` only saw task `poolId` and fell through to `defaultPoolId` (e.g. `mixed-local-ssh` overriding declared `local-mac-only`).
> 
> Parsing adds **`poolId` on `PlanDefinition`** in workflow-core and app plan parsers, with validation that rejects **`scratch: true` together with `poolId`** and empty strings. Plan stacks inherit **`poolId` from stack defaults** like other workflow fields.
> 
> At load time, **`resolveExecutorRouting` receives `taskDef.poolId ?? plan.poolId`**, so precedence is task, then plan, then config default; scratch plans still skip pool resolution. The repro test is flipped from **`it.fails` to passing**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ce5ea650108d6ca192f52e8a1b0a69ba4b1d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->