### PR TITLE
[Web worker decisions](1) Expose read parity on refresh

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -185,6 +185,35 @@ describe('buildWebInvokerDispatch', () => {
     expect(await dispatch('invoker:get-history-tasks', [])).toEqual(historyRows);
   });
 
+  it('get-worker-decisions mirrors the owner read handler', async () => {
+    const listWorkerActions = vi.fn(() => []);
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [],
+        listWorkerActions,
+      },
+    });
+
+    await expect(dispatch('invoker:get-worker-decisions', [{
+      workflowId: 'wf-1',
+      decision: 'act',
+      limit: 25,
+      offset: 0,
+    }])).resolves.toEqual({
+      workflowId: 'wf-1',
+      actions: [],
+      limit: 25,
+      offset: 0,
+      hasMore: false,
+    });
+    expect(listWorkerActions).toHaveBeenCalledWith({
+      workflowId: 'wf-1',
+      decision: 'act',
+      limit: 26,
+      offset: 0,
+    });
+  });
+
   it('get-events returns a paginated page for a task', async () => {
     const events = [{ id: 1, taskId: 't1', eventType: 'task.running', createdAt: '2026-07-01T00:00:00Z' }];
     const getEvents = vi.fn(() => events);

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -17,6 +17,7 @@ import type {
   BundledSkillsStatus,
   Logger,
   SystemDiagnostics,
+  WorkerDecisionsRequest,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -30,6 +31,7 @@ import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
 import { resolveAgentSession } from '../headless-query-list.js';
+import { listWorkerDecisions } from '../worker-control.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
 import type { TaskTerminalAdapter } from '../task-terminal-adapter.js';
 
@@ -142,6 +144,11 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:get-worker-status':
       case 'invoker:get-workers':
         return deps.getWorkers?.() ?? { generatedAt: new Date().toISOString(), workers: [] };
+      case 'invoker:get-worker-decisions':
+        return listWorkerDecisions(
+          persistence,
+          (args[0] ?? {}) as WorkerDecisionsRequest,
+        );
       case 'invoker:get-action-graph':
         return buildCurrentActionGraphSnapshot({
           orchestrator,


### PR DESCRIPTION
## Summary

Web refresh now reads worker decisions through the same persistence helper as the Electron owner.

Filtering, pagination, and response shape stay shared.

## Review Claim

Approve exposing the existing worker-decisions read on the web owner surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This adds only a read channel and delegates to the existing owner helper. It introduces no mutation and preserves the helper's filtering, pagination, and response shape.

## Slice Rationale

One missing activation case caused the graph refresh sequence to issue an `unknown_channel` response while every adjacent read succeeded.

## Non-goals

- No worker-decision storage changes.
- No UI layout changes.
- No new filtering or pagination behavior.
- No changes to Ready Work mutation semantics.

## Architecture

### Before

```mermaid
graph LR
    A["Web graph refresh"] --> B["Worker-decisions channel"]
    B --> C["unknown_channel"]
```

### After

```mermaid
graph LR
    A["Web graph refresh"] --> B["Worker-decisions channel"]
    B --> C["Existing owner read helper"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/web-invoker-dispatch.test.ts -t "get-worker-decisions mirrors the owner read handler"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/web-invoker-dispatch.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] Live demo browser refresh: all ten observed `/invoke` responses returned `ok: true`, including `invoker:get-worker-decisions`.

</details>

## Visual Proof

[Refresh walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-5bbaa1/invoker-demo-worker-decisions-refresh-d4c7c6c.webm)

![Graph after the deployed refresh](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-5bbaa1/invoker-demo-worker-decisions-refresh-d4c7c6c.png)

Manually inspected: the 6-second and 9.5-second walkthrough frames show the graph before and after refresh, with the workflow panel intact, the worker-decisions empty state rendered, and no failure banner.

The HTTP response parity is not visible in pixels; the same captured run logged `invoker:get-worker-decisions` with `ok: true` and `failedCalls: []`, while the focused regression covers its response shape.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ddf419bb422821192c8bb630e0248c3c2561a229`
- Post-revert steps: Rebuild and redeploy the app package if this revision is deployed.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving worker decisions by workflow and decision criteria.
  - Results now include available actions, pagination details, and an indicator when more results are available.
  - Supports configurable limits and offsets for navigating decision history.

- **Tests**
  - Added coverage to verify response formatting and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->