### PR TITLE
slack-manager watchdog: retry owner relaunch after giving up, at a slow cadence

### DIFF
--- a/packages/slack-manager/src/__tests__/watchdog.test.ts
+++ b/packages/slack-manager/src/__tests__/watchdog.test.ts
@@ -32,7 +32,7 @@ describe('createWatchdog', () => {
     expect(launch).toHaveBeenCalledTimes(2);
   });
 
-  it('gives up and alerts after maxAttempts, then stops auto-restarting', async () => {
+  it('gives up and alerts after maxAttempts, then only retries at the slow give-up cadence', async () => {
     let nowMs = 0;
     const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' }));
     const alert = vi.fn();
@@ -40,6 +40,7 @@ describe('createWatchdog', () => {
       client: { isHealthy: vi.fn(async () => false), launch },
       log: () => {}, alert,
       failuresBeforeRelaunch: 1, maxAttempts: 3, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      giveUpRetryIntervalMs: 100_000,
       now: () => nowMs,
     });
 
@@ -51,8 +52,49 @@ describe('createWatchdog', () => {
     expect(launch).toHaveBeenCalledTimes(3);
     expect(alert).toHaveBeenCalledTimes(1);
 
-    nowMs += 10_000; await wd.tick(); // gave up — no further launches
+    nowMs += 10_000; await wd.tick(); // gave up — still inside the slow give-up cadence, no launch yet
     expect(launch).toHaveBeenCalledTimes(3);
+  });
+
+  it('after giving up, keeps trying at giveUpRetryIntervalMs instead of staying down forever', async () => {
+    // Reproduces the production incident (2026-08-29): a genuine split-brain blocked the
+    // final fast-retry attempt, the blocking process died on its own minutes later, but the
+    // old code never tried again — Invoker stayed down 10+ hours until a human manually
+    // replied `@Invoker restart`. The watchdog must keep trying at a slow, non-spammy cadence,
+    // and recover on its own once the real-world blocker is gone.
+    let nowMs = 0;
+    let blockerGone = false;
+    let ownerHealthy = false;
+    const launch = vi.fn(async (): Promise<LaunchResult> => {
+      if (!blockerGone) return { healthy: false, cause: 'split-brain', holderPid: 999 };
+      ownerHealthy = true;
+      return { healthy: true };
+    });
+    const alert = vi.fn();
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => ownerHealthy), launch },
+      log: () => {}, alert,
+      failuresBeforeRelaunch: 1, maxAttempts: 2, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      giveUpRetryIntervalMs: 50_000,
+      alertCooldownMs: 1_000_000, // isolate the retry-cadence assertion from alert spam
+      now: () => nowMs,
+    });
+
+    await wd.tick();
+    nowMs += 2_000; await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(2); // gave up here
+
+    nowMs += 10_000; await wd.tick(); // well inside giveUpRetryIntervalMs — no retry yet
+    expect(launch).toHaveBeenCalledTimes(2);
+
+    nowMs += 50_000; await wd.tick(); // past giveUpRetryIntervalMs — one more attempt, still blocked
+    expect(launch).toHaveBeenCalledTimes(3);
+
+    // The real-world blocker (the stray split-brain process) has now died on its own.
+    blockerGone = true;
+    nowMs += 50_000; await wd.tick(); // next slow-cadence attempt succeeds
+    expect(launch).toHaveBeenCalledTimes(4);
+    expect(ownerHealthy).toBe(true);
   });
 
   it('keeps attempt state after a successful relaunch until health is stable', async () => {

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -4,9 +4,20 @@
  * Every `intervalMs` it checks `isHealthy()` (IPC ping, HTTP `/api/health`
  * fallback). After `failuresBeforeRelaunch` consecutive failures it calls
  * `launch()`. Relaunch attempts are spaced by an exponential backoff
- * (`baseBackoffMs` → `maxBackoffMs`); after `maxAttempts` it posts an alert and
- * stops auto-restarting until Invoker is healthy again (e.g. via a manual
- * `restart`). This backoff is the load-bearing guard against restart storms.
+ * (`baseBackoffMs` → `maxBackoffMs`); after `maxAttempts` it posts an alert.
+ * This backoff is the load-bearing guard against restart storms.
+ *
+ * After giving up, the watchdog does not stay silent forever: every
+ * `giveUpRetryIntervalMs` it makes one more relaunch attempt (without
+ * resetting the fast-retry attempt counter or spamming additional alerts
+ * beyond the existing cooldown). This recovers a case observed in production
+ * (2026-08-29): a genuine split-brain (a stray owner process alive but not
+ * answering IPC) blocked the final fast-retry attempt, then that stray
+ * process died on its own ~11 minutes later — but nothing ever tried again,
+ * leaving Invoker down for over 10 hours until a human noticed and manually
+ * replied `@Invoker restart`. A blocking condition that resolves itself
+ * after the fast-retry budget is exhausted must not require a human to
+ * notice a Slack alert to recover.
  *
  * A single healthy ping after relaunch does not clear attempt state. Invoker
  * must stay healthy for `stableHealthyPolls` consecutive ticks before the
@@ -31,6 +42,7 @@ export interface WatchdogDeps {
   stableHealthyPolls?: number;
   /** Minimum time between lobby/operator alerts while still down. */
   alertCooldownMs?: number;
+  giveUpRetryIntervalMs?: number;
   now?: () => number;
 }
 
@@ -49,6 +61,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   const maxBackoffMs = deps.maxBackoffMs ?? 300_000;
   const stableHealthyPolls = deps.stableHealthyPolls ?? 3;
   const alertCooldownMs = deps.alertCooldownMs ?? 30 * 60_000;
+  const giveUpRetryIntervalMs = deps.giveUpRetryIntervalMs ?? 20 * 60_000;
   const now = deps.now ?? (() => Date.now());
 
   let consecutiveFailures = 0;
@@ -57,6 +70,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   let backoffMs = baseBackoffMs;
   let nextAttemptAt = 0;
   let gaveUp = false;
+  let nextGiveUpRetryAt = 0;
   let lastAlertAt: number | null = null;
   let lastLaunchFailure: LaunchResult | null = null;
   let busy = false;
@@ -84,6 +98,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
     backoffMs = baseBackoffMs;
     nextAttemptAt = 0;
     gaveUp = false;
+    nextGiveUpRetryAt = 0;
   };
 
   const inRecovery = (): boolean =>
@@ -128,6 +143,22 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
             `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts.${splitBrainDetail()} Reply \`@Invoker restart\` to retry.`,
           );
         }
+        if (now() < nextGiveUpRetryAt) return;
+        nextGiveUpRetryAt = now() + giveUpRetryIntervalMs;
+        deps.log(
+          'warn',
+          `Invoker still down after giving up — making one periodic recovery attempt (next in ${giveUpRetryIntervalMs}ms if this fails)`,
+        );
+        const retryResult = await deps.client.launch();
+        if (retryResult.healthy) {
+          consecutiveFailures = 0;
+          consecutiveHealthy = 0;
+          nextAttemptAt = 0;
+          lastLaunchFailure = null;
+          deps.log('info', 'watchdog periodic recovery attempt succeeded — confirming stable health');
+          return;
+        }
+        lastLaunchFailure = retryResult;
         return;
       }
 
@@ -148,6 +179,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
       lastLaunchFailure = result;
       if (attempts >= maxAttempts) {
         gaveUp = true;
+        nextGiveUpRetryAt = now() + giveUpRetryIntervalMs;
         if (canAlert()) {
           lastAlertAt = now();
           await deps.alert(


### PR DESCRIPTION
## Summary

DO1's Invoker owner was down for 10+ hours today with zero automatic recovery attempts.

This surfaced while investigating an unrelated IPC error against the live owner.

The watchdog's fast-attempt budget was exhausted by a real stray-owner-lock condition at 10:47 UTC.

That blocking process died on its own about 11 minutes later, but nothing tried again.

## Review Claim

After giving up, the watchdog now makes one more attempt every giveUpRetryIntervalMs instead of staying silent forever.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only adds a slow-cadence attempt after the existing give-up point.

The fast-attempt budget, exponential backoff, and alert cooldown are unchanged.

Does not add extra alerts beyond the existing cooldown, and does not reset the fast-attempt counter.

## Slice Rationale

One review claim, one file plus its companion, isolated from any other watchdog change.

## Non-goals

No change to why the owner process exited in the first place.

No change to the stray-owner-lock detection itself, the fast-attempt backoff, or the per-ping timeout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test`
- [x] `pnpm --filter @invoker/slack-manager build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Invoker auto-recovery behavior in production (default 20m slow retries after give-up); mitigated by unchanged fast backoff and alert limits, but could add launch attempts on persistently broken hosts.
> 
> **Overview**
> **Fixes a gap where the slack-manager watchdog stopped all relaunch attempts after `maxAttempts`, so transient blockers (e.g. split-brain lock) could clear and Invoker still stayed down until manual `@Invoker restart`.**
> 
> After the fast-retry budget is exhausted, the watchdog now schedules **one** `launch()` every `giveUpRetryIntervalMs` (default **20 minutes**). Fast exponential backoff, attempt counting, and alert cooldown behavior are unchanged; give-up alerts still respect cooldown and the fast-attempt counter is not reset on these slow retries. Successful periodic launches clear failure state and continue through the existing stable-health confirmation path.
> 
> Tests were updated to assert no launch inside the slow cadence right after give-up, and a new scenario models split-brain blocking through give-up, then self-healing when the blocker disappears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ac11c05166543d669f4df12b4d0a3a74acd1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->