### PR TITLE
[admin-bypass-repair-bot-thread-pr-11255-75c692a](1) Validate positive timing config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -350,16 +350,44 @@ describe('loadConfig', () => {
     expect(config.diskHeadroom).toEqual({ cleanupEnabled: false });
   });
 
-  it('loads adminBypassE2eBabysit with unrestricted numeric values', () => {
+  it('loads adminBypassE2eBabysit with positive numeric values', () => {
     const adminBypassE2eBabysit = {
       enabled: true,
-      intervalMinutes: -1,
+      intervalMinutes: 5,
       watchedWorkerKinds: ['pr-admin-bypass-land', 'e2e-autofix'],
-      staleTtlMinutes: 0,
+      staleTtlMinutes: 30,
     };
     writeUserConfig({ adminBypassE2eBabysit });
 
     expect(loadConfig().adminBypassE2eBabysit).toEqual(adminBypassE2eBabysit);
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.intervalMinutes of %s', (intervalMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { intervalMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.intervalMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([0, -1])('rejects adminBypassE2eBabysit.staleTtlMinutes of %s', (staleTtlMinutes) => {
+    writeUserConfig({ adminBypassE2eBabysit: { staleTtlMinutes } });
+
+    expect(() => loadConfig()).toThrow(
+      /adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0/,
+    );
+  });
+
+  it.each([
+    { shape: 'null', value: null },
+    { shape: 'array', value: [] },
+    { shape: 'boolean', value: true },
+    { shape: 'number', value: 1 },
+    { shape: 'string', value: 'invalid' },
+  ])('rejects malformed adminBypassE2eBabysit shape: $shape', ({ value: adminBypassE2eBabysit }) => {
+    writeUserConfig({ adminBypassE2eBabysit });
+
+    expect(() => loadConfig()).toThrow(/adminBypassE2eBabysit must be an object/);
   });
 
   it('loads config when adminBypassE2eBabysit is omitted', () => {

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,6 +1,7 @@
 import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
 import {
   normalizeGithubOwnerRepo,
+  type AdminBypassE2eBabysitConfig,
   type CatstackDeployConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
@@ -255,6 +256,37 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {
+  const adminBypassE2eBabysit = config.adminBypassE2eBabysit;
+  if (adminBypassE2eBabysit === undefined) return;
+  if (
+    typeof adminBypassE2eBabysit !== 'object'
+    || adminBypassE2eBabysit === null
+    || Array.isArray(adminBypassE2eBabysit)
+  ) {
+    throw new Error('adminBypassE2eBabysit must be an object');
+  }
+  const typed = adminBypassE2eBabysit as AdminBypassE2eBabysitConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.staleTtlMinutes !== undefined) {
+    if (
+      typeof typed.staleTtlMinutes !== 'number'
+      || !Number.isInteger(typed.staleTtlMinutes)
+      || typed.staleTtlMinutes <= 0
+    ) {
+      throw new Error('adminBypassE2eBabysit.staleTtlMinutes must be an integer > 0');
+    }
+  }
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   const nestedExecutionAgent = config.defaultExecution?.executionAgent;
   const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
@@ -286,5 +318,6 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateAdminBypassE2eBabysitConfig(config);
   return config;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Validation-only change at config load; risk is configs that previously used zero/negative timings or a non-object value will now fail to start until fixed.
> 
> **Overview**
> Adds **config validation** for `adminBypassE2eBabysit` so Invoker fails fast on bad user config instead of accepting arbitrary values.
> 
> When the block is present, it must be a plain object. **`intervalMinutes`** and **`staleTtlMinutes`**, if set, must be integers **greater than zero** (zero and negatives are rejected). Omitted block behavior is unchanged.
> 
> Tests now use valid positive timings in the happy path and cover rejection of invalid numbers and non-object shapes (null, array, primitives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cce361cb7d5934bbd8ea653e8a020e87bea025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->