### PR TITLE
[admin-bypass-repair-bot-thread-pr-11168-f45e8fb](1) Parse balanced JSON from wrapped publisher output

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -416,6 +416,16 @@ describe('make-pr stack publish body contract', () => {
     expect(parsed[0]?.title).toBe(title);
   });
 
+  it('does not let a valid-JSON decoy in leading commentary shadow the real artifacts payload', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    // "{}" is itself valid, parseable JSON -- a naive first-match scanner
+    // would stop here and never reach the real payload below it.
+    const raw = `Status: {}\nHere is the published review stack:\n${payload}`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
   it('still throws "must output JSON" for genuinely non-JSON output', () => {
     expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
       'make-pr stack publisher must output JSON',

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -380,6 +380,47 @@ describe('make-pr stack publish body contract', () => {
     // The caller validates this empty body and falls through to the next agent.
     expect(validateReviewStackPrBody(parsed[0]?.body ?? '').length).toBeGreaterThan(0);
   });
+
+  it('parses JSON wrapped in a ```json fenced code block despite the no-fences instruction', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```json\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('parses JSON wrapped in a bare ``` fenced code block', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts a JSON object surrounded by commentary the agent added despite instructions', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = `Here is the published review stack:\n${payload}\nLet me know if you need anything else.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts balanced JSON when surrounding commentary and quoted strings contain braces', () => {
+    const title = 'Keep } inside an escaped "quote" and { inside the string';
+    const payload = JSON.stringify({
+      artifacts: [{ id: 'a', url: 'https://x/1', title }],
+    });
+    const raw = `Preparing {draft} output.\n${payload}\nFinished with } commentary.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.title).toBe(title);
+  });
+
+  it('still throws "must output JSON" for genuinely non-JSON output', () => {
+    expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
+      'make-pr stack publisher must output JSON',
+    );
+  });
 });
 
 // ── resolveSkillPathViaAgent ─────────────────────────────

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -408,6 +408,11 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
 
 function extractJsonPayload(raw: string): string {
   const trimmed = raw.trim();
+  // Prefer the LAST balanced, parseable top-level JSON object rather than the
+  // first: agent output can contain leading commentary that happens to
+  // include its own valid JSON object (even just "{}"), which would
+  // otherwise shadow the real payload appearing later in the same output.
+  let lastValid: string | undefined;
   for (let start = 0; start < trimmed.length; start += 1) {
     if (trimmed[start] !== '{') continue;
 
@@ -437,15 +442,17 @@ function extractJsonPayload(raw: string): string {
           const candidate = trimmed.slice(start, end + 1);
           try {
             JSON.parse(candidate);
-            return candidate;
+            lastValid = candidate;
           } catch {
-            break;
+            // Not valid JSON; fall through and keep scanning from end + 1.
           }
+          start = end;
+          break;
         }
       }
     }
   }
-  return trimmed;
+  return lastValid ?? trimmed;
 }
 
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -406,12 +406,58 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
   return providerId;
 }
 
+function extractJsonPayload(raw: string): string {
+  const trimmed = raw.trim();
+  for (let start = 0; start < trimmed.length; start += 1) {
+    if (trimmed[start] !== '{') continue;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let end = start; end < trimmed.length; end += 1) {
+      const character = trimmed[end];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === '{') {
+        depth += 1;
+      } else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = trimmed.slice(start, end + 1);
+          try {
+            JSON.parse(candidate);
+            return candidate;
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return trimmed;
+}
+
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.trim());
   } catch {
-    throw new Error('make-pr stack publisher must output JSON');
+    try {
+      parsed = JSON.parse(extractJsonPayload(raw));
+    } catch {
+      throw new Error('make-pr stack publisher must output JSON');
+    }
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1312,26 +1312,6 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
         self.assertEqual(actions, ())
 
-    def test_empty_required_checks_failed_observed_catstack_ci_repairs_before_squash_or_requeue(self):
-        checks = {
-            "lint": check("lint"),
-            "test": check("test", "failure"),
-        }
-        stack = StackGroup("s", (pr(9003, base="master", labels={"admin-bypass"}, checks=checks, latest=None),))
-        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9003, "test")])
-        self.assertNotIn("squash_merge", {a.kind for a in actions})
-        self.assertNotIn("requeue", {a.kind for a in actions})
-
-    def test_catstack_failing_test_plans_repair_not_squash_or_queue(self):
-        checks = {
-            "lint": check("lint"),
-            "test": check("test", "failure"),
-        }
-        stack = StackGroup("s", (pr(9010, base="main", labels={"admin-bypass"}, checks=checks, latest=None),))
-        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9010, "test")])
-
     def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
         stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1312,6 +1312,26 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
         self.assertEqual(actions, ())
 
+    def test_empty_required_checks_failed_observed_catstack_ci_repairs_before_squash_or_requeue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9003, base="master", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9003, "test")])
+        self.assertNotIn("squash_merge", {a.kind for a in actions})
+        self.assertNotIn("requeue", {a.kind for a in actions})
+
+    def test_catstack_failing_test_plans_repair_not_squash_or_queue(self):
+        checks = {
+            "lint": check("lint"),
+            "test": check("test", "failure"),
+        }
+        stack = StackGroup("s", (pr(9010, base="main", labels={"admin-bypass"}, checks=checks, latest=None),))
+        actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 9010, "test")])
+
     def test_squash_merge_waits_when_no_ci_signal_observed_yet(self):
         stack = StackGroup("s", (pr(9003, labels={"admin-bypass"}, checks={}),))
         actions = plan_stack_actions(stack, frozenset(), self.ledger(), 1)


### PR DESCRIPTION
## Summary

Accept review-stack publisher JSON when one valid object is wrapped in code fences or surrounding text.

Track JSON nesting outside quoted strings so braces in escaped content or surrounding text do not truncate the payload.

Keep exact JSON parsing first and preserve the existing malformed-output error.

## Workflow Summary

admin-bypass-repair-bot-thread-pr-11168-f45e8fb — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1787973088071-2/repair | Resolve bot review thread on PR #11168 | completed |
| wf-1787973088071-2/safe-push | Safely push PR #11168 only if its head did not move | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1787973088071-2/repair — Resolve bot review thread on PR #11168
.../admin-bypass-no-mergify-repair.test.ts         | 75 ++++++++++++++++++++++
 .../src/__tests__/pr-authoring.test.ts             | 41 ++++++++++++
 packages/execution-engine/src/pr-authoring.ts      | 48 +++++++++++++-
 scripts/mergify_admin_requeue_plan.py              | 11 ++--
 scripts/test_mergify_admin_requeue.py              | 20 ++++++
 5 files changed, 190 insertions(+), 5 deletions(-)

### wf-1787973088071-2/safe-push — Safely push PR #11168 only if its head did not move
.../admin-bypass-no-mergify-repair.test.ts         | 75 ++++++++++++++++++++++
 .../src/__tests__/pr-authoring.test.ts             | 41 ++++++++++++
 packages/execution-engine/src/pr-authoring.ts      | 48 +++++++++++++-
 scripts/mergify_admin_requeue_plan.py              | 11 ++--
 scripts/test_mergify_admin_requeue.py              | 20 ++++++
 5 files changed, 190 insertions(+), 5 deletions(-)

</details>

## Review Claim

Publisher output parsing accepts one balanced JSON object inside common agent wrappers while preserving the existing artifact rules.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Assumptions: unconfirmed because publication is headless. Artifact ordering, dependency checks, required body checks, provider IDs, branch fields, and malformed-output errors remain unchanged.

## Slice Rationale

The parser behavior and its directly affected cases stay together because both define acceptance at the same publisher-output boundary.

## Non-goals

No prompt schema, artifact shape, GitHub mutation, user interface, or unrelated behavior changes.

## Architecture

### Before

```mermaid
graph TD
    A["publisher emits wrapped output"] --> B["parse entire response as JSON"]
    B --> C["reject otherwise valid artifact payload"]
```

### After

```mermaid
graph TD
    A["publisher emits output"] --> B["try exact JSON first"]
    B --> C["scan for one balanced JSON object"]
    C --> D["run unchanged artifact validation"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-authoring.test.ts`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/admin-bypass-repair-bot-thread-pr-11168-f45e8fb.md --base stack/EdbertChan/fix/no-mergify-observed-ci-repair/mergify-observed-ci-repair-2-repair-failed--66a9d85d`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 82bf6cb5732acc2ed9b0f9fbbb51104873a7632a`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing fallback at the publisher-output boundary; strict-parse-first behavior and artifact validation are preserved.
> 
> **Overview**
> **`parseMakePrStackPublishResult`** still parses clean JSON first; when that fails it now runs a brace-balancing scan (string/escape aware) and **`JSON.parse`s the last valid top-level object** in the agent response, so fences, prose, or a leading `{}` decoy do not block the real `artifacts` payload.
> 
> Downstream artifact validation, dependency rules, and the existing **"must output JSON"** error for non-JSON text are unchanged. New unit tests cover fenced blocks, commentary wrappers, braces inside strings, and decoy-object cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81545ac3011b55509fb1cef49e6eba7271b51dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->