### PR TITLE
[admin-bypass-e2e-babysit worker](1) domain worker

### DIFF
--- a/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_WATCHED_WORKER_KINDS,
+  REPAIR_FILING_STALE_TTL_MS,
+  runAdminBypassE2eBabysitTick,
+  type AdminBypassE2eBabysitWorkerOptions,
+  type InvestigativePlanSubmitter,
+  type RepairFilingRow,
+  type RepairFilingStore,
+  type WorkerLifecycleReader,
+  type WorkerLifecycleSnapshot,
+  type WorkerLifecycleStarter,
+} from '../workers/admin-bypass-e2e-babysit-worker.js';
+import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
+
+class FakeWorkerLifecycle implements WorkerLifecycleReader, WorkerLifecycleStarter {
+  readonly startCalls: string[] = [];
+
+  constructor(private readonly workers: readonly WorkerLifecycleSnapshot[]) {}
+
+  listWorkers(): readonly WorkerLifecycleSnapshot[] {
+    return this.workers;
+  }
+
+  start(kind: string): void {
+    this.startCalls.push(kind);
+  }
+}
+
+class FakeRepairFilingStore implements RepairFilingStore {
+  readonly deleteCalls: Array<[kind: string, subject: string, stateSha: string]> = [];
+
+  constructor(
+    private readonly rows: readonly RepairFilingRow[],
+    private readonly deleteError?: Error,
+  ) {}
+
+  listRepairFilings(): readonly RepairFilingRow[] {
+    return this.rows;
+  }
+
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): void {
+    this.deleteCalls.push([kind, subject, stateSha]);
+    if (this.deleteError) throw this.deleteError;
+  }
+}
+
+class FakeInvestigativePlanSubmitter implements InvestigativePlanSubmitter {
+  readonly submittedPlans: string[] = [];
+
+  submitPlan(planText: string): void {
+    this.submittedPlans.push(planText);
+  }
+}
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  } as unknown as AdminBypassE2eBabysitWorkerOptions['logger'];
+}
+
+function makeDecisionStore(): {
+  store: WorkerDecisionStore;
+  rows: Array<{ subjectId: string; status: string }>;
+} {
+  const rows: Array<{ subjectId: string; status: string }> = [];
+  return {
+    rows,
+    store: {
+      getWorkerAction: () => undefined,
+      upsertWorkerAction: (action) => {
+        rows.push({ subjectId: action.subjectId, status: action.status });
+        return action as never;
+      },
+    },
+  };
+}
+
+describe('runAdminBypassE2eBabysitTick', () => {
+  it('starts only a watched worker that is desired-enabled and stopped, then files one investigation', async () => {
+    const workerLifecycle = new FakeWorkerLifecycle([
+      { kind: DEFAULT_WATCHED_WORKER_KINDS[0], desiredEnabled: true, lifecycle: 'stopped' },
+      { kind: DEFAULT_WATCHED_WORKER_KINDS[1], desiredEnabled: true, lifecycle: 'running' },
+      { kind: 'unwatched-worker', desiredEnabled: true, lifecycle: 'stopped' },
+    ]);
+    const repairFilings = new FakeRepairFilingStore([]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle,
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(workerLifecycle.startCalls).toEqual([DEFAULT_WATCHED_WORKER_KINDS[0]]);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(planSubmitter.submittedPlans[0]).toContain('scratch: true');
+    expect(planSubmitter.submittedPlans[0]).toContain(DEFAULT_WATCHED_WORKER_KINDS[0]);
+  });
+
+  it('deletes only a repair filing older than the stale TTL, then files one investigation', async () => {
+    const now = Date.now();
+    const oldRow: RepairFilingRow = {
+      kind: 'admin-requeue:rebase-conflict',
+      subject: '11219',
+      stateSha: 'sha-old',
+      createdAt: new Date(now - REPAIR_FILING_STALE_TTL_MS - 60_000).toISOString(),
+    };
+    const youngRow: RepairFilingRow = {
+      kind: 'ci-regression:required-fast-guardrails',
+      subject: 'master',
+      stateSha: 'sha-young',
+      createdAt: new Date(now).toISOString(),
+    };
+    const repairFilings = new FakeRepairFilingStore([oldRow, youngRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(repairFilings.deleteCalls).toEqual([[oldRow.kind, oldRow.subject, oldRow.stateSha]]);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(planSubmitter.submittedPlans[0]).toContain('scratch: true');
+    expect(planSubmitter.submittedPlans[0]).toContain(oldRow.kind);
+    expect(planSubmitter.submittedPlans[0]).toContain(oldRow.subject);
+  });
+
+  it('does not submit a plan when there is nothing to act on', async () => {
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([
+        { kind: DEFAULT_WATCHED_WORKER_KINDS[0], desiredEnabled: false, lifecycle: 'stopped' },
+      ]),
+      repairFilings: new FakeRepairFilingStore([{
+        kind: 'ci-regression:fleet',
+        subject: 'master',
+        stateSha: 'sha-fresh',
+        createdAt: new Date().toISOString(),
+      }]),
+      planSubmitter,
+      store,
+    });
+
+    expect(planSubmitter.submittedPlans).toHaveLength(0);
+  });
+
+  it('logs and records a failed deletion without throwing out of the tick', async () => {
+    const staleRow: RepairFilingRow = {
+      kind: 'admin-requeue:rebase-conflict',
+      subject: '11219',
+      stateSha: 'sha-stale',
+      createdAt: new Date(Date.now() - REPAIR_FILING_STALE_TTL_MS - 60_000).toISOString(),
+    };
+    const logger = makeLogger();
+    const repairFilings = new FakeRepairFilingStore([staleRow], new Error('delete failed'));
+    const { store, rows } = makeDecisionStore();
+
+    await expect(runAdminBypassE2eBabysitTick({
+      logger,
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter: new FakeInvestigativePlanSubmitter(),
+      store,
+    })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(rows).toContainEqual({ subjectId: 'admin-requeue:rebase-conflict:11219:sha-stale', status: 'failed' });
+  });
+});

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -1,0 +1,311 @@
+import type { Logger } from '@invoker/contracts';
+
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND = 'admin-bypass-e2e-babysit';
+
+export const REPAIR_FILING_STALE_TTL_MS = 5_400_000;
+
+export const DEFAULT_WATCHED_WORKER_KINDS = [
+  'pr-admin-bypass-land',
+  'e2e-autofix',
+  'claude-oauth-refresh',
+] as const;
+
+const DEFAULT_INTERVAL_MS = 10 * 60_000;
+
+export interface WorkerLifecycleSnapshot {
+  readonly kind: string;
+  readonly desiredEnabled: boolean;
+  readonly lifecycle: 'running' | 'stopped' | 'exited';
+}
+
+export interface WorkerLifecycleReader {
+  listWorkers(): readonly WorkerLifecycleSnapshot[] | Promise<readonly WorkerLifecycleSnapshot[]>;
+}
+
+export interface WorkerLifecycleStarter {
+  start(kind: string): unknown;
+}
+
+export interface RepairFilingRow {
+  readonly kind: string;
+  readonly subject: string;
+  readonly stateSha: string;
+  readonly createdAt: string;
+}
+
+export interface RepairFilingStore {
+  listRepairFilings(): readonly RepairFilingRow[] | Promise<readonly RepairFilingRow[]>;
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): unknown;
+}
+
+export interface InvestigativePlanSubmitter {
+  submitPlan(planText: string): unknown;
+}
+
+export interface AdminBypassE2eBabysitWorkerConfig {
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  watchedWorkerKinds?: readonly string[];
+  staleTtlMs?: number;
+  workerLifecycle: WorkerLifecycleReader & WorkerLifecycleStarter;
+  repairFilings: RepairFilingStore;
+  planSubmitter: InvestigativePlanSubmitter;
+  store?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export interface AdminBypassE2eBabysitWorkerOptions {
+  logger: Logger;
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  watchedWorkerKinds?: readonly string[];
+  staleTtlMs?: number;
+  workerLifecycle: WorkerLifecycleReader & WorkerLifecycleStarter;
+  repairFilings: RepairFilingStore;
+  planSubmitter: InvestigativePlanSubmitter;
+  store?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export type AdminBypassE2eBabysitAction =
+  | {
+      readonly type: 'worker-start';
+      readonly kind: string;
+    }
+  | {
+      readonly type: 'repair-filing-delete';
+      readonly kind: string;
+      readonly subject: string;
+      readonly stateSha: string;
+      readonly createdAt: string;
+    };
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function investigativePrompt(action: AdminBypassE2eBabysitAction): string {
+  if (action.type === 'worker-start') {
+    return (
+      'Assume zero prior context. Investigate a production worker-lifecycle finding: '
+      + `worker kind ${JSON.stringify(action.kind)} was desiredEnabled=true but lifecycle=stopped, `
+      + 'so the admin-bypass-e2e-babysit worker attempted to start it. Determine what caused this state '
+      + 'and what would durably prevent recurrence. Support conclusions with evidence and propose a concrete prevention.'
+    );
+  }
+  return (
+    'Assume zero prior context. Investigate a production repair-filings finding: '
+    + `the admin-bypass-e2e-babysit worker attempted to delete a stale repair_filings row with kind `
+    + `${JSON.stringify(action.kind)}, subject ${JSON.stringify(action.subject)}, stateSha `
+    + `${JSON.stringify(action.stateSha)}, and createdAt ${JSON.stringify(action.createdAt)}. `
+    + 'Determine what caused the claim to remain stale and what would durably prevent recurrence. '
+    + 'Support conclusions with evidence and propose a concrete prevention.'
+  );
+}
+
+export function buildInvestigativePlanYaml(actions: readonly AdminBypassE2eBabysitAction[]): string {
+  const taskLines = actions.flatMap((action, index) => {
+    const prompt = investigativePrompt(action);
+    return [
+      `  - id: investigate-finding-${index + 1}`,
+      `    description: ${yamlString(prompt)}`,
+      `    prompt: ${yamlString(prompt)}`,
+      '    dependencies: []',
+    ];
+  });
+  return [
+    'name: "Investigate admin-bypass e2e babysit intervention"',
+    'scratch: true',
+    'onFinish: none',
+    'mergeMode: no_op',
+    '',
+    'tasks:',
+    ...taskLines,
+    '',
+  ].join('\n');
+}
+
+function recordDecision(
+  store: WorkerDecisionStore | undefined,
+  row: {
+    actionType: string;
+    externalKey: string;
+    subjectType: string;
+    subjectId: string;
+    status: 'completed' | 'failed';
+    summary: string;
+    payload: Record<string, unknown>;
+  },
+): void {
+  if (!store) return;
+  recordWorkerDecisionRow(store, {
+    workerKind: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+    ...row,
+  });
+}
+
+export async function runAdminBypassE2eBabysitTick(
+  options: AdminBypassE2eBabysitWorkerOptions,
+): Promise<void> {
+  const actions: AdminBypassE2eBabysitAction[] = [];
+  const watchedWorkerKinds = new Set(options.watchedWorkerKinds ?? DEFAULT_WATCHED_WORKER_KINDS);
+  const workers = await options.workerLifecycle.listWorkers();
+
+  for (const worker of workers) {
+    if (!watchedWorkerKinds.has(worker.kind)) continue;
+    if (worker.desiredEnabled !== true || worker.lifecycle !== 'stopped') continue;
+
+    actions.push({ type: 'worker-start', kind: worker.kind });
+    try {
+      await options.workerLifecycle.start(worker.kind);
+      options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] started stopped desired-enabled worker`, {
+        module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+        kind: worker.kind,
+      });
+      recordDecision(options.store, {
+        actionType: 'start-worker',
+        externalKey: `worker:${worker.kind}`,
+        subjectType: 'worker',
+        subjectId: worker.kind,
+        status: 'completed',
+        summary: `Started desired-enabled stopped worker ${worker.kind}`,
+        payload: { kind: worker.kind },
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(
+        `[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] failed to start worker ${worker.kind}: ${detail}`,
+        { module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND, kind: worker.kind },
+      );
+      recordDecision(options.store, {
+        actionType: 'start-worker',
+        externalKey: `worker:${worker.kind}`,
+        subjectType: 'worker',
+        subjectId: worker.kind,
+        status: 'failed',
+        summary: `Failed to start desired-enabled stopped worker ${worker.kind}: ${detail}`,
+        payload: { kind: worker.kind, error: detail },
+      });
+    }
+  }
+
+  const staleTtlMs = options.staleTtlMs ?? REPAIR_FILING_STALE_TTL_MS;
+  const repairFilings = await options.repairFilings.listRepairFilings();
+  for (const row of repairFilings) {
+    if (!(Date.now() - Date.parse(row.createdAt) > staleTtlMs)) continue;
+
+    const subjectId = `${row.kind}:${row.subject}:${row.stateSha}`;
+    actions.push({
+      type: 'repair-filing-delete',
+      kind: row.kind,
+      subject: row.subject,
+      stateSha: row.stateSha,
+      createdAt: row.createdAt,
+    });
+    try {
+      await options.repairFilings.deleteRepairFiling(row.kind, row.subject, row.stateSha);
+      options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] deleted stale repair filing`, {
+        module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+        kind: row.kind,
+        subject: row.subject,
+        stateSha: row.stateSha,
+        createdAt: row.createdAt,
+      });
+      recordDecision(options.store, {
+        actionType: 'delete-stale-repair-filing',
+        externalKey: `repair-filing:${subjectId}`,
+        subjectType: 'repair-filing',
+        subjectId,
+        status: 'completed',
+        summary: `Deleted stale repair filing ${subjectId}`,
+        payload: { ...row, staleTtlMs },
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(
+        `[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] failed to delete stale repair filing ${subjectId}: ${detail}`,
+        {
+          module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+          kind: row.kind,
+          subject: row.subject,
+          stateSha: row.stateSha,
+          createdAt: row.createdAt,
+        },
+      );
+      recordDecision(options.store, {
+        actionType: 'delete-stale-repair-filing',
+        externalKey: `repair-filing:${subjectId}`,
+        subjectType: 'repair-filing',
+        subjectId,
+        status: 'failed',
+        summary: `Failed to delete stale repair filing ${subjectId}: ${detail}`,
+        payload: { ...row, staleTtlMs, error: detail },
+      });
+    }
+  }
+
+  if (actions.length === 0) return;
+  try {
+    await options.planSubmitter.submitPlan(buildInvestigativePlanYaml(actions));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    options.logger.error(
+      `[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] failed to submit investigative plan: ${detail}`,
+      { module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND, actionCount: actions.length },
+    );
+  }
+}
+
+export function createAdminBypassE2eBabysitWorker(
+  config: AdminBypassE2eBabysitWorkerConfig & { logger: Logger },
+): WorkerRuntime {
+  const options: AdminBypassE2eBabysitWorkerOptions = {
+    logger: config.logger,
+    intervalMs: config.intervalMs,
+    tickOnStart: config.tickOnStart,
+    watchedWorkerKinds: config.watchedWorkerKinds,
+    staleTtlMs: config.staleTtlMs,
+    workerLifecycle: config.workerLifecycle,
+    repairFilings: config.repairFilings,
+    planSubmitter: config.planSubmitter,
+    store: config.store,
+  };
+  const onTick: WorkerTick = config.onTick ?? (async () => {
+    await runAdminBypassE2eBabysitTick(options);
+  });
+  return createWorkerRuntime({
+    kind: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+    logger: config.logger,
+    onTick,
+    intervalMs: config.intervalMs ?? DEFAULT_INTERVAL_MS,
+    tickOnStart: config.tickOnStart ?? true,
+  });
+}
+
+type UnwiredAdminBypassE2eBabysitDependencies = WorkerRuntimeDependencies & {
+  adminBypassE2eBabysit: AdminBypassE2eBabysitWorkerConfig;
+};
+
+export function registerAdminBypassE2eBabysitWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+    note: 'Restarts desired-enabled watched workers and expires stale repair-filing claims, then files investigations.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
+      const config = (deps as UnwiredAdminBypassE2eBabysitDependencies).adminBypassE2eBabysit;
+      return createAdminBypassE2eBabysitWorker({
+        logger: deps.logger,
+        ...config,
+        store: config.store ?? deps.store,
+      });
+    },
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

Add the domain-only `admin-bypass-e2e-babysit` worker behind injected dependencies.

The tick coordinates selected worker restarts, aged repair-filing releases, and one follow-up investigation after an intervention.

This slice adds deterministic domain behavior and focused coverage without app wiring or UI exposure.

## Review Claim

Approve the domain tick's coordination of bounded interventions and its injected dependency seams.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker can only start already desired watched workers, release over-age repair filings, and request an investigation through narrow injected dependencies. It cannot merge PRs, edit repositories, or restart the owner process.

## Slice Rationale

Keeping the domain tick independent from app integration makes this routing slice deterministic and leaves real dependency wiring for step 2.

## Non-goals

No app wiring, real SQLite adapter, worker-runtime controller integration, Workers UI copy, Python admin-bypass changes, force-merge capability, repository editing, or owner-process restart behavior.

## Architecture

### Before

```mermaid
graph TD
  A["Owner interventions"] --> B["Manual worker restart"]
  A --> C["Manual repair-filing release"]
  A --> D["Manual follow-up investigation"]
```

### After

```mermaid
graph TD
  A["admin-bypass-e2e-babysit tick"] --> B{"desired watched worker stopped?"}
  B -->|yes| C["start through injected lifecycle dependency"]
  A --> D{"repair filing exceeds configured age?"}
  D -->|yes| E["release through injected filing dependency"]
  C --> F["request one investigative follow-up"]
  E --> F
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- admin-bypass-e2e-babysit-worker.test.ts`
- [x] `pnpm run check:comments`
- [x] `scripts/scrub-handoff-artifacts.sh`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
