### PR TITLE
[admin-bypass-e2e-babysit worker (2) app wiring](1) Add runtime dependency fields

### DIFF
--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -40,6 +40,13 @@ import type {
   IdleTaskCleanupWorkerStore,
   IdleTaskCleanupWorkerSubmitter,
 } from './workers/idle-task-cleanup-worker.js';
+import type {
+  AdminBypassE2eBabysitWorkerConfig,
+  InvestigativePlanSubmitter,
+  RepairFilingStore,
+  WorkerLifecycleReader,
+  WorkerLifecycleStarter,
+} from './workers/admin-bypass-e2e-babysit-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
@@ -96,4 +103,8 @@ export interface WorkerRuntimeDependencies {
   mergifyQueueResearch?: MergifyQueueResearchWorkerConfig;
   /** Idle-task-cleanup worker configuration (dry-run only; see the worker's own docs). */
   idleTaskCleanup?: IdleTaskCleanupWorkerConfig;
+  adminBypassE2eBabysit?: AdminBypassE2eBabysitWorkerConfig;
+  workerLifecycleStarter?: WorkerLifecycleReader & WorkerLifecycleStarter;
+  repairFilingStore?: RepairFilingStore;
+  investigativePlanSubmitter?: InvestigativePlanSubmitter;
 }


### PR DESCRIPTION
## Summary

Give the worker runtime four optional dependency fields for the babysit worker.

Existing workers remain source-compatible because every new field is optional.

## Review Claim

Approve the optional runtime dependency fields required by the babysit worker.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every new field is optional, so existing worker dependency objects and construction paths remain valid. This slice does not add accepted-value rules or live objects.

## Slice Rationale

Keeping runtime dependencies separate lets reviewers inspect the execution-engine foundation before app configuration and startup behavior.

## Non-goals

No app config, numeric validation, startup wiring, built-in registration, UI changes, or default enablement.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- admin-bypass-e2e-babysit-worker.test.ts`
- [x] `git diff --check HEAD^ HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
