### PR TITLE
[admin-bypass-repair-bot-thread-pr-11256-8277f79](1) Activate the built-in worker

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -350,16 +350,44 @@ describe('loadConfig', () => {
     expect(config.diskHeadroom).toEqual({ cleanupEnabled: false });
   });
 
-  it('loads adminBypassE2eBabysit with unrestricted numeric values', () => {
+  it('loads adminBypassE2eBabysit with positive numeric values', () => {
     const adminBypassE2eBabysit = {
       enabled: true,
-      intervalMinutes: -1,
+      intervalMinutes: 5,
       watchedWorkerKinds: ['pr-admin-bypass-land', 'e2e-autofix'],
-      staleTtlMinutes: 0,
+      staleTtlMinutes: 30,
     };
     writeUserConfig({ adminBypassE2eBabysit });
 
     expect(loadConfig().adminBypassE2eBabysit).toEqual(adminBypassE2eBabysit);
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.intervalMinutes of %s', (intervalMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { intervalMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.intervalMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.staleTtlMinutes of %s', (staleTtlMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { staleTtlMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([
+    { shape: 'null', value: null },
+    { shape: 'array', value: [] },
+    { shape: 'boolean', value: true },
+    { shape: 'number', value: 1 },
+    { shape: 'string', value: 'invalid' },
+  ])('rejects malformed adminBypassE2eBabysit shape: $shape', ({ value: adminBypassE2eBabysit }) => {
+    writeUserConfig({ adminBypassE2eBabysit });
+
+    expect(() => loadConfig()).toThrow(/adminBypassE2eBabysit must be an object/);
   });
 
   it('loads config when adminBypassE2eBabysit is omitted', () => {

--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -24,6 +24,7 @@ describe('headless worker registry', () => {
     expect(stdout).toContain('Worker kinds');
     expect(stdout).not.toContain('pr-summary-refresh');
     expect(stdout).toContain(INFRA_REPAIR_WORKER_KIND);
+    expect(stdout).toContain('admin-bypass-e2e-babysit');
   });
 
   it('maps configured SSH targets into disk-headroom worker dependencies', () => {

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,6 +1,7 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
 import {
   normalizeGithubOwnerRepo,
+  type AdminBypassE2eBabysitConfig,
   type CatstackDeployConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
@@ -255,6 +256,37 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {
+  const adminBypassE2eBabysit = config.adminBypassE2eBabysit;
+  if (adminBypassE2eBabysit === undefined) return;
+  if (
+    typeof adminBypassE2eBabysit !== 'object'
+    || adminBypassE2eBabysit === null
+    || Array.isArray(adminBypassE2eBabysit)
+  ) {
+    throw new Error('adminBypassE2eBabysit must be an object');
+  }
+  const typed = adminBypassE2eBabysit as AdminBypassE2eBabysitConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.staleTtlMinutes !== undefined) {
+    if (
+      typeof typed.staleTtlMinutes !== 'number'
+      || !Number.isInteger(typed.staleTtlMinutes)
+      || typed.staleTtlMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0');
+    }
+  }
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -286,5 +318,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateAdminBypassE2eBabysitConfig(config);
   return config;
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -371,6 +371,13 @@ function buildRegisteredOwnerWorkerDeps(
   checkMergeGateStatuses: NonNullable<WorkerRuntimeDependencies['reviewGate']>['checkMergeGateStatuses'],
   planningCommandBuilder: PlanningCommandBuilder,
   executionAgentRegistry: AgentRegistry,
+  adminBypassE2eBabysitDeps: Pick<
+    WorkerRuntimeDependencies,
+    | 'adminBypassE2eBabysit'
+    | 'workerLifecycleStarter'
+    | 'repairFilingStore'
+    | 'investigativePlanSubmitter'
+  >,
 ): WorkerRuntimeDependencies {
   const remoteTargets = Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
     name,
@@ -472,8 +479,20 @@ function buildRegisteredOwnerWorkerDeps(
         sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
       }),
     },
+    ...adminBypassE2eBabysitDeps,
   };
 }
+
+function toWorkerLifecycleSnapshots(workers: WorkerStatusSnapshot['workers']) {
+  return workers.map((worker) => ({
+    kind: worker.kind,
+    desiredEnabled: worker.desiredEnabled ?? worker.autoStarts,
+    lifecycle: worker.lifecycle,
+  }));
+}
+
+let startAdminBypassE2eBabysitWorker: ((kind: string) => unknown) | undefined;
+let submitAdminBypassE2eBabysitPlan: ((planText: string) => unknown) | undefined;
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
   const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
@@ -1353,6 +1372,7 @@ function startHeadlessMode(): void {
           logger,
         }, { staged: true, repositoryBinding })
       );
+      submitAdminBypassE2eBabysitPlan = (planText) => loadGeneratedPlan(planText);
 
       // Web clients get planning-chat token streaming over SSE. The bridge does
       // not exist yet when these handlers are built, so route through a
@@ -2086,12 +2106,56 @@ function startHeadlessMode(): void {
             },
             planningCommandBuilder,
             agentRegistry,
+            {
+              adminBypassE2eBabysit: {
+                enabled: invokerConfig.adminBypassE2eBabysit?.enabled ?? false,
+                intervalMs: invokerConfig.adminBypassE2eBabysit?.intervalMinutes === undefined
+                  ? undefined
+                  : invokerConfig.adminBypassE2eBabysit.intervalMinutes * 60_000,
+                watchedWorkerKinds: invokerConfig.adminBypassE2eBabysit?.watchedWorkerKinds,
+                staleTtlMs: invokerConfig.adminBypassE2eBabysit?.staleTtlMinutes === undefined
+                  ? undefined
+                  : invokerConfig.adminBypassE2eBabysit.staleTtlMinutes * 60_000,
+              },
+              workerLifecycleStarter: {
+                listWorkers: () => toWorkerLifecycleSnapshots((
+                  workerRuntimeController?.snapshot()
+                  ?? createLocalWorkerStatusSnapshot({
+                    registry: createRegisteredWorkerRegistry(),
+                    persistence,
+                    autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+                  })
+                ).workers),
+                start: (kind) => {
+                  if (!startAdminBypassE2eBabysitWorker) {
+                    throw new Error('admin-bypass-e2e-babysit worker lifecycle starter is not ready');
+                  }
+                  return startAdminBypassE2eBabysitWorker(kind);
+                },
+              },
+              repairFilingStore: {
+                listRepairFilings: () => persistence.listRepairFilings(),
+                deleteRepairFiling: (kind, subject, stateSha) => (
+                  persistence.deleteRepairFiling(kind, subject, stateSha)
+                ),
+              },
+              investigativePlanSubmitter: {
+                submitPlan: (planText) => {
+                  if (!submitAdminBypassE2eBabysitPlan) {
+                    throw new Error('admin-bypass-e2e-babysit investigative plan submitter is not ready');
+                  }
+                  return submitAdminBypassE2eBabysitPlan(planText);
+                },
+              },
+            },
           ),
           autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
         });
+        const activeWorkerRuntimeController = workerRuntimeController;
+        startAdminBypassE2eBabysitWorker = (kind) => activeWorkerRuntimeController.start(kind);
         if (!readOnlyMode) {
           const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
           if (reconciledWorkerActions > 0) {
@@ -3006,6 +3070,12 @@ startMainProcessBootstrap({
       buildCommandServiceInvalidationDeps,
     });
     guiMutationTaskActions = mutationActions;
+    submitAdminBypassE2eBabysitPlan = (planText) => loadPlanSubmissionBundle(planText, {
+      persistence,
+      orchestrator,
+      allowGraphMutation: invokerConfig.allowGraphMutation,
+      logger,
+    }, { staged: true });
 
     const guiMutationRegistrationContext: GuiMutationRegistrationContext = {
       ipcMain,
@@ -3316,12 +3386,56 @@ startMainProcessBootstrap({
           },
           planningCommandBuilder,
           agentRegistry,
+          {
+            adminBypassE2eBabysit: {
+              enabled: invokerConfig.adminBypassE2eBabysit?.enabled ?? false,
+              intervalMs: invokerConfig.adminBypassE2eBabysit?.intervalMinutes === undefined
+                ? undefined
+                : invokerConfig.adminBypassE2eBabysit.intervalMinutes * 60_000,
+              watchedWorkerKinds: invokerConfig.adminBypassE2eBabysit?.watchedWorkerKinds,
+              staleTtlMs: invokerConfig.adminBypassE2eBabysit?.staleTtlMinutes === undefined
+                ? undefined
+                : invokerConfig.adminBypassE2eBabysit.staleTtlMinutes * 60_000,
+            },
+            workerLifecycleStarter: {
+              listWorkers: () => toWorkerLifecycleSnapshots((
+                workerRuntimeController?.snapshot()
+                ?? createLocalWorkerStatusSnapshot({
+                  registry: createRegisteredWorkerRegistry(),
+                  persistence,
+                  autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+                })
+              ).workers),
+              start: (kind) => {
+                if (!startAdminBypassE2eBabysitWorker) {
+                  throw new Error('admin-bypass-e2e-babysit worker lifecycle starter is not ready');
+                }
+                return startAdminBypassE2eBabysitWorker(kind);
+              },
+            },
+            repairFilingStore: {
+              listRepairFilings: () => persistence.listRepairFilings(),
+              deleteRepairFiling: (kind, subject, stateSha) => (
+                persistence.deleteRepairFiling(kind, subject, stateSha)
+              ),
+            },
+            investigativePlanSubmitter: {
+              submitPlan: (planText) => {
+                if (!submitAdminBypassE2eBabysitPlan) {
+                  throw new Error('admin-bypass-e2e-babysit investigative plan submitter is not ready');
+                }
+                return submitAdminBypassE2eBabysitPlan(planText);
+              },
+            },
+          },
         ),
         autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
+      const activeWorkerRuntimeController = workerRuntimeController;
+      startAdminBypassE2eBabysitWorker = (kind) => activeWorkerRuntimeController.start(kind);
     }
 
     // Fail orphaned in-flight tasks left by a previous crash, then start ready work.

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -16,6 +16,7 @@ import { registerSlackBugScanWorker } from './workers/slack-bug-scan-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 import { registerCrossRepoResearchWorker } from './workers/cross-repo-research-worker.js';
 import { registerCatstackDeployWorker } from './workers/catstack-deploy-worker.js';
+import { registerAdminBypassE2eBabysitWorker } from './workers/admin-bypass-e2e-babysit-worker.js';
 import { registerMergifyQueueResearchWorker } from './workers/mergify-queue-research-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
@@ -38,6 +39,7 @@ export function registerBuiltinWorkers(
   registerIdleTaskCleanupWorker(registry);
   registerCrossRepoResearchWorker(registry);
   registerCatstackDeployWorker(registry);
+  registerAdminBypassE2eBabysitWorker(registry);
   registerMergifyQueueResearchWorker(registry);
   return registry;
 }

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -48,13 +48,11 @@ export interface InvestigativePlanSubmitter {
 }
 
 export interface AdminBypassE2eBabysitWorkerConfig {
+  enabled?: boolean;
   intervalMs?: number;
   tickOnStart?: boolean;
   watchedWorkerKinds?: readonly string[];
   staleTtlMs?: number;
-  workerLifecycle: WorkerLifecycleReader & WorkerLifecycleStarter;
-  repairFilings: RepairFilingStore;
-  planSubmitter: InvestigativePlanSubmitter;
   store?: WorkerDecisionStore;
   onTick?: WorkerTick;
 }
@@ -262,7 +260,12 @@ export async function runAdminBypassE2eBabysitTick(
 }
 
 export function createAdminBypassE2eBabysitWorker(
-  config: AdminBypassE2eBabysitWorkerConfig & { logger: Logger },
+  config: AdminBypassE2eBabysitWorkerConfig & {
+    logger: Logger;
+    workerLifecycle: WorkerLifecycleReader & WorkerLifecycleStarter;
+    repairFilings: RepairFilingStore;
+    planSubmitter: InvestigativePlanSubmitter;
+  },
 ): WorkerRuntime {
   const options: AdminBypassE2eBabysitWorkerOptions = {
     logger: config.logger,
@@ -287,10 +290,6 @@ export function createAdminBypassE2eBabysitWorker(
   });
 }
 
-type UnwiredAdminBypassE2eBabysitDependencies = WorkerRuntimeDependencies & {
-  adminBypassE2eBabysit: AdminBypassE2eBabysitWorkerConfig;
-};
-
 export function registerAdminBypassE2eBabysitWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
@@ -299,10 +298,16 @@ export function registerAdminBypassE2eBabysitWorker(
     note: 'Restarts desired-enabled watched workers and expires stale repair-filing claims, then files investigations.',
     source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
-      const config = (deps as UnwiredAdminBypassE2eBabysitDependencies).adminBypassE2eBabysit;
+      const config = deps.adminBypassE2eBabysit ?? {};
+      if (!deps.workerLifecycleStarter || !deps.repairFilingStore || !deps.investigativePlanSubmitter) {
+        throw new Error('admin-bypass-e2e-babysit worker dependencies are not wired');
+      }
       return createAdminBypassE2eBabysitWorker({
         logger: deps.logger,
         ...config,
+        workerLifecycle: deps.workerLifecycleStarter,
+        repairFilings: deps.repairFilingStore,
+        planSubmitter: deps.investigativePlanSubmitter,
         store: config.store ?? deps.store,
       });
     },


### PR DESCRIPTION
## Summary

Connect the babysit worker to the built-in registry and real owner-process dependencies.

Startup now adapts worker snapshots to the lifecycle shape consumed by the babysitter.

The worker remains opt-in and defaults to disabled.

## Review Claim

Approve startup routing from the babysit worker to real lifecycle, repair-filing, and plan-submission dependencies.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The lifecycle dependency can only inspect workers and start a selected kind. The repair dependency can only inspect and release filings.

The worker cannot stop workers, insert filings, kill processes, or enable itself by default.

## Slice Rationale

This real-object routing follows the dependency and configuration foundations, keeping startup sequencing as one locally reviewable change.

## Non-goals

No changes to tick policy, Workers UI, other worker configuration, other worker startup order, or default enablement.

## Architecture

### Before

```mermaid
graph TD
  A["main.ts startup"] --> B["build worker dependencies"]
  B --> C["construct worker runtime controller"]
  B --> D["wire plan submission later"]
  E["babysit worker"] --> F["injected dependencies unavailable"]
```

### After

```mermaid
graph TD
  A["main.ts startup"] --> B["build dependencies with deferred references"]
  B --> C["construct worker runtime controller"]
  C --> D["fill lifecycle reference"]
  B --> E["wire in-process plan submission"]
  E --> F["fill plan submitter reference"]
  D --> G["babysit worker uses real dependencies"]
  F --> G
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-worker.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/admin-bypass-e2e-babysit-worker.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm run check:comments`
- [x] `pnpm run check:required-builds`
- [x] `git diff --check origin/stack/EdbertChan/plan/admin-bypass-e2e-babysit-worker-2-app-wiring/admin-bypass-e2e-babysit-worker-2-app-wiring-3--23a78d20...HEAD`

</details>

## Visual Proof

![Workers panel with Admin Bypass E2e Babysit selected](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260829-668e10/admin-bypass-repair-bot-thread-pr-11256-registered.png)

Manually inspected: The Workers panel shows 22 registered workers with Admin Bypass E2e Babysit selected. Its details show Built In, Available, Stopped, and Enable worker.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Remove any `adminBypassE2eBabysit` config section before reverting the earlier config slices.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, the worker can start other worker kinds, delete stale repair-filing rows, and submit investigative plans—operational automation with bounded deps, but still opt-in by default.
> 
> **Overview**
> Registers **admin-bypass-e2e-babysit** in the built-in worker registry and wires it through owner startup in both **standalone headless** and **GUI owner** paths.
> 
> `buildRegisteredOwnerWorkerDeps` now accepts babysit-specific deps: config from `invokerConfig.adminBypassE2eBabysit` (**enabled defaults to false**), a **worker lifecycle** adapter that maps runtime snapshots and starts kinds via the worker controller (filled in after the controller is created), **repair-filing** list/delete on persistence, and **investigative plan** submission through staged `loadPlanSubmissionBundle`.
> 
> The babysit worker factory now pulls lifecycle, repair store, and plan submitter from `WorkerRuntimeDependencies` instead of the config object, and fails fast if those deps are missing. Headless `worker list` tests expect the new kind to appear among registered workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6b2cda8ce20b27f17571c3c46de63580bfa0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->