### PR TITLE
[Duplicate PR title collision](1) Flag conflicted PRs matching a merged title

### DIFF
--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -141,6 +141,14 @@ class GhClient:
         value = self._run_json(args)
         return value if isinstance(value, list) else []
 
+    def list_merged_prs(self, repo: str, limit: int = 300) -> list[dict]:
+        args = [
+            "gh", "pr", "list", "--repo", repo, "--state", "merged", "--limit", str(limit),
+            "--json", "number,title",
+        ]
+        value = self._run_json(args)
+        return value if isinstance(value, list) else []
+
     def pr_detail(self, repo: str, number: int) -> dict:
         owner, name = repo.split("/", 1)
         query = (

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -465,3 +465,64 @@ def submit_close_pr(pr_number: int, repo: str, reason: str, expected_head_oid: s
             f"submit_close_pr failed for PR #{pr_number}: "
             f"{completed.stderr.strip() or completed.stdout.strip()}"
         )
+
+
+def _flag_probable_duplicate_command_script(
+    pr_number: int, repo: str, evidence: str, expected_head_oid: str, merged_pr_number: int,
+) -> str:
+    # Comment-only -- never closes. See plan_flag_probable_duplicates' own
+    # docstring for why a modify/modify conflict can't be auto-resolved.
+    lines = [
+        "set -euo pipefail",
+        f"num={pr_number}",
+        f"repo={shlex.quote(repo)}",
+        f"expected={shlex.quote(expected_head_oid)}",
+        'current_json="$(gh pr view "$num" --repo "$repo" --json state,headRefOid)"',
+        'current_state="$(printf \'%s\' "$current_json" | jq -r \'.state\')"',
+        'current_head="$(printf \'%s\' "$current_json" | jq -r \'.headRefOid\')"',
+        'if [ "$current_state" != "OPEN" ] || [ "$current_head" != "$expected" ]; then',
+        '  echo "stale-pr: #$num is $current_state at $current_head; expected OPEN at $expected" >&2',
+        "  exit 20",
+        "fi",
+        f"merged={merged_pr_number}",
+        f"evidence={shlex.quote(evidence)}",
+        'gh pr comment "$num" --repo "$repo" --body "Invoker probable-duplicate flag: this PR looks like a duplicate of already-merged #$merged. $evidence Needs a human or agent to confirm the conflicting content is equivalent, then close as duplicate."',
+        'echo "pr-duplicate-close: flagged #$num as probable duplicate of #$merged"',
+    ]
+    return "\n".join(lines)
+
+
+def _flag_probable_duplicate_plan_yaml(
+    pr_number: int, repo: str, evidence: str, expected_head_oid: str, merged_pr_number: int,
+) -> str:
+    command_script = _flag_probable_duplicate_command_script(pr_number, repo, evidence, expected_head_oid, merged_pr_number)
+    indented_command = "\n".join(f"      {line}" if line else "" for line in command_script.splitlines())
+    safe_evidence = evidence.replace('"', "'").replace("\n", " ")
+    return (
+        f"name: flag-duplicate-pr-{pr_number}-vs-{merged_pr_number}\n"
+        "onFinish: none\n"
+        "baseBranch: master\n"
+        "tasks:\n"
+        "  - id: flag\n"
+        f'    description: "Flag PR #{pr_number} as a probable duplicate of #{merged_pr_number}: {safe_evidence}"\n'
+        "    command: |\n"
+        f"{indented_command}\n"
+    )
+
+
+def submit_flag_probable_duplicate(pr_number: int, repo: str, evidence: str, expected_head_oid: str, merged_pr_number: int) -> None:
+    plan_yaml = _flag_probable_duplicate_plan_yaml(pr_number, repo, evidence, expected_head_oid, merged_pr_number)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=f"-flag-duplicate-pr-{pr_number}.yaml", delete=False, encoding="utf-8",
+    ) as handle:
+        handle.write(plan_yaml)
+        plan_path = handle.name
+    try:
+        completed = _run_headless('headless_mutation run "$2"', plan_path)
+    finally:
+        Path(plan_path).unlink(missing_ok=True)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"submit_flag_probable_duplicate failed for PR #{pr_number}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )

--- a/scripts/pr_duplicate_close_exec.py
+++ b/scripts/pr_duplicate_close_exec.py
@@ -13,16 +13,16 @@ try:
     from .mergify_admin_requeue_snapshot import GhClient
     from .pr_duplicate_close_executor import PrDuplicateCloseExecutor
     from .pr_duplicate_close_git_facts import GitFactsClient
-    from .pr_duplicate_close_model import CandidatePr, GitFacts
-    from .pr_duplicate_close_plan import plan_close_actions
+    from .pr_duplicate_close_model import FLAG_DUPLICATE, CandidatePr, GitFacts
+    from .pr_duplicate_close_plan import plan_close_actions, plan_flag_probable_duplicates
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger
     from mergify_admin_requeue_snapshot import GhClient
     from pr_duplicate_close_executor import PrDuplicateCloseExecutor
     from pr_duplicate_close_git_facts import GitFactsClient
-    from pr_duplicate_close_model import CandidatePr, GitFacts
-    from pr_duplicate_close_plan import plan_close_actions
+    from pr_duplicate_close_model import FLAG_DUPLICATE, CandidatePr, GitFacts
+    from pr_duplicate_close_plan import plan_close_actions, plan_flag_probable_duplicates
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -45,7 +45,7 @@ def _compute_landed_facts(git_facts: GitFactsClient, head_sha: str) -> GitFacts:
     if merge_base_sha is None:
         return GitFacts(
             merge_base_sha=None, is_ancestor=False, is_empty_diff=False,
-            all_commits_equivalent=False, is_rebase_equivalent=False,
+            all_commits_equivalent=False, is_rebase_equivalent=False, has_conflict=False,
         )
     return GitFacts(
         merge_base_sha=merge_base_sha,
@@ -53,7 +53,21 @@ def _compute_landed_facts(git_facts: GitFactsClient, head_sha: str) -> GitFacts:
         is_empty_diff=git_facts.is_empty_diff(head_sha),
         all_commits_equivalent=git_facts.all_commits_equivalent(head_sha),
         is_rebase_equivalent=git_facts.is_rebase_equivalent(head_sha),
+        has_conflict=git_facts.has_conflict(head_sha),
     )
+
+
+def _merged_pr_number_by_title(gh: GhClient, repo: str) -> dict[str, int]:
+    merged_by_title: dict[str, int] = {}
+    for item in gh.list_merged_prs(repo):
+        title = str(item.get("title") or "")
+        number = int(item.get("number") or 0)
+        if not title or not number:
+            continue
+        # `gh pr list --state merged` is newest-first; keep the first (most
+        # recent) match on a title collision among merged PRs themselves.
+        merged_by_title.setdefault(title, number)
+    return merged_by_title
 
 
 def _compute_patch_id(git_facts: GitFactsClient, pr: CandidatePr) -> str | None:
@@ -71,7 +85,8 @@ def _compute_patch_id(git_facts: GitFactsClient, pr: CandidatePr) -> str | None:
 def print_action(action, dry_run: bool) -> None:
     prefix = "DRY-RUN " if dry_run else ""
     kept = f" kept=#{action.kept_pr_number}" if action.kept_pr_number is not None else ""
-    print(f"{prefix}close PR #{action.pr_number} reason={action.reason}{kept} evidence={action.evidence}")
+    verb = "flag" if action.kind == FLAG_DUPLICATE else "close"
+    print(f"{prefix}{verb} PR #{action.pr_number} reason={action.reason}{kept} evidence={action.evidence}")
 
 
 def run_cycle(args: argparse.Namespace) -> bool:
@@ -110,6 +125,8 @@ def run_cycle(args: argparse.Namespace) -> bool:
         patch_ids[pr.number] = _compute_patch_id(git_facts, pr)
 
     actions = plan_close_actions(prs, facts_by_pr, patch_ids, ledger)
+    merged_by_title = _merged_pr_number_by_title(gh, args.repo)
+    actions += plan_flag_probable_duplicates(prs, facts_by_pr, merged_by_title, ledger)
     logger.trace("pr-duplicate-close-scan-planned", repo=args.repo, action_count=len(actions))
 
     submitted = 0

--- a/scripts/pr_duplicate_close_executor.py
+++ b/scripts/pr_duplicate_close_executor.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 try:
     from .mergify_admin_requeue_snapshot import GhClient
-    from .mergify_admin_requeue_workflow_fastpath import submit_close_pr
-    from .pr_duplicate_close_model import CLOSE_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
+    from .mergify_admin_requeue_workflow_fastpath import submit_close_pr, submit_flag_probable_duplicate
+    from .pr_duplicate_close_model import CLOSE_DUPLICATE, FLAG_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
 except ImportError:
     from mergify_admin_requeue_snapshot import GhClient
-    from mergify_admin_requeue_workflow_fastpath import submit_close_pr
-    from pr_duplicate_close_model import CLOSE_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
+    from mergify_admin_requeue_workflow_fastpath import submit_close_pr, submit_flag_probable_duplicate
+    from pr_duplicate_close_model import CLOSE_DUPLICATE, FLAG_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
 
 
 class PrDuplicateCloseExecutor:
@@ -57,13 +57,22 @@ class PrDuplicateCloseExecutor:
                 return False
 
         try:
-            submit_close_pr(
-                pr_number=action.pr_number,
-                repo=self.repo,
-                reason=action.evidence,
-                expected_head_oid=action.expected_head_oid,
-                kept_pr_number=action.kept_pr_number,
-            )
+            if action.kind == FLAG_DUPLICATE:
+                submit_flag_probable_duplicate(
+                    pr_number=action.pr_number,
+                    repo=self.repo,
+                    evidence=action.evidence,
+                    expected_head_oid=action.expected_head_oid,
+                    merged_pr_number=action.kept_pr_number,
+                )
+            else:
+                submit_close_pr(
+                    pr_number=action.pr_number,
+                    repo=self.repo,
+                    reason=action.evidence,
+                    expected_head_oid=action.expected_head_oid,
+                    kept_pr_number=action.kept_pr_number,
+                )
         except RuntimeError as exc:
             self.logger.trace(
                 "pr-duplicate-close-submit-failed",

--- a/scripts/pr_duplicate_close_git_facts.py
+++ b/scripts/pr_duplicate_close_git_facts.py
@@ -63,6 +63,20 @@ class GitFactsClient:
         lines = [line for line in completed.stdout.splitlines() if line.strip()]
         return len(lines) > 0 and all(line.startswith("-") for line in lines)
 
+    def has_conflict(self, head_sha: str, upstream: str = "origin/master") -> bool:
+        """True when merging head onto upstream hits any conflict at all,
+        of any kind. Used only as a corroborating signal (never sufficient
+        on its own) for a probable-duplicate flag -- see
+        pr_duplicate_close_plan.plan_flag_probable_duplicates.
+        """
+        merge_base_sha = self.merge_base(upstream, head_sha)
+        if merge_base_sha is None:
+            return False
+        result = self._run([
+            "git", "merge-tree", "--write-tree", f"--merge-base={merge_base_sha}", upstream, head_sha,
+        ])
+        return result.returncode != 0
+
     def is_rebase_equivalent(self, head_sha: str, upstream: str = "origin/master") -> bool:
         """True when head's only differences from upstream are add/add
         conflicts (the same file independently added on both sides) and

--- a/scripts/pr_duplicate_close_model.py
+++ b/scripts/pr_duplicate_close_model.py
@@ -25,6 +25,7 @@ class GitFacts:
     is_empty_diff: bool
     all_commits_equivalent: bool
     is_rebase_equivalent: bool = False
+    has_conflict: bool = False
 
 
 LANDED_ANCESTOR = "landed:ancestor"
@@ -33,14 +34,16 @@ LANDED_PATCH_EQUIVALENT = "landed:patch-equivalent"
 LANDED_REBASE_EQUIVALENT = "landed:rebase-equivalent"
 DUPLICATE_SAME_BRANCH = "duplicate:same-branch"
 DUPLICATE_SAME_DIFF = "duplicate:same-diff"
+DUPLICATE_TITLE_COLLISION_MERGED = "duplicate:title-collision-merged"
 
 CLOSE_LANDED = "close_landed"
 CLOSE_DUPLICATE = "close_duplicate"
+FLAG_DUPLICATE = "flag_duplicate"
 
 
 @dataclass(frozen=True)
 class CloseAction:
-    kind: str  # CLOSE_LANDED | CLOSE_DUPLICATE
+    kind: str  # CLOSE_LANDED | CLOSE_DUPLICATE | FLAG_DUPLICATE
     pr_number: int
     expected_head_oid: str
     reason: str  # one of the *_* signal constants above

--- a/scripts/pr_duplicate_close_plan.py
+++ b/scripts/pr_duplicate_close_plan.py
@@ -16,6 +16,8 @@ try:
         CLOSE_LANDED,
         DUPLICATE_SAME_BRANCH,
         DUPLICATE_SAME_DIFF,
+        DUPLICATE_TITLE_COLLISION_MERGED,
+        FLAG_DUPLICATE,
         LANDED_ANCESTOR,
         LANDED_EMPTY_DIFF,
         LANDED_PATCH_EQUIVALENT,
@@ -33,6 +35,8 @@ except ImportError:
         CLOSE_LANDED,
         DUPLICATE_SAME_BRANCH,
         DUPLICATE_SAME_DIFF,
+        DUPLICATE_TITLE_COLLISION_MERGED,
+        FLAG_DUPLICATE,
         LANDED_ANCESTOR,
         LANDED_EMPTY_DIFF,
         LANDED_PATCH_EQUIVALENT,
@@ -158,4 +162,55 @@ def plan_close_actions(
                 kept_pr_number=group.kept_pr_number,
             ))
 
+    return tuple(actions)
+
+
+def plan_flag_probable_duplicates(
+    prs: Sequence[CandidatePr],
+    facts_by_pr: Mapping[int, GitFacts],
+    merged_pr_number_by_title: Mapping[str, int],
+    ledger,
+) -> tuple[CloseAction, ...]:
+    """Comment-only flag (never a close) for a PR whose title exactly
+    matches an already-merged PR's title while genuinely conflicting with
+    master.
+
+    is_rebase_equivalent only auto-closes the add/add case; a modify/modify
+    conflict is deliberately left to "the normal (human/repair) path"
+    because auto-preferring either side could silently discard a real
+    change (see its docstring). A same-repo title collision plus a real
+    conflict is strong evidence of the near-duplicate-slice pattern (an
+    independently regenerated PR for a fix that already landed under a
+    different plan run), but proving the conflicting hunk itself is truly
+    equivalent needs a human or agent reading the diff -- exactly what
+    #11153 vs #10820 needed. This only ever posts a comment; it never
+    closes anything, so a false positive costs a comment, not a PR.
+    """
+    actions: list[CloseAction] = []
+    for pr in prs:
+        if pr.state != "OPEN" or pr.is_draft:
+            continue
+        facts = facts_by_pr.get(pr.number)
+        if facts is None or not facts.has_conflict:
+            continue
+        if facts.is_ancestor or facts.is_empty_diff or facts.all_commits_equivalent or facts.is_rebase_equivalent:
+            continue
+        merged_number = merged_pr_number_by_title.get(pr.title)
+        if merged_number is None or merged_number == pr.number:
+            continue
+        if _already_submitted(ledger, pr.number, pr.head_ref_oid, DUPLICATE_TITLE_COLLISION_MERGED, merged_number):
+            continue
+        evidence = (
+            f"title exactly matches already-merged #{merged_number}; GitHub reports a merge "
+            f"conflict, so this needs a human or agent to confirm the conflicting content is "
+            f"equivalent before closing (head {pr.head_ref_oid})"
+        )
+        actions.append(CloseAction(
+            kind=FLAG_DUPLICATE,
+            pr_number=pr.number,
+            expected_head_oid=pr.head_ref_oid,
+            reason=DUPLICATE_TITLE_COLLISION_MERGED,
+            evidence=evidence,
+            kept_pr_number=merged_number,
+        ))
     return tuple(actions)

--- a/scripts/test_pr_duplicate_close_exec.py
+++ b/scripts/test_pr_duplicate_close_exec.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from pr_duplicate_close_exec import _compute_patch_id
+from pr_duplicate_close_exec import _compute_patch_id, _merged_pr_number_by_title
 from pr_duplicate_close_git_facts import GitFactsClient
 from pr_duplicate_close_model import CandidatePr
 
@@ -133,6 +133,33 @@ class UnfetchableBase(ComputePatchIdTestCase):
         pr = candidate(base_ref_name="this-branch-does-not-exist", head_ref_oid=head)
 
         self.assertIsNone(_compute_patch_id(self.client, pr))
+
+
+class FakeGh:
+    def __init__(self, merged: list[dict]):
+        self.merged = merged
+
+    def list_merged_prs(self, repo: str) -> list[dict]:
+        return self.merged
+
+
+class MergedPrNumberByTitle(unittest.TestCase):
+    def test_maps_title_to_number(self):
+        gh = FakeGh([{"number": 10820, "title": "No-Mergify observed CI repair (2) Repair failed observed checks"}])
+        result = _merged_pr_number_by_title(gh, "owner/repo")
+        self.assertEqual(result, {"No-Mergify observed CI repair (2) Repair failed observed checks": 10820})
+
+    def test_first_seen_wins_on_title_collision_among_merged_prs(self):
+        gh = FakeGh([
+            {"number": 200, "title": "dup title"},
+            {"number": 100, "title": "dup title"},
+        ])
+        result = _merged_pr_number_by_title(gh, "owner/repo")
+        self.assertEqual(result["dup title"], 200)
+
+    def test_skips_entries_missing_title_or_number(self):
+        gh = FakeGh([{"number": 0, "title": "no number"}, {"number": 5, "title": ""}])
+        self.assertEqual(_merged_pr_number_by_title(gh, "owner/repo"), {})
 
 
 if __name__ == "__main__":

--- a/scripts/test_pr_duplicate_close_executor.py
+++ b/scripts/test_pr_duplicate_close_executor.py
@@ -68,6 +68,19 @@ def duplicate_action(**kw) -> dm.CloseAction:
     return dm.CloseAction(**base)
 
 
+def flag_action(**kw) -> dm.CloseAction:
+    base = dict(
+        kind=dm.FLAG_DUPLICATE,
+        pr_number=11153,
+        expected_head_oid="bfc6",
+        reason=dm.DUPLICATE_TITLE_COLLISION_MERGED,
+        evidence="title exactly matches already-merged #10820",
+        kept_pr_number=10820,
+    )
+    base.update(kw)
+    return dm.CloseAction(**base)
+
+
 class ExecutorTestCase(unittest.TestCase):
     def _ledger(self):
         d = tempfile.mkdtemp()
@@ -131,6 +144,48 @@ class CasGuards(ExecutorTestCase):
             pr_number=5, repo="owner/repo", reason="duplicate of open PR #9",
             expected_head_oid="h5", kept_pr_number=9,
         )
+
+
+class FlagProbableDuplicate(ExecutorTestCase):
+    def test_flag_never_checks_the_merged_prs_state(self):
+        # #10820 is MERGED, not OPEN -- the CLOSE_DUPLICATE "kept PR must
+        # still be open" guard would wrongly block this. A flag only
+        # references an immutable merged PR, so that check must not apply.
+        gh = FakeGh({11153: {"state": "OPEN", "headRefOid": "bfc6"}})
+        executor = ex.PrDuplicateCloseExecutor(gh, self._ledger(), FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_flag_probable_duplicate") as submit:
+            performed = executor.execute(flag_action())
+
+        self.assertTrue(performed)
+        self.assertNotIn(10820, gh.calls)
+        submit.assert_called_once_with(
+            pr_number=11153, repo="owner/repo",
+            evidence="title exactly matches already-merged #10820",
+            expected_head_oid="bfc6", merged_pr_number=10820,
+        )
+
+    def test_flag_records_ledger_on_success(self):
+        gh = FakeGh({11153: {"state": "OPEN", "headRefOid": "bfc6"}})
+        ledger = self._ledger()
+        executor = ex.PrDuplicateCloseExecutor(gh, ledger, FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_flag_probable_duplicate"):
+            executor.execute(flag_action())
+
+        self.assertEqual(
+            ledger.count(dm.LEDGER_KIND_SUBMIT, 11153, "bfc6", dm.ledger_key(dm.DUPLICATE_TITLE_COLLISION_MERGED, 10820)), 1,
+        )
+
+    def test_flag_still_aborts_on_stale_head(self):
+        gh = FakeGh({11153: {"state": "OPEN", "headRefOid": "moved"}})
+        executor = ex.PrDuplicateCloseExecutor(gh, self._ledger(), FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_flag_probable_duplicate") as submit:
+            performed = executor.execute(flag_action())
+
+        self.assertFalse(performed)
+        submit.assert_not_called()
 
 
 class SuccessfulHandoff(ExecutorTestCase):

--- a/scripts/test_pr_duplicate_close_git_facts.py
+++ b/scripts/test_pr_duplicate_close_git_facts.py
@@ -147,6 +147,30 @@ class IsRebaseEquivalent(GitFactsTestCase):
         self.assertFalse(self.client.is_rebase_equivalent(feature_sha, "master"))
 
 
+class HasConflict(GitFactsTestCase):
+    def test_true_for_modify_modify_conflict(self):
+        write_and_commit(self.repo, "shared.txt", "original\n", "shared base content")
+        run(self.repo, "checkout", "-q", "-b", "pr-a")
+        pr_a_sha = write_and_commit(self.repo, "shared.txt", "pr-a's real change\n", "PR A modifies shared.txt")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(self.repo, "shared.txt", "master's different change\n", "master modifies shared.txt")
+
+        self.assertTrue(self.client.has_conflict(pr_a_sha, "master"))
+
+    def test_true_for_add_add_conflict(self):
+        run(self.repo, "checkout", "-q", "-b", "pr-a")
+        pr_a_sha = write_and_commit(self.repo, "domain.mjs", "same\n", "PR A adds domain.mjs")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(self.repo, "domain.mjs", "different\n", "master already has domain.mjs")
+
+        self.assertTrue(self.client.has_conflict(pr_a_sha, "master"))
+
+    def test_false_for_a_clean_merge(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "feature.txt", "feature\n", "feature commit")
+        self.assertFalse(self.client.has_conflict(feature_sha, "master"))
+
+
 class AllCommitsEquivalent(GitFactsTestCase):
     def test_true_when_master_has_an_equivalent_commit(self):
         run(self.repo, "checkout", "-q", "-b", "feature")

--- a/scripts/test_pr_duplicate_close_plan.py
+++ b/scripts/test_pr_duplicate_close_plan.py
@@ -203,5 +203,74 @@ class PlanCloseActions(DuplicateCloseTestCase):
         self.assertEqual(len(actions), 1)
 
 
+class PlanFlagProbableDuplicates(DuplicateCloseTestCase):
+    # Reproduces the #11153-vs-#10820 shape: an open PR whose title exactly
+    # matches an already-merged PR's title, but the git-level content
+    # genuinely conflicts (a modify/modify rename, not add/add) so none of
+    # the safe landed/rebase-equivalent signals fire. is_rebase_equivalent
+    # only ever handles add/add — this is the residual gap it leaves.
+
+    def test_title_collision_with_conflict_is_flagged(self):
+        pr = candidate(number=11153, title="No-Mergify observed CI repair (2) Repair failed observed checks", head_ref_oid="bfc6")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {11153: facts(has_conflict=True)},
+            {"No-Mergify observed CI repair (2) Repair failed observed checks": 10820},
+            self._ledger(),
+        )
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].kind, dm.FLAG_DUPLICATE)
+        self.assertEqual(actions[0].pr_number, 11153)
+        self.assertEqual(actions[0].kept_pr_number, 10820)
+        self.assertEqual(actions[0].reason, dm.DUPLICATE_TITLE_COLLISION_MERGED)
+
+    def test_no_title_collision_is_not_flagged(self):
+        pr = candidate(number=1, title="Unrelated title", head_ref_oid="h1")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {1: facts(has_conflict=True)}, {"Something else": 999}, self._ledger(),
+        )
+        self.assertEqual(actions, ())
+
+    def test_no_conflict_is_not_flagged(self):
+        # A title collision with no actual git conflict isn't this signal's
+        # job — could be a legitimate re-run of the same generated title.
+        pr = candidate(number=1, title="dup title", head_ref_oid="h1")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {1: facts(has_conflict=False)}, {"dup title": 999}, self._ledger(),
+        )
+        self.assertEqual(actions, ())
+
+    def test_already_caught_by_a_safe_signal_is_not_flagged(self):
+        # is_rebase_equivalent (or any other safe signal) already closes this
+        # via the normal landed path — flagging it too would be redundant.
+        pr = candidate(number=1, title="dup title", head_ref_oid="h1")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {1: facts(has_conflict=True, is_rebase_equivalent=True)}, {"dup title": 999}, self._ledger(),
+        )
+        self.assertEqual(actions, ())
+
+    def test_title_collision_with_itself_is_not_flagged(self):
+        pr = candidate(number=999, title="dup title", head_ref_oid="h1")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {999: facts(has_conflict=True)}, {"dup title": 999}, self._ledger(),
+        )
+        self.assertEqual(actions, ())
+
+    def test_already_flagged_is_not_replanned(self):
+        pr = candidate(number=1, title="dup title", head_ref_oid="h1")
+        ledger = self._ledger()
+        ledger.record(dm.LEDGER_KIND_SUBMIT, 1, "h1", dm.ledger_key(dm.DUPLICATE_TITLE_COLLISION_MERGED, 999))
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {1: facts(has_conflict=True)}, {"dup title": 999}, ledger,
+        )
+        self.assertEqual(actions, ())
+
+    def test_draft_pr_is_not_flagged(self):
+        pr = candidate(number=1, title="dup title", is_draft=True, head_ref_oid="h1")
+        actions = p.plan_flag_probable_duplicates(
+            [pr], {1: facts(has_conflict=True)}, {"dup title": 999}, self._ledger(),
+        )
+        self.assertEqual(actions, ())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

PR #11153 sat blocked for hours: it was a regenerated copy of already-merged #10820 (same title, same files), but the one conflicting hunk was an independent rename, not a text match.

Nothing caught that shape, so the repair loop retried it forever and posted an unhelpful "cap reached" comment. This adds a comment-only flag for that case.

## Review Claim

Approve a new, comment-only check: when an open PR's title exactly matches an already-merged PR's title and GitHub reports a real conflict, post a comment naming the merged PR instead of staying silent.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This never closes a PR. It only posts a comment (CAS-guarded on the PR's own state/head, same pattern as the existing close path), so a false positive costs one comment, not a lost PR. The existing `is_rebase_equivalent` add/add-only auto-close rule is untouched — this is a separate, narrower signal for the modify/modify case that rule deliberately leaves alone.

## Slice Rationale

Sanity-checked against #11153's real head SHA (fetched from origin): none of the existing landed/duplicate signals fire on it, `has_conflict` is true, and the new function produces exactly the flag this incident needed. This is a standalone addition to the already-deployed `pr-duplicate-close` worker, not a change to the higher-blast-radius retry/cap pipeline that posted the "retry cap reached" comment.

## Non-goals

Does not auto-close a modify/modify conflict. Does not change `is_rebase_equivalent` or any of the three existing "landed" signals. Does not touch `mergify_admin_requeue_plan.py`'s retry-cap logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_pr_duplicate_close_git_facts.py`
- [ ] `python3 scripts/test_pr_duplicate_close_plan.py`
- [ ] `python3 scripts/test_pr_duplicate_close_exec.py`
- [ ] `python3 scripts/test_pr_duplicate_close_executor.py`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b9dcbf911f`
- Post-revert steps: None
- Data migration? No

</details>
