### PR TITLE
[PR duplicate-close rebase check](1) Catch near-duplicate PRs via rebase-equivalence

### DIFF
--- a/scripts/pr_duplicate_close_exec.py
+++ b/scripts/pr_duplicate_close_exec.py
@@ -45,13 +45,14 @@ def _compute_landed_facts(git_facts: GitFactsClient, head_sha: str) -> GitFacts:
     if merge_base_sha is None:
         return GitFacts(
             merge_base_sha=None, is_ancestor=False, is_empty_diff=False,
-            all_commits_equivalent=False,
+            all_commits_equivalent=False, is_rebase_equivalent=False,
         )
     return GitFacts(
         merge_base_sha=merge_base_sha,
         is_ancestor=git_facts.is_ancestor(head_sha),
         is_empty_diff=git_facts.is_empty_diff(head_sha),
         all_commits_equivalent=git_facts.all_commits_equivalent(head_sha),
+        is_rebase_equivalent=git_facts.is_rebase_equivalent(head_sha),
     )
 
 

--- a/scripts/pr_duplicate_close_git_facts.py
+++ b/scripts/pr_duplicate_close_git_facts.py
@@ -7,10 +7,14 @@ from pathlib import Path
 class GitFactsClient:
     """Local-git read-only facts. No `gh` calls, no mutation.
 
-    All three "landed" signals are independent and OR'd by the policy layer:
+    All four "landed" signals are independent and OR'd by the policy layer:
     ancestry catches direct/rebase merges, empty-diff catches squash merges
     (the merged commits are never ancestors of master), and
     all_commits_equivalent catches per-commit reword/rebase onto master.
+    is_rebase_equivalent catches a near-duplicate PR left behind when two
+    open PRs independently add the same file and only one lands (the
+    other's head still textually differs from master, so the first three
+    signals all miss it, even though rebasing it would produce no change).
     """
 
     def __init__(self, cwd: Path | str | None = None):
@@ -58,6 +62,47 @@ class GitFactsClient:
             return False
         lines = [line for line in completed.stdout.splitlines() if line.strip()]
         return len(lines) > 0 and all(line.startswith("-") for line in lines)
+
+    def is_rebase_equivalent(self, head_sha: str, upstream: str = "origin/master") -> bool:
+        """True when head's only differences from upstream are add/add
+        conflicts (the same file independently added on both sides) and
+        resolving those in upstream's favor reproduces upstream's tree
+        exactly.
+
+        Deliberately narrow: a modify/modify or delete/modify conflict means
+        head and upstream genuinely diverge on content that already existed
+        before either branched -- auto-preferring upstream there could
+        silently discard a real, intentional change, so any such conflict
+        makes this return False and defers to the normal (human/repair)
+        path. Only the add/add case -- two independent additions of what
+        turns out to be the same thing -- is safe to auto-resolve, and only
+        that case is actually left unmatched by is_ancestor/is_empty_diff/
+        all_commits_equivalent (see PR #11149 vs #11159).
+        """
+        merge_base_sha = self.merge_base(upstream, head_sha)
+        if merge_base_sha is None:
+            return False
+        plain = self._run([
+            "git", "merge-tree", "--write-tree", f"--merge-base={merge_base_sha}", upstream, head_sha,
+        ])
+        if plain.returncode == 0:
+            # Clean merge, no conflicts to resolve -- not this signal's job;
+            # is_ancestor/is_empty_diff already cover a genuinely clean case.
+            return False
+        conflict_lines = [line for line in plain.stdout.splitlines() if line.startswith("CONFLICT")]
+        if not conflict_lines or any("(add/add)" not in line for line in conflict_lines):
+            return False
+        resolved = self._run([
+            "git", "merge-tree", "--write-tree", "-X", "ours",
+            f"--merge-base={merge_base_sha}", upstream, head_sha,
+        ])
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            return False
+        result_tree = resolved.stdout.splitlines()[0].strip()
+        upstream_tree = self._run(["git", "rev-parse", f"{upstream}^{{tree}}"])
+        if upstream_tree.returncode != 0:
+            return False
+        return result_tree == upstream_tree.stdout.strip()
 
     def patch_id(self, merge_base_sha: str, head_sha: str) -> str | None:
         diff = self._run(["git", "diff", f"{merge_base_sha}..{head_sha}"])

--- a/scripts/pr_duplicate_close_model.py
+++ b/scripts/pr_duplicate_close_model.py
@@ -24,11 +24,13 @@ class GitFacts:
     is_ancestor: bool
     is_empty_diff: bool
     all_commits_equivalent: bool
+    is_rebase_equivalent: bool = False
 
 
 LANDED_ANCESTOR = "landed:ancestor"
 LANDED_EMPTY_DIFF = "landed:empty-diff"
 LANDED_PATCH_EQUIVALENT = "landed:patch-equivalent"
+LANDED_REBASE_EQUIVALENT = "landed:rebase-equivalent"
 DUPLICATE_SAME_BRANCH = "duplicate:same-branch"
 DUPLICATE_SAME_DIFF = "duplicate:same-diff"
 

--- a/scripts/pr_duplicate_close_plan.py
+++ b/scripts/pr_duplicate_close_plan.py
@@ -19,6 +19,7 @@ try:
         LANDED_ANCESTOR,
         LANDED_EMPTY_DIFF,
         LANDED_PATCH_EQUIVALENT,
+        LANDED_REBASE_EQUIVALENT,
         LEDGER_KIND_SUBMIT,
         CandidatePr,
         CloseAction,
@@ -35,6 +36,7 @@ except ImportError:
         LANDED_ANCESTOR,
         LANDED_EMPTY_DIFF,
         LANDED_PATCH_EQUIVALENT,
+        LANDED_REBASE_EQUIVALENT,
         LEDGER_KIND_SUBMIT,
         CandidatePr,
         CloseAction,
@@ -54,6 +56,8 @@ def classify_landed(pr: CandidatePr, facts: GitFacts | None) -> CloseAction | No
         signals.append(LANDED_EMPTY_DIFF)
     if facts.all_commits_equivalent:
         signals.append(LANDED_PATCH_EQUIVALENT)
+    if facts.is_rebase_equivalent:
+        signals.append(LANDED_REBASE_EQUIVALENT)
     if not signals:
         return None
     evidence = f"content already on origin/master ({', '.join(signals)}; head {pr.head_ref_oid})"

--- a/scripts/test_pr_duplicate_close_git_facts.py
+++ b/scripts/test_pr_duplicate_close_git_facts.py
@@ -87,6 +87,66 @@ class IsEmptyDiff(GitFactsTestCase):
         self.assertTrue(self.client.is_empty_diff(feature_sha, "master"))
 
 
+class IsRebaseEquivalent(GitFactsTestCase):
+    def test_true_for_add_add_conflict_with_trivially_different_content(self):
+        # Matches the real PR #11149 vs #11159 shape: two open PRs
+        # independently add the same domain file, one with a couple of
+        # extra comment lines. Neither is_ancestor, is_empty_diff, nor
+        # all_commits_equivalent catches this -- the head still textually
+        # differs from master -- but rebasing it produces no real change.
+        run(self.repo, "checkout", "-q", "-b", "pr-a")
+        pr_a_sha = write_and_commit(
+            self.repo, "domain.mjs", "export function f() {}\n\nconst X = 1;\n", "PR A adds domain.mjs",
+        )
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(
+            self.repo, "domain.mjs",
+            "export function f() {}\n\n// mirrors an existing convention\nconst X = 1;\n",
+            "master already has domain.mjs (landed via a sibling PR)",
+        )
+
+        self.assertFalse(self.client.is_ancestor(pr_a_sha, "master"))
+        self.assertFalse(self.client.is_empty_diff(pr_a_sha, "master"))
+        self.assertFalse(self.client.all_commits_equivalent(pr_a_sha, "master"))
+        self.assertTrue(self.client.is_rebase_equivalent(pr_a_sha, "master"))
+
+    def test_false_when_a_real_new_file_is_also_present(self):
+        # The add/add conflict alone is trivial, but this PR also carries a
+        # genuinely new, non-conflicting file -- rebasing it would NOT
+        # produce an empty diff, so it must not be flagged as landed.
+        run(self.repo, "checkout", "-q", "-b", "pr-a")
+        (self.repo / "domain.mjs").write_text("export function f() {}\n\nconst X = 1;\n", encoding="utf-8")
+        (self.repo / "unique.mjs").write_text("export const REAL_NEW_THING = 1;\n", encoding="utf-8")
+        run(self.repo, "add", "domain.mjs", "unique.mjs")
+        run(self.repo, "commit", "-q", "-m", "PR A adds domain.mjs and a real new file")
+        pr_a_sha = run(self.repo, "rev-parse", "HEAD")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(
+            self.repo, "domain.mjs",
+            "export function f() {}\n\n// mirrors an existing convention\nconst X = 1;\n",
+            "master already has domain.mjs",
+        )
+
+        self.assertFalse(self.client.is_rebase_equivalent(pr_a_sha, "master"))
+
+    def test_false_when_conflict_is_modify_modify_not_add_add(self):
+        # A modify/modify conflict means head and upstream genuinely diverge
+        # on content that already existed -- must never be auto-resolved in
+        # upstream's favor, since that could silently discard a real fix.
+        write_and_commit(self.repo, "shared.txt", "original\n", "shared base content")
+        run(self.repo, "checkout", "-q", "-b", "pr-a")
+        pr_a_sha = write_and_commit(self.repo, "shared.txt", "pr-a's real change\n", "PR A modifies shared.txt")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(self.repo, "shared.txt", "master's different change\n", "master modifies shared.txt")
+
+        self.assertFalse(self.client.is_rebase_equivalent(pr_a_sha, "master"))
+
+    def test_false_for_a_genuinely_unrelated_pr(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "feature.txt", "feature\n", "feature commit")
+        self.assertFalse(self.client.is_rebase_equivalent(feature_sha, "master"))
+
+
 class AllCommitsEquivalent(GitFactsTestCase):
     def test_true_when_master_has_an_equivalent_commit(self):
         run(self.repo, "checkout", "-q", "-b", "feature")

--- a/scripts/test_pr_duplicate_close_plan.py
+++ b/scripts/test_pr_duplicate_close_plan.py
@@ -75,6 +75,10 @@ class ClassifyLanded(DuplicateCloseTestCase):
         action = p.classify_landed(candidate(), facts(all_commits_equivalent=True))
         self.assertEqual(action.reason, dm.LANDED_PATCH_EQUIVALENT)
 
+    def test_rebase_equivalent_signal_alone(self):
+        action = p.classify_landed(candidate(), facts(is_rebase_equivalent=True))
+        self.assertEqual(action.reason, dm.LANDED_REBASE_EQUIVALENT)
+
     def test_landed_action_carries_expected_head(self):
         pr = candidate(number=42, head_ref_oid="deadbeef")
         action = p.classify_landed(pr, facts(is_ancestor=True))


### PR DESCRIPTION
## Summary

The `pr-duplicate-close` worker is supposed to auto-close a PR once its content has already landed on master through another PR.

It missed one case. PR #11149 sat open with a merge conflict for hours because its content had already landed via a near-identical sibling PR, #11159. The two diffs were the same except for two comment lines added during #11159's own review.

The worker's three existing checks all compare the PR's head against master as-is. A trivial textual difference like that made every one say "not landed."

The PR was never flagged, and had to be closed by hand. This adds a fourth check that tolerates that kind of trivial difference.

## Review Claim

`is_rebase_equivalent` correctly flags a PR as already-landed when its only difference from master is a trivial add/add conflict (the same file independently added on both sides), and correctly leaves alone any PR with a real, non-trivial difference from master.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only adds a new read-only git fact (`git merge-tree`, no working-tree or ref mutation) and one new signal consumed by the existing close-decision policy. It never auto-resolves a `modify/modify` or `delete/modify` conflict — only `add/add` — so a PR that genuinely diverges from master's existing content is never misclassified as landed and closed.

## Slice Rationale

One self-contained fix to one worker's detection logic, with its own regression tests. No other file in the repo depends on this signal.

## Non-goals

Does not change how a flagged PR gets closed, does not touch the other three landed signals, and does not wire `pr-duplicate-close`'s tests into CI (a pre-existing gap, out of scope here).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_pr_duplicate_close_git_facts.py`
- [ ] `python3 scripts/test_pr_duplicate_close_plan.py`
- [ ] `python3 scripts/test_pr_duplicate_close_exec.py`
- [ ] `python3 scripts/test_pr_duplicate_close_executor.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e1b2b84`
- Post-revert steps: None
- Data migration? No

</details>
