### PR TITLE
[Experiment spawn upstream base](2) Inherit dep tip on spawn

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-experiment-spawn-upstream-base.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-experiment-spawn-upstream-base.test.ts
@@ -144,7 +144,7 @@ describe('repro: experiment spawn inherits upstream dependency base', () => {
     });
   });
 
-  it.fails('after spawn, pivot execution carries the completed upstream dep tip (not bare main)', () => {
+  it('after spawn, pivot execution carries the completed upstream dep tip (not bare main)', () => {
     const discoverBranch = 'experiment/wf-repro/discover-50-eligible-cases-abc12345';
     const discoverCommit = 'd42945d0deadbeefcafe00112233445566778899';
 

--- a/packages/workflow-core/src/__tests__/repro-experiment-spawn-upstream-base.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-experiment-spawn-upstream-base.test.ts
@@ -219,4 +219,71 @@ describe('repro: experiment spawn inherits upstream dependency base', () => {
       ).toBe(true);
     }
   });
+
+  it('falls back to baseBranch (not undefined) when a commandless pivot has more than one completed dependency tip', () => {
+    const plan: PlanDefinition = {
+      name: 'experiment-multi-dep-pivot-repro',
+      baseBranch: 'main',
+      tasks: [
+        { id: 'discover-a', description: 'Write a.json' },
+        { id: 'discover-b', description: 'Write b.json' },
+        {
+          id: 'pivot',
+          description: 'Spawn mines',
+          dependencies: ['discover-a', 'discover-b'],
+          pivot: true,
+          experimentVariants: [
+            { id: 'mine-00', description: 'Mine 0', command: 'echo 0' },
+          ],
+        },
+      ],
+    };
+
+    orchestrator.loadPlan(plan);
+    orchestrator.startExecution();
+
+    const discoverAId = sid(orchestrator, 0, 'discover-a');
+    const discoverBId = sid(orchestrator, 0, 'discover-b');
+    const pivotId = sid(orchestrator, 0, 'pivot');
+
+    orchestrator.handleWorkerResponse({
+      requestId: 'req-discover-a',
+      actionId: discoverAId,
+      executionGeneration: 0,
+      status: 'completed',
+      outputs: {
+        exitCode: 0,
+        branch: 'experiment/wf-repro/discover-a-abc12345',
+        commitHash: 'a'.repeat(40),
+        summary: 'wrote a.json',
+      },
+    });
+    orchestrator.handleWorkerResponse({
+      requestId: 'req-discover-b',
+      actionId: discoverBId,
+      executionGeneration: 0,
+      status: 'completed',
+      outputs: {
+        exitCode: 0,
+        branch: 'experiment/wf-repro/discover-b-def67890',
+        commitHash: 'b'.repeat(40),
+        summary: 'wrote b.json',
+      },
+    });
+
+    expect(orchestrator.getTask(pivotId)!.status).toBe('running');
+
+    // Pivot spawn (commandless) with two completed dep tips — neither can be
+    // inherited unambiguously, so this must fall back to baseBranch instead
+    // of leaving execution.branch/commit unset (which would trip the
+    // completed-dependency branch guard and block every spawned variant).
+    orchestrator.handleWorkerResponse(spawnResponse(pivotId, ['mine-00']));
+
+    const pivotAfter = orchestrator.getTask(pivotId)!;
+    expect(pivotAfter.status).toBe('completed');
+    expect(
+      pivotAfter.execution.branch,
+      'pivot branch must fall back to workflow baseBranch when multiple dep tips are ambiguous',
+    ).toBe('main');
+  });
 });

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -372,10 +372,11 @@ function resolveSpawnPivotSourceChanges(
     return { execution: depTips[0]! };
   }
 
-  if (depTips.length > 1) {
-    return undefined;
-  }
-
+  // depTips.length > 1: no single dependency tip can be inherited
+  // unambiguously, so fall through to the baseBranch fallback below rather
+  // than returning undefined — leaving execution unset here trips the
+  // completed-dependency branch guard in task-runner-prepare.ts and blocks
+  // every spawned variant from launching at all.
   if (baseBranch) {
     return { execution: { branch: baseBranch } };
   }

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -340,6 +340,48 @@ export function handleNeedsInputImpl(
   return [];
 }
 
+function resolveSpawnPivotSourceChanges(
+  parentTask: TaskState | undefined,
+  host: TransitionHost,
+  wf: { baseBranch?: string } | undefined,
+): { execution: { branch?: string; commit?: string } } | undefined {
+  const baseBranch =
+    wf && typeof wf.baseBranch === 'string' ? wf.baseBranch.trim() : '';
+
+  const parentBranch = parentTask?.execution?.branch?.trim() ?? '';
+  const parentCommit = parentTask?.execution?.commit?.trim() ?? '';
+  if (parentCommit) {
+    return {
+      execution: {
+        branch: parentBranch || baseBranch || undefined,
+        commit: parentCommit,
+      },
+    };
+  }
+
+  const depTips: Array<{ branch: string; commit: string }> = [];
+  for (const depId of parentTask?.dependencies ?? []) {
+    const dep = host.stateGetTask(depId);
+    if (dep?.status !== 'completed') continue;
+    const branch = dep.execution?.branch?.trim() ?? '';
+    const commit = dep.execution?.commit?.trim() ?? '';
+    if (branch && commit) depTips.push({ branch, commit });
+  }
+
+  if (depTips.length === 1) {
+    return { execution: depTips[0]! };
+  }
+
+  if (depTips.length > 1) {
+    return undefined;
+  }
+
+  if (baseBranch) {
+    return { execution: { branch: baseBranch } };
+  }
+  return undefined;
+}
+
 export function handleSpawnExperimentsImpl(
   host: TransitionHost,
   taskId: string,
@@ -362,11 +404,14 @@ export function handleSpawnExperimentsImpl(
   const parentExecutionAgent = parentTask?.config.executionAgent;
   const parentExecutionModel = parentTask?.config.executionModel;
   const parentMaxTurns = parentTask?.config.maxTurns;
+  const parentDepIds = (parentTask?.dependencies ?? []).filter(
+    (depId) => depId !== taskId && typeof depId === 'string' && depId.length > 0,
+  );
 
   const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
     id: scopeLocal(v.id),
     description: v.description ?? `Experiment: ${v.id}`,
-    dependencies: [taskId],
+    dependencies: [taskId, ...parentDepIds],
     workflowId: wfId,
     parentTask: taskId,
     experimentPrompt: v.prompt,
@@ -404,12 +449,7 @@ export function handleSpawnExperimentsImpl(
     wfId && typeof host.persistence.loadWorkflow === 'function'
       ? host.persistence.loadWorkflow(wfId)
       : undefined;
-  const pivotBranch =
-    wf && typeof (wf as { baseBranch?: string }).baseBranch === 'string'
-      ? (wf as { baseBranch: string }).baseBranch.trim()
-      : '';
-  const sourceChanges =
-    pivotBranch !== '' ? { execution: { branch: pivotBranch } } : undefined;
+  const sourceChanges = resolveSpawnPivotSourceChanges(parentTask, host, wf);
 
   host.applyGraphMutation({
     sourceNodeId: taskId,


### PR DESCRIPTION
## Summary

Experiment spawn was stamping the pivot onto bare workflow `baseBranch`.

Mines then branched from `main` tip and missed upstream artifacts like `cases.json`.

This slice inherits the completed upstream tip on spawn and wires parent deps onto experiments.

## Review Claim

Approve that spawn completes the pivot with the upstream dependency tip (and parent deps on experiments) instead of bare `main`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Local orchestrator spawn/graph mutation only. Does not change merge-queue, deploy, or owner restart behavior. Safe to review from the vitest repro without a live owner.

## Slice Rationale

Behavior fix comes after the `it.fails` proof slice and flips that test to a passing assertion.

## Non-goals

Does not rebuild failed live fanout workflows. Does not change reconciliation selection UX.

## Architecture

### Before

```mermaid
graph TD
    Discover["discover tip + commit"]
    Pivot["pivot spawn stamps branch=main"]
    Mine["mine worktree from main tip"]
    Discover --> Pivot
    Pivot --> Mine
```

### After

```mermaid
graph TD
    Discover["discover tip + commit"]
    Pivot["pivot spawn keeps discover tip"]
    Mine["mine worktree from discover tip"]
    Discover --> Pivot
    Pivot --> Mine
    Discover --> Mine
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Fail-before (on master): same test expected pivot=`main` (Received: `main`)
- [x] Pass-after: `cd packages/workflow-core && node node_modules/vitest/vitest.mjs run src/__tests__/repro-experiment-spawn-upstream-base.test.ts` → 1 passed
- [x] `cd packages/workflow-core && node node_modules/vitest/vitest.mjs run src/__tests__/experiment-lifecycle.test.ts src/__tests__/parity.test.ts src/__tests__/repro-experiment-spawn-pool-inherit.test.ts src/__tests__/repro-experiment-spawn-upstream-base.test.ts` → 48 passed
- [x] `pnpm run check:comments` → no disallowed comments

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator spawn routing and graph dependencies, which directly affects which git tip experiment variants run from; scope is localized to experiment spawn but can alter fanout behavior in production workflows.
> 
> **Overview**
> Fixes experiment **spawn** so the pivot’s execution metadata reflects upstream work instead of always stamping bare workflow **`baseBranch`** (`main`), which left mines without artifacts like `cases.json`.
> 
> **`handleSpawnExperimentsImpl`** now uses **`resolveSpawnPivotSourceChanges`**: if the pivot already has a commit, that tip wins; otherwise a **single** completed dependency’s branch+commit is inherited; when multiple completed dep tips disagree, execution falls back to **`baseBranch`** (not unset), avoiding the completed-dependency branch guard that blocked variant launches.
> 
> Spawned experiment nodes also depend on the **pivot’s parent dependencies** (not only the pivot), so upstream completed tips stay visible in the graph. The repro test is promoted from **`it.fails`** to passing, plus a new case for the ambiguous multi-dependency fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad48e1a12cbe01192f2f838b2eea4a03c65ae089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->