### PR TITLE
[admin-bypass-repair-bot-thread-pr-11208-490328a](2) Normalize remote freshness paths

### DIFF
--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -202,6 +202,40 @@ describe('stale task specification preflight', () => {
     }
   });
 
+  it('expands a tilde-prefixed remote working directory before checking freshness', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'invoker-stale-task-remote-home-'));
+    const repo = join(fakeHome, 'workspace');
+    try {
+      mkdirSync(repo);
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+      mkdirSync(join(repo, 'packages/ui/src'), { recursive: true });
+      const appPath = join(repo, 'packages/ui/src/App.tsx');
+      writeFileSync(appPath, 'export const camera = "selection-only";\n');
+      execFileSync('git', ['add', '.'], { cwd: repo });
+      execFileSync('git', ['commit', '-qm', 'old camera base'], { cwd: repo });
+      const snapshotCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+      writeFileSync(appPath, 'export const camera = "selection-recenter";\n');
+      execFileSync('git', ['commit', '-qam', 'change camera behavior'], { cwd: repo });
+
+      const output = execFileSync('bash', ['-c', buildRemoteTaskFreshnessScript({
+        cwd: '~/workspace',
+        snapshotCommit,
+        taskText: 'Modify packages/ui/src/App.tsx.',
+      })], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome },
+      });
+
+      expect(parseRemoteTaskFreshnessReport(output)).toMatchObject({
+        reasons: ['path:packages/ui/src/App.tsx'],
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   it('is wired before command construction and stops with needs_input', () => {
     const executorSource = readFileSync(new URL('../worktree-executor.ts', import.meta.url), 'utf8');
     const freshnessIndex = executorSource.indexOf('const freshness = await inspectTaskFreshness');

--- a/packages/execution-engine/src/remote-shell-fragments.ts
+++ b/packages/execution-engine/src/remote-shell-fragments.ts
@@ -11,6 +11,19 @@ export function buildPortableBase64DecodeFunction(functionName = 'invoker_base64
 }`;
 }
 
+export function buildRemotePathNormalizeFunction(): string {
+  return `normalize_remote_path() {
+  local path="$1"
+  if [[ "$path" == '~' ]]; then
+    printf '%s\\n' "$HOME"
+  elif [[ "\${path:0:2}" == '~/' ]]; then
+    printf '%s/%s\\n' "$HOME" "\${path:2}"
+  else
+    printf '%s\\n' "$path"
+  fi
+}`;
+}
+
 export function buildSourceInvokerEnvScript(remoteInvokerHome = '~/.invoker', varName = 'INVOKER_RUNTIME_HOME'): string {
   return `${varName}='${remoteInvokerHome.replace(/'/g, `'\\''`)}'
 if [[ "$${varName}" == '~' ]]; then

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -16,7 +16,10 @@ import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { createExecutionBench } from './execution-bench.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
-import { buildSourceInvokerEnvScript } from './remote-shell-fragments.js';
+import {
+  buildRemotePathNormalizeFunction,
+  buildSourceInvokerEnvScript,
+} from './remote-shell-fragments.js';
 import { canonicalizeRemoteManagedWorkspacePath } from './conflict-resolver.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
@@ -325,20 +328,6 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
 `;
   }
 
-  private remotePathNormalizeFunction(): string {
-    return `normalize_remote_path() {
-  local path="$1"
-  if [[ "$path" == '~' ]]; then
-    printf '%s\\n' "$HOME"
-  elif [[ "\${path:0:2}" == '~/' ]]; then
-    printf '%s/%s\\n' "$HOME" "\${path:2}"
-  else
-    printf '%s\\n' "$path"
-  fi
-}
-`;
-  }
-
   private buildRuntimeBootstrapScript(options: {
     executionId: string;
     actionId: string;
@@ -384,7 +373,7 @@ ensure_managed_pnpm_workspace
 }
 load_remote_profile_path
 set -euo pipefail
-${this.remotePathNormalizeFunction()}
+${buildRemotePathNormalizeFunction()}
 ${buildSourceInvokerEnvScript(this.remoteInvokerHome, 'INVOKER_HOME')}
 STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -1,5 +1,6 @@
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { buildRemotePathNormalizeFunction } from './remote-shell-fragments.js';
 
 export interface TaskFreshnessAnchor {
   kind: 'path' | 'symbol';
@@ -247,7 +248,9 @@ export function buildRemoteTaskFreshnessScript(args: {
   const specification = parseTaskFreshnessSpecification(args.taskText);
   const lines = [
     'set -euo pipefail',
-    `cd ${shellQuote(args.cwd)}`,
+    buildRemotePathNormalizeFunction(),
+    `CWD=$(normalize_remote_path ${shellQuote(args.cwd)})`,
+    'cd "$CWD"',
     'CURRENT_COMMIT=$(git rev-parse HEAD)',
     'STALE_REASONS=""',
     'append_stale_reason() {',


### PR DESCRIPTION
## Summary

Expands tilde-prefixed remote worktree paths before the SSH task-freshness check changes directories.

The correction reuses the executor's existing path normalization and adds a real shell regression test for `~/workspace`.

## Review Claim

Approve remote path normalization before the SSH task-freshness script enters its working directory.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Normalization changes only `~` and `~/` prefixes. Absolute and other paths pass through unchanged, and local execution behavior is untouched.

## Slice Rationale

This focused follow-up addresses the bot review independently from the broader freshness routing so the remote path correction and its regression proof remain local.

## Non-goals

- Do not alter task-freshness classification rules.
- Do not change workspace allocation or SSH transport behavior.
- Do not modify absolute remote paths.
- Do not address unrelated review findings on PR #11208.

## Architecture

### Before

The remote freshness script quoted a tilde-prefixed worktree path literally, so the shell could not enter that directory.

### After

The script expands supported home-relative prefixes with the shared remote helper before entering the worktree and evaluating repository freshness.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- task-specification-preflight.test.ts ssh-executor.test.ts task-runner.test.ts task-runner-fix-publish-and-ssh.test.ts`

  ```text
  Test Files  4 passed (4)
  Tests  318 passed | 1 skipped (319)
  ```

- [x] `pnpm --filter @invoker/execution-engine build`

  ```text
  ESM Build success in 71ms
  DTS Build success in 2880ms
  ```

- [x] `pnpm run check:comments`

  ```text
  [comments] Checked added source lines; no disallowed comments found.
  ```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert b68516af961c8ca594b8bd38ca8f6a9198db1d8d`
- Post-revert steps: Re-run the focused task-specification preflight and SSH executor suites.
- Data migration? No.

</details>

## Workflow Summary

admin-bypass-repair-bot-thread-pr-11208-490328a — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1787973092434-3/repair | Resolve bot review thread on PR #11208 | completed |
| wf-1787973092434-3/safe-push | Safely push PR #11208 only if its head did not move | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1787973092434-3/repair — Resolve bot review thread on PR #11208
packages/contracts/src/types.ts                    |   1 +
.../__tests__/task-specification-preflight.test.ts | 258 ++++++++++++++++
.../execution-engine/src/remote-shell-fragments.ts |  13 +
packages/execution-engine/src/ssh-executor.ts      |  96 +++++-
.../execution-engine/src/task-runner-prepare.ts    |   5 +
.../src/task-specification-preflight.ts            | 323 +++++++++++++++++++++
packages/execution-engine/src/worktree-executor.ts |  57 ++++
7 files changed, 737 insertions(+), 16 deletions(-)

### wf-1787973092434-3/safe-push — Safely push PR #11208 only if its head did not move
packages/contracts/src/types.ts                    |   1 +
.../__tests__/task-specification-preflight.test.ts | 258 ++++++++++++++++
.../execution-engine/src/remote-shell-fragments.ts |  13 +
packages/execution-engine/src/ssh-executor.ts      |  96 +++++-
.../execution-engine/src/task-runner-prepare.ts    |   5 +
.../src/task-specification-preflight.ts            | 323 +++++++++++++++++++++
packages/execution-engine/src/worktree-executor.ts |  57 ++++
7 files changed, 737 insertions(+), 16 deletions(-)

</details>
