### PR TITLE
[GUI Startup Dialog](1) Show a dialog instead of silently quitting on GUI startup failures

### DIFF
--- a/packages/app/src/__tests__/owner-split-brain.test.ts
+++ b/packages/app/src/__tests__/owner-split-brain.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   OWNER_SPLIT_BRAIN_PREFIX,
+  buildGuiLockConflictPrompt,
   isWriterLockHeldError,
   parseWriterLockHolderPid,
   probeLockHolderOwner,
   resolveOwnerServeLockFailure,
+  terminateAndAwaitExit,
   type ProbeBus,
 } from '../owner-split-brain.js';
 
@@ -104,5 +106,79 @@ describe('resolveOwnerServeLockFailure', () => {
     expect(resolution.message).toContain(OWNER_SPLIT_BRAIN_PREFIX);
     expect(resolution.message).toContain('PID 266663');
     expect(resolution.message).toContain('/tmp/ipc.sock');
+  });
+});
+
+describe('buildGuiLockConflictPrompt', () => {
+  it('offers a kill button naming the holder pid when one is parseable', () => {
+    const prompt = buildGuiLockConflictPrompt(HELD_ERROR);
+    expect(prompt.holderPid).toBe(266663);
+    expect(prompt.message).toContain('PID 266663');
+    expect(prompt.buttons).toEqual(['Quit Other Instance and Retry', 'Quit']);
+    expect(prompt.killButtonIndex).toBe(0);
+    expect(prompt.cancelId).toBe(1);
+    expect(prompt.buttons[prompt.cancelId]).toBe('Quit');
+  });
+
+  it('falls back to an informational-only prompt when no pid is parseable', () => {
+    const prompt = buildGuiLockConflictPrompt(new Error('[db-writer-lock] already held by PID unknown.'));
+    expect(prompt.holderPid).toBeNull();
+    expect(prompt.killButtonIndex).toBeNull();
+    expect(prompt.buttons).toEqual(['Quit']);
+    expect(prompt.cancelId).toBe(0);
+  });
+});
+
+describe('terminateAndAwaitExit', () => {
+  it('sends SIGTERM and resolves true once isPidAlive flips to false', async () => {
+    let aliveCalls = 0;
+    const sleepCalls: number[] = [];
+    const terminatePid = vi.fn();
+    const isPidAlive = vi.fn(() => {
+      aliveCalls++;
+      return aliveCalls < 3;
+    });
+    const sleep = vi.fn((ms: number) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    });
+
+    const exited = await terminateAndAwaitExit(4242, { terminatePid, isPidAlive, sleep, now: () => 0 });
+
+    expect(exited).toBe(true);
+    expect(terminatePid).toHaveBeenCalledWith(4242);
+    expect(sleepCalls).toEqual([200, 200]);
+  });
+
+  it('resolves false once the timeout elapses without the pid dying', async () => {
+    let elapsed = 0;
+    const isPidAlive = () => true;
+    const sleep = (ms: number) => {
+      elapsed += ms;
+      return Promise.resolve();
+    };
+
+    const exited = await terminateAndAwaitExit(4242, {
+      terminatePid: () => {},
+      isPidAlive,
+      sleep,
+      now: () => elapsed,
+      timeoutMs: 500,
+    });
+
+    expect(exited).toBe(false);
+  });
+
+  it('still checks liveness when terminatePid throws (e.g. already dead)', async () => {
+    const isPidAlive = vi.fn(() => false);
+    const exited = await terminateAndAwaitExit(4242, {
+      terminatePid: () => { throw new Error('ESRCH'); },
+      isPidAlive,
+      sleep: () => Promise.resolve(),
+      now: () => 0,
+    });
+
+    expect(exited).toBe(true);
+    expect(isPidAlive).toHaveBeenCalledWith(4242);
   });
 });

--- a/packages/app/src/__tests__/owner-split-brain.test.ts
+++ b/packages/app/src/__tests__/owner-split-brain.test.ts
@@ -44,6 +44,10 @@ describe('parseWriterLockHolderPid', () => {
   it('returns null when no pid is present', () => {
     expect(parseWriterLockHolderPid(new Error('[db-writer-lock] already held by PID unknown.'))).toBeNull();
   });
+
+  it('returns null for PID 0', () => {
+    expect(parseWriterLockHolderPid(new Error('[db-writer-lock] already held by PID 0.'))).toBeNull();
+  });
 });
 
 describe('probeLockHolderOwner', () => {
@@ -127,9 +131,23 @@ describe('buildGuiLockConflictPrompt', () => {
     expect(prompt.buttons).toEqual(['Quit']);
     expect(prompt.cancelId).toBe(0);
   });
+
+  it('does not offer to terminate PID 0', () => {
+    const prompt = buildGuiLockConflictPrompt(new Error('[db-writer-lock] already held by PID 0.'));
+    expect(prompt.holderPid).toBeNull();
+    expect(prompt.killButtonIndex).toBeNull();
+    expect(prompt.buttons).toEqual(['Quit']);
+  });
 });
 
 describe('terminateAndAwaitExit', () => {
+  it('rejects PID 0 without attempting to terminate it', async () => {
+    const terminatePid = vi.fn();
+
+    await expect(terminateAndAwaitExit(0, { terminatePid })).resolves.toBe(false);
+    expect(terminatePid).not.toHaveBeenCalled();
+  });
+
   it('sends SIGTERM and resolves true once isPidAlive flips to false', async () => {
     let aliveCalls = 0;
     const sleepCalls: number[] = [];

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2906,7 +2906,12 @@ startMainProcessBootstrap({
             cancelId: prompt.cancelId,
             defaultId: prompt.cancelId,
           });
-          if (prompt.killButtonIndex !== null && response === prompt.killButtonIndex && prompt.holderPid !== null) {
+          if (
+            prompt.killButtonIndex !== null
+            && response === prompt.killButtonIndex
+            && prompt.holderPid !== null
+            && prompt.holderPid > 0
+          ) {
             const exited = await terminateAndAwaitExit(prompt.holderPid);
             if (!exited) {
               showStartupErrorDialog(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -194,7 +194,12 @@ import {
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { isWriterLockHeldError, resolveOwnerServeLockFailure } from './owner-split-brain.js';
+import {
+  buildGuiLockConflictPrompt,
+  isWriterLockHeldError,
+  resolveOwnerServeLockFailure,
+  terminateAndAwaitExit,
+} from './owner-split-brain.js';
 import { createOwnerSocketSentinel, type OwnerSocketSentinel } from './owner-socket-sentinel.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
@@ -2821,6 +2826,10 @@ startMainProcessBootstrap({
     }, 0);
   }
 
+  const showStartupErrorDialog = (title: string, message: string): void => {
+    dialog.showErrorBox(title, message);
+  };
+
   const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
     const guiOwnerPreference = resolveGuiOwnerPreference();
@@ -2862,6 +2871,7 @@ startMainProcessBootstrap({
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+        showStartupErrorDialog('Invoker failed to start', message);
         process.exitCode = 1;
         app.quit();
         return;
@@ -2878,6 +2888,7 @@ startMainProcessBootstrap({
         const message = err instanceof Error ? err.message : String(err);
         if (!message.includes('[db-writer-lock]')) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+          showStartupErrorDialog('Invoker failed to start', message);
           process.exitCode = 1;
           app.quit();
           return;
@@ -2886,16 +2897,52 @@ startMainProcessBootstrap({
         if (!isStandaloneCapable(owner)) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
           process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
-          process.exitCode = 1;
-          app.quit();
-          return;
+          const prompt = buildGuiLockConflictPrompt(err);
+          const { response } = await dialog.showMessageBox({
+            type: 'warning',
+            title: prompt.title,
+            message: prompt.message,
+            buttons: prompt.buttons,
+            cancelId: prompt.cancelId,
+            defaultId: prompt.cancelId,
+          });
+          if (prompt.killButtonIndex !== null && response === prompt.killButtonIndex && prompt.holderPid !== null) {
+            const exited = await terminateAndAwaitExit(prompt.holderPid);
+            if (!exited) {
+              showStartupErrorDialog(
+                'Could not stop the other instance',
+                `PID ${prompt.holderPid} is still running. Quit it manually (Activity Monitor, or `
+                  + `kill -9 ${prompt.holderPid}), then relaunch Invoker.`,
+              );
+              process.exitCode = 1;
+              app.quit();
+              return;
+            }
+            try {
+              recordStartupMark('initServices.retryAfterKill.start', { holderPid: prompt.holderPid });
+              await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+              recordStartupMark('initServices.retryAfterKill.end', { ownerMode: true });
+            } catch (retryErr) {
+              const retryMessage = retryErr instanceof Error ? retryErr.message : String(retryErr);
+              process.stderr.write(`${RED}Error:${RESET} ${retryMessage}\n`);
+              showStartupErrorDialog('Invoker failed to start', retryMessage);
+              process.exitCode = 1;
+              app.quit();
+              return;
+            }
+          } else {
+            process.exitCode = 1;
+            app.quit();
+            return;
+          }
+        } else {
+          recordStartupMark('initServices.readOnly.start', { ownerId: owner.ownerId });
+          await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+          ownerMode = false;
+          guiUsingDaemonOwner = false;
+          daemonOwnerLoss.clearConnectionLost();
+          recordStartupMark('initServices.readOnly.end', { ownerMode: false, ownerId: owner.ownerId });
         }
-        recordStartupMark('initServices.readOnly.start', { ownerId: owner.ownerId });
-        await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
-        ownerMode = false;
-        guiUsingDaemonOwner = false;
-        daemonOwnerLoss.clearConnectionLost();
-        recordStartupMark('initServices.readOnly.end', { ownerMode: false, ownerId: owner.ownerId });
       }
     }
 

--- a/packages/app/src/owner-split-brain.ts
+++ b/packages/app/src/owner-split-brain.ts
@@ -52,7 +52,7 @@ export function parseWriterLockHolderPid(err: unknown): number | null {
   const match = /already held by PID (\d+)/.exec(err.message);
   if (!match) return null;
   const pid = Number.parseInt(match[1], 10);
-  return Number.isFinite(pid) ? pid : null;
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
 }
 
 export function isPidAlive(pid: number): boolean {
@@ -110,6 +110,7 @@ export async function terminateAndAwaitExit(
     timeoutMs?: number;
   } = {},
 ): Promise<boolean> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
   const terminatePid = deps.terminatePid ?? ((p: number) => process.kill(p, 'SIGTERM'));
   const alive = deps.isPidAlive ?? isPidAlive;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));

--- a/packages/app/src/owner-split-brain.ts
+++ b/packages/app/src/owner-split-brain.ts
@@ -55,6 +55,78 @@ export function parseWriterLockHolderPid(err: unknown): number | null {
   return Number.isFinite(pid) ? pid : null;
 }
 
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export interface GuiLockConflictPrompt {
+  holderPid: number | null;
+  title: string;
+  message: string;
+  buttons: string[];
+  cancelId: number;
+  killButtonIndex: number | null;
+}
+
+export function buildGuiLockConflictPrompt(err: unknown): GuiLockConflictPrompt {
+  const holderPid = parseWriterLockHolderPid(err);
+  const title = 'Invoker is already running elsewhere';
+  if (holderPid === null) {
+    return {
+      holderPid: null,
+      title,
+      message:
+        'Another Invoker instance is holding the database, but it isn\'t reachable to share this window with. '
+        + 'Close that instance, then relaunch Invoker.',
+      buttons: ['Quit'],
+      cancelId: 0,
+      killButtonIndex: null,
+    };
+  }
+  return {
+    holderPid,
+    title,
+    message:
+      `Another Invoker instance (PID ${holderPid}) is holding the database, but it isn't reachable to share `
+      + 'this window with. You can quit that process and continue here, or quit this launch.',
+    buttons: ['Quit Other Instance and Retry', 'Quit'],
+    cancelId: 1,
+    killButtonIndex: 0,
+  };
+}
+
+export async function terminateAndAwaitExit(
+  pid: number,
+  deps: {
+    terminatePid?: (pid: number) => void;
+    isPidAlive?: (pid: number) => boolean;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+    timeoutMs?: number;
+  } = {},
+): Promise<boolean> {
+  const terminatePid = deps.terminatePid ?? ((p: number) => process.kill(p, 'SIGTERM'));
+  const alive = deps.isPidAlive ?? isPidAlive;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = deps.now ?? (() => Date.now());
+  const timeoutMs = deps.timeoutMs ?? 10_000;
+  try {
+    terminatePid(pid);
+  } catch {
+    return !alive(pid);
+  }
+  const deadline = now() + timeoutMs;
+  while (now() < deadline && alive(pid)) {
+    await sleep(200);
+  }
+  return !alive(pid);
+}
+
 function raceTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`owner-ping probe timed out after ${ms}ms`)), ms);


### PR DESCRIPTION
## Summary

Invoker's GUI could fail to open with zero visible error. This happened when another checkout's `owner-serve` process held `invoker.db`'s writer lock in a mode this window couldn't join.

The app wrote a message to `stderr` and quit.

That message is invisible in a launched app with no attached terminal, so the person just saw nothing happen.

`runGuiReadyBootstrap` now shows a dialog for every startup failure in this path instead of writing to `stderr` alone.

For the specific case of another live process holding the lock, the dialog also offers a button that quits that process and boots normally once it's gone.

## Review Claim

`packages/app/src/main.ts`'s three startup-failure exits in `runGuiReadyBootstrap` now show a dialog instead of writing only to `stderr`, and the lock-conflict case gains a user-triggered path that ends that process and boots normally afterward, backed by new pure helper functions for detecting and ending an unreachable lock holder.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

No process is ever terminated without an explicit click on the dialog's one button labeled to do that. The dialog's default button and its Escape/close action always resolve to "just quit this launch," never to killing anything. Termination sends `SIGTERM`, not `SIGKILL`, so the other process's own lock-release and shutdown cleanup still run.

## Slice Rationale

This is one self-contained startup-failure path in one file, plus its two small supporting modules, with focused coverage of its own. It doesn't touch the separate `app.requestSingleInstanceLock()` "you already have a window open" dialog, which already existed and covers a different scenario.

## Non-goals

This does not add a kill button to the other two startup-failure dialogs (a generic `initServices` error, and the daemon-owner bootstrap failure) — those aren't "a live PID is blocking you," so an informational dialog is the correct fix there.

This does not change `acquireDbWriterLock`'s locking behavior. It already self-reclaims a lock directory once the holder PID is confirmed dead, so no retry logic was needed there.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/owner-split-brain.test.ts`
- [ ] `pnpm --filter @invoker/core build && pnpm --filter @invoker/persistence build && pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

</details>

## Visual Proof

Repro'd the exact failure this fixes, end to end, in an isolated sandbox `INVOKER_DB_DIR`/`INVOKER_IPC_SOCKET` (never touching a real running Invoker instance): a disposable process held the fake lock directory, the GUI launched against it, and the code path this PR changes ran for real.

**Before this change:** the same scenario, on the prior code, only produced this `stderr` output and a silent quit — the window never appeared:

```
Error: [db-writer-lock] Cannot acquire writer lock for .../invoker.db — already held by PID 97015.
Detached viewer fallback requires a reachable owner, but no owner answered IPC.
```

**After:**

![Sequence: the new lock-conflict dialog naming the holder PID with Quit Other Instance and Retry / Quit buttons, then Invoker's normal Planning-chat window open after that process was ended and the app retried successfully](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-e9d883/gui-lock-conflict-flow.gif)

Manually inspected: the gif opens on the dialog reading "Another Invoker instance (PID 70415) is holding the database, but it isn't reachable to share this window with. You can quit that process and continue here, or quit this launch," with two buttons, "Quit Other Instance and Retry" and "Quit." The click on that button is real (driven via the accessibility API against the live dialog, not simulated). It then holds on Invoker's normal window, titled "Invoker," showing the Planning-chat empty state ("What do you want to build?") — the disposable blocking process was confirmed dead (`ps` showed it gone) before this frame was captured. This is the isolated sandbox instance's fresh, empty planning chat, the expected state for a first boot against an empty test database, not a real workflow.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GUI handling for database lock conflicts during startup.
  * Displays actionable prompts when another process holds the lock, including an option to terminate the identified process and retry.
  * Provides informational messaging when the lock holder cannot be identified.

* **Bug Fixes**
  * Startup failures now show an error dialog alongside command-line error output.
  * Added safeguards for failed termination attempts, retry failures, and termination timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->