### PR TITLE
[Repo Clone Probe](1) Retry and surface the real git error

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults, assertNoDuplicateTaskIds } from '../plan-parser.js';
+import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults, assertNoDuplicateTaskIds, assertRepoUrlCloneable } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -95,6 +95,37 @@ tasks:
 
     await expect(parsePlanFile(planPath)).rejects.toThrow(
       'repoUrl "https://example.invalid/repo.git" is not a readable git repository',
+    );
+    execFileSyncSpy.mockRestore();
+  });
+
+  it('survives a single transient failure of the remote clone probe', () => {
+    // Matches the real incident: a momentary git/network blip made
+    // assertRepoUrlCloneable's one-shot probe permanently wedge a PR's
+    // repair claim, because the caller's own error-recovery path also
+    // depends on the same infra and silently swallowed its own failure.
+    const execFileSyncSpy = vi.spyOn(childProcess, 'execFileSync');
+    execFileSyncSpy.mockImplementationOnce(() => {
+      const err = new Error('git ls-remote failed');
+      (err as { stderr?: Buffer }).stderr = Buffer.from('fatal: unable to access: transient network error');
+      throw err;
+    });
+    execFileSyncSpy.mockImplementationOnce(() => Buffer.from(''));
+
+    expect(() => assertRepoUrlCloneable('https://github.com/example/repo.git')).not.toThrow();
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(2);
+    execFileSyncSpy.mockRestore();
+  });
+
+  it('surfaces the real git error after all retry attempts are exhausted', () => {
+    const execFileSyncSpy = vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+      const err = new Error('git ls-remote failed');
+      (err as { stderr?: Buffer }).stderr = Buffer.from('fatal: could not resolve host: github.com');
+      throw err;
+    });
+
+    expect(() => assertRepoUrlCloneable('https://github.com/example/repo.git')).toThrow(
+      'fatal: could not resolve host: github.com',
     );
     execFileSyncSpy.mockRestore();
   });

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -162,6 +162,21 @@ export function detectDefaultBranchRemote(repoUrl: string): string {
   return 'main';
 }
 
+const REMOTE_CLONE_PROBE_ATTEMPTS = 2;
+const REMOTE_CLONE_PROBE_RETRY_DELAY_MS = 500;
+
+function sleepSyncMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function describeCloneProbeError(err: unknown): string {
+  const stderr = (err as { stderr?: Buffer | string })?.stderr;
+  const stderrText = stderr ? stderr.toString().trim() : '';
+  if (stderrText) return stderrText.split('\n')[0]!;
+  const message = err instanceof Error ? err.message : String(err);
+  return message.split('\n')[0]!;
+}
+
 function assertLocalGitRepoReadable(localPath: string): void {
   if (!existsSync(localPath)) throw new Error('Path does not exist');
   execFileSync('git', ['-c', 'safe.directory=*', '-C', localPath, 'rev-parse', '--git-dir'], {
@@ -182,24 +197,45 @@ export function assertRepoUrlCloneable(repoUrl: string): void {
     );
   }
 
-  try {
-    if (isLocalPath) {
+  if (isLocalPath) {
+    try {
       assertLocalGitRepoReadable(trimmed);
       return;
+    } catch (err) {
+      throw new PlanParseError(
+        `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials. (${describeCloneProbeError(err)})`,
+      );
     }
-    if (isFileUrl) {
+  }
+  if (isFileUrl) {
+    try {
       assertLocalGitRepoReadable(fileURLToPath(trimmed));
       return;
+    } catch (err) {
+      throw new PlanParseError(
+        `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials. (${describeCloneProbeError(err)})`,
+      );
     }
-    execFileSync('git', ['ls-remote', '--exit-code', '--', trimmed, 'HEAD'], {
-      stdio: ['ignore', 'ignore', 'ignore'],
-      timeout: 10_000,
-    });
-  } catch {
-    throw new PlanParseError(
-      `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials.`,
-    );
   }
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= REMOTE_CLONE_PROBE_ATTEMPTS; attempt += 1) {
+    try {
+      execFileSync('git', ['ls-remote', '--exit-code', '--', trimmed, 'HEAD'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 10_000,
+      });
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < REMOTE_CLONE_PROBE_ATTEMPTS) {
+        sleepSyncMs(REMOTE_CLONE_PROBE_RETRY_DELAY_MS);
+      }
+    }
+  }
+  throw new PlanParseError(
+    `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials. (${describeCloneProbeError(lastError)}, after ${REMOTE_CLONE_PROBE_ATTEMPTS} attempts)`,
+  );
 }
 
 export class PlanParseError extends Error {


### PR DESCRIPTION
## Summary

Plan submission runs a `git ls-remote` probe against a repo URL before accepting the plan.

That probe made one attempt only, and any transient network blip failed it outright. A real blip on a public, working repo tonight left a PR repair permanently stuck, because the caller had already taken a claim-lock first.

The probe now makes a second attempt for a remote URL, and the thrown error includes the real git stderr instead of a generic "check credentials" message.

## Review Claim

Approve giving the remote clone probe a second attempt and surfacing the real git error text in `assertRepoUrlCloneable`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Local and `file://` paths are unchanged (still one attempt — a missing local path is not transient). Only remote URL probing gets a second attempt, capped at 2 total tries with a 500ms pause between them, and each attempt still bounded by the existing 10s timeout, so a genuinely broken URL still fails fast rather than hanging.

## Slice Rationale

This is the direct fix for tonight's incident: a transient `git ls-remote` failure during an admin-bypass repair's plan submission left a `repair_filing_ledger` claim stuck (because the release-on-failure path swallows its own errors), which blocked PR #11153's automated repair. This slice only hardens the probe itself; it does not touch the ledger's silent-swallow behavior.

## Non-goals

Does not change `default_release_repair_filing`'s silent-failure handling in `mergify_admin_requeue_repairer.py` — that's a separate, still-open fix.

Does not change the local/`file://` path, which stays at one attempt.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- plan-parser` — includes two new tests: "survives a single transient failure of the remote clone probe" and "surfaces the real git error after all retry attempts are exhausted"
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert aee4a57ee1`
- Post-revert steps: None
- Data migration? No

</details>
