### PR TITLE
[Production owner service profile detection](1) Recognize the production owner service as production

### DIFF
--- a/packages/contracts/src/__tests__/resolve-active-profile-env.test.ts
+++ b/packages/contracts/src/__tests__/resolve-active-profile-env.test.ts
@@ -2,9 +2,9 @@ import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { resolveActiveInvokerProfileEnv, resolveRepoRoot } from '../index.js';
+import { resolveActiveInvokerProfileEnv, resolveInvokerIpcSocketPath, resolveRepoRoot } from '../index.js';
 
 const tempDirs: string[] = [];
 
@@ -24,6 +24,37 @@ afterEach(() => {
 });
 
 describe('resolveActiveInvokerProfileEnv', () => {
+  describe('when spawned by the production owner service', () => {
+    const originalMarker = process.env.INVOKER_PRODUCTION_OWNER_SERVICE;
+
+    beforeEach(() => {
+      process.env.INVOKER_PRODUCTION_OWNER_SERVICE = '1';
+    });
+
+    afterEach(() => {
+      if (originalMarker === undefined) delete process.env.INVOKER_PRODUCTION_OWNER_SERVICE;
+      else process.env.INVOKER_PRODUCTION_OWNER_SERVICE = originalMarker;
+    });
+
+    it('skips dev-profile detection even on a git-checkout source root', () => {
+      const repoRoot = resolveRepoRoot(process.cwd());
+
+      const actual = resolveActiveInvokerProfileEnv({ repoRoot });
+
+      expect(actual).toEqual({ INVOKER_RUNTIME_KIND: 'packaged', INVOKER_PRODUCTION_OWNER_SERVICE: '1' });
+      expect(actual.INVOKER_DEVELOPMENT_PROFILE).toBeUndefined();
+    });
+
+    it('resolves the plain production socket path, not a dev-profile one', () => {
+      const repoRoot = resolveRepoRoot(process.cwd());
+      const profileEnv = resolveActiveInvokerProfileEnv({ repoRoot });
+      const socketPath = resolveInvokerIpcSocketPath(profileEnv);
+
+      expect(socketPath).not.toContain('/dev/');
+      expect(socketPath.endsWith('/.invoker/ipc-transport.sock')).toBe(true);
+    });
+  });
+
   it('matches the development profile script for this repository', () => {
     const repoRoot = resolveRepoRoot(process.cwd());
     const scriptPath = join(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');

--- a/packages/contracts/src/resolve-active-profile-env.ts
+++ b/packages/contracts/src/resolve-active-profile-env.ts
@@ -22,6 +22,9 @@ function isEnvironmentOverrides(value: unknown): value is Record<string, string>
 export function resolveActiveInvokerProfileEnv(
   options: ResolveActiveInvokerProfileEnvOptions = {},
 ): Record<string, string> {
+  if (process.env.INVOKER_PRODUCTION_OWNER_SERVICE === '1') {
+    return { INVOKER_RUNTIME_KIND: 'packaged', INVOKER_PRODUCTION_OWNER_SERVICE: '1' };
+  }
   try {
     const repoRoot = resolve(options.repoRoot ?? resolveRepoRoot(process.cwd()));
     const scriptPath = resolve(repoRoot, 'scripts', 'with-invoker-development-profile.mjs');


### PR DESCRIPTION
## Summary

Every conflict repair and failed-check repair on the deployed host was silently no-op-ing, even after last night's related fix landed and today's build gap closed.

The real cause: the client-side code that resolves which socket to talk to has no way to know it's running as a child of the real production service. It always assumes it might be a developer's incidental local git checkout, and redirects to an isolated dev socket that nothing is listening on.

The production service itself already carries a marker proving it's the real thing. This slice makes the client-side resolver check for that marker before falling back to dev-profile detection.

## Review Claim

`resolveActiveInvokerProfileEnv` now returns the plain production environment immediately when it detects it is running as (or under) the production owner service, instead of always spawning the dev-profile detection script.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only short-circuits to the production shape when a specific environment marker is present, and that marker is only ever set by the production owner service itself and inherited by its own child processes. A normal developer checkout without that marker set falls through to the exact same dev-profile detection as before, unchanged.

## Slice Rationale

One targeted fix isolated from the two unrelated things it was masking (a stale build artifact, an unbuilt package) — both already shipped as their own separate slices.

## Non-goals

Does not change `scripts/with-invoker-development-profile.mjs` itself, does not change anything about how the production owner service starts, and does not touch any repair-worker logic beyond the socket it now correctly reaches.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/contracts test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 389692023d`
- Post-revert steps: None
- Data migration? No

</details>
