### PR TITLE
[Fix e2e-regression-watch ref-sync false-positive loop](1) Filter git ref-update lines before identity extraction

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -266,6 +266,13 @@ export function buildMarkerComment(sha, jobName, failureId = JOB_LEVEL_FAILURE_I
   return `<!-- ${buildMarker(sha, jobName, failureId)} -->`;
 }
 
+function stripGitRefListingLines(text) {
+  return text
+    .split('\n')
+    .filter((line) => !/\[(?:new branch|new tag)\]|\s->\s+(?:origin\/|refs\/)/.test(line))
+    .join('\n');
+}
+
 /**
  * Derive stable per-test / per-repro identities from a CI job log.
  * Multiple distinct failures under one job must each get their own repair
@@ -273,7 +280,7 @@ export function buildMarkerComment(sha, jobName, failureId = JOB_LEVEL_FAILURE_I
  * repro after an earlier same-job repair had already been filed).
  */
 export function extractFailureIdentitiesFromLog(logText) {
-  const text = String(logText ?? '');
+  const text = stripGitRefListingLines(String(logText ?? ''));
   if (!text.trim()) return [];
 
   const found = new Map();

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -1294,6 +1294,19 @@ describe('per-test failure identity under one CI job', () => {
     assert.equal(identities.some((entry) => entry.failureId.includes('repro-babysit-pr-body-human-split')), true);
   });
 
+  it('ignores git ref-sync listings while preserving genuine failure identities', () => {
+    const log = [
+      '* [new branch]  experiment/wf-98378590220/repro-event-loop-block/390bb7f -> origin/experiment/wf-98378590220/repro-event-loop-block/390bb7f',
+      '* [new tag]  repro-asar-enotdir-snapshot -> repro-asar-enotdir-snapshot',
+      'FAIL packages/some-package/src/__tests__/real-distinct-failure.test.ts',
+    ].join('\n');
+    const identities = extractFailureIdentitiesFromLog(log);
+
+    assert.equal(identities.some((entry) => entry.failureId.includes('repro-event-loop-block')), false);
+    assert.equal(identities.some((entry) => entry.failureId.includes('repro-asar-enotdir')), false);
+    assert.equal(identities.some((entry) => entry.failureId.includes('real-distinct-failure')), true);
+  });
+
   it('reproduces the bug: two distinct repros under one job must each get their own repair lifecycle', () => {
     // Observed (pre-fix): after filing a repair for the first Mergify Admin
     // Requeue failure, a later red observation that failed in a different


### PR DESCRIPTION
## Summary

Git fetch output can mention old Invoker task branches whose names contain `repro-*`.

The CI log parser classified those branch names as independent failures and launched excess repair work.

This change filters git ref-update lines before identity extraction while preserving genuine failure lines in the same log.

## Review Claim

Approve filtering git ref-update lines before failure-identity extraction so branch names cannot become false failure identities while real failure signals remain detectable.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only lines matching git ref-update shapes (`[new branch]`, `[new tag]`, or updates targeting `origin/` or `refs/`) are excluded; every other log line reaches the existing detectors unchanged.

## Slice Rationale

The parser change and its incident-shaped regression test form one local review claim at the existing CI log-classification boundary.

## Non-goals

This does not change log retrieval, repair filing state, attempt caps, or any existing failure-identity detector.

## Architecture

### Before

```mermaid
graph TD
    A["Raw CI job log"] --> B["Failure-identity detectors"]
    B --> C["Repair workflows"]
```

### After

```mermaid
graph TD
    A["Raw CI job log"] --> B["Remove git ref-update lines"]
    B --> C["Failure-identity detectors"]
    C --> D["Repair workflows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: Re-run `node --test scripts/e2e-regression-watch.test.mjs`.
- Data migration? No

</details>
