### PR TITLE
feat(engine): stop outdated task reconstruction

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -61,6 +61,7 @@ export interface WorkRequestInputs {
   baseBranch?: string;
   /** Already-resolved base commit for baseBranch, used to skip redundant base ref resolution. */
   baseCommit?: string;
+  specificationSnapshotCommit?: string;
   /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   executionAgent?: string;
   /** Agent-specific model selector. The selected CLI owns validation. */

--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -202,6 +202,40 @@ describe('stale task specification preflight', () => {
     }
   });
 
+  it('expands a tilde-prefixed remote working directory before checking freshness', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'invoker-stale-task-remote-home-'));
+    const repo = join(fakeHome, 'workspace');
+    try {
+      mkdirSync(repo);
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+      mkdirSync(join(repo, 'packages/ui/src'), { recursive: true });
+      const appPath = join(repo, 'packages/ui/src/App.tsx');
+      writeFileSync(appPath, 'export const camera = "selection-only";\n');
+      execFileSync('git', ['add', '.'], { cwd: repo });
+      execFileSync('git', ['commit', '-qm', 'old camera base'], { cwd: repo });
+      const snapshotCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+      writeFileSync(appPath, 'export const camera = "selection-recenter";\n');
+      execFileSync('git', ['commit', '-qam', 'change camera behavior'], { cwd: repo });
+
+      const output = execFileSync('bash', ['-c', buildRemoteTaskFreshnessScript({
+        cwd: '~/workspace',
+        snapshotCommit,
+        taskText: 'Modify packages/ui/src/App.tsx.',
+      })], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome },
+      });
+
+      expect(parseRemoteTaskFreshnessReport(output)).toMatchObject({
+        reasons: ['path:packages/ui/src/App.tsx'],
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   it('is wired before command construction and stops with needs_input', () => {
     const executorSource = readFileSync(new URL('../worktree-executor.ts', import.meta.url), 'utf8');
     const freshnessIndex = executorSource.indexOf('const freshness = await inspectTaskFreshness');

--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -1,0 +1,224 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRemoteTaskFreshnessScript,
+  evaluateTaskFreshness,
+  inspectTaskFreshness,
+  parseRemoteTaskFreshnessReport,
+  parseTaskFreshnessSpecification,
+} from '../task-specification-preflight.js';
+
+const CAMERA_TASK = `
+Files:
+- packages/ui/src/App.tsx
+- packages/ui/src/lib/graph-camera.ts
+
+Preserve guarded-behavior: selection-camera-inert.
+Modify the existing \`packages/ui/src/lib/graph-camera.ts\`; do not create it.
+`;
+
+describe('stale task specification preflight', () => {
+  it('stops the old camera task when a referenced path changed after its snapshot', () => {
+    const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
+
+    expect(evaluateTaskFreshness({
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: ['packages/ui/src/App.tsx'],
+      changedGuardedBehaviorIds: [],
+      missingAnchors: [],
+    })).toEqual({
+      status: 'stale',
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      changedReferencedPaths: ['packages/ui/src/App.tsx'],
+      changedGuardedBehaviorIds: [],
+      missingAnchors: [],
+      message: expect.stringContaining('replan/recreate'),
+    });
+  });
+
+  it('stops when a named guarded behavior changed', () => {
+    const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
+
+    expect(evaluateTaskFreshness({
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: ['packages/ui/src/other.ts'],
+      changedGuardedBehaviorIds: ['selection-camera-inert'],
+      missingAnchors: [],
+    })).toMatchObject({
+      status: 'stale',
+      changedGuardedBehaviorIds: ['selection-camera-inert'],
+    });
+  });
+
+  it('stops when an explicit existing/do-not-create anchor is absent', () => {
+    const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
+
+    expect(evaluateTaskFreshness({
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: [],
+      changedGuardedBehaviorIds: [],
+      missingAnchors: specification.anchors,
+    })).toMatchObject({
+      status: 'stale',
+      missingAnchors: [
+        expect.objectContaining({
+          kind: 'path',
+          value: 'packages/ui/src/lib/graph-camera.ts',
+        }),
+      ],
+    });
+  });
+
+  it('allows unrelated base changes and current-base attempts', () => {
+    const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
+
+    expect(evaluateTaskFreshness({
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: ['README.md'],
+      changedGuardedBehaviorIds: [],
+      missingAnchors: [],
+    })).toEqual({ status: 'current' });
+
+    expect(evaluateTaskFreshness({
+      snapshotCommit: 'current-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: ['packages/ui/src/App.tsx'],
+      changedGuardedBehaviorIds: ['selection-camera-inert'],
+      missingAnchors: [],
+    })).toEqual({ status: 'current' });
+  });
+
+  it('does not invent anchors from ordinary file references', () => {
+    const specification = parseTaskFreshnessSpecification('Modify packages/ui/src/App.tsx.');
+
+    expect(specification.referencedPaths).toEqual(['packages/ui/src/App.tsx']);
+    expect(specification.anchors).toEqual([]);
+  });
+
+  it('returns the same terminal decision for a repeated mismatch', () => {
+    const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
+    const input = {
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      specification,
+      changedPaths: ['packages/ui/src/App.tsx'],
+      changedGuardedBehaviorIds: [] as string[],
+      missingAnchors: [] as typeof specification.anchors,
+    };
+
+    expect(evaluateTaskFreshness(input)).toEqual(evaluateTaskFreshness(input));
+    expect(evaluateTaskFreshness(input).status).toBe('stale');
+  });
+
+  it('inspects the real pre-agent git boundary for changed referenced paths', async () => {
+    const gitCalls: string[][] = [];
+    const decision = await inspectTaskFreshness({
+      cwd: '/repo',
+      snapshotCommit: 'old-camera-base',
+      taskText: 'Modify packages/ui/src/App.tsx.',
+      runGit: async args => {
+        gitCalls.push(args);
+        if (args[0] === 'rev-parse') return 'current-base\n';
+        if (args[0] === 'cat-file') return '';
+        if (args[1] === '--name-only') return 'packages/ui/src/App.tsx\n';
+        if (args[1] === '--unified=0') return '';
+        throw new Error(`unexpected git call: ${args.join(' ')}`);
+      },
+    });
+
+    expect(decision).toMatchObject({
+      status: 'stale',
+      snapshotCommit: 'old-camera-base',
+      currentCommit: 'current-base',
+      changedReferencedPaths: ['packages/ui/src/App.tsx'],
+    });
+    expect(gitCalls).toContainEqual([
+      'diff', '--name-only', 'old-camera-base', 'current-base', '--',
+    ]);
+  });
+
+  it('stops when the immutable snapshot can no longer be resolved', async () => {
+    const decision = await inspectTaskFreshness({
+      cwd: '/repo',
+      snapshotCommit: 'missing-camera-base',
+      taskText: 'Modify packages/ui/src/App.tsx.',
+      runGit: async args => {
+        if (args[0] === 'rev-parse') return 'current-base\n';
+        if (args[0] === 'cat-file') throw new Error('bad object');
+        throw new Error(`unexpected git call: ${args.join(' ')}`);
+      },
+    });
+
+    expect(decision).toMatchObject({
+      status: 'stale',
+      snapshotUnavailable: true,
+      snapshotCommit: 'missing-camera-base',
+      currentCommit: 'current-base',
+      message: expect.stringContaining('replan/recreate'),
+    });
+  });
+
+  it('runs the same referenced-path guard in an SSH-compatible shell', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'invoker-stale-task-preflight-'));
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+      mkdirSync(join(repo, 'packages/ui/src'), { recursive: true });
+      const appPath = join(repo, 'packages/ui/src/App.tsx');
+      writeFileSync(appPath, 'export const camera = "selection-only";\n');
+      execFileSync('git', ['add', '.'], { cwd: repo });
+      execFileSync('git', ['commit', '-qm', 'old camera base'], { cwd: repo });
+      const snapshotCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+      writeFileSync(appPath, 'export const camera = "selection-recenter";\n');
+      execFileSync('git', ['commit', '-qam', 'change camera behavior'], { cwd: repo });
+
+      const output = execFileSync('bash', ['-c', buildRemoteTaskFreshnessScript({
+        cwd: repo,
+        snapshotCommit,
+        taskText: 'Modify packages/ui/src/App.tsx.',
+      })], { encoding: 'utf8' });
+
+      expect(parseRemoteTaskFreshnessReport(output)).toMatchObject({
+        reasons: ['path:packages/ui/src/App.tsx'],
+      });
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('is wired before command construction and stops with needs_input', () => {
+    const executorSource = readFileSync(new URL('../worktree-executor.ts', import.meta.url), 'utf8');
+    const freshnessIndex = executorSource.indexOf('const freshness = await inspectTaskFreshness');
+    const commandIndex = executorSource.indexOf('const { cmd, args, agentSessionId } = this.buildCommandAndArgs');
+
+    expect(freshnessIndex).toBeGreaterThan(-1);
+    expect(commandIndex).toBeGreaterThan(freshnessIndex);
+    expect(executorSource.slice(freshnessIndex, commandIndex)).toContain("status: 'needs_input'");
+
+    const prepareSource = readFileSync(new URL('../task-runner-prepare.ts', import.meta.url), 'utf8');
+    expect(prepareSource).toContain('specificationSnapshotCommit');
+    expect(prepareSource).toContain('loadAttempt.call(host.persistence, attemptId)?.snapshotCommit');
+
+    const sshSource = readFileSync(new URL('../ssh-executor.ts', import.meta.url), 'utf8');
+    const sshFreshnessIndex = sshSource.indexOf('await this.inspectRemoteTaskFreshness');
+    const sshSpawnIndex = sshSource.indexOf('await this.spawnSshRemoteStdin');
+    expect(sshFreshnessIndex).toBeGreaterThan(-1);
+    expect(sshSpawnIndex).toBeGreaterThan(sshFreshnessIndex);
+  });
+});

--- a/packages/execution-engine/src/remote-shell-fragments.ts
+++ b/packages/execution-engine/src/remote-shell-fragments.ts
@@ -11,6 +11,19 @@ export function buildPortableBase64DecodeFunction(functionName = 'invoker_base64
 }`;
 }
 
+export function buildRemotePathNormalizeFunction(): string {
+  return `normalize_remote_path() {
+  local path="$1"
+  if [[ "$path" == '~' ]]; then
+    printf '%s\\n' "$HOME"
+  elif [[ "\${path:0:2}" == '~/' ]]; then
+    printf '%s/%s\\n' "$HOME" "\${path:2}"
+  else
+    printf '%s\\n' "$path"
+  fi
+}`;
+}
+
 export function buildSourceInvokerEnvScript(remoteInvokerHome = '~/.invoker', varName = 'INVOKER_RUNTIME_HOME'): string {
   return `${varName}='${remoteInvokerHome.replace(/'/g, `'\\''`)}'
 if [[ "$${varName}" == '~' ]]; then

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -16,7 +16,10 @@ import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { createExecutionBench } from './execution-bench.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
-import { buildSourceInvokerEnvScript } from './remote-shell-fragments.js';
+import {
+  buildRemotePathNormalizeFunction,
+  buildSourceInvokerEnvScript,
+} from './remote-shell-fragments.js';
 import { canonicalizeRemoteManagedWorkspacePath } from './conflict-resolver.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
@@ -325,20 +328,6 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
 `;
   }
 
-  private remotePathNormalizeFunction(): string {
-    return `normalize_remote_path() {
-  local path="$1"
-  if [[ "$path" == '~' ]]; then
-    printf '%s\\n' "$HOME"
-  elif [[ "\${path:0:2}" == '~/' ]]; then
-    printf '%s/%s\\n' "$HOME" "\${path:2}"
-  else
-    printf '%s\\n' "$path"
-  fi
-}
-`;
-  }
-
   private buildRuntimeBootstrapScript(options: {
     executionId: string;
     actionId: string;
@@ -384,7 +373,7 @@ ensure_managed_pnpm_workspace
 }
 load_remote_profile_path
 set -euo pipefail
-${this.remotePathNormalizeFunction()}
+${buildRemotePathNormalizeFunction()}
 ${buildSourceInvokerEnvScript(this.remoteInvokerHome, 'INVOKER_HOME')}
 STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -32,6 +32,11 @@ import {
   createSshRemoteScriptError,
   parseOwnedWorktreePath,
 } from './ssh-git-exec.js';
+import {
+  buildRemoteTaskFreshnessScript,
+  formatRemoteTaskFreshnessMessage,
+  parseRemoteTaskFreshnessReport,
+} from './task-specification-preflight.js';
 
 // The post-task "record and push" step opens a fresh SSH connection after the
 // task's own child process has already exited. Unlike that first connection,
@@ -175,6 +180,66 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
       user: this.user,
       host: this.host,
     }, { batchMode: true });
+  }
+
+  private stopForStaleTask(
+    request: WorkRequest,
+    handle: ExecutorHandle,
+    message: string,
+    agentSessionId?: string,
+  ): ExecutorHandle {
+    const executionId = handle.executionId;
+    const entry: SshEntry = {
+      process: null,
+      request,
+      outputListeners: new Set(),
+      outputBuffer: [],
+      outputBufferBytes: 0,
+      evictedChunkCount: 0,
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+      agentSessionId,
+    };
+    this.registerEntry(handle, entry);
+    setTimeout(() => {
+      const liveEntry = this.entries.get(executionId);
+      if (!liveEntry || liveEntry.completed) return;
+      liveEntry.completed = true;
+      this.emitComplete(executionId, {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        executionGeneration: request.executionGeneration,
+        status: 'needs_input',
+        outputs: {
+          exitCode: 1,
+          error: message,
+          summary: message,
+          branch: handle.branch,
+          workspacePath: handle.workspacePath,
+        },
+      });
+    }, 0);
+    return handle;
+  }
+
+  private async inspectRemoteTaskFreshness(
+    request: WorkRequest,
+    workspacePath: string,
+  ): Promise<string | undefined> {
+    if (request.actionType !== 'ai_task') return undefined;
+    const taskText = [request.inputs.description, request.inputs.prompt]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join('\n');
+    const output = await this.execRemoteCapture(buildRemoteTaskFreshnessScript({
+      cwd: workspacePath,
+      snapshotCommit: request.inputs.specificationSnapshotCommit,
+      taskText,
+    }), 'task_freshness_preflight');
+    const report = parseRemoteTaskFreshnessReport(output);
+    return report
+      ? formatRemoteTaskFreshnessMessage(request.inputs.specificationSnapshotCommit, report)
+      : undefined;
   }
 
   /** SSH args without `BatchMode` so `-t` / interactive sessions work for external Terminal.app. */
@@ -630,6 +695,11 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       hasAgentSessionId: !!agentSessionId,
     });
 
+    const staleTaskMessage = await this.inspectRemoteTaskFreshness(request, workspacePath);
+    if (staleTaskMessage) {
+      return this.stopForStaleTask(request, handle, staleTaskMessage, agentSessionId);
+    }
+
     // No-command tasks complete immediately
     if (!request.inputs.command && !request.inputs.prompt) {
       const response: WorkResponse = {
@@ -889,6 +959,11 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       }
       handle.workspacePath =
         remoteWt.startsWith(`${remoteHome}/`) ? `~${remoteWt.slice(remoteHome.length)}` : remoteWt;
+    }
+
+    const staleTaskMessage = await this.inspectRemoteTaskFreshness(request, remoteWt);
+    if (staleTaskMessage) {
+      return this.stopForStaleTask(request, handle, staleTaskMessage, agentSessionId);
     }
 
     // Step 4: No-command tasks complete immediately

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -105,6 +105,10 @@ export async function buildWorkRequest(
   const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
   const freshBase = task.config.workflowId ? host.freshBaseCommits.get(task.config.workflowId) : undefined;
   const baseCommit = freshBase && freshBase.branch === baseBranch ? freshBase.commit : undefined;
+  const loadAttempt = host.persistence.loadAttempt;
+  const specificationSnapshotCommit = typeof loadAttempt === 'function'
+    ? loadAttempt.call(host.persistence, attemptId)?.snapshotCommit
+    : undefined;
 
   // Persist the experiment branch as soon as the executor knows it — well
   // before `git worktree add` could leak a worktree without a recorded branch
@@ -160,6 +164,7 @@ export async function buildWorkRequest(
       lifecycleTag,
       baseBranch,
       baseCommit,
+      specificationSnapshotCommit,
       freshWorkspace: host.shouldUseFreshWorkspace(task),
       reusableWorktree: task.execution.branch && task.execution.workspacePath
         ? {

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -1,0 +1,320 @@
+import { access } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export interface TaskFreshnessAnchor {
+  kind: 'path' | 'symbol';
+  value: string;
+  clause: string;
+}
+
+export interface TaskFreshnessSpecification {
+  referencedPaths: string[];
+  guardedBehaviorIds: string[];
+  anchors: TaskFreshnessAnchor[];
+}
+
+export type TaskFreshnessDecision =
+  | { status: 'current' }
+  | {
+      status: 'stale';
+      snapshotCommit?: string;
+      currentCommit: string;
+      changedReferencedPaths: string[];
+      changedGuardedBehaviorIds: string[];
+      missingAnchors: TaskFreshnessAnchor[];
+      snapshotUnavailable?: boolean;
+      message: string;
+    };
+
+const REPO_PATH_PATTERN = /(?:^|[\s`'"(])((?:\.github|corpus|docs|engine|packages|scripts|tests)\/[A-Za-z0-9_@./-]+)/g;
+const BACKTICK_TOKEN_PATTERN = /`([^`]+)`/g;
+const ANCHOR_CLAUSE_PATTERN = /\b(?:already exists?|existing|do not create|must not create|without creating)\b/i;
+const GUARDED_MARKER_PATTERN = /guarded-behavior:\s*([A-Za-z0-9][\w-]*)/gi;
+const GUARDED_PROSE_PATTERN = /guarded behavior(?:\s+(?:id|marker))?\s*(?:`|"|')?([A-Za-z0-9][\w-]*)/gi;
+const REMOTE_REPORT_MARKER = '__INVOKER_TASK_FRESHNESS_STALE__';
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort();
+}
+
+function normalizedRepoPaths(text: string): string[] {
+  const paths: string[] = [];
+  for (const match of text.matchAll(REPO_PATH_PATTERN)) {
+    const value = match[1]?.replace(/[),.;:]+$/, '');
+    if (value && !value.split('/').includes('..')) paths.push(value);
+  }
+  return uniqueSorted(paths);
+}
+
+export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpecification {
+  const referencedPaths = normalizedRepoPaths(text);
+  const guardedBehaviorIds = uniqueSorted([
+    ...[...text.matchAll(GUARDED_MARKER_PATTERN)].map(match => match[1]!),
+    ...[...text.matchAll(GUARDED_PROSE_PATTERN)].map(match => match[1]!),
+  ]);
+  const anchors: TaskFreshnessAnchor[] = [];
+
+  for (const rawClause of text.split(/\r?\n/)) {
+    const clause = rawClause.trim();
+    if (!clause || !ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
+    const paths = normalizedRepoPaths(clause);
+    for (const value of paths) anchors.push({ kind: 'path', value, clause });
+    for (const tokenMatch of clause.matchAll(BACKTICK_TOKEN_PATTERN)) {
+      const value = tokenMatch[1]?.trim();
+      if (!value || paths.includes(value) || !/^[A-Za-z_$][\w$]*$/.test(value)) continue;
+      anchors.push({ kind: 'symbol', value, clause });
+    }
+  }
+
+  const dedupedAnchors = new Map<string, TaskFreshnessAnchor>();
+  for (const anchor of anchors) dedupedAnchors.set(`${anchor.kind}:${anchor.value}`, anchor);
+
+  return {
+    referencedPaths,
+    guardedBehaviorIds,
+    anchors: [...dedupedAnchors.values()].sort((left, right) =>
+      `${left.kind}:${left.value}`.localeCompare(`${right.kind}:${right.value}`)),
+  };
+}
+
+export function evaluateTaskFreshness(args: {
+  snapshotCommit?: string;
+  currentCommit: string;
+  specification: TaskFreshnessSpecification;
+  changedPaths: string[];
+  changedGuardedBehaviorIds: string[];
+  missingAnchors: TaskFreshnessAnchor[];
+}): TaskFreshnessDecision {
+  const {
+    snapshotCommit,
+    currentCommit,
+    specification,
+    changedPaths,
+    changedGuardedBehaviorIds,
+    missingAnchors,
+  } = args;
+  const commitsDiffer = Boolean(snapshotCommit && snapshotCommit !== currentCommit);
+  const referencedPathSet = new Set(specification.referencedPaths);
+  const guardedIdSet = new Set(specification.guardedBehaviorIds);
+  const changedReferencedPaths = commitsDiffer
+    ? uniqueSorted(changedPaths.filter(path => referencedPathSet.has(path)))
+    : [];
+  const changedRelevantGuardIds = commitsDiffer
+    ? uniqueSorted(changedGuardedBehaviorIds.filter(id => guardedIdSet.has(id)))
+    : [];
+
+  if (
+    changedReferencedPaths.length === 0
+    && changedRelevantGuardIds.length === 0
+    && missingAnchors.length === 0
+  ) {
+    return { status: 'current' };
+  }
+
+  const mismatchDetails = [
+    changedReferencedPaths.length > 0
+      ? `changed referenced paths: ${changedReferencedPaths.join(', ')}`
+      : undefined,
+    changedRelevantGuardIds.length > 0
+      ? `changed guarded behaviors: ${changedRelevantGuardIds.join(', ')}`
+      : undefined,
+    missingAnchors.length > 0
+      ? `absent existing/do-not-create anchors: ${missingAnchors.map(anchor => `${anchor.kind}:${anchor.value}`).join(', ')}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+
+  return {
+    status: 'stale',
+    snapshotCommit,
+    currentCommit,
+    changedReferencedPaths,
+    changedGuardedBehaviorIds: changedRelevantGuardIds,
+    missingAnchors,
+    message:
+      `Stale task specification blocked before agent execution `
+      + `(snapshot=${snapshotCommit ?? 'none'}, current=${currentCommit}): ${mismatchDetails.join('; ')}. `
+      + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.',
+  };
+}
+
+export async function inspectTaskFreshness(args: {
+  cwd: string;
+  snapshotCommit?: string;
+  taskText: string;
+  runGit: (gitArgs: string[]) => Promise<string>;
+  pathExists?: (absolutePath: string) => Promise<boolean>;
+  symbolExists?: (symbol: string, commit: string) => Promise<boolean>;
+}): Promise<TaskFreshnessDecision> {
+  const specification = parseTaskFreshnessSpecification(args.taskText);
+  const currentCommit = (await args.runGit(['rev-parse', 'HEAD'])).trim();
+  const commitsDiffer = Boolean(args.snapshotCommit && args.snapshotCommit !== currentCommit);
+  if (commitsDiffer) {
+    try {
+      await args.runGit(['cat-file', '-e', `${args.snapshotCommit!}^{commit}`]);
+    } catch {
+      return {
+        status: 'stale',
+        snapshotCommit: args.snapshotCommit,
+        currentCommit,
+        changedReferencedPaths: [],
+        changedGuardedBehaviorIds: [],
+        missingAnchors: [],
+        snapshotUnavailable: true,
+        message:
+          `Stale task specification blocked before agent execution `
+          + `(snapshot=${args.snapshotCommit}, current=${currentCommit}): snapshot commit is unavailable. `
+          + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.',
+      };
+    }
+  }
+  const changedPaths = commitsDiffer
+    ? (await args.runGit(['diff', '--name-only', args.snapshotCommit!, currentCommit, '--']))
+      .split(/\r?\n/)
+      .map(path => path.trim())
+      .filter(Boolean)
+    : [];
+
+  const changedGuardedBehaviorIds: string[] = [];
+  if (commitsDiffer && specification.guardedBehaviorIds.length > 0 && changedPaths.length > 0) {
+    const diff = await args.runGit(['diff', '--unified=0', args.snapshotCommit!, currentCommit, '--', ...changedPaths]);
+    for (const id of specification.guardedBehaviorIds) {
+      const marker = `guarded-behavior: ${id}`;
+      const ownerPaths = new Set<string>();
+      for (const commit of [args.snapshotCommit!, currentCommit]) {
+        try {
+          const matches = await args.runGit(['grep', '-l', '-F', '-e', marker, commit, '--']);
+          for (const rawPath of matches.split(/\r?\n/).map(value => value.trim()).filter(Boolean)) {
+            ownerPaths.add(rawPath.startsWith(`${commit}:`) ? rawPath.slice(commit.length + 1) : rawPath);
+          }
+        } catch {
+          continue;
+        }
+      }
+      if (diff.includes(marker) || changedPaths.some(path => ownerPaths.has(path))) {
+        changedGuardedBehaviorIds.push(id);
+      }
+    }
+  }
+
+  const pathExists = args.pathExists ?? (async (absolutePath: string) => {
+    try {
+      await access(absolutePath);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  const symbolExists = args.symbolExists ?? (async (symbol: string, commit: string) => {
+    try {
+      await args.runGit(['grep', '-F', '-e', symbol, commit, '--']);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  const missingAnchors: TaskFreshnessAnchor[] = [];
+  for (const anchor of specification.anchors) {
+    const exists = anchor.kind === 'path'
+      ? await pathExists(resolve(args.cwd, anchor.value))
+      : await symbolExists(anchor.value, currentCommit);
+    if (!exists) missingAnchors.push(anchor);
+  }
+
+  return evaluateTaskFreshness({
+    snapshotCommit: args.snapshotCommit,
+    currentCommit,
+    specification,
+    changedPaths,
+    changedGuardedBehaviorIds,
+    missingAnchors,
+  });
+}
+
+export interface RemoteTaskFreshnessReport {
+  currentCommit: string;
+  reasons: string[];
+}
+
+export function buildRemoteTaskFreshnessScript(args: {
+  cwd: string;
+  snapshotCommit?: string;
+  taskText: string;
+}): string {
+  const specification = parseTaskFreshnessSpecification(args.taskText);
+  const lines = [
+    'set -euo pipefail',
+    `cd ${shellQuote(args.cwd)}`,
+    'CURRENT_COMMIT=$(git rev-parse HEAD)',
+    'STALE_REASONS=""',
+    'append_stale_reason() {',
+    '  if [[ -n "$STALE_REASONS" ]]; then STALE_REASONS="$STALE_REASONS|$1"; else STALE_REASONS=$1; fi',
+    '}',
+  ];
+
+  for (const anchor of specification.anchors) {
+    if (anchor.kind === 'path') {
+      lines.push(
+        `if [[ ! -e ${shellQuote(anchor.value)} ]]; then append_stale_reason ${shellQuote(`anchor:path:${anchor.value}`)}; fi`,
+      );
+    } else {
+      lines.push(
+        `if ! git grep -F -q -e ${shellQuote(anchor.value)} "$CURRENT_COMMIT" --; then append_stale_reason ${shellQuote(`anchor:symbol:${anchor.value}`)}; fi`,
+      );
+    }
+  }
+
+  if (args.snapshotCommit) {
+    lines.push(
+      `SNAPSHOT_COMMIT=${shellQuote(args.snapshotCommit)}`,
+      'if [[ "$SNAPSHOT_COMMIT" != "$CURRENT_COMMIT" ]]; then',
+      '  if ! git cat-file -e "$SNAPSHOT_COMMIT^{commit}" 2>/dev/null; then',
+      "    append_stale_reason 'snapshot-unavailable'",
+      '  else',
+      '    CHANGED_PATHS=$(git diff --name-only "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)',
+    );
+    for (const path of specification.referencedPaths) {
+      lines.push(
+        `    if printf '%s\n' "$CHANGED_PATHS" | grep -F -x -q -- ${shellQuote(path)}; then append_stale_reason ${shellQuote(`path:${path}`)}; fi`,
+      );
+    }
+    if (specification.guardedBehaviorIds.length > 0) {
+      lines.push('    GUARDED_DIFF=$(git diff --unified=0 "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)');
+      for (const id of specification.guardedBehaviorIds) {
+        lines.push(
+          `    if printf '%s\n' "$GUARDED_DIFF" | grep -F -q -- ${shellQuote(`guarded-behavior: ${id}`)}; then append_stale_reason ${shellQuote(`guard:${id}`)}; fi`,
+        );
+      }
+    }
+    lines.push('  fi', 'fi');
+  }
+
+  lines.push(
+    'if [[ -n "$STALE_REASONS" ]]; then',
+    `  printf '%s\\t%s\\t%s\\n' ${shellQuote(REMOTE_REPORT_MARKER)} "$CURRENT_COMMIT" "$STALE_REASONS"`,
+    'fi',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+export function parseRemoteTaskFreshnessReport(output: string): RemoteTaskFreshnessReport | undefined {
+  const prefix = `${REMOTE_REPORT_MARKER}\t`;
+  const line = output.split(/\r?\n/).find(value => value.startsWith(prefix));
+  if (!line) return undefined;
+  const [, currentCommit = '', rawReasons = ''] = line.split('\t');
+  const reasons = rawReasons.split('|').map(value => value.trim()).filter(Boolean);
+  if (!currentCommit || reasons.length === 0) return undefined;
+  return { currentCommit, reasons };
+}
+
+export function formatRemoteTaskFreshnessMessage(
+  snapshotCommit: string | undefined,
+  report: RemoteTaskFreshnessReport,
+): string {
+  return `Stale task specification blocked before agent execution `
+    + `(snapshot=${snapshotCommit ?? 'none'}, current=${report.currentCommit}): ${report.reasons.join(', ')}. `
+    + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.';
+}

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -1,5 +1,6 @@
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { buildRemotePathNormalizeFunction } from './remote-shell-fragments.js';
 
 export interface TaskFreshnessAnchor {
   kind: 'path' | 'symbol';
@@ -247,7 +248,9 @@ export function buildRemoteTaskFreshnessScript(args: {
   const specification = parseTaskFreshnessSpecification(args.taskText);
   const lines = [
     'set -euo pipefail',
-    `cd ${shellQuote(args.cwd)}`,
+    buildRemotePathNormalizeFunction(),
+    `CWD=$(normalize_remote_path ${shellQuote(args.cwd)})`,
+    'cd "$CWD"',
     'CURRENT_COMMIT=$(git rev-parse HEAD)',
     'STALE_REASONS=""',
     'append_stale_reason() {',

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -25,6 +25,7 @@ import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { sanitizeBranchForPath } from './git-utils.js';
 import { loadLinearEnv } from './remote-agent-env.js';
+import { inspectTaskFreshness } from './task-specification-preflight.js';
 
 // Re-export for backward compatibility
 export { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
@@ -402,6 +403,62 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
           );
         }
         throw err;
+      }
+    }
+
+    if (request.actionType === 'ai_task') {
+      const taskText = [request.inputs.description, request.inputs.prompt]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join('\n');
+      const freshness = await inspectTaskFreshness({
+        cwd: acquired.worktreePath,
+        snapshotCommit: request.inputs.specificationSnapshotCommit,
+        taskText,
+        runGit: args => this.execGitSimple(args, acquired.worktreePath),
+      });
+      if (freshness.status === 'stale') {
+        const entry: WorktreeEntry = {
+          process: null,
+          request,
+          worktreeDir: acquired.worktreePath,
+          branch: acquired.branch,
+          phase: 'completed',
+          outputListeners: new Set(),
+          outputBuffer: [],
+          outputBufferBytes: 0,
+          evictedChunkCount: 0,
+          completeListeners: new Set(),
+          heartbeatListeners: new Set(),
+          completed: false,
+          poolSoftRelease: acquired.softRelease,
+          leaseResourceKey: acquired.leaseResourceKey,
+          leaseHolderId: acquired.leaseHolderId,
+        };
+        this.registerEntry(handle, entry);
+        handle.workspacePath = acquired.worktreePath;
+        handle.branch = acquired.branch;
+        handle.leaseResourceKey = acquired.leaseResourceKey;
+        handle.leaseHolderId = acquired.leaseHolderId;
+        setTimeout(() => {
+          const liveEntry = this.entries.get(executionId);
+          if (!liveEntry || liveEntry.completed) return;
+          liveEntry.completed = true;
+          this.emitComplete(executionId, {
+            requestId: request.requestId,
+            actionId: request.actionId,
+            executionGeneration: request.executionGeneration,
+            status: 'needs_input',
+            outputs: {
+              exitCode: 1,
+              error: freshness.message,
+              summary: freshness.message,
+              branch: acquired.branch,
+              workspacePath: acquired.worktreePath,
+            },
+          });
+          this.softReleasePoolSlot(liveEntry);
+        }, 0);
+        return handle;
       }
     }
 


### PR DESCRIPTION
## Summary

Routes repository-mismatched AI work to `needs_input` before local or SSH process spawn.

The decision compares attempt lineage and named task claims with the prepared worktree, returning exact evidence and a replan/recreate instruction.

## Review Claim

Approve one pre-spawn routing decision applied identically by local and SSH-managed executors.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only AI work with a relevant changed path/guarded ID, unavailable snapshot, or absent explicit existing/do-not-create anchor stops. Current snapshots, unrelated changes, ordinary references, and no-snapshot work without contradictory anchors proceed unchanged.

## Slice Rationale

Snapshot production, the shared classifier, and both executor branches must land together so every execution environment reaches the same terminal decision.

## Architecture

### Before

Local and SSH executors launched AI work after worktree preparation without comparing the attempt snapshot with named task claims.

### After

Preparation forwards the selected attempt snapshot. Both executors apply one classifier before process spawn and route mismatches to `needs_input` with snapshot/current context.

## Non-goals

- Do not stop work for every base SHA change.
- Do not rewrite prompts or reconstruct missing baseline behavior.
- Do not synthesize a snapshot for attempts that do not already own one.
- Do not change command-task, merge-gate, dependency-merge, or agent-selection behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] The pre-implementation focused repro exited 1 with `ERR_MODULE_NOT_FOUND` before the preflight module existed.

- [x] `pnpm --filter @invoker/execution-engine test -- task-specification-preflight.test.ts ssh-executor.test.ts task-runner.test.ts task-runner-fix-publish-and-ssh.test.ts`

  ```text
  Test Files  4 passed (4)
  Tests  317 passed | 1 skipped (318)
  ```

- [x] `pnpm --filter @invoker/execution-engine build`

- [ ] Full execution-engine suite: stopped after five minutes without progress after `docker-executor.test.ts`; 8 of 142 files had completed. The four directly affected suites above completed with exit code 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: revert the commits in this PR, then revert the parent contract PR if unused.
- Post-revert steps: Re-run the four focused execution-engine suites.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added task-specification freshness checks before AI task execution.
  - Detects changes to referenced files, guarded behaviors, and required paths or symbols.
  - Works across local worktrees and remote SSH workspaces.
- **Bug Fixes**
  - Prevents stale tasks from starting against outdated repository state.
  - Marks affected tasks as needing input with details about the workspace and changes, allowing replanning from the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->