### PR TITLE
[Demo control fixes](1) Modern Codex sandbox flags

### DIFF
--- a/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
@@ -9,10 +9,13 @@ describe('CodexExecutionAgent', () => {
     expect(spec.args).toEqual(['exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'test prompt']);
   });
 
-  it('supports explicit sandboxed full-auto mode when bypass is disabled', () => {
+  it('uses the workspace-write sandbox when bypass is disabled', () => {
     const agent = new CodexExecutionAgent({ bypassApprovalsAndSandbox: false, fullAuto: true });
     const spec = agent.buildCommand('test prompt');
-    expect(spec.args).toEqual(['exec', '--json', '--full-auto', 'test prompt']);
+    expect(spec).toMatchObject({
+      args: ['exec', '--json', '--sandbox', 'workspace-write', 'test prompt'],
+    });
+    expect(spec.args).not.toContain('--full-auto');
   });
   it('passes executionModel through as --model', () => {
     const agent = new CodexExecutionAgent();
@@ -66,6 +69,12 @@ describe('CodexExecutionAgent', () => {
     expect(spec.cmd).toBe('codex');
     expect(spec.args).toEqual(['exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'fix the bug']);
     expect(spec.sessionId).toBeDefined();
+  });
+  it('buildFixCommand uses the workspace-write sandbox when bypass is disabled', () => {
+    const agent = new CodexExecutionAgent({ bypassApprovalsAndSandbox: false, fullAuto: true });
+    const spec = agent.buildFixCommand('fix the bug');
+    expect(spec.args).toEqual(['exec', '--json', '--sandbox', 'workspace-write', 'fix the bug']);
+    expect(spec.args).not.toContain('--full-auto');
   });
   it('buildFixCommand passes executionModel through', () => {
     const agent = new CodexExecutionAgent();

--- a/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
 
 describe('CodexPlanningAgent', () => {
-  it('builds a sandboxed full-auto codex exec command and ignores model', () => {
+  it('builds a workspace-write sandboxed codex exec command and ignores model', () => {
     const agent = new CodexPlanningAgent({ command: 'codex-test' });
-    expect(agent.buildPlanningCommand('p', { model: 'ignored' })).toEqual({
+    const command = agent.buildPlanningCommand('p', { model: 'ignored' });
+    expect(command).toEqual({
       command: 'codex-test',
-      args: ['exec', '--json', '--full-auto', 'p'],
+      args: ['exec', '--json', '--sandbox', 'workspace-write', 'p'],
     });
+    expect(command.args).not.toContain('--full-auto');
   });
 
   it('defaults the command to codex', () => {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -85,7 +85,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
-    else if (this.fullAuto) args.push('--full-auto');
+    else if (this.fullAuto) args.push('--sandbox', 'workspace-write');
     args.push(...this.buildModelArgs(options.executionModel), fullPrompt);
     return { cmd: this.command, args, sessionId, fullPrompt };
   }
@@ -101,7 +101,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
-    else if (this.fullAuto) args.push('--full-auto');
+    else if (this.fullAuto) args.push('--sandbox', 'workspace-write');
     args.push(...this.buildModelArgs(options.executionModel), prompt);
     return { cmd: this.command, args, sessionId };
   }

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -22,7 +22,7 @@ export class CodexPlanningAgent implements PlanningAgent {
   buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
-    else if (this.fullAuto) args.push('--full-auto');
+    else if (this.fullAuto) args.push('--sandbox', 'workspace-write');
     args.push(prompt);
     return { command: this.command, args };
   }


### PR DESCRIPTION
## Summary

Route sandboxed Codex planning, execution, and fix invocations through explicit `--sandbox workspace-write` arguments instead of the obsolete `--full-auto` alias.

The routing retains the existing sandbox boundary while using the modern argument form.

## Review Claim

Sandboxed Codex planning and execution route through `--sandbox workspace-write` while dangerous bypass stays unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the non-bypass full-auto argument spelling changes; dangerous-bypass, resume, model, Claude, and OMP behavior stay unchanged.

## Slice Rationale

Planning and execution shared the same sandbox route, so both argument builders and their directly affected coverage form one compatibility claim.

## Non-goals

No capability probing, authentication changes, model-list changes, process-runner refactor, or dangerous-bypass behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments`

  ```text
  [comments] Checked added source lines; no disallowed comments found.
  ```

- [x] `pnpm --filter @invoker/execution-engine test -- codex-execution-agent.test.ts codex-planning-agent.test.ts`

  ```text
  Test Files  2 passed (2)
  Tests  15 passed (15)
  ```

- [x] `bash scripts/scrub-handoff-artifacts.sh`

  ```text
  scrub-handoff-artifacts-ok
  ```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Re-run the two focused Codex agent test files.
- Data migration? No.

</details>
