### PR TITLE
[admin-bypass-e2e-babysit worker (3) Workers UI display](1) Add Workers UI display copy

### DIFF
--- a/packages/ui/src/__tests__/worker-display.test.ts
+++ b/packages/ui/src/__tests__/worker-display.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getWorkerDisplayCopy } from '../lib/worker-display.js';
+
+describe('getWorkerDisplayCopy', () => {
+  it('returns dedicated display copy for the admin-bypass/e2e babysit worker', () => {
+    expect(getWorkerDisplayCopy('admin-bypass-e2e-babysit')).toEqual({
+      name: 'Admin-bypass/e2e babysit',
+      idleText: 'Idle. Restarts stopped admin-bypass/e2e workers and clears stale repair-filing claims when turned on.',
+      noActionText: 'No admin-bypass-e2e-babysit runs recorded yet.',
+    });
+  });
+
+  it('preserves the existing catstack-deploy display copy byte-for-byte', () => {
+    expect(getWorkerDisplayCopy('catstack-deploy')).toEqual({
+      name: 'Catstack deploy',
+      idleText: 'Idle. Clone/pulls catstack and runs ./install.sh on this machine and every remoteTargets host when turned on.',
+      noActionText: 'No catstack-deploy runs recorded yet.',
+    });
+  });
+});

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -134,6 +134,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No catstack-deploy runs recorded yet.',
     };
   }
+  if (kind === 'admin-bypass-e2e-babysit') {
+    return {
+      name: 'Admin-bypass/e2e babysit',
+      idleText: 'Idle. Restarts stopped admin-bypass/e2e workers and clears stale repair-filing claims when turned on.',
+      noActionText: 'No admin-bypass-e2e-babysit runs recorded yet.',
+    };
+  }
   return {
     name: formatWorkerValue(kind),
     idleText: 'Idle. Waiting for worker-owned work.',


### PR DESCRIPTION
## Summary

Adds a plain-language name and idle copy for the `admin-bypass-e2e-babysit` worker in the Workers panel.

Without this branch, the worker falls back to a formatted raw kind and generic idle text.

## Review Claim

Approve the dedicated Workers display copy for `admin-bypass-e2e-babysit`, with existing worker copy preserved.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Display-copy-only change; it does not alter worker behavior, data flow, dependencies, or existing worker copy.

## Slice Rationale

Workers UI copy is the top surface layer, reviewed independently from the domain worker and app-wiring slices below it.

## Non-goals

Does not change worker logic, registration, configuration, routes, or components.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- worker-display.test.ts`
- [x] `pnpm run check:comments`
- [x] `scripts/scrub-handoff-artifacts.sh`

</details>

## Visual Proof

![Raw formatted worker name and generic idle copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-851fa0/raw-fallback.png)

![Dedicated worker name and admin-bypass/e2e idle copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-851fa0/dedicated-copy.png)

Manually inspected: The raw-fallback image shows "Admin Bypass E2e Babysit" with generic "Idle. Waiting for worker-owned work." copy. The dedicated-copy image shows "Admin-bypass/e2e babysit" with the worker-specific idle sentence. Both show the selected worker running in the Workers panel.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit SHA>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-copy-only change in the UI layer; no worker logic, routing, or data flow.
> 
> **Overview**
> Adds dedicated Workers panel **name**, **idle**, and **no-action** strings for the `admin-bypass-e2e-babysit` worker in `getWorkerDisplayCopy`, so it no longer shows formatted kind text and generic “waiting for worker-owned work” copy.
> 
> Introduces `worker-display.test.ts` with expectations for the new babysit copy and a regression check that `catstack-deploy` copy is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abb32707bde447bc358abebf25dc50d4b8e4568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->