### PR TITLE
feat(contracts): carry task specification snapshot

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -61,6 +61,7 @@ export interface WorkRequestInputs {
   baseBranch?: string;
   /** Already-resolved base commit for baseBranch, used to skip redundant base ref resolution. */
   baseCommit?: string;
+  specificationSnapshotCommit?: string;
   /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   executionAgent?: string;
   /** Agent-specific model selector. The selected CLI owns validation. */


### PR DESCRIPTION
## Summary

Adds the selected attempt's immutable specification snapshot to `WorkRequestInputs`.

This contract lets every execution environment receive the same repository lineage value without rediscovering it.

## Review Claim

Approve one transport contract field for task-specification lineage.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The field is optional, so existing producers and consumers remain source-compatible until the dependent enforcement PR activates it.

## Slice Rationale

This PR defines only the shared transport shape. The dependent PR owns production and consumption so reviewers can evaluate that behavior separately.

## Architecture

### Before

`WorkRequestInputs` carried the resolved launch base but not the attempt snapshot associated with the task specification.

### After

`WorkRequestInputs.specificationSnapshotCommit` can carry that immutable attempt value across executor boundaries.

## Non-goals

- Do not populate or consume the new field in this PR.
- Do not change task status or launch behavior.
- Do not persist another snapshot owner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before reverting the dependent enforcement PR.
- Revert command: `git revert d81815215f`
- Post-revert steps: Re-run the contracts build.
- Data migration? No.

</details>
