### PR TITLE
[Demo control fixes](3) HTML unlock page

### DIFF
--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -125,10 +125,13 @@ describe('startWebBridge', () => {
     expect(String(res.headers['set-cookie'])).toContain('invoker_web=');
   });
 
-  it('rejects the handshake with a bad token', async () => {
+  it('shows the unlock page with an error hint on a bad token', async () => {
     const { port } = await startBridge();
     const res = await request(port, '/?token=wrong');
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('Invoker Demo');
+    expect(res.body).toContain('Demo token');
   });
 
   it('runs /invoke with a valid cookie and wraps the dispatch result', async () => {
@@ -286,10 +289,16 @@ describe('startWebBridge static serving', () => {
     return await bridge.whenReady;
   }
 
-  it('requires the cookie for the page and assets', async () => {
+  it('shows the unlock page when no cookie is present', async () => {
     const port = await startStaticBridge();
-    expect((await request(port, '/')).status).toBe(401);
-    expect((await request(port, '/assets/web-abc.js')).status).toBe(401);
+    const rootRes = await request(port, '/');
+    expect(rootRes.status).toBe(200);
+    expect(rootRes.headers['content-type']).toContain('text/html');
+    expect(rootRes.body).toContain('Invoker Demo');
+    expect(rootRes.body).toContain('Demo token');
+    const assetRes = await request(port, '/assets/web-abc.js');
+    expect(assetRes.status).toBe(200);
+    expect(assetRes.body).toContain('Invoker Demo');
   });
 
   it('serves the shell and assets with the right content types once authed', async () => {

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -124,6 +124,100 @@ function sendJson(res: ServerResponse, status: number, body: unknown, req?: Inco
   res.end(responseBody);
 }
 
+function sendUnlockPage(res: ServerResponse): void {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Invoker Demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f0f0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      max-width: 400px;
+      padding: 2rem;
+      text-align: center;
+    }
+    h1 {
+      font-size: 1.5rem;
+      margin-bottom: 1rem;
+      color: #fff;
+    }
+    p {
+      font-size: 0.95rem;
+      margin-bottom: 1.5rem;
+      color: #a0a0a0;
+    }
+    form { display: flex; flex-direction: column; gap: 0.75rem; }
+    input {
+      padding: 0.75rem 1rem;
+      font-size: 1rem;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #1a1a1a;
+      color: #fff;
+    }
+    input:focus { outline: none; border-color: #6366f1; }
+    button {
+      padding: 0.75rem 1rem;
+      font-size: 1rem;
+      font-weight: 500;
+      border: none;
+      border-radius: 6px;
+      background: #6366f1;
+      color: #fff;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    button:hover { background: #4f46e5; }
+    .error {
+      margin-top: 1rem;
+      padding: 0.75rem;
+      background: #7f1d1d;
+      border-radius: 6px;
+      color: #fca5a5;
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Invoker Demo</h1>
+    <p>Enter the demo token to continue.</p>
+    <form id="unlock-form">
+      <input type="password" id="token" name="token" placeholder="Demo token" required autocomplete="off">
+      <button type="submit">Unlock</button>
+    </form>
+    <div class="error" id="error">Invalid token. Please try again.</div>
+  </div>
+  <script>
+    document.getElementById('unlock-form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      var token = document.getElementById('token').value;
+      window.location.href = '/?token=' + encodeURIComponent(token);
+    });
+    if (window.location.search.includes('token=') && !document.cookie.includes('invoker_web=')) {
+      document.getElementById('error').style.display = 'block';
+    }
+  </script>
+</body>
+</html>`;
+  res.writeHead(200, {
+    'content-type': 'text/html; charset=utf-8',
+    'cache-control': 'no-cache',
+  });
+  res.end(html);
+}
+
 /**
  * Resolve the directory holding the built UI (`web.html` + assets), mirroring
  * window-lifecycle's packaged-vs-repo resolution. `appRootDir` is the main
@@ -287,7 +381,7 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
         const queryToken = url.searchParams.get('token');
         if (pathname === '/' && queryToken !== null) {
           if (!safeEqual(queryToken, token)) {
-            sendJson(res, 401, { error: 'unauthorized' });
+            sendUnlockPage(res);
             return;
           }
           res.writeHead(302, {
@@ -299,7 +393,7 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
         }
 
         if (!cookieValid(req)) {
-          sendJson(res, 401, { error: 'unauthorized' });
+          sendUnlockPage(res);
           return;
         }
         serveStatic(res, pathname);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace raw JSON 401 responses with a human-friendly HTML unlock page that displays a token input form.

Visitors accessing the demo URL without a token now see a styled unlock page instead of a cryptic JSON error. The page preserves the token gate while improving the visitor experience.

## Review Claim

The web bridge serves an HTML unlock page for unauthenticated demo visitors.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the unauthenticated response format changes from JSON to HTML. Token validation and cookie exchange logic remain unchanged.

## Slice Rationale

The unlock page is a self-contained visitor-facing presentation concern, independent of other demo fixes.

## Non-goals

No changes to authenticated routes, token validation logic, or cookie behavior.

## Architecture

### Before

```mermaid
graph LR
    A["Visitor hits /"] --> B["No cookie"]
    B --> C["JSON 401: unauthorized"]
```

### After

```mermaid
graph LR
    A["Visitor hits /"] --> B["No cookie"]
    B --> C["HTML unlock page with token form"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- web-bridge-server.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bab5357a-3482-4eb7-bcbd-bb01f1ab8f40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab5357a-3482-4eb7-bcbd-bb01f1ab8f40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

