### PR TITLE
[Demo control fixes 3: preserve planning repository binding](2) Bind GUI planning submission

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -11,6 +11,7 @@ import type {
   InAppPlanningCreateSessionRequest,
   InAppPlanningDiscardDraftRequest,
   InAppPlanningRebindRepoRequest,
+  InAppPlanningRepoBinding,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -1294,7 +1295,11 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
 
   async function loadGeneratedPlanPreview(
     planText: string,
-    options?: { preserveTaskHandles?: boolean; logLabel?: string },
+    options?: {
+      preserveTaskHandles?: boolean;
+      logLabel?: string;
+      repositoryBinding?: InAppPlanningRepoBinding;
+    },
   ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
     return loadPlanSubmissionBundle(planText, {
       persistence,
@@ -1304,6 +1309,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }, {
       logLabel: options?.logLabel ?? 'plan-from-goal',
       preserveTaskHandles: options?.preserveTaskHandles,
+      repositoryBinding: options?.repositoryBinding,
       taskHandles,
       staged: true,
     });
@@ -1414,9 +1420,10 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {
     return submitPlanningChatDraft(request as InAppPlanningSubmitRequest, {
       sessions: planningChatSessions,
-      loadGeneratedPlan: (planText) => loadGeneratedPlanPreview(planText, {
+      loadGeneratedPlan: (planText, repositoryBinding) => loadGeneratedPlanPreview(planText, {
         preserveTaskHandles: true,
         logLabel: 'planning-chat-submit',
+        repositoryBinding,
       }),
       planningSessionStore: ownerMode ? persistence : undefined,
     });


### PR DESCRIPTION
## Summary

Pass the planning session's bound repository through the GUI approval adapter into the shared approved-plan loader.

This completes repository binding for the desktop planning surface without changing plan authorization or loader policy.

## Review Claim

GUI planning approvals provide their session's repository binding to the shared approved-plan loader.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the GUI planning approval adapter gains repository context. Its staged loading, task-handle preservation, authorization boundary, and every non-planning GUI mutation remain unchanged.

## Slice Rationale

This activation slice connects the GUI owner adapter to the repository-aware loader established by the preceding repository-context slice.

## Non-goals

No loader policy change, plan parsing change, headless adapter change, executor fallback, or unrelated GUI mutation behavior change.

## Architecture

### Before

```mermaid
graph LR
    A["GUI planning approval"] --> B["GUI owner adapter"]
    B --> C["Approved-plan loader without repository context"]
```

### After

```mermaid
graph LR
    A["GUI planning approval"] --> B["GUI owner adapter with session binding"]
    B --> C["Repository-aware approved-plan loader"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments`

  ```text
  [comments] Checked added source lines; no disallowed comments found.
  ```

- [x] `pnpm --filter @invoker/app test --run src/__tests__/in-app-planner.test.ts src/__tests__/plan-submission-loader.test.ts -t "bound repository"`

  ```text
  Test Files  2 passed (2)
  Tests  2 passed | 83 skipped (85)
  ```

- [x] `bash scripts/scrub-handoff-artifacts.sh`

  ```text
  scrub-handoff-artifacts-ok
  ```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 4990d2e9c`
- Post-revert steps: Re-run the focused bound-repository tests.
- Data migration? No.

</details>
