### PR TITLE
[Dispatch Acknowledgement](2) Track Mergify repairs until acknowledgement

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -13,7 +13,7 @@ import {
   createAutoFixRecoveryTick,
   shouldRecreateMergeGateInsteadOfAutoFix,
 } from '../auto-fix-recovery.js';
-import { autoFixBareRetryExternalKey } from '../auto-fix-retry-cap.js';
+import { autoFixBareRetryExternalKey, autoFixRetryCapExternalKey } from '../auto-fix-retry-cap.js';
 import type {
   WorkerActionRecord,
   WorkerActionWrite,
@@ -305,5 +305,48 @@ describe('auto-fix recovery merge-gate recreate routing', () => {
     expect(channel).toBe(AUTO_FIX_RECREATE_CHANNEL);
     expect(args).toEqual([mergeTask.id]);
     expect(harness.attemptLedger.get(autoFixAttemptLedgerKeyFromTask(mergeTask))).toBe(0);
+  });
+});
+
+describe('auto-fix dispatch acknowledgement accounting', () => {
+  it('leaves both retry ledgers unspent when fix submission is not acknowledged', async () => {
+    const failedTask = makeFailedTask({
+      execution: {
+        generation: 2,
+        selectedAttemptId: 'attempt-1',
+        branch: 'feature/build',
+        error: 'TypeScript assertion failed',
+        failureClass: undefined,
+      },
+    });
+    const harness = makeHarness(failedTask);
+    harness.actions.set(`${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(failedTask.id)}`, toRecord({
+      id: `${AUTO_FIX_WORKER_KIND}:${autoFixBareRetryExternalKey(failedTask.id)}`,
+      workerKind: AUTO_FIX_WORKER_KIND,
+      externalKey: autoFixBareRetryExternalKey(failedTask.id),
+      actionType: 'auto-retry',
+      subjectType: 'task',
+      subjectId: failedTask.id,
+      status: 'queued',
+      attemptCount: 1,
+      workflowId: 'wf-1',
+      taskId: failedTask.id,
+    }));
+    harness.submit.mockImplementation(() => { throw new Error('owner unavailable'); });
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await expect(tick({ reason: 'poll' } as never)).rejects.toThrow('owner unavailable');
+
+    expect(harness.attemptLedger.get(autoFixAttemptLedgerKeyFromTask(failedTask))).toBe(0);
+    const cap = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${autoFixRetryCapExternalKey(failedTask.id)}`);
+    expect(cap).toMatchObject({ status: 'failed', attemptCount: 0 });
+    expect(cap?.payload).toMatchObject({ dispatchState: 'not-acknowledged', failurePhase: 'submission' });
   });
 });

--- a/packages/execution-engine/src/__tests__/auto-fix-retry-cap.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-retry-cap.test.ts
@@ -6,6 +6,8 @@ import {
   autoFixRetryCapExternalKey,
   checkAutoFixRetryCap,
   recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
 } from '../auto-fix-retry-cap.js';
 import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
 
@@ -106,6 +108,26 @@ describe('checkAutoFixRetryCap', () => {
 });
 
 describe('recordAutoFixRetryConsumed', () => {
+  it('keeps pending and unacknowledged requests at zero attempts, then charges an acknowledged request', () => {
+    const { store } = makeFakeStore();
+
+    recordAutoFixRetryPending(store, 'task-1', { workflowId: 'wf-1' });
+    let saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'pending', attemptCount: 0 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'pending' });
+
+    recordAutoFixRetryUnacknowledged(store, 'task-1', new Error('owner unavailable'), { workflowId: 'wf-1' });
+    saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'failed', attemptCount: 0 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'not-acknowledged', failurePhase: 'submission' });
+
+    recordAutoFixRetryPending(store, 'task-1', { workflowId: 'wf-1' });
+    recordAutoFixRetryConsumed(store, 'task-1', { workflowId: 'wf-1' });
+    saved = store.getWorkerAction?.('autofix', 'retry-cap:task-1');
+    expect(saved).toMatchObject({ status: 'queued', attemptCount: 1 });
+    expect(saved?.payload).toMatchObject({ dispatchState: 'acknowledged' });
+  });
+
   it('increments the durable counter under the retry-cap external key', () => {
     const { store } = makeFakeStore();
 

--- a/packages/execution-engine/src/__tests__/requeue-attempt-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-attempt-ledger.test.ts
@@ -49,6 +49,15 @@ describe('requeue attempt ledger', () => {
     expect(ledger.hasEscalated(k)).toBe(true);
   });
 
+  it('refunds a decision when dispatch was not acknowledged', () => {
+    const ledger = createRequeueAttemptLedger();
+    const k = key('wf-1/gate', 5);
+    expect(ledger.decide(k, BUDGET, BACKOFF, 0)).toMatchObject({ kind: 'requeue', attemptsAfter: 1 });
+    expect(ledger.refund(k)).toBe(0);
+    expect(ledger.attempts(k)).toBe(0);
+    expect(ledger.decide(k, BUDGET, BACKOFF, 1)).toMatchObject({ kind: 'requeue', attemptsAfter: 1 });
+  });
+
   it('keys by taskId+generation so a new generation gets a fresh budget', () => {
     const ledger = createRequeueAttemptLedger();
     const gen5 = key('wf-1/gate', 5);

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -39,6 +39,8 @@ import {
   autoFixBareRetryExternalKey,
   checkAutoFixRetryCap,
   recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
 } from './auto-fix-retry-cap.js';
 import { recordWorkerDecisionRow, isMeaningfulSkipReason } from './worker-decision-ledger.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
@@ -618,12 +620,21 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
       }
 
       if (!hasBareRetryAlreadySubmitted(options, candidate)) {
-        const intentId = options.submitter.submit(
-          candidate.workflowId,
-          'normal',
-          AUTO_FIX_BARE_RETRY_CHANNEL,
-          [candidate.taskId],
-        );
+        recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+        let intentId: number;
+        try {
+          intentId = options.submitter.submit(
+            candidate.workflowId,
+            'normal',
+            AUTO_FIX_BARE_RETRY_CHANNEL,
+            [candidate.taskId],
+          );
+        } catch (error) {
+          recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+            workflowId: candidate.workflowId,
+          });
+          throw error;
+        }
         submittedThisTick.add(candidate.taskId);
         logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-bare-retry-submitted', {
           workflowId: candidate.workflowId,
@@ -650,12 +661,21 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
       // Merge gates with a missing/non-git workspace cannot be fixed in-place.
       // Recreate the gate instead of burning fix-with-agent retry budget.
       if (shouldRecreateMergeGateInsteadOfAutoFix(candidate.task)) {
-        const intentId = options.submitter.submit(
-          candidate.workflowId,
-          'normal',
-          AUTO_FIX_RECREATE_CHANNEL,
-          [candidate.taskId],
-        );
+        recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+        let intentId: number;
+        try {
+          intentId = options.submitter.submit(
+            candidate.workflowId,
+            'normal',
+            AUTO_FIX_RECREATE_CHANNEL,
+            [candidate.taskId],
+          );
+        } catch (error) {
+          recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+            workflowId: candidate.workflowId,
+          });
+          throw error;
+        }
         submittedThisTick.add(candidate.taskId);
         logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-recreate-submitted', {
           workflowId: candidate.workflowId,
@@ -710,7 +730,17 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
       });
       const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true });
-      const intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+      let intentId: number;
+      try {
+        intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      } catch (error) {
+        options.attemptLedger.refund(autoFixAttemptLedgerKeyFromTask(candidate.task));
+        recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+          workflowId: candidate.workflowId,
+        });
+        throw error;
+      }
       submittedThisTick.add(candidate.taskId);
       logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-submitted', {
         workflowId: candidate.workflowId,

--- a/packages/execution-engine/src/auto-fix-retry-cap.ts
+++ b/packages/execution-engine/src/auto-fix-retry-cap.ts
@@ -55,8 +55,8 @@ export interface AutoFixRetryCapDecision {
 /**
  * Decide whether a worker may submit one more automatic retry for `taskId`
  * without exceeding the configured budget. Read-only: callers must invoke
- * {@link recordAutoFixRetryConsumed} after a submission actually happens so the
- * durable counter advances.
+ * {@link recordAutoFixRetryConsumed} after the queue acknowledges submission so
+ * the durable counter advances.
  */
 export function checkAutoFixRetryCap(
   store: WorkerDecisionStore,
@@ -69,7 +69,51 @@ export function checkAutoFixRetryCap(
   return { allowed, consumed, budget };
 }
 
-/** Advance the durable per-task retry counter by one after a submission. */
+export function recordAutoFixRetryPending(
+  store: WorkerDecisionStore,
+  taskId: string,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: AUTO_FIX_RETRY_CAP_ACTION_TYPE,
+    externalKey: autoFixRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'pending',
+    summary: fields.summary ?? 'Automatic retry request awaiting queue acknowledgement',
+    incrementAttempt: false,
+    payload: { dispatchState: 'pending' },
+  });
+}
+
+export function recordAutoFixRetryUnacknowledged(
+  store: WorkerDecisionStore,
+  taskId: string,
+  error: unknown,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: AUTO_FIX_RETRY_CAP_ACTION_TYPE,
+    externalKey: autoFixRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'failed',
+    summary: fields.summary ?? 'Automatic retry request was not acknowledged',
+    incrementAttempt: false,
+    payload: {
+      dispatchState: 'not-acknowledged',
+      failurePhase: 'submission',
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
 export function recordAutoFixRetryConsumed(
   store: WorkerDecisionStore,
   taskId: string,
@@ -86,6 +130,7 @@ export function recordAutoFixRetryConsumed(
     status: 'queued',
     summary: fields.summary ?? 'Durable per-task auto-fix retry counter',
     incrementAttempt: true,
+    payload: { dispatchState: 'acknowledged' },
   });
 }
 

--- a/packages/execution-engine/src/repair-workflow-spec.ts
+++ b/packages/execution-engine/src/repair-workflow-spec.ts
@@ -8,7 +8,12 @@ import type {
 import type { PlanDefinition, TaskState } from '@invoker/workflow-core';
 
 import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from './auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from './auto-fix-retry-cap.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -425,12 +430,21 @@ export function queueRepairWorkflowSpawn(
     source: 'worker',
     queuedByRepairWorkflowGuard: true,
   });
-  const intentId = options.submitter.submit(
-    event.workflowId,
-    'normal',
-    SPAWN_REPAIR_WORKFLOW_CHANNEL,
-    [payload],
-  );
+  recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(
+      event.workflowId,
+      'normal',
+      SPAWN_REPAIR_WORKFLOW_CHANNEL,
+      [payload],
+    );
+  } catch (error) {
+    recordAutoFixRetryUnacknowledged(options.store, event.taskId, error, {
+      workflowId: event.workflowId,
+    });
+    throw error;
+  }
   recordRepairWorkflowAction(options.store, event, actionKey, 'queued', 'Queued CI repair workflow spawn', {
     channel: SPAWN_REPAIR_WORKFLOW_CHANNEL,
     failedChecksHash: ciFailureChecksHash(event.failedChecks),

--- a/packages/execution-engine/src/requeue-attempt-ledger.ts
+++ b/packages/execution-engine/src/requeue-attempt-ledger.ts
@@ -34,6 +34,7 @@ export interface RequeueAttemptLedger {
     backoffMs: number,
     nowMs: number,
   ): RequeueDecision;
+  refund(key: RequeueLedgerKey): number;
   hasEscalated(key: RequeueLedgerKey): boolean;
   markEscalated(key: RequeueLedgerKey): void;
 }
@@ -93,6 +94,13 @@ export function createRequeueAttemptLedger(): RequeueAttemptLedger {
         attemptsAfter: entry.attempts,
         budget,
       };
+    },
+    refund(key) {
+      const entry = entries.get(ledgerMapKey(key));
+      if (!entry || entry.attempts === 0) return 0;
+      entry.attempts -= 1;
+      entry.lastRequeueAtMs = undefined;
+      return entry.attempts;
     },
     hasEscalated(key) {
       return entries.get(ledgerMapKey(key))?.escalated ?? false;

--- a/packages/execution-engine/src/requeue-retry-cap.ts
+++ b/packages/execution-engine/src/requeue-retry-cap.ts
@@ -29,6 +29,51 @@ export function checkRequeueRetryCap(
   return { allowed, consumed, budget };
 }
 
+export function recordRequeueRetryPending(
+  store: WorkerDecisionStore,
+  taskId: string,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: REQUEUE_RETRY_CAP_WORKER_KIND,
+    actionType: REQUEUE_RETRY_CAP_ACTION_TYPE,
+    externalKey: requeueRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'pending',
+    summary: fields.summary ?? 'Requeue request awaiting queue acknowledgement',
+    incrementAttempt: false,
+    payload: { dispatchState: 'pending' },
+  });
+}
+
+export function recordRequeueRetryUnacknowledged(
+  store: WorkerDecisionStore,
+  taskId: string,
+  error: unknown,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: REQUEUE_RETRY_CAP_WORKER_KIND,
+    actionType: REQUEUE_RETRY_CAP_ACTION_TYPE,
+    externalKey: requeueRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'failed',
+    summary: fields.summary ?? 'Requeue request was not acknowledged',
+    incrementAttempt: false,
+    payload: {
+      dispatchState: 'not-acknowledged',
+      failurePhase: 'submission',
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
 export function recordRequeueRetryConsumed(
   store: WorkerDecisionStore,
   taskId: string,
@@ -45,5 +90,6 @@ export function recordRequeueRetryConsumed(
     status: 'queued',
     summary: fields.summary ?? 'Durable per-task requeue retry counter',
     incrementAttempt: true,
+    payload: { dispatchState: 'acknowledged' },
   });
 }

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -24,7 +24,12 @@ import {
   type AutoFixAttemptLedger,
 } from './auto-fix-attempt-ledger.js';
 import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from './auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from './auto-fix-retry-cap.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -537,6 +542,9 @@ function recordCiRepairSubmitFailure(
   },
 ): ReviewGateCiRepairResult {
   options.attemptLedger.refund(input.attemptLedgerKey);
+  recordAutoFixRetryUnacknowledged(options.store, event.taskId, input.error, {
+    workflowId: event.workflowId,
+  });
   const errorMessage = input.error instanceof Error ? input.error.message : String(input.error);
   recordCiFailureAction(
     options,
@@ -729,6 +737,7 @@ export async function queueReviewGateCiRepair(
         members: candidate.members,
         triggering: singlePrPayload,
       });
+      recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
       let stackIntentId: number;
       try {
         stackIntentId = options.submitter.submit(
@@ -781,6 +790,7 @@ export async function queueReviewGateCiRepair(
   }
 
   const args = buildReviewGateCiRepairWorkflowMutationArgs(singlePrPayload);
+  recordAutoFixRetryPending(options.store, event.taskId, { workflowId: event.workflowId });
   let intentId: number;
   try {
     intentId = options.submitter.submit(

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -11,7 +11,12 @@ import { FailureClassifier } from '@invoker/workflow-core';
 import type { SshInfraFailureClass, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 import { isLivenessFailureTask, normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
-import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from '../auto-fix-retry-cap.js';
+import {
+  checkAutoFixRetryCap,
+  recordAutoFixRetryConsumed,
+  recordAutoFixRetryPending,
+  recordAutoFixRetryUnacknowledged,
+} from '../auto-fix-retry-cap.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
 import {
   resolveRemoteBranchOwnerPath,
@@ -744,7 +749,16 @@ async function submitFollowUpMutation(
     return;
   }
 
-  const intentId = options.submitter.submit(candidate.workflowId, 'normal', channel, args);
+  recordAutoFixRetryPending(options.store, candidate.taskId, { workflowId: candidate.workflowId });
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(candidate.workflowId, 'normal', channel, args);
+  } catch (error) {
+    recordAutoFixRetryUnacknowledged(options.store, candidate.taskId, error, {
+      workflowId: candidate.workflowId,
+    });
+    throw error;
+  }
   recordTaskDecision(options, candidate, reason, 'completed', summary, {
     channel,
     ...payload,

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -14,6 +14,8 @@ import {
 import {
   checkRequeueRetryCap,
   recordRequeueRetryConsumed,
+  recordRequeueRetryPending,
+  recordRequeueRetryUnacknowledged,
 } from '../requeue-retry-cap.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
@@ -228,12 +230,20 @@ export function createRequeueRecoveryTick(options: RequeueWorkerPolicyOptions): 
         continue;
       }
 
-      const intentId = options.submitter.submit(
-        workflowId,
-        'normal',
-        REQUEUE_COMMAND_CHANNEL,
-        buildRequeueMutationArgs(latest.id),
-      );
+      recordRequeueRetryPending(options.store, latest.id, { workflowId });
+      let intentId: number;
+      try {
+        intentId = options.submitter.submit(
+          workflowId,
+          'normal',
+          REQUEUE_COMMAND_CHANNEL,
+          buildRequeueMutationArgs(latest.id),
+        );
+      } catch (error) {
+        options.ledger.refund(key);
+        recordRequeueRetryUnacknowledged(options.store, latest.id, error, { workflowId });
+        throw error;
+      }
       recordRequeueRetryConsumed(options.store, latest.id, {
         workflowId,
       });

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -77,11 +77,11 @@ _headless_query_invoke() {
     run_with_optional_timeout "$seconds" "$INVOKER_HEADLESS_CLIENT_BIN" "$@"
     return $?
   fi
-  if command -v invoker-ui >/dev/null 2>&1; then
-    run_with_optional_timeout "$seconds" invoker-ui --headless "$@"
+  if [ -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then
+    run_with_optional_timeout "$seconds" node "$REPO_ROOT/packages/app/dist/headless-client.js" "$@"
     return $?
   fi
-  run_with_optional_timeout "$seconds" node "$REPO_ROOT/packages/app/dist/headless-client.js" "$@"
+  run_with_optional_timeout "$seconds" invoker-ui --headless "$@"
 }
 
 headless_query() {

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -70,6 +70,14 @@ class AsyncRepairPlan:
     yaml_text: str
 
 
+@dataclass(frozen=True)
+class RepairSubmissionAcknowledgement:
+    workflow_id: str | None = None
+
+
+_WORKFLOW_ID_RE = re.compile(r"(?:Workflow ID:|workflow:)\s*(wf-[^\s]+)")
+
+
 def _write_plan_header(*, name: str, base_branch: str, repo: str, merge_mode: str = "manual") -> str:
     return (
         f"name: {name}\n"
@@ -327,7 +335,7 @@ def build_repair_bot_thread_plan(
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 
-def submit_async_repair_plan(plan: AsyncRepairPlan) -> None:
+def submit_async_repair_plan(plan: AsyncRepairPlan) -> RepairSubmissionAcknowledgement:
     with tempfile.NamedTemporaryFile(
         "w", encoding="utf-8", suffix=".yaml", prefix=f"{plan.plan_name}-", delete=False
     ) as handle:
@@ -344,5 +352,7 @@ def submit_async_repair_plan(plan: AsyncRepairPlan) -> None:
                 f"submit_async_repair_plan failed for {plan.plan_name}: "
                 f"{completed.stderr.strip() or completed.stdout.strip()}"
             )
+        match = _WORKFLOW_ID_RE.search(completed.stdout)
+        return RepairSubmissionAcknowledgement(workflow_id=match.group(1) if match else None)
     finally:
         plan_path.unlink(missing_ok=True)

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -81,12 +81,13 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(json.dumps(action.__dict__, sort_keys=True))
         return
     prefix = "DRY-RUN " if dry_run else ""
+    repair_prefix = prefix if dry_run else "PENDING "
     if action.kind == "requeue":
         head = pr.head_ref_oid if pr else ""
         print(f"{prefix}requeue PR #{action.pr_number} head={head} reason={action.detail}")
     elif action.kind == "repair_check":
         key = action.key.split(":", 1)[-1]
-        print(f"{prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
+        print(f"{repair_prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
     elif action.kind == "comment_blocked":
         print(f"BLOCK PR #{action.pr_number} {action.detail}")
     elif action.kind == "comment_admin_bypass_nudge":
@@ -100,13 +101,24 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         head = pr.head_ref_oid if pr else ""
         print(f"{prefix}squash-merge PR #{action.pr_number} head={head} reason={action.detail}")
     elif action.kind == "rebase_onto_base":
-        print(f"{prefix}rebase-onto-base PR #{action.pr_number} onto={action.key}")
+        print(f"{repair_prefix}rebase-onto-base PR #{action.pr_number} onto={action.key}")
     elif action.kind == "rebase_onto_master":
-        print(f"{prefix}rebase-onto-master PR #{action.pr_number} {action.detail}")
+        print(f"{repair_prefix}rebase-onto-master PR #{action.pr_number} {action.detail}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
         print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
+
+
+def print_repair_acknowledged(action: Action, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps({"event": "repair-dispatch-acknowledged", **action.__dict__}, sort_keys=True))
+        return
+    if action.kind == "repair_check":
+        key = action.key.split(":", 1)[-1]
+        print(f"ACKNOWLEDGED repair-check PR #{action.pr_number} check={json.dumps(key)}")
+    elif action.kind == "rebase_onto_master":
+        print(f"ACKNOWLEDGED rebase-onto-master PR #{action.pr_number} {action.detail}")
 
 
 def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClient, logger: AdminBypassLogger) -> dict[int, bool]:
@@ -133,6 +145,25 @@ def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClie
                 error=str(exc),
             )
     return stale_base_by_pr
+
+
+def report_repair_dispatch_failure(
+    executor: AdminBypassGhExecutor,
+    logger: AdminBypassLogger,
+    pr: PrSnapshot,
+    action_kind: str,
+    now: int,
+) -> None:
+    try:
+        executor.comment_repair_dispatch_failed(pr, action_kind, now)
+    except Exception as exc:
+        logger.trace(
+            "admin-bypass-repair-dispatch-failure-comment-failed",
+            repo=executor.repo,
+            pr_number=pr.number,
+            action_kind=action_kind,
+            error=str(exc),
+        )
 
 
 def run_cycle(
@@ -261,6 +292,7 @@ def run_cycle(
                                 "repair-check", action.pr_number, pr.head_ref_oid, check_name, now,
                                 meta={"workflowId": workflow_id, "via": "fastpath"},
                             )
+                            print_repair_acknowledged(action, args.json)
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
@@ -290,6 +322,8 @@ def run_cycle(
                                     pr_number=pr.number,
                                     check_name=check_name,
                                 )
+                            if outcome.status == "submitted":
+                                print_repair_acknowledged(action, args.json)
                             progressed = outcome.status in {"pushed", "prereq_created", "submitted", "queue_only_noop"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1
@@ -325,6 +359,7 @@ def run_cycle(
                         release_repair_filing(kind, str(action.pr_number), pr.head_ref_oid)
                         if pr.latest_mergify is not None:
                             release_repair_filing(kind, str(action.pr_number), mergify_check_state_sha(pr, pr.latest_mergify))
+                    report_repair_dispatch_failure(executor, logger, pr, action.kind, now)
                     should_poll = True
                     continue
                 if progressed:
@@ -343,9 +378,12 @@ def run_cycle(
                             REBASE_ONTO_MASTER_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now,
                             meta={"workflowId": workflow_id, "via": "fastpath"},
                         )
+                        print_repair_acknowledged(action, args.json)
                         progressed = True
                     else:
                         outcome = repairer.rebase_onto_master(pr, action.detail, now)
+                        if outcome.status == "submitted":
+                            print_repair_acknowledged(action, args.json)
                         progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1
@@ -361,6 +399,7 @@ def run_cycle(
                     )
                     if release_repair_filing is not None:
                         release_repair_filing(REBASE_ONTO_MASTER_FILING_KIND, str(action.pr_number), pr.head_ref_oid)
+                    report_repair_dispatch_failure(executor, logger, pr, action.kind, now)
                     should_poll = True
                     continue
                 if progressed:

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -19,6 +19,7 @@ except ImportError:
 
 ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
 RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND = "restore-admin-bypass-label"
+REPAIR_DISPATCH_FAILURE_LEDGER_KIND = "comment-repair-dispatch-failed"
 
 
 def admin_bypass_nudge_body() -> str:
@@ -145,6 +146,17 @@ class AdminBypassGhExecutor:
                 now,
                 meta={"detail": detail},
             )
+
+    def comment_repair_dispatch_failed(self, pr: PrSnapshot, action_kind: str, now: int) -> None:
+        if self.ledger.count(REPAIR_DISPATCH_FAILURE_LEDGER_KIND, pr.number, pr.head_ref_oid, action_kind) != 0:
+            return
+        body = (
+            "Invoker repair dispatch was not acknowledged. The request was recorded as pending, "
+            "then closed without consuming the code-repair retry budget; "
+            f"automatic retry remains enabled for current head {pr.head_ref_oid[:7]}."
+        )
+        self.gh.comment(self.repo, pr.number, body)
+        self.ledger.record(REPAIR_DISPATCH_FAILURE_LEDGER_KIND, pr.number, pr.head_ref_oid, action_kind, now)
 
     def execute(self, action: Action, pr: PrSnapshot, now: int) -> bool:
         self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -121,7 +121,7 @@ def default_claim_repair_filing(kind: str, subject: str, state_sha: str) -> bool
         return not result["inserted"]
     except Exception as exc:
         print(
-            f"mergify_admin_requeue: default_claim_repair_filing failed for kind={kind!r} subject={subject!r} state_sha={state_sha!r}, assuming already claimed: {exc}",
+            f"mergify_admin_requeue: repair-filing claim failed for kind={kind!r} subject={subject!r} state_sha={state_sha!r}; skipping this filing tick without consuming code-repair retry budget: {exc}",
             file=sys.stderr,
         )
         return True
@@ -496,8 +496,7 @@ def retry_decision(
     return decision
 
 
-# An async repair submission (repairer.py's ledger.record(submit_kind, ...), written
-# only after a successful `headless_mutation run` submission) is "in flight" until a
+# An acknowledged async repair submission is "in flight" until a
 # same-kind "-settled" row lands with an equal-or-later epoch. The submitted plan's
 # `normalize` task writes that settle row unconditionally as its first action, so
 # reaching `normalize` at all -- pushed, no-op, prereq-created, or still-invalid --

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -52,6 +52,60 @@ class AdminBypassRepairer:
         # foreign= parameter.
         self.is_foreign = repo != DEFAULT_INVOKER_REPO
 
+    def submit_repair_plan(
+        self,
+        plan: async_repair.AsyncRepairPlan,
+        submit_kind: str,
+        pr_number: int,
+        head_sha: str,
+        key: str,
+        now: int | None,
+    ) -> None:
+        pending_kind = f"{submit_kind}-pending"
+        self.ledger.record(
+            pending_kind,
+            pr_number,
+            head_sha,
+            key,
+            now,
+            meta={"planName": plan.plan_name, "dispatchState": "pending"},
+        )
+        try:
+            acknowledgement = async_repair.submit_async_repair_plan(plan)
+        except Exception as exc:
+            self.ledger.record(
+                f"{pending_kind}-settled",
+                pr_number,
+                head_sha,
+                key,
+                now,
+                meta={
+                    "outcomeClass": "infra",
+                    "failurePhase": "submission",
+                    "dispatchState": "not-acknowledged",
+                    "planName": plan.plan_name,
+                    "error": str(exc),
+                },
+            )
+            raise
+        self.ledger.record(
+            submit_kind,
+            pr_number,
+            head_sha,
+            key,
+            now,
+            meta={
+                "dispatchState": "acknowledged",
+                "planName": plan.plan_name,
+                **(
+                    {"workflowId": acknowledgement.workflow_id}
+                    if isinstance(acknowledgement, async_repair.RepairSubmissionAcknowledgement)
+                    and isinstance(acknowledgement.workflow_id, str)
+                    else {}
+                ),
+            },
+        )
+
     def blocked_outcome(
         self,
         status: str,
@@ -200,13 +254,7 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        # Record before submitting: once submitted, the workflow is real and
-        # running whether or not this process survives another instruction.
-        # Recording first means a broken ledger write (e.g. disk full) raises
-        # here and skips the submission entirely, instead of leaving a real,
-        # running repair permanently invisible to the retry-cap count.
-        self.ledger.record("repair-check", pr.number, start_head, check_name, now)
-        async_repair.submit_async_repair_plan(plan)
+        self.submit_repair_plan(plan, "repair-check", pr.number, start_head, check_name, now)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def rebase_onto_master(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
@@ -227,10 +275,7 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        # See repair_check: record before submitting so a broken ledger write
-        # blocks the submission instead of orphaning a real, running repair.
-        self.ledger.record("rebase-onto-master", pr.number, start_head, key, now)
-        async_repair.submit_async_repair_plan(plan)
+        self.submit_repair_plan(plan, "rebase-onto-master", pr.number, start_head, key, now)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_bot_thread(self, pr: PrSnapshot, thread_id: str, now: int | None = None) -> RepairOutcome:
@@ -247,8 +292,5 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        # See repair_check: record before submitting so a broken ledger write
-        # blocks the submission instead of orphaning a real, running repair.
-        self.ledger.record("repair-bot-thread", pr.number, start_head, thread_id, now)
-        async_repair.submit_async_repair_plan(plan)
+        self.submit_repair_plan(plan, "repair-bot-thread", pr.number, start_head, thread_id, now)
         return self.blocked_outcome("submitted", thread_id, start_head, start_head)

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -290,24 +290,79 @@ def _repairer_plan_name(kind: str, pr: int, head: str, key: str) -> str:
 
 
 def settle_repairer_plan_rows(ledger, now: int) -> int:
-    """Write `<kind>-settled` rows for repairer.py's ad-hoc repair plans whose
-    workflow reached a terminal status but whose own safe-push task never ran
-    to write it. Returns how many rows were settled."""
-    pending = [row for row in ledger.rows if row.get("kind") in _REPAIRER_PLAN_SETTLE_KINDS]
-    if not pending:
-        return 0
-    workflows: list[dict] | None = None
-    settled = 0
-    for row in pending:
-        kind = str(row.get("kind"))
+    """Reconcile pending requests, then settle acknowledged repair workflows."""
+    pending_requests = [
+        row for row in ledger.rows
+        if str(row.get("kind") or "").endswith("-pending")
+        and str(row.get("kind") or "").removesuffix("-pending") in _REPAIRER_PLAN_SETTLE_KINDS
+    ]
+    acknowledged = []
+    for row in ledger.rows:
+        kind = row.get("kind")
+        if kind not in _REPAIRER_PLAN_SETTLE_KINDS:
+            continue
         pr = int(row.get("pr", -1))
         head = str(row.get("headSha") or "")
         key = str(row.get("key") or "")
         existing = ledger.latest(f"{kind}-settled", pr, head, key)
-        if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+        if existing is None or int(existing.get("epoch", 0) or 0) < int(row.get("epoch", 0) or 0):
+            acknowledged.append(row)
+    if not pending_requests and not acknowledged:
+        return 0
+    workflows = list_workflows()
+    if workflows is None:
+        return 0
+    settled = 0
+    for row in pending_requests:
+        pending_kind = str(row.get("kind"))
+        kind = pending_kind.removesuffix("-pending")
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
+        pending_epoch = int(row.get("epoch", 0) or 0)
+        existing_ack = ledger.latest(kind, pr, head, key)
+        if existing_ack is not None and int(existing_ack.get("epoch", 0) or 0) >= pending_epoch:
             continue
-        if workflows is None:
-            workflows = list_workflows() or []
+        existing_settle = ledger.latest(f"{pending_kind}-settled", pr, head, key)
+        if existing_settle is not None and int(existing_settle.get("epoch", 0) or 0) >= pending_epoch:
+            continue
+        meta = row.get("meta") or {}
+        plan_name = str(meta.get("planName") or _repairer_plan_name(kind, pr, head, key))
+        match = next((workflow for workflow in workflows if workflow.get("name") == plan_name), None)
+        if match is not None:
+            ledger.record(
+                kind,
+                pr,
+                head,
+                key,
+                now,
+                meta={
+                    "dispatchState": "acknowledged",
+                    "acknowledgedBy": "pending-request-observer",
+                    "planName": plan_name,
+                    "workflowId": match.get("id"),
+                },
+            )
+        else:
+            ledger.record(
+                f"{pending_kind}-settled",
+                pr,
+                head,
+                key,
+                now,
+                meta={
+                    "dispatchState": "not-acknowledged",
+                    "failurePhase": "submission",
+                    "outcomeClass": "infra",
+                    "planName": plan_name,
+                },
+            )
+        settled += 1
+    for row in acknowledged:
+        kind = str(row.get("kind"))
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
         plan_name = _repairer_plan_name(kind, pr, head, key)
         match = next((w for w in workflows if w.get("name") == plan_name), None)
         if match is None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -36,7 +36,7 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_plan import plan_stack_execution, repair_in_flight
+from scripts.mergify_admin_requeue_plan import count_code_repair_attempts, plan_stack_execution, repair_in_flight
 from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
@@ -429,13 +429,32 @@ Failing checks
             ledger.count("rebase-onto-master", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
             1,
         )
+        self.assertEqual(
+            ledger.count("rebase-onto-master-pending", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
+            1,
+        )
 
-    def test_rebase_onto_master_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
-        # The ledger row is written before submission (not after) so a broken
-        # ledger write can never leave a real, running repair uncounted. The
-        # cost is the mirror case here: if submission itself fails, the
-        # attempt is still counted -- an acceptable trade since submission
-        # failures are rare and non-silent, unlike a lost ledger write.
+    def test_repair_request_is_pending_until_submitter_acknowledges_it(self):
+        item = pr(2665, merge_state="DIRTY", latest=mergify())
+        ledger = self.ledger()
+        repairer = self.repairer(object(), ledger)
+        key = f"rebase-onto-master:{item.number}"
+
+        def acknowledge(plan):
+            self.assertEqual(ledger.count("rebase-onto-master-pending", item.number, item.head_ref_oid, key), 1)
+            self.assertEqual(ledger.count("rebase-onto-master", item.number, item.head_ref_oid, key), 0)
+            return None
+
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=acknowledge,
+        ):
+            repairer.rebase_onto_master(item, "GitHub reports merge conflict", 1)
+
+        acknowledged = ledger.latest("rebase-onto-master", item.number, item.head_ref_oid, key)
+        self.assertEqual(acknowledged["meta"]["dispatchState"], "acknowledged")
+
+    def test_rebase_onto_master_submission_failure_is_infra_and_does_not_spend_code_retry(self):
         item = pr(2661, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
@@ -446,11 +465,15 @@ Failing checks
             with self.assertRaises(RuntimeError):
                 repairer.rebase_onto_master(item, "GitHub reports merge conflict", 1)
         self.assertEqual(
-            ledger.count("rebase-onto-master", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
-            1,
+            count_code_repair_attempts(ledger, "rebase-onto-master", item.number, f"rebase-onto-master:{item.number}"),
+            0,
         )
+        self.assertEqual(ledger.count("rebase-onto-master-pending", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"), 1)
+        self.assertEqual(ledger.count("rebase-onto-master-pending-settled", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"), 1)
+        actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 2)
+        self.assertEqual([(action.kind, action.pr_number) for action in actions], [("rebase_onto_master", item.number)])
 
-    def test_repair_check_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
+    def test_repair_check_submission_failure_is_infra_and_does_not_spend_code_retry(self):
         item = pr(2662, latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
@@ -461,7 +484,62 @@ Failing checks
             ):
                 with self.assertRaises(RuntimeError):
                     repairer.repair_check(item, "PR Body", 1)
-        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 1)
+        self.assertEqual(count_code_repair_attempts(ledger, "repair-check", item.number, "PR Body"), 0)
+
+    def test_bot_thread_submission_failure_is_infra_and_does_not_spend_code_retry(self):
+        item = pr(2663, threads=(ReviewThread("tbot", False, ("coderabbitai[bot]",)),), latest=mergify())
+        ledger = self.ledger()
+        repairer = self.repairer(object(), ledger)
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=RuntimeError("submit failed"),
+        ):
+            with self.assertRaises(RuntimeError):
+                repairer.repair_bot_thread(item, "tbot", 1)
+        self.assertEqual(count_code_repair_attempts(ledger, "repair-bot-thread", item.number, "tbot"), 0)
+
+    def test_next_cycle_retries_prestart_failure_and_only_success_spends_budget(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        item = pr(2664, merge_state="DIRTY", latest=mergify())
+        stack = StackGroup("s", (item,))
+
+        class FakeGh:
+            def compare_status(self, repo, base, head):
+                return "ahead"
+
+            def comment(self, repo, pr_number, body):
+                pass
+
+            def issue_comments(self, repo, pr_number):
+                return []
+
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=FakeGh()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(exec_impl, "settle_workflow_fastpath_rows", return_value=0):
+                            with mock.patch.object(exec_impl, "settle_repairer_plan_rows", return_value=0):
+                                with mock.patch.object(exec_impl.time, "time", side_effect=[100, 101]):
+                                    with mock.patch(
+                                        "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                                        side_effect=[RuntimeError("owner IPC failed"), None],
+                                    ) as submit:
+                                        first_should_poll = exec_impl.run_cycle(args)
+                                        second_should_poll = exec_impl.run_cycle(args)
+
+        self.assertTrue(first_should_poll)
+        self.assertTrue(second_should_poll)
+        self.assertEqual(submit.call_count, 2)
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(
+            refreshed.count("rebase-onto-master-pending", item.number, item.head_ref_oid, f"rebase-onto-master:{item.number}"),
+            2,
+        )
+        self.assertEqual(
+            count_code_repair_attempts(refreshed, "rebase-onto-master", item.number, f"rebase-onto-master:{item.number}"),
+            1,
+        )
 
     def test_candidate_stack_includes_unlabeled_upper_prs(self):
         def raw(number, base, head, labels):
@@ -650,6 +728,40 @@ Failing checks
         self.assertEqual(degraded[0]["failed"], 2)
         self.assertEqual(degraded[0]["last_error"], "second failure")
 
+    def test_rebase_dispatch_failure_says_request_was_not_acknowledged_and_no_retry_was_spent(self):
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        item = pr(7401, merge_state="DIRTY", latest=mergify())
+        stack = StackGroup("s", (item,))
+
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def issue_comments(self, repo, pr_number):
+                return []
+
+        fake_gh = FakeGh()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "rebase_onto_master", side_effect=RuntimeError("owner IPC failed")):
+                            with redirect_stdout(stdout):
+                                should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        self.assertIn("PENDING rebase-onto-master PR #7401", stdout.getvalue())
+        self.assertNotIn("ACKNOWLEDGED rebase-onto-master PR #7401", stdout.getvalue())
+        self.assertEqual(len(fake_gh.comments), 1)
+        body = fake_gh.comments[0][2]
+        self.assertIn("repair dispatch was not acknowledged", body)
+        self.assertIn("recorded as pending", body)
+        self.assertIn("without consuming the code-repair retry budget", body)
+        self.assertIn("automatic retry remains enabled", body)
+
     def test_run_cycle_does_not_log_degraded_when_any_repair_dispatch_succeeds(self):
         args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
@@ -767,7 +879,10 @@ Failing checks
                         with mock.patch.object(AdminBypassRepairer, "repair_check", side_effect=subprocess.CalledProcessError(1, ["claude"])) as repair_check:
                             should_poll = exec_impl.run_cycle(args)
         self.assertEqual(repair_check.call_count, 1)
-        self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
+        self.assertEqual(len(fake_gh.comments), 2)
+        self.assertEqual(fake_gh.comments[0][0:2], ("owner/repo", 6601))
+        self.assertIn("repair dispatch was not acknowledged", fake_gh.comments[0][2])
+        self.assertEqual(fake_gh.comments[1], ("owner/repo", 6602, "@mergifyio queue"))
         self.assertTrue(should_poll)
 
     def test_run_cycle_attempts_every_independent_stack_in_one_tick(self):
@@ -1316,6 +1431,45 @@ The merge conditions cannot be satisfied due to failing checks
 
 
 class WorkflowFastpathTests(unittest.TestCase):
+    def test_headless_query_prefers_repo_ipc_client_over_invoker_ui_appimage(self):
+        repo_client = REPO_ROOT / "packages" / "app" / "dist" / "headless-client.js"
+        client_existed = repo_client.exists()
+        repo_client.parent.mkdir(parents=True, exist_ok=True)
+        if not client_existed:
+            repo_client.write_text("", encoding="utf-8")
+            self.addCleanup(repo_client.unlink, missing_ok=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_bin = Path(tmp)
+            invoker_ui = fake_bin / "invoker-ui"
+            node = fake_bin / "node"
+            invoker_ui.write_text("#!/bin/sh\necho appimage-client >&2\nexit 99\n", encoding="utf-8")
+            node.write_text("#!/bin/sh\necho repo-node-client\n", encoding="utf-8")
+            invoker_ui.chmod(0o755)
+            node.chmod(0o755)
+            env = dict(os.environ)
+            env.update({
+                "PATH": f"{fake_bin}:{env['PATH']}",
+                "INVOKER_HEADLESS_FORCE_OWNER_IPC": "1",
+                "INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS": "0",
+            })
+            env.pop("INVOKER_HEADLESS_CLIENT_BIN", None)
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'set -euo pipefail; source "$1"; headless_query query review-gate owner/repo#1 --output json',
+                    "bash",
+                    str(REPO_ROOT / "scripts" / "headless-lib.sh"),
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout, "repo-node-client\n")
+
     def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
         with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -232,7 +232,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
 
     def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
         plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
-        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="Workflow ID: wf-ack\n", stderr="")
         written_paths = []
 
         def fake_run_headless(command, *extra_args):
@@ -242,8 +242,9 @@ class AsyncRepairPlanTests(unittest.TestCase):
             return completed
 
         with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", side_effect=fake_run_headless) as run:
-            async_repair.submit_async_repair_plan(plan)
+            acknowledgement = async_repair.submit_async_repair_plan(plan)
         run.assert_called_once()
+        self.assertEqual(acknowledgement.workflow_id, "wf-ack")
         self.assertFalse(written_paths[0].exists())
 
     def test_submit_async_repair_plan_honors_submit_test_seam(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -10,11 +10,13 @@ Run:  python3 scripts/test_mergify_admin_requeue_plan.py
 
 from __future__ import annotations
 
+import io
 import shutil
 import sys
 import tempfile
 import unittest
 import unittest.mock
+from contextlib import redirect_stderr
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -1400,9 +1402,13 @@ class DefaultClaimAndReleaseRepairFiling(PlannerTestCase):
         self.assertTrue(already_claimed)
 
     def test_fails_closed_when_the_ledger_call_raises(self):
+        stderr = io.StringIO()
         with unittest.mock.patch.object(p.repair_filing_ledger, "insert_repair_filing", side_effect=RuntimeError("headless_mutation timed out")):
-            already_claimed = p.default_claim_repair_filing("k", "s", "sha")
+            with redirect_stderr(stderr):
+                already_claimed = p.default_claim_repair_filing("k", "s", "sha")
         self.assertTrue(already_claimed)
+        self.assertIn("skipping this filing tick without consuming code-repair retry budget", stderr.getvalue())
+        self.assertNotIn("assuming already claimed", stderr.getvalue())
 
     def test_release_calls_through(self):
         with unittest.mock.patch.object(p.repair_filing_ledger, "release_repair_filing", return_value={"released": True}) as release:

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -177,6 +177,65 @@ class RepairerPlanSettleObserver(unittest.TestCase):
         from mergify_admin_requeue_model import Ledger
         return Ledger(Path(tmpdir) / "state.jsonl")
 
+    def test_promotes_crash_left_pending_request_when_invoker_has_the_workflow(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "4f4e937" + "0" * 33
+            key = "rebase-onto-master:11149"
+            plan_name = f.rebase_onto_master_plan_name(11149, head)
+            ledger.record(
+                "rebase-onto-master-pending",
+                11149,
+                head,
+                key,
+                100,
+                meta={"dispatchState": "pending", "planName": plan_name},
+            )
+            workflows = [{"id": "wf-repair", "name": plan_name, "status": "running"}]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 1)
+
+            acknowledged = ledger.latest("rebase-onto-master", 11149, head, key)
+            self.assertEqual(acknowledged["meta"]["dispatchState"], "acknowledged")
+            self.assertEqual(acknowledged["meta"]["acknowledgedBy"], "pending-request-observer")
+            self.assertEqual(acknowledged["meta"]["workflowId"], "wf-repair")
+
+    def test_closes_unacknowledged_pending_request_without_creating_an_attempt(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "4f4e937" + "0" * 33
+            key = "rebase-onto-master:11149"
+            ledger.record(
+                "rebase-onto-master-pending",
+                11149,
+                head,
+                key,
+                100,
+                meta={
+                    "dispatchState": "pending",
+                    "planName": f.rebase_onto_master_plan_name(11149, head),
+                },
+            )
+            with mock.patch.object(f, "list_workflows", return_value=[]):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 1)
+
+            self.assertIsNone(ledger.latest("rebase-onto-master", 11149, head, key))
+            closed = ledger.latest("rebase-onto-master-pending-settled", 11149, head, key)
+            self.assertEqual(closed["meta"]["dispatchState"], "not-acknowledged")
+
+    def test_leaves_pending_request_open_when_invoker_cannot_be_queried(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "4f4e937" + "0" * 33
+            key = "rebase-onto-master:11149"
+            ledger.record("rebase-onto-master-pending", 11149, head, key, 100)
+            with mock.patch.object(f, "list_workflows", return_value=None):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("rebase-onto-master-pending-settled", 11149, head, key))
+
     def test_settles_a_failed_bot_thread_repair_by_matching_its_plan_name(self):
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

The Mergify repairer records a pending request before handing work to Invoker.

It announces acknowledgement only after Invoker accepts the handoff. Handoffs that throw do not consume the repair attempt cap.

An observer reconciles crash-left pending requests against workflow names before deciding whether the cap advances.

## Review Claim

Approve the Mergify maintenance policy that counts only Invoker-acknowledged repair work and reports rejected handoffs accurately.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every repair request is recorded as pending before dispatch. Only an acknowledged workflow consumes the cap; unacknowledged requests remain eligible, while acknowledged work stays bounded.

## Slice Rationale

This slice contains the Mergify-specific ledger, observer, client selection, and operator messaging needed to enforce one tooling policy.

The preceding stack slice owns the execution-engine worker paths.

## Non-goals

- Does not change the configured repair attempt cap.
- Does not resolve pull-request merge conflicts without a repair workflow.
- Does not deploy or mutate production worker state.

## Architecture

### Before

```mermaid
flowchart TD
    A["Mergify repair selected"] --> B["Attempt recorded"]
    B --> C["Invoker handoff"]
    C --> D["Rejected handoff remains charged"]
```

### After

```mermaid
flowchart TD
    A["Mergify repair selected"] --> B["Pending request recorded"]
    B --> C["Invoker handoff"]
    C -->|"acknowledged"| D["Attempt recorded"]
    C -->|"rejected"| E["Pending request closed without charge"]
    B -->|"process exits"| F["Observer matches workflow name"]
    F -->|"workflow found"| D
    F -->|"no workflow found"| E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue.MergifyAdminRequeueTests.test_repair_request_is_pending_until_submitter_acknowledges_it`
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_async_repair scripts.test_mergify_admin_requeue_workflow_fastpath`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's merge commit>`
- Post-revert steps: Redeploy the PR-maintenance worker if this change has already reached production.
- Data migration? No

</details>
