### PR TITLE
[admin-bypass-e2e-babysit worker (2) app wiring](3) Validate positive timing config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -350,16 +350,44 @@ describe('loadConfig', () => {
     expect(config.diskHeadroom).toEqual({ cleanupEnabled: false });
   });
 
-  it('loads adminBypassE2eBabysit with unrestricted numeric values', () => {
+  it('loads adminBypassE2eBabysit with positive numeric values', () => {
     const adminBypassE2eBabysit = {
       enabled: true,
-      intervalMinutes: -1,
+      intervalMinutes: 5,
       watchedWorkerKinds: ['pr-admin-bypass-land', 'e2e-autofix'],
-      staleTtlMinutes: 0,
+      staleTtlMinutes: 30,
     };
     writeUserConfig({ adminBypassE2eBabysit });
 
     expect(loadConfig().adminBypassE2eBabysit).toEqual(adminBypassE2eBabysit);
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.intervalMinutes of %s', (intervalMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { intervalMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.intervalMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.staleTtlMinutes of %s', (staleTtlMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { staleTtlMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([
+    { shape: 'null', value: null },
+    { shape: 'array', value: [] },
+    { shape: 'boolean', value: true },
+    { shape: 'number', value: 1 },
+    { shape: 'string', value: 'invalid' },
+  ])('rejects malformed adminBypassE2eBabysit shape: $shape', ({ value: adminBypassE2eBabysit }) => {
+    writeUserConfig({ adminBypassE2eBabysit });
+
+    expect(() => loadConfig()).toThrow(/adminBypassE2eBabysit must be an object/);
   });
 
   it('loads config when adminBypassE2eBabysit is omitted', () => {

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,6 +1,7 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
 import {
   normalizeGithubOwnerRepo,
+  type AdminBypassE2eBabysitConfig,
   type CatstackDeployConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
@@ -255,6 +256,37 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {
+  const adminBypassE2eBabysit = config.adminBypassE2eBabysit;
+  if (adminBypassE2eBabysit === undefined) return;
+  if (
+    typeof adminBypassE2eBabysit !== 'object'
+    || adminBypassE2eBabysit === null
+    || Array.isArray(adminBypassE2eBabysit)
+  ) {
+    throw new Error('adminBypassE2eBabysit must be an object');
+  }
+  const typed = adminBypassE2eBabysit as AdminBypassE2eBabysitConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.staleTtlMinutes !== undefined) {
+    if (
+      typeof typed.staleTtlMinutes !== 'number'
+      || !Number.isInteger(typed.staleTtlMinutes)
+      || typed.staleTtlMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0');
+    }
+  }
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -286,5 +318,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateAdminBypassE2eBabysitConfig(config);
   return config;
 }


### PR DESCRIPTION
## Summary

Reject non-positive babysit cadence and repair-filing age values during config loading.

Omitted values and positive values continue loading normally.

## Review Claim

Approve positive-number validation for the babysit worker's two timing settings.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

This check only narrows accepted config values. Configs that omit the babysit section, or provide positive timing values, retain their prior behavior.

## Slice Rationale

Keeping numeric validation separate from field declaration makes the accepted-value rule one focused review unit.

## Non-goals

No new config fields, runtime dependency changes, startup wiring, built-in registration, UI changes, or default enablement.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- config.test.ts`
- [x] `git diff --check HEAD^ HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows accepted config at load time only; omitted or valid positive values behave as before, with no runtime worker wiring in this change.
> 
> **Overview**
> Adds **`adminBypassE2eBabysit`** validation during Invoker config load so invalid babysit settings fail fast instead of being accepted silently.
> 
> **`intervalMinutes`** and **`staleTtlMinutes`** must be integers **> 0** when present; zero, negatives, and non-integers throw with explicit messages. The block must be a plain object (not `null`, arrays, or primitives). Omitted section or omitted timing fields still load as before.
> 
> Tests in `config.test.ts` now use positive example values and cover rejection cases for bad shapes and non-positive timings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4282b144e73ea8573f14f9454c7d6f2036862a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration validation for admin bypass settings.
  - Invalid zero, negative, or non-integer interval values are now rejected.
  - Configuration loading now reports errors when required timing values are not positive integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->