### PR TITLE
fix(policy): require human approval for guarded bypass

### DIFF
--- a/scripts/cron-pr-auto-label.sh
+++ b/scripts/cron-pr-auto-label.sh
@@ -53,6 +53,13 @@ pr_is_test_only_diff() {
   return 0
 }
 
+guarded_bypass_is_eligible() {
+  node "$(dirname "$0")/guarded-behavior-approval.mjs" \
+    --pr "$1" \
+    --repo "$TARGET_REPO" \
+    --json
+}
+
 # When sourced (e.g. by tests), expose the functions above without running
 # the scan/submit flow below.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
@@ -109,6 +116,11 @@ while IFS= read -r pr; do
     fi
   fi
   [ "$eligible" -eq 1 ] || continue
+
+  if ! approval_output="$(guarded_bypass_is_eligible "$num" 2>&1)"; then
+    log_line "PR #$num: guarded-behavior approval required; skipping: $approval_output"
+    continue
+  fi
 
   plan_file="$PLAN_DIR/label-pr-$num.yaml"
   {

--- a/scripts/guarded-behavior-approval.mjs
+++ b/scripts/guarded-behavior-approval.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { collectGuardedBehaviorMarkers } from './validate-pr-body.mjs';
+
+function normalizeReview(review) {
+  const login = String(review?.user?.login ?? review?.author?.login ?? '').trim();
+  return {
+    id: Number(review?.id ?? 0),
+    login,
+    userType: String(review?.user?.type ?? review?.author?.type ?? ''),
+    state: String(review?.state ?? '').toUpperCase(),
+    commitId: String(review?.commit_id ?? review?.commitId ?? review?.commit?.oid ?? ''),
+    submittedAt: String(review?.submitted_at ?? review?.submittedAt ?? ''),
+  };
+}
+
+export function isBotReviewer(review) {
+  const normalized = normalizeReview(review);
+  const login = normalized.login.toLowerCase();
+  return normalized.userType.toLowerCase() === 'bot'
+    || login.endsWith('[bot]')
+    || login.endsWith('-bot')
+    || login === 'mergify'
+    || login === 'coderabbitai';
+}
+
+function latestReviewsByHuman(reviews) {
+  const sorted = reviews
+    .map(normalizeReview)
+    .filter(review => review.login && !isBotReviewer({
+      user: { login: review.login, type: review.userType },
+    }))
+    .sort((left, right) => {
+      const timeOrder = left.submittedAt.localeCompare(right.submittedAt);
+      return timeOrder !== 0 ? timeOrder : left.id - right.id;
+    });
+  const latest = new Map();
+  for (const review of sorted) latest.set(review.login.toLowerCase(), review);
+  return [...latest.values()];
+}
+
+export function analyzeGuardedBehaviorApproval({ diffText = '', headSha = '', reviews = [] } = {}) {
+  const markers = collectGuardedBehaviorMarkers(diffText);
+  if (markers.length === 0) {
+    return { eligible: true, guarded: false, markers: [], reason: 'unguarded-diff' };
+  }
+  if (!headSha) {
+    return { eligible: false, guarded: true, markers, reason: 'missing-head-sha', approvingReviewers: [] };
+  }
+
+  const latestHumanReviews = latestReviewsByHuman(Array.isArray(reviews) ? reviews : []);
+  if (latestHumanReviews.some(review => review.state === 'CHANGES_REQUESTED')) {
+    return { eligible: false, guarded: true, markers, reason: 'latest-human-changes-requested', approvingReviewers: [] };
+  }
+
+  const approvingReviewers = latestHumanReviews
+    .filter(review => review.state === 'APPROVED' && review.commitId === headSha)
+    .map(review => review.login)
+    .sort();
+  if (approvingReviewers.length === 0) {
+    const reason = latestHumanReviews.some(review => review.state === 'APPROVED')
+      ? 'approval-not-on-current-head'
+      : latestHumanReviews.some(review => review.state === 'DISMISSED')
+        ? 'approval-dismissed'
+        : 'missing-current-head-human-approval';
+    return { eligible: false, guarded: true, markers, reason, approvingReviewers: [] };
+  }
+
+  return {
+    eligible: true,
+    guarded: true,
+    markers,
+    reason: 'current-head-human-approval',
+    approvingReviewers,
+  };
+}
+
+function defaultRunGh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function parseReviews(raw) {
+  const parsed = JSON.parse(raw || '[]');
+  if (!Array.isArray(parsed)) return [];
+  return parsed.flatMap(value => Array.isArray(value) ? value : [value]);
+}
+
+export function checkGuardedBehaviorApprovalForPr({
+  prNumber,
+  repo,
+  headSha,
+  runGh = defaultRunGh,
+}) {
+  if (!Number.isInteger(Number(prNumber)) || Number(prNumber) <= 0) {
+    throw new Error(`invalid PR number: ${prNumber}`);
+  }
+  const prArgs = repo ? ['--repo', repo] : [];
+  const resolvedHeadSha = headSha || JSON.parse(runGh([
+    'pr', 'view', String(prNumber), ...prArgs, '--json', 'headRefOid',
+  ])).headRefOid;
+  const diffText = runGh(['pr', 'diff', String(prNumber), ...prArgs]);
+  const repoPath = repo || '{owner}/{repo}';
+  const reviews = parseReviews(runGh([
+    'api', '--paginate', '--slurp', `repos/${repoPath}/pulls/${prNumber}/reviews`,
+  ]));
+  return analyzeGuardedBehaviorApproval({ diffText, headSha: resolvedHeadSha, reviews });
+}
+
+function parseArgs(argv) {
+  let prNumber;
+  let repo;
+  let json = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--pr') prNumber = Number(argv[++index]);
+    else if (arg === '--repo') repo = argv[++index];
+    else if (arg === '--json') json = true;
+    else if (arg === '--help' || arg === '-h') return { help: true };
+    else throw new Error(`unrecognized argument: ${arg}`);
+  }
+  return { prNumber, repo, json, help: false };
+}
+
+const HELP = `guarded-behavior-approval — require current-head human approval before admin-bypass
+
+Usage:
+  node scripts/guarded-behavior-approval.mjs --pr <number> [--repo owner/repo] [--json]
+`;
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`error: ${error.message}\n${HELP}`);
+    process.exit(2);
+  }
+  if (args.help) {
+    console.log(HELP);
+    return;
+  }
+  if (!args.prNumber) {
+    console.error(`error: --pr is required\n${HELP}`);
+    process.exit(2);
+  }
+  try {
+    const result = checkGuardedBehaviorApprovalForPr(args);
+    if (args.json) console.log(JSON.stringify(result));
+    else console.log(
+      result.eligible
+        ? `guarded-bypass eligible: ${result.reason}`
+        : `guarded-bypass denied: ${result.reason}`,
+    );
+    if (!result.eligible) process.exit(1);
+  } catch (error) {
+    console.error(`guarded-bypass check failed: ${error.message}`);
+    process.exit(2);
+  }
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -36,6 +36,8 @@ import { execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+import { checkGuardedBehaviorApprovalForPr } from './guarded-behavior-approval.mjs';
+
 export const TRUNK_DEFAULT = 'master';
 export const STACK_PREFIX_DEFAULT = 'stack/';
 const ACTIVE_MERGIFY_QUEUE_STATUSES = new Set(['queued', 'waiting_for_merge']);
@@ -365,6 +367,27 @@ function main() {
   if (targets.length === 0) {
     console.error('\nerror: no open PRs to queue.');
     process.exit(1);
+  }
+
+  for (const pr of targets) {
+    let approval;
+    try {
+      approval = checkGuardedBehaviorApprovalForPr({
+        prNumber: pr.number,
+        headSha: pr.headRefOid,
+        runGh: gh,
+      });
+    } catch (e) {
+      console.error(`\nerror: guarded-behavior approval check failed for PR #${pr.number}: ${e.message}`);
+      process.exit(2);
+    }
+    if (!approval.eligible) {
+      console.error(
+        `\nerror: refusing admin-bypass for guarded PR #${pr.number}: ${approval.reason}. `
+        + 'A non-bot reviewer must approve the current head SHA.',
+      );
+      process.exit(1);
+    }
   }
 
   console.log(`\nExecuting: adding 'admin-bypass' to ${targets.length} verified PR(s), bottom-to-top.`);

--- a/scripts/test-cron-pr-auto-label-matching.sh
+++ b/scripts/test-cron-pr-auto-label-matching.sh
@@ -61,6 +61,13 @@ assert_not_test_only "$(printf '%s\n%s' "packages/foo/src/__tests__/bar.test.ts"
 assert_not_test_only "packages/foo/src/bar.ts"
 assert_not_test_only ""
 
+policy_line="$(grep -n 'guarded_bypass_is_eligible "$num"' "$REPO_ROOT/scripts/cron-pr-auto-label.sh" | cut -d: -f1)"
+label_line="$(grep -n -- '--add-label admin-bypass' "$REPO_ROOT/scripts/cron-pr-auto-label.sh" | cut -d: -f1)"
+if [ -z "$policy_line" ] || [ -z "$label_line" ] || [ "$policy_line" -ge "$label_line" ]; then
+  echo "[test] FAIL: guarded approval check must run before cron label submission" >&2
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   exit 1
 fi

--- a/scripts/test-guarded-behavior-approval.mjs
+++ b/scripts/test-guarded-behavior-approval.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { analyzeGuardedBehaviorApproval } from './guarded-behavior-approval.mjs';
+
+const HEAD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const OLD_HEAD = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const GUARDED_DIFF = `diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx
+--- a/packages/ui/src/App.tsx
++++ b/packages/ui/src/App.tsx
+@@ -1,2 +1,2 @@
+ // guarded-behavior: selection-camera-inert
+-const selectionMovesCamera = false;
++const selectionMovesCamera = true;
+`;
+
+function review({ login = 'human-reviewer', type = 'User', state = 'APPROVED', commitId = HEAD, id = 1 }) {
+  return {
+    id,
+    state,
+    commit_id: commitId,
+    submitted_at: `2026-08-28T00:00:${String(id).padStart(2, '0')}Z`,
+    user: { login, type },
+  };
+}
+
+function analyze(reviews, diffText = GUARDED_DIFF) {
+  return analyzeGuardedBehaviorApproval({ diffText, headSha: HEAD, reviews });
+}
+
+assert.deepEqual(analyze([], 'diff --git a/README.md b/README.md\n+ordinary\n'), {
+  eligible: true,
+  guarded: false,
+  markers: [],
+  reason: 'unguarded-diff',
+});
+
+assert.equal(analyze([]).eligible, false, 'guarded diff without reviews must be denied');
+assert.equal(analyze([review({ login: 'review-bot[bot]', type: 'Bot' })]).eligible, false, 'bot approval must be denied');
+assert.equal(analyze([review({ commitId: OLD_HEAD })]).eligible, false, 'stale-head approval must be denied');
+assert.equal(analyze([review({ state: 'DISMISSED' })]).eligible, false, 'dismissed approval must be denied');
+assert.equal(analyze([
+  review({ state: 'APPROVED', id: 1 }),
+  review({ state: 'CHANGES_REQUESTED', id: 2 }),
+]).eligible, false, 'a later changes-requested review must deny');
+
+assert.deepEqual(analyze([review({ state: 'APPROVED' })]), {
+  eligible: true,
+  guarded: true,
+  markers: [{ id: 'selection-camera-inert', path: 'packages/ui/src/App.tsx', line: 1 }],
+  reason: 'current-head-human-approval',
+  approvingReviewers: ['human-reviewer'],
+});
+
+const landStackSource = readFileSync(new URL('./land-stack.mjs', import.meta.url), 'utf8');
+const cronSource = readFileSync(new URL('./cron-pr-auto-label.sh', import.meta.url), 'utf8');
+assert.ok(
+  landStackSource.indexOf('checkGuardedBehaviorApprovalForPr')
+    < landStackSource.indexOf("labels[]=admin-bypass"),
+  'land-stack must check guarded approval before its direct label add',
+);
+assert.ok(
+  cronSource.indexOf('guarded_bypass_is_eligible "$num"')
+    < cronSource.indexOf('--add-label admin-bypass'),
+  'cron must check guarded approval before generating its label task',
+);
+
+const directLabelFiles = execFileSync('rg', [
+  '-l',
+  'labels\\[\\]=admin-bypass|--add-label admin-bypass',
+  'scripts',
+], { encoding: 'utf8' })
+  .trim()
+  .split(/\r?\n/)
+  .filter(Boolean)
+  .filter(path => !/\/(?:test[-_]|fixtures\/)/.test(path))
+  .sort();
+assert.deepEqual(directLabelFiles, [
+  'scripts/cron-pr-auto-label.sh',
+  'scripts/land-stack.mjs',
+]);
+
+console.log('guarded-behavior approval policy tests passed');

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -131,7 +131,7 @@ test('queue targets include the whole open stack in order', () => {
   assert.deepEqual(targets.map((pr) => pr.number), [2174, 2175]);
 });
 
-function runCli(prNumbers) {
+function runCli(prNumbers, { diffs = {}, reviews = {} } = {}) {
   const tmp = mkdtempSync(join(tmpdir(), 'land-stack-test-'));
   const bin = join(tmp, 'bin');
   const log = join(tmp, 'gh.log');
@@ -144,8 +144,14 @@ const prs = {
   '2174': { number: 2174, headRefOid: ${JSON.stringify(SHA_2174)}, headRefName: ${JSON.stringify(STACK_BR_BOTTOM)}, baseRefName: 'master', state: 'OPEN', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
   '2175': { number: 2175, headRefOid: ${JSON.stringify(SHA_2175)}, headRefName: ${JSON.stringify(STACK_BR_TOP)}, baseRefName: ${JSON.stringify(STACK_BR_BOTTOM)}, state: 'OPEN', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
 };
+const diffs = ${JSON.stringify(diffs)};
+const reviews = ${JSON.stringify(reviews)};
 if (process.argv[2] === 'pr' && process.argv[3] === 'view') {
   process.stdout.write(JSON.stringify(prs[process.argv[4]]));
+  process.exit(0);
+}
+if (process.argv[2] === 'pr' && process.argv[3] === 'diff') {
+  process.stdout.write(diffs[process.argv[4]] || 'diff --git a/README.md b/README.md\\n+ordinary\\n');
   process.exit(0);
 }
 if (process.argv[2] === 'pr' && process.argv[3] === 'list') {
@@ -153,6 +159,12 @@ if (process.argv[2] === 'pr' && process.argv[3] === 'list') {
   process.exit(0);
 }
 const ghArgs = process.argv.slice(2);
+if (ghArgs[0] === 'api' && ghArgs.some((arg) => arg.includes('/pulls/') && arg.endsWith('/reviews'))) {
+  const endpoint = ghArgs.find((arg) => arg.includes('/pulls/') && arg.endsWith('/reviews'));
+  const number = endpoint.split('/pulls/')[1].split('/')[0];
+  process.stdout.write(JSON.stringify([reviews[number] || []]));
+  process.exit(0);
+}
 if (ghArgs[0] === 'api' && ghArgs.includes('POST') && ghArgs.some((arg) => arg.startsWith('repos/{owner}/{repo}/issues/'))) {
   fs.appendFileSync(log, process.argv.slice(2).join(' ') + '\\n');
   process.exit(0);
@@ -187,6 +199,34 @@ test('execute labels every verified PR bottom-to-top', () => {
     'api --silent --method POST repos/{owner}/{repo}/issues/2174/labels -f labels[]=admin-bypass',
     'api --silent --method POST repos/{owner}/{repo}/issues/2175/labels -f labels[]=admin-bypass',
   ]);
+});
+
+test('execute refuses a guarded diff without current-head human approval', () => {
+  const guardedDiff = 'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx\n--- a/packages/ui/src/App.tsx\n+++ b/packages/ui/src/App.tsx\n@@ -1,2 +1,2 @@\n // guarded-behavior: selection-camera-inert\n-old\n+new\n';
+  const { res, edits } = runCli(['2174', '2175'], {
+    diffs: { 2174: guardedDiff },
+  });
+  assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`);
+  assert.match(res.stderr, /refusing admin-bypass for guarded PR #2174/);
+  assert.deepEqual(edits, []);
+});
+
+test('execute labels a guarded diff after current-head human approval', () => {
+  const guardedDiff = 'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx\n--- a/packages/ui/src/App.tsx\n+++ b/packages/ui/src/App.tsx\n@@ -1,2 +1,2 @@\n // guarded-behavior: selection-camera-inert\n-old\n+new\n';
+  const { res, edits } = runCli(['2174', '2175'], {
+    diffs: { 2174: guardedDiff },
+    reviews: {
+      2174: [{
+        id: 1,
+        state: 'APPROVED',
+        commit_id: SHA_2174,
+        submitted_at: '2026-08-28T00:00:01Z',
+        user: { login: 'human-reviewer', type: 'User' },
+      }],
+    },
+  });
+  assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+  assert.equal(edits.length, 2);
 });
 
 console.log(`\n${passed} tests passed`);


### PR DESCRIPTION
## Summary

Requires current-head human approval before either production path can add `admin-bypass` to a guarded-behavior diff.

Unguarded PRs retain existing eligibility. Guarded denials identify no-review, bot-only, old-head, dismissed, and later changes-requested states.

## Review Claim

Approve one centralized guarded-bypass policy consumed immediately before both direct label-add paths.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only PRs touching a `guarded-behavior` marker gain the new approval requirement. The `selection-camera-inert` fixture proves the policy without changing product behavior. Both paths evaluate every target before performing any label mutation.

## Slice Rationale

The pure decision, land-stack enforcement, cron enforcement, and two-site inventory form one complete administrative boundary. Omitting either consumer would leave a live bypass.

## Architecture

### Before

`land-stack.mjs` and `cron-pr-auto-label.sh` independently added `admin-bypass` after their existing eligibility checks. Guarded markers affected disclosure only.

### After

Both consumers call `guarded-behavior-approval.mjs` immediately before label creation. Guarded diffs require a latest non-bot `APPROVED` review tied to the current head SHA.

## Non-goals

- Do not require approval for unguarded diffs.
- Do not change ordinary Mergify queue behavior.
- Do not add, dismiss, or synthesize reviews.
- Do not remove labels or merge any PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Failing repro before implementation: `node scripts/test-guarded-behavior-approval.mjs`

  ```text
  Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'scripts/guarded-behavior-approval.mjs'
  EXIT_CODE=1
  ```

- [x] `node scripts/test-guarded-behavior-approval.mjs`

  ```text
  guarded-behavior approval policy tests passed
  ```

- [x] `node scripts/test-land-stack.mjs`

  ```text
  16 tests passed
  ```

- [x] `bash scripts/test-cron-pr-auto-label-matching.sh`

  ```text
  [test] PASS: pr-auto-label matching logic
  ```

- [x] Syntax checks: `node --check` for both modules and `bash -n scripts/cron-pr-auto-label.sh`
- [x] Live read-only smoke against unguarded PR #11207: `{"eligible":true,"guarded":false,"markers":[],"reason":"unguarded-diff"}`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d7a54429fb`
- Post-revert steps: Re-run all three focused scripts.
- Data migration? No.

</details>
