### PR TITLE
[Demo control fixes 3: preserve planning repository binding](1) Resolve approved plan binding

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -795,6 +795,34 @@ tasks:
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
 
+  it('passes the bound repository to the submit loader', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'bound-repository-submit',
+      title: 'Bound repository submit',
+      status: 'draft_ready',
+      repoUrl: '/home/demo/demo-repo',
+      baseBranch: 'main',
+      draftPlanText: VALID_PLAN_TEXT,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+    });
+    sessions.set(session.id, session);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    });
+
+    await expect(submitPlanningChatDraft({ sessionId: session.id }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toMatchObject({ ok: true, workflowId: 'wf-1' });
+
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(
+      VALID_PLAN_TEXT,
+      { repoUrl: '/home/demo/demo-repo', baseBranch: 'main' },
+    );
+  });
+
   it('submits a valid final draft plan without a closing YAML fence', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN_WITHOUT_CLOSING_FENCE);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/__tests__/plan-submission-loader.test.ts
+++ b/packages/app/src/__tests__/plan-submission-loader.test.ts
@@ -35,6 +35,36 @@ function makeDeps() {
 }
 
 describe('loadPlanSubmissionBundle', () => {
+  it('resolves only dot to the bound repository while preserving an explicit repository URL', async () => {
+    const { deps, loadedPlans } = makeDeps();
+
+    await loadPlanSubmissionBundle(`
+name: Bound Repository Stack
+repoUrl: .
+workflows:
+  - name: Bound Repository Workflow
+    featureBranch: plan/bound-repository
+    tasks:
+      - id: bound
+        description: Use the planning session repository
+  - name: Explicit Repository Workflow
+    repoUrl: git@github.com:test/explicit-repo.git
+    featureBranch: plan/explicit-repository
+    tasks:
+      - id: explicit
+        description: Keep the explicit repository
+`, deps, {
+      repositoryBinding: {
+        repoUrl: '/home/demo/demo-repo',
+        baseBranch: 'main',
+      },
+    });
+
+    expect(loadedPlans).toHaveLength(2);
+    expect(loadedPlans[0]?.repoUrl).toBe('/home/demo/demo-repo');
+    expect(loadedPlans[1]?.repoUrl).toBe('git@github.com:test/explicit-repo.git');
+  });
+
   it('passes staged state only when requested by the planning preview path', async () => {
     const { deps } = makeDeps();
     const plan = `

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1233,7 +1233,10 @@ export async function submitPlanningChatDraft(
   request: InAppPlanningSubmitRequest,
   deps: {
     sessions: InAppPlanningChatSessions;
-    loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+    loadGeneratedPlan: (
+      planText: string,
+      repositoryBinding?: InAppPlanningRepoBinding,
+    ) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
     planningSessionStore?: InAppPlanningSessionStore;
   },
 ): Promise<InAppPlanningSubmitResponse> {
@@ -1266,9 +1269,14 @@ export async function submitPlanningChatDraft(
         }
         planText = approvedDraft.planText;
       }
+      const repositoryBinding = session.repoUrl && session.baseBranch
+        ? { repoUrl: session.repoUrl, baseBranch: session.baseBranch }
+        : undefined;
       const approved = await submitPlanningReview({
         planText,
-        loadPlan: deps.loadGeneratedPlan,
+        loadPlan: repositoryBinding
+          ? (approvedPlanText) => deps.loadGeneratedPlan(approvedPlanText, repositoryBinding)
+          : deps.loadGeneratedPlan,
       });
       if (!approved.ok) {
         return approved;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -66,6 +66,7 @@ import type {
   InAppPlanningDiscardDraftRequest,
   InAppPlanningListSessionsResponse,
   InAppPlanningRebindRepoRequest,
+  InAppPlanningRepoBinding,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -1343,13 +1344,14 @@ function startHeadlessMode(): void {
 
       const loadGeneratedPlan = async (
         planText: string,
+        repositoryBinding?: InAppPlanningRepoBinding,
       ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => (
         loadPlanSubmissionBundle(planText, {
           persistence,
           orchestrator,
           allowGraphMutation: invokerConfig.allowGraphMutation,
           logger,
-        }, { staged: true })
+        }, { staged: true, repositoryBinding })
       );
 
       // Web clients get planning-chat token streaming over SSE. The bridge does

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@invoker/contracts';
+import type { InAppPlanningRepoBinding, Logger } from '@invoker/contracts';
 import { PINNED_WORKFLOW_BASE_BRANCH, type PlanDefinition } from '@invoker/workflow-core';
 import { backupPlan } from './plan-backup.js';
 
@@ -22,6 +22,7 @@ export interface PlanSubmissionLoadDeps {
 export interface PlanSubmissionLoadOptions {
   logLabel?: string;
   preserveTaskHandles?: boolean;
+  repositoryBinding?: InAppPlanningRepoBinding;
   taskHandles?: { clear(): void };
   staged?: boolean;
 }
@@ -48,7 +49,10 @@ export async function loadPlanSubmissionBundle(
   }
 
   for (const parsedPlan of submission.plans) {
-    let plan = applyConfiguredPlanDefaults(parsedPlan);
+    const resolvedPlan = parsedPlan.repoUrl === '.' && options?.repositoryBinding
+      ? { ...parsedPlan, repoUrl: options.repositoryBinding.repoUrl }
+      : parsedPlan;
+    let plan = applyConfiguredPlanDefaults(resolvedPlan);
     if (!submission.isStack) {
       plan = { ...plan, baseBranch: PINNED_WORKFLOW_BASE_BRANCH };
     }


### PR DESCRIPTION
## Summary

Resolve an approved `repoUrl: .` against explicit repository context when loading a planning draft.

The shared planning service and owner-process adapter carry that context without changing the approved plan text.

## Review Claim

Approved-plan loading resolves only `repoUrl: .` against an explicitly supplied planning repository binding.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the exact `repoUrl: .` marker is substituted, and only when an explicit planning binding is supplied. Absolute URLs, SSH URLs, immutable draft authorization, and non-planning load paths remain unchanged.

## Slice Rationale

The loader, shared planning service, and owner-process adapter form one repository-context routing claim. The GUI adapter follows as a separate activation slice.

## Non-goals

No GUI handler change, plan-doctor policy change, executor working-directory fallback, planner prompt change, generic path normalization, or demo-specific special case.

## Architecture

### Before

```mermaid
graph LR
    A["Approved planning draft with repoUrl: ."] --> B["Approved-plan loader"]
    B --> C["Runtime plan keeps repoUrl: ."]
```

### After

```mermaid
graph LR
    A["Approved planning draft with repoUrl: ."] --> B["Approved-plan loader with repository context"]
    B --> C["Runtime plan uses the bound repository"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments`

  ```text
  [comments] Checked added source lines; no disallowed comments found.
  ```

- [x] `pnpm --filter @invoker/app test --run src/__tests__/in-app-planner.test.ts src/__tests__/plan-submission-loader.test.ts -t "bound repository"`

  ```text
  Test Files  2 passed (2)
  Tests  2 passed | 83 skipped (85)
  ```

- [x] `bash scripts/scrub-handoff-artifacts.sh`

  ```text
  scrub-handoff-artifacts-ok
  ```

</details>

## Visual Proof

![Live demo graph with the repository-bound planning task completed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-3c0328/invoker-demo-live-task.png)

Manually inspected: the screenshot shows the selected task as completed, its `echo DEMO_PLAN_EXECUTED_OK_V2` command, and a `task.completed` timeline event.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 3398a78c19`
- Post-revert steps: Re-run the focused bound-repository tests.
- Data migration? No.

</details>
