### PR TITLE
[Experiment spawn pool inherit](3) Also inherit maxTurns on experiment spawn

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-experiment-spawn-pool-inherit.test.ts
@@ -138,7 +138,7 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
     });
   });
 
-  it('spawned experiment tasks keep the pivot poolId, runnerKind, and execution agent/model', () => {
+  it('spawned experiment tasks keep the pivot poolId, runnerKind, execution agent/model, and maxTurns', () => {
     const plan: PlanDefinition = {
       name: 'experiment-pool-inherit-repro',
       baseBranch: 'main',
@@ -150,6 +150,7 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
           poolId: 'local-mac-only',
           executionAgent: 'codex',
           executionModel: 'o3',
+          maxTurns: 42,
           experimentVariants: [
             { id: 'mine-00', description: 'Mine 0', command: 'echo 0' },
             { id: 'mine-01', description: 'Mine 1', command: 'echo 1' },
@@ -169,6 +170,7 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
     expect(pivot.config.runnerKind).toBe('ssh');
     expect(pivot.config.executionAgent).toBe('codex');
     expect(pivot.config.executionModel).toBe('o3');
+    expect(pivot.config.maxTurns).toBe(42);
 
     orchestrator.handleWorkerResponse(spawnResponse(pivotId, ['mine-00', 'mine-01']));
 
@@ -178,11 +180,13 @@ describe('repro: experiment spawn inherits pivot pool executor', () => {
       expect(exp.config.poolId, `${local} poolId`).toBe(pivot.config.poolId);
       expect(exp.config.executionAgent, `${local} executionAgent`).toBe(pivot.config.executionAgent);
       expect(exp.config.executionModel, `${local} executionModel`).toBe(pivot.config.executionModel);
+      expect(exp.config.maxTurns, `${local} maxTurns`).toBe(pivot.config.maxTurns);
     }
 
     const recon = orchestrator.getTask(`${pivotId}-reconciliation`)!;
     expect(recon.config.executionAgent).toBe('codex');
     expect(recon.config.executionModel).toBe('o3');
+    expect(recon.config.maxTurns).toBe(42);
   });
 
   it('spawn/graph-mutation throws when runnerKind=ssh without poolId', () => {

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -217,6 +217,7 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       ...(nodeDef.poolId ? { poolId: nodeDef.poolId } : {}),
       ...(nodeDef.executionAgent ? { executionAgent: nodeDef.executionAgent } : {}),
       ...(nodeDef.executionModel ? { executionModel: nodeDef.executionModel } : {}),
+      ...(nodeDef.maxTurns !== undefined ? { maxTurns: nodeDef.maxTurns } : {}),
     } as const;
     let nodeConfig: TaskConfig;
     switch (nodeDef.runnerKind) {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -552,6 +552,7 @@ export interface GraphMutationNodeDef {
   dockerImage?: string;
   executionAgent?: string;
   executionModel?: string;
+  maxTurns?: number;
   isReconciliation?: boolean;
   requiresManualApproval?: boolean;
   isMergeNode?: boolean;

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -361,6 +361,7 @@ export function handleSpawnExperimentsImpl(
     parentTask?.config.runnerKind === 'docker' ? parentTask.config.dockerImage : undefined;
   const parentExecutionAgent = parentTask?.config.executionAgent;
   const parentExecutionModel = parentTask?.config.executionModel;
+  const parentMaxTurns = parentTask?.config.maxTurns;
 
   const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
     id: scopeLocal(v.id),
@@ -376,6 +377,7 @@ export function handleSpawnExperimentsImpl(
     dockerImage: parentDockerImage,
     executionAgent: parentExecutionAgent,
     executionModel: parentExecutionModel,
+    maxTurns: parentMaxTurns,
   }));
 
   const reconciliationId = `${taskId}-reconciliation`;
@@ -394,6 +396,7 @@ export function handleSpawnExperimentsImpl(
       dockerImage: parentDockerImage,
       executionAgent: parentExecutionAgent,
       executionModel: parentExecutionModel,
+      maxTurns: parentMaxTurns,
     },
   ];
 


### PR DESCRIPTION
## Summary

Experiment spawn now copies the pivot task's maxTurns onto every variant and the reconciliation node.

Replacement tasks already preserved turn budgets; spawn was dropping them so Claude/Codex variants silently lost the pivot cap.

## Review Claim

Approve inheriting pivot maxTurns onto experiment and reconciliation nodes at spawn, matching task-replacement parity.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only graph-mutation spawn config inheritance changes; no change to pool selection, lease logic, or agent/model resolution.

## Slice Rationale

Follow-up to the pool/agent/model inherit land (#11162). maxTurns was the remaining replacement-task parity gap and is small enough to review alone.

## Non-goals

Does not change default maxTurns when the pivot leaves it unset.

Does not inherit poolMemberId, prompts, or approval flags onto variants.

## Architecture

### Before

```mermaid
graph TD
    P["pivot maxTurns set"]
    E["exp maxTurns missing"]
    P --> E
```

### After

```mermaid
graph TD
    P["pivot maxTurns set"]
    E["exp and recon inherit maxTurns"]
    P --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/repro-experiment-spawn-pool-inherit.test.ts src/__tests__/graph-mutation.test.ts src/__tests__/experiment-lifecycle.test.ts`
- [x] `pnpm run check:comments`
- [x] `bash scripts/repro/experiment-spawn-pool-inherit.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
