### PR TITLE
[Required builds contracts gap](1) Build @invoker/contracts before deploy

### DIFF
--- a/scripts/required-builds.sh
+++ b/scripts/required-builds.sh
@@ -4,5 +4,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+pnpm --filter @invoker/contracts build
 pnpm --filter @invoker/surfaces build
 pnpm --filter @invoker/transport build

--- a/scripts/test-required-builds.sh
+++ b/scripts/test-required-builds.sh
@@ -21,18 +21,28 @@ echo "PASS: required-builds.sh builds @invoker/contracts"
 # that exports what headless-ipc.js needs. A grep-only check could pass
 # even if the filter target is spelled correctly but the underlying build
 # silently fails or emits a stale artifact.
+BUILD_LOG="$(mktemp)"
+trap 'rm -f "$BUILD_LOG"' EXIT
+
 rm -f packages/contracts/dist/index.js
-pnpm --filter @invoker/contracts build >/tmp/test-required-builds-contracts.log 2>&1 || {
+pnpm --filter @invoker/contracts build >"$BUILD_LOG" 2>&1 || {
   echo "FAIL: pnpm --filter @invoker/contracts build failed" >&2
-  cat /tmp/test-required-builds-contracts.log >&2
+  cat "$BUILD_LOG" >&2
   exit 1
 }
 test -f packages/contracts/dist/index.js || {
   echo "FAIL: packages/contracts/dist/index.js was not produced" >&2
   exit 1
 }
-grep -q 'resolveActiveInvokerProfileEnv' packages/contracts/dist/index.js || {
-  echo "FAIL: built packages/contracts/dist/index.js does not export resolveActiveInvokerProfileEnv" >&2
-  exit 1
-}
-echo "PASS: pnpm --filter @invoker/contracts build produces a dist exporting resolveActiveInvokerProfileEnv"
+node -e "
+  import('$ROOT/packages/contracts/dist/index.js').then((mod) => {
+    if (typeof mod.resolveActiveInvokerProfileEnv !== 'function') {
+      console.error('FAIL: built packages/contracts/dist/index.js does not export resolveActiveInvokerProfileEnv as a function');
+      process.exit(1);
+    }
+    console.log('PASS: pnpm --filter @invoker/contracts build produces a dist exporting resolveActiveInvokerProfileEnv');
+  }).catch((err) => {
+    console.error('FAIL: could not import built packages/contracts/dist/index.js:', err.message);
+    process.exit(1);
+  });
+"

--- a/scripts/test-required-builds.sh
+++ b/scripts/test-required-builds.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Static: required-builds.sh must build @invoker/contracts. This package's
+# dist is loaded directly (not just re-exported through a bundler) by
+# scripts/headless-ipc.js's CONTRACTS_DIST path, so a stale or missing
+# contracts build breaks that script silently -- see the incident where
+# packages/contracts/dist/index.js sat 12 days stale on a deployed host,
+# missing resolveActiveInvokerProfileEnv entirely, because no build step
+# anywhere ever rebuilt it.
+grep -q '^pnpm --filter @invoker/contracts build$' scripts/required-builds.sh || {
+  echo "FAIL: scripts/required-builds.sh no longer builds @invoker/contracts" >&2
+  exit 1
+}
+echo "PASS: required-builds.sh builds @invoker/contracts"
+
+# Behavioral: prove the build this script runs actually produces a dist
+# that exports what headless-ipc.js needs. A grep-only check could pass
+# even if the filter target is spelled correctly but the underlying build
+# silently fails or emits a stale artifact.
+rm -f packages/contracts/dist/index.js
+pnpm --filter @invoker/contracts build >/tmp/test-required-builds-contracts.log 2>&1 || {
+  echo "FAIL: pnpm --filter @invoker/contracts build failed" >&2
+  cat /tmp/test-required-builds-contracts.log >&2
+  exit 1
+}
+test -f packages/contracts/dist/index.js || {
+  echo "FAIL: packages/contracts/dist/index.js was not produced" >&2
+  exit 1
+}
+grep -q 'resolveActiveInvokerProfileEnv' packages/contracts/dist/index.js || {
+  echo "FAIL: built packages/contracts/dist/index.js does not export resolveActiveInvokerProfileEnv" >&2
+  exit 1
+}
+echo "PASS: pnpm --filter @invoker/contracts build produces a dist exporting resolveActiveInvokerProfileEnv"


### PR DESCRIPTION
## Summary

Every open PR's conflict repair and failed-check repair silently stopped working for 11+ hours today.

The cause: `packages/contracts/dist/index.js` on the deployed host was 12 days stale, missing a function a same-day PR added. `scripts/headless-ipc.js` loads that file directly, so calling it threw, and the repair worker's fail-closed safety net swallowed the error with no visible alert.

Nothing ever rebuilt that package on its own. `required-builds.sh` only ran two build filters, and this one was missing, even though a standalone script depends on its dist output directly.

## Review Claim

`required-builds.sh` now builds `@invoker/contracts`, and a regression test proves the build actually produces a working dist with the function the deployed host needs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only adds one build-filter line and one new standalone test script. It changes nothing about what gets deployed once built, only which packages get built.

## Slice Rationale

One-line build-script fix with its own proof, isolated from the unrelated repair-worker bug it was masking.

## Non-goals

Does not touch `deploy-do1.sh` itself (it already calls `required-builds.sh`), does not change any repair-worker logic, and does not wire this new test into a CI suite (a pre-existing gap for this whole test family, out of scope here).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-required-builds.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 506a7b05f3`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * The required build process now includes the contracts package before building surfaces and transport components.

* **Tests**
  * Added automated verification that the contracts build runs successfully and produces a functional output artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->