### PR TITLE
[Dispatch Acknowledgement](1) Count engine retries after queue acknowledgement

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -13,7 +13,7 @@ import {
   createAutoFixRecoveryTick,
   shouldRecreateMergeGateInsteadOfAutoFix,
 } from '../auto-fix-recovery.js';
-import { autoFixBareRetryExternalKey } from '../auto-fix-retry-cap.js';
+import { autoFixBareRetryExternalKey, autoFixRetryCapExternalKey } from '../auto-fix-retry-cap.js';
 import type {
   WorkerActionRecord,
   WorkerActionWrite,
@@ -305,5 +305,48 @@ describe('auto-fix recovery merge-gate recreate routing', () => {
     expect(channel).toBe(AUTO_FIX_RECREATE_CHANNEL);
     expect(args).toEqual([mergeTask.id]);
     expect(harness.attemptLedger.get(autoFixAttemptLedgerKeyFromTask(mergeTask))).toBe(0);
+  });
+});
+
+describe('auto-fix dispatch acknowledgement accounting', () => {
+  it('leaves both retry ledgers unspent when fix submission is not acknowledged', async () => {
+    const failedTask = makeFailedTask({
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        branch: 'feature/build',
+        error: 'TypeScript assertion failed',
+        failureClass: undefined,
+      },
+    });
+    const harness = makeHarness(failedTask);
+    harness.actions.set(`${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(failedTask.id)}`, toRecord({
+      id: `${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(failedTask.id)}`,
+      workerKind: AUTO_FIX_WORKER_KIND,
+      externalKey: autoFixBareRetryExternalKey(failedTask.id),
+      actionType: 'auto-retry',
+      subjectType: 'task',
+      subjectId: failedTask.id,
+      status: 'queued',
+      attemptCount: 1,
+      workflowId: 'wf-1',
+      taskId: failedTask.id,
+    }));
+    harness.submit.mockImplementation(() => { throw new Error('owner unavailable'); });
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await expect(tick({ reason: 'poll' } as never)).rejects.toThrow('owner unavailable');
+
+    expect(harness.attemptLedger.get(autoFixAttemptLedgerKeyFromTask(failedTask))).toBe(0);
+    const cap = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${autoFixRetryCapExternalKey(failedTask.id)}`);
+    expect(cap).toMatchObject({ status: 'failed', attemptCount: 0 });
+    expect(cap?.payload).toMatchObject({ dispatchState: 'not-acknowledged', failurePhase: 'submission' });
   });
 });

--- a/packages/execution-engine/src/__tests__/auto-fix-retry-cap.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-retry-cap.test.ts
@@ -6,6 +6,8 @@ import {
   autoFixRetryCapExternalKey,
   checkAutoFixRetryCap,
   recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
 } from '../auto-fix-retry-cap.js';
 import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
 
@@ -106,6 +108,26 @@ describe('checkAutoFixRetryCap', () => {
 });
 
 describe('recordAutoFixRetryConsumed', () => {
+  it('keeps pending and unacknowledged requests at zero attempts, then charges an acknowledged request', () => {
+    const { store } = makeFakeStore();
+
+    recordAutoFixRetryPending(store, 'task-1', { workflowId: 'wf-1' });
+    let saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'pending', attemptCount: 0 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'pending' });
+
+    recordAutoFixRetryUnacknowledged(store, 'task-1', new Error('owner unavailable'), { workflowId: 'wf-1' });
+    saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'failed', attemptCount: 0 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'not-acknowledged', failurePhase: 'submission' });
+
+    recordAutoFixRetryPending(store, 'task-1', { workflowId: 'wf-1' });
+    recordAutoFixRetryConsumed(store, 'task-1', { workflowId: 'wf-1' });
+    saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'queued', attemptCount: 1 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'acknowledged' });
+  });
+
   it('increments the durable counter under the retry-cap external key', () => {
     const { store } = makeFakeStore();
 

--- a/packages/execution-engine/src/__tests__/requeue-attempt-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-attempt-ledger.test.ts
@@ -49,6 +49,15 @@ describe('requeue attempt ledger', () => {
     expect(ledger.hasEscalated(k)).toBe(true);
   });
 
+  it('refunds a decision when dispatch was not acknowledged', () => {
+    const ledger = createRequeueAttemptLedger();
+    const k = key('wf-1/gate', 5);
+    expect(ledger.decide(k, BUDGET, BACKOFF, 0)).toMatchObject({ kind: 'requeue', attemptsAfter: 1 });
+    expect(ledger.refund(k)).toBe(0);
+    expect(ledger.attempts(k)).toBe(0);
+    expect(ledger.decide(k, BUDGET, BACKOFF, 1)).toMatchObject({ kind: 'requeue', attemptsAfter: 1 });
+  });
+
   it('keys by taskId+generation so a new generation gets a fresh budget', () => {
     const ledger = createRequeueAttemptLedger();
     const gen5 = key('wf-1/gate', 5);

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -39,6 +39,8 @@ import {
   autoFixBareRetryExternalKey,
   checkAutoFixRetryCap,
   recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
 } from './auto-fix-retry-cap.js';
 import { recordWorkerDecisionRow, isMeaningfulSkipReason } from './worker-decision-ledger.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
@@ -618,12 +620,21 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
       }
 
       if (!hasBareRetryAlreadySubmitted(options, candidate)) {
-        const intentId = options.submitter.submit(
-          candidate.workflowId,
-          'normal',
-          AUTO_FIX_BARE_RETRY_CHANNEL,
-          [candidate.taskId],
-        );
+        recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+        let intentId: number;
+        try {
+          intentId = options.submitter.submit(
+            candidate.workflowId,
+            'normal',
+            AUTO_FIX_BARE_RETRY_CHANNEL,
+            [candidate.taskId],
+          );
+        } catch (error) {
+          recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+            workflowId: candidate.workflowId,
+          });
+          throw error;
+        }
         submittedThisTick.add(candidate.taskId);
         logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-bare-retry-submitted', {
           workflowId: candidate.workflowId,
@@ -650,12 +661,21 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
       // Merge gates with a missing/non-git workspace cannot be fixed in-place.
       // Recreate the gate instead of burning fix-with-agent retry budget.
       if (shouldRecreateMergeGateInsteadOfAutoFix(candidate.task)) {
-        const intentId = options.submitter.submit(
-          candidate.workflowId,
-          'normal',
-          AUTO_FIX_RECREATE_CHANNEL,
-          [candidate.taskId],
-        );
+        recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+        let intentId: number;
+        try {
+          intentId = options.submitter.submit(
+            candidate.workflowId,
+            'normal',
+            AUTO_FIX_RECREATE_CHANNEL,
+            [candidate.taskId],
+          );
+        } catch (error) {
+          recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+            workflowId: candidate.workflowId,
+          });
+          throw error;
+        }
         submittedThisTick.add(candidate.taskId);
         logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-recreate-submitted', {
           workflowId: candidate.workflowId,
@@ -710,7 +730,17 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
       });
       const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true });
-      const intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+      let intentId: number;
+      try {
+        intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      } catch (error) {
+        options.attemptLedger.refund(autoFixAttemptLedgerKeyFromTask(candidate.task));
+        recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+          workflowId: candidate.workflowId,
+        });
+        throw error;
+      }
       submittedThisTick.add(candidate.taskId);
       logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-submitted', {
         workflowId: candidate.workflowId,

--- a/packages/execution-engine/src/auto-fix-retry-cap.ts
+++ b/packages/execution-engine/src/auto-fix-retry-cap.ts
@@ -55,8 +55,8 @@ export interface AutoFixRetryCapDecision {
 /**
  * Decide whether a worker may submit one more automatic retry for `taskId`
  * without exceeding the configured budget. Read-only: callers must invoke
- * {@link recordAutoFixRetryConsumed} after a submission actually happens so the
- * durable counter advances.
+ * {@link recordAutoFixRetryConsumed} after the queue acknowledges submission so
+ * the durable counter advances.
  */
 export function checkAutoFixRetryCap(
   store: WorkerDecisionStore,
@@ -69,7 +69,51 @@ export function checkAutoFixRetryCap(
   return { allowed, consumed, budget };
 }
 
-/** Advance the durable per-task retry counter by one after a submission. */
+export function recordAutoFixRetryPending(
+  store: WorkerDecisionStore,
+  taskId: string,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: AUTO_FIX_RETRY_CAP_ACTION_TYPE,
+    externalKey: autoFixRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'pending',
+    summary: fields.summary ?? 'Automatic retry request awaiting queue acknowledgement',
+    incrementAttempt: false,
+    payload: { dispatchState: 'pending' },
+  });
+}
+
+export function recordAutoFixRetryUnacknowledged(
+  store: WorkerDecisionStore,
+  taskId: string,
+  error: unknown,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: AUTO_FIX_RETRY_CAP_ACTION_TYPE,
+    externalKey: autoFixRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'failed',
+    summary: fields.summary ?? 'Automatic retry request was not acknowledged',
+    incrementAttempt: false,
+    payload: {
+      dispatchState: 'not-acknowledged',
+      failurePhase: 'submission',
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
 export function recordAutoFixRetryConsumed(
   store: WorkerDecisionStore,
   taskId: string,
@@ -86,6 +130,7 @@ export function recordAutoFixRetryConsumed(
     status: 'queued',
     summary: fields.summary ?? 'Durable per-task auto-fix retry counter',
     incrementAttempt: true,
+    payload: { dispatchState: 'acknowledged' },
   });
 }
 

--- a/packages/execution-engine/src/repair-workflow-spec.ts
+++ b/packages/execution-engine/src/repair-workflow-spec.ts
@@ -8,7 +8,12 @@ import type {
 import type { PlanDefinition, TaskState } from '@invoker/workflow-core';
 
 import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from './auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from './auto-fix-retry-cap.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -425,12 +430,21 @@ export function queueRepairWorkflowSpawn(
     source: 'worker',
     queuedByRepairWorkflowGuard: true,
   });
-  const intentId = options.submitter.submit(
-    event.workflowId,
-    'normal',
-    SPAWN_REPAIR_WORKFLOW_CHANNEL,
-    [payload],
-  );
+  recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(
+      event.workflowId,
+      'normal',
+      SPAWN_REPAIR_WORKFLOW_CHANNEL,
+      [payload],
+    );
+  } catch (error) {
+    recordAutoFixRetryUnacknowledged(options.store, event.taskId, error, {
+      workflowId: event.workflowId,
+    });
+    throw error;
+  }
   recordRepairWorkflowAction(options.store, event, actionKey, 'queued', 'Queued CI repair workflow spawn', {
     channel: SPAWN_REPAIR_WORKFLOW_CHANNEL,
     failedChecksHash: ciFailureChecksHash(event.failedChecks),

--- a/packages/execution-engine/src/requeue-attempt-ledger.ts
+++ b/packages/execution-engine/src/requeue-attempt-ledger.ts
@@ -34,6 +34,7 @@ export interface RequeueAttemptLedger {
     backoffMs: number,
     nowMs: number,
   ): RequeueDecision;
+  refund(key: RequeueLedgerKey): number;
   hasEscalated(key: RequeueLedgerKey): boolean;
   markEscalated(key: RequeueLedgerKey): void;
 }
@@ -93,6 +94,13 @@ export function createRequeueAttemptLedger(): RequeueAttemptLedger {
         attemptsAfter: entry.attempts,
         budget,
       };
+    },
+    refund(key) {
+      const entry = entries.get(ledgerMapKey(key));
+      if (!entry || entry.attempts === 0) return 0;
+      entry.attempts -= 1;
+      entry.lastRequeueAtMs = undefined;
+      return entry.attempts;
     },
     hasEscalated(key) {
       return entries.get(ledgerMapKey(key))?.escalated ?? false;

--- a/packages/execution-engine/src/requeue-retry-cap.ts
+++ b/packages/execution-engine/src/requeue-retry-cap.ts
@@ -29,6 +29,51 @@ export function checkRequeueRetryCap(
   return { allowed, consumed, budget };
 }
 
+export function recordRequeueRetryPending(
+  store: WorkerDecisionStore,
+  taskId: string,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: REQUEUE_RETRY_CAP_WORKER_KIND,
+    actionType: REQUEUE_RETRY_CAP_ACTION_TYPE,
+    externalKey: requeueRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'pending',
+    summary: fields.summary ?? 'Requeue request awaiting queue acknowledgement',
+    incrementAttempt: false,
+    payload: { dispatchState: 'pending' },
+  });
+}
+
+export function recordRequeueRetryUnacknowledged(
+  store: WorkerDecisionStore,
+  taskId: string,
+  error: unknown,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: REQUEUE_RETRY_CAP_WORKER_KIND,
+    actionType: REQUEUE_RETRY_CAP_ACTION_TYPE,
+    externalKey: requeueRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'failed',
+    summary: fields.summary ?? 'Requeue request was not acknowledged',
+    incrementAttempt: false,
+    payload: {
+      dispatchState: 'not-acknowledged',
+      failurePhase: 'submission',
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
 export function recordRequeueRetryConsumed(
   store: WorkerDecisionStore,
   taskId: string,
@@ -45,5 +90,6 @@ export function recordRequeueRetryConsumed(
     status: 'queued',
     summary: fields.summary ?? 'Durable per-task requeue retry counter',
     incrementAttempt: true,
+    payload: { dispatchState: 'acknowledged' },
   });
 }

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -24,7 +24,12 @@ import {
   type AutoFixAttemptLedger,
 } from './auto-fix-attempt-ledger.js';
 import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from './auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from './auto-fix-retry-cap.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -537,6 +542,9 @@ function recordCiRepairSubmitFailure(
   },
 ): ReviewGateCiRepairResult {
   options.attemptLedger.refund(input.attemptLedgerKey);
+  recordAutoFixRetryUnacknowledged(options.store, event.taskId, input.error, {
+    workflowId: event.workflowId,
+  });
   const errorMessage = input.error instanceof Error ? input.error.message : String(input.error);
   recordCiFailureAction(
     options,
@@ -729,6 +737,7 @@ export async function queueReviewGateCiRepair(
         members: candidate.members,
         triggering: singlePrPayload,
       });
+      recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
       let stackIntentId: number;
       try {
         stackIntentId = options.submitter.submit(
@@ -781,6 +790,7 @@ export async function queueReviewGateCiRepair(
   }
 
   const args = buildReviewGateCiRepairWorkflowMutationArgs(singlePrPayload);
+  recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
   let intentId: number;
   try {
     intentId = options.submitter.submit(

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -11,7 +11,12 @@ import { FailureClassifier } from '@invoker/workflow-core';
 import type { SshInfraFailureClass, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 import { isLivenessFailureTask, normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from '../auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from '../auto-fix-retry-cap.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
 import {
   resolveRemoteBranchOwnerPath,
@@ -744,7 +749,16 @@ async function submitFollowUpMutation(
     return;
   }
 
-  const intentId = options.submitter.submit(candidate.workflowId, 'normal', channel, args);
+  recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(candidate.workflowId, 'normal', channel, args);
+  } catch (error) {
+    recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+      workflowId: candidate.workflowId,
+    });
+    throw error;
+  }
   recordTaskDecision(options, candidate, reason, 'completed', summary, {
     channel,
     ...payload,

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -14,6 +14,8 @@ import {
 import {
   checkRequeueRetryCap,
   recordRequeueRetryConsumed,
+  recordRequeueRetryPending,
+  recordRequeueRetryUnacknowledged,
 } from '../requeue-retry-cap.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
@@ -228,12 +230,20 @@ export function createRequeueRecoveryTick(options: RequeueWorkerPolicyOptions): 
         continue;
       }
 
-      const intentId = options.submitter.submit(
-        workflowId,
-        'normal',
-        REQUEUE_COMMAND_CHANNEL,
-        buildRequeueMutationArgs(latest.id),
-      );
+      recordRequeueRetryPending(options.store, latest.id, { workflowId });
+      let intentId: number;
+      try {
+        intentId = options.submitter.submit(
+          workflowId,
+          'normal',
+          REQUEUE_COMMAND_CHANNEL,
+          buildRequeueMutationArgs(latest.id),
+        );
+      } catch (error) {
+        options.ledger.refund(key);
+        recordRequeueRetryUnacknowledged(options.store, latest.id, error, { workflowId });
+        throw error;
+      }
       recordRequeueRetryConsumed(options.store, latest.id, {
         workflowId,
       });


### PR DESCRIPTION
## Summary

Workers record an outbound mutation as pending before contacting the owner queue.

The durable dispatch budget advances only after the queue returns an intent identifier. Handoffs that throw refund transient reservations and can run again.

## Review Claim

Approve one acknowledgement boundary for every execution-engine worker mutation path that spends the shared dispatch budget.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every budgeted worker request is pending before dispatch. Only acknowledged requests consume budget; unacknowledged requests remain eligible, while acknowledged work stays bounded.

## Slice Rationale

This slice owns execution-engine routing across recovery, requeue, CI repair, and infrastructure repair workers.

The Mergify-specific tooling policy is isolated in the next stack slice.

## Non-goals

- Does not change configured budget values.
- Does not change owner mutation APIs or intent execution.
- Does not change Mergify maintenance scripts.

## Architecture

### Before

```mermaid
flowchart TD
    A["Worker selects an action"] --> B["Budget advances"]
    B --> C["Owner handoff"]
    C --> D["Rejected handoff remains charged"]
```

### After

```mermaid
flowchart TD
    A["Worker selects an action"] --> B["Pending request recorded"]
    B --> C["Owner handoff"]
    C -->|"intent identifier returned"| D["Budget advances"]
    C -->|"handoff rejected"| E["Not acknowledged; reservation refunded"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/auto-fix-retry-cap.test.ts src/__tests__/requeue-attempt-ledger.test.ts src/__tests__/requeue-worker.test.ts src/__tests__/infra-repair-worker.test.ts src/__tests__/repair-workflow-spawn.test.ts src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/execution-engine test -- --run` — 1756 passed, 1 skipped, and 3 unrelated tests failed in `ssh-executor.test.ts` and `worker-registry.test.ts`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
