### PR TITLE
mergify-admin-requeue: bound repair-filing ledger calls to 10s

### DIFF
--- a/scripts/repair_filing_ledger.py
+++ b/scripts/repair_filing_ledger.py
@@ -26,6 +26,19 @@ except ImportError:
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+# Shorter than run_headless's own 30s default: an insert/release call here is
+# a best-effort dedup claim whose caller (mergify_admin_requeue_plan.py's
+# default_claim_repair_filing/default_release_repair_filing) already treats
+# any failure as "skip this filing tick, retry next time" -- no data is lost
+# on a fast timeout. Measured live against the production DO1 owner under
+# real task load (2026-08-29): a single insert call took the full existing
+# 30s before timing out. A cron tick needing this for several PRs in one
+# pass can rack up multiple 30s stalls and exceed the worker's own 240s tick
+# budget, which kills the whole tick (losing every other PR's triage that
+# cycle, not just this best-effort claim). Failing this specific call faster
+# bounds that cost without weakening anything else's reliability.
+REPAIR_FILING_LEDGER_TIMEOUT_SECONDS = 10
+
 
 class RepairFilingLedgerError(RuntimeError):
     """Raised when the headless_mutation call itself fails or its output can't be parsed."""
@@ -73,7 +86,7 @@ def insert_repair_filing(
     if metadata is not None:
         command += ' --metadata "$5"'
         args.append(json.dumps(dict(metadata)))
-    completed = run_headless_fn(command, *args)
+    completed = run_headless_fn(command, *args, timeout_seconds=REPAIR_FILING_LEDGER_TIMEOUT_SECONDS)
     if completed.returncode != 0:
         raise RepairFilingLedgerError(
             f"repair-filing insert failed (exit {completed.returncode}): {completed.stderr.strip()}"
@@ -103,6 +116,7 @@ def release_repair_filing(
     completed = run_headless_fn(
         'headless_mutation repair-filing release --kind "$2" --subject "$3" --state-sha "$4"',
         kind, subject, state_sha,
+        timeout_seconds=REPAIR_FILING_LEDGER_TIMEOUT_SECONDS,
     )
     if completed.returncode != 0:
         raise RepairFilingLedgerError(

--- a/scripts/test_repair_filing_ledger.py
+++ b/scripts/test_repair_filing_ledger.py
@@ -30,7 +30,7 @@ class InsertRepairFiling(unittest.TestCase):
         calls = []
         result = rfl.insert_repair_filing(
             "ci-regression:fleet", "master", "sha-a",
-            run_headless_fn=lambda *a: calls.append(a) or completed(
+            run_headless_fn=lambda *a, **kw: calls.append(a) or completed(
                 stdout=json.dumps({"inserted": True, "row": {"id": 1}}),
             ),
         )
@@ -42,14 +42,14 @@ class InsertRepairFiling(unittest.TestCase):
     def test_rejects_a_duplicate_key(self):
         result = rfl.insert_repair_filing(
             "admin-requeue:rebase-conflict", "9425", "sha-b",
-            run_headless_fn=lambda *a: completed(stdout=json.dumps({"inserted": False, "row": {"id": 1}})),
+            run_headless_fn=lambda *a, **kw: completed(stdout=json.dumps({"inserted": False, "row": {"id": 1}})),
         )
         self.assertFalse(result["inserted"])
 
     def test_unwraps_the_ipc_delegated_envelope(self):
         result = rfl.insert_repair_filing(
             "k", "s", "sha",
-            run_headless_fn=lambda *a: completed(stdout=json.dumps({
+            run_headless_fn=lambda *a, **kw: completed(stdout=json.dumps({
                 "ok": True,
                 "response": {"inserted": True, "row": {"id": 2}},
             })),
@@ -60,7 +60,7 @@ class InsertRepairFiling(unittest.TestCase):
         calls = []
         rfl.insert_repair_filing(
             "k", "s", "sha", metadata={"memberJobs": ["a", "b"]},
-            run_headless_fn=lambda *a: calls.append(a) or completed(stdout=json.dumps({"inserted": True, "row": {}})),
+            run_headless_fn=lambda *a, **kw: calls.append(a) or completed(stdout=json.dumps({"inserted": True, "row": {}})),
         )
         command, kind, subject, sha, metadata_json = calls[0]
         self.assertIn("--metadata", command)
@@ -70,20 +70,36 @@ class InsertRepairFiling(unittest.TestCase):
         with self.assertRaises(rfl.RepairFilingLedgerError):
             rfl.insert_repair_filing(
                 "k", "s", "sha",
-                run_headless_fn=lambda *a: completed(returncode=1, stderr="owner unreachable"),
+                run_headless_fn=lambda *a, **kw: completed(returncode=1, stderr="owner unreachable"),
             )
 
     def test_raises_on_unparseable_output(self):
         with self.assertRaises(rfl.RepairFilingLedgerError):
-            rfl.insert_repair_filing("k", "s", "sha", run_headless_fn=lambda *a: completed(stdout="not json"))
+            rfl.insert_repair_filing("k", "s", "sha", run_headless_fn=lambda *a, **kw: completed(stdout="not json"))
 
     def test_requires_kind_subject_and_state_sha(self):
         with self.assertRaises(ValueError):
-            rfl.insert_repair_filing("", "s", "sha", run_headless_fn=lambda *a: completed())
+            rfl.insert_repair_filing("", "s", "sha", run_headless_fn=lambda *a, **kw: completed())
         with self.assertRaises(ValueError):
-            rfl.insert_repair_filing("k", "", "sha", run_headless_fn=lambda *a: completed())
+            rfl.insert_repair_filing("k", "", "sha", run_headless_fn=lambda *a, **kw: completed())
         with self.assertRaises(ValueError):
-            rfl.insert_repair_filing("k", "s", "", run_headless_fn=lambda *a: completed())
+            rfl.insert_repair_filing("k", "s", "", run_headless_fn=lambda *a, **kw: completed())
+
+    def test_uses_a_shorter_timeout_than_run_headless_default(self):
+        # Reproduces the production incident (2026-08-29): a real insert call
+        # against the live DO1 owner under task load took the full 30s
+        # run_headless default before timing out. Several such calls in one
+        # pr-admin-bypass-land tick exceeded that worker's 240s tick budget
+        # and got the whole tick killed. This call is a best-effort dedup
+        # claim whose caller already treats any failure as "retry next
+        # tick", so it must fail faster than run_headless's general default.
+        seen_kwargs = {}
+        rfl.insert_repair_filing(
+            "k", "s", "sha",
+            run_headless_fn=lambda *a, **kw: seen_kwargs.update(kw) or completed(stdout=json.dumps({"inserted": True, "row": {}})),
+        )
+        self.assertEqual(seen_kwargs.get("timeout_seconds"), rfl.REPAIR_FILING_LEDGER_TIMEOUT_SECONDS)
+        self.assertLess(rfl.REPAIR_FILING_LEDGER_TIMEOUT_SECONDS, 30)
 
 
 class ReleaseRepairFiling(unittest.TestCase):
@@ -91,7 +107,7 @@ class ReleaseRepairFiling(unittest.TestCase):
         calls = []
         result = rfl.release_repair_filing(
             "k", "s", "sha",
-            run_headless_fn=lambda *a: calls.append(a) or completed(stdout=json.dumps({"released": True})),
+            run_headless_fn=lambda *a, **kw: calls.append(a) or completed(stdout=json.dumps({"released": True})),
         )
         self.assertEqual(result, {"released": True})
         command = calls[0][0]
@@ -99,7 +115,15 @@ class ReleaseRepairFiling(unittest.TestCase):
 
     def test_raises_on_failure_instead_of_silently_succeeding(self):
         with self.assertRaises(rfl.RepairFilingLedgerError):
-            rfl.release_repair_filing("k", "s", "sha", run_headless_fn=lambda *a: completed(returncode=1))
+            rfl.release_repair_filing("k", "s", "sha", run_headless_fn=lambda *a, **kw: completed(returncode=1))
+
+    def test_uses_a_shorter_timeout_than_run_headless_default(self):
+        seen_kwargs = {}
+        rfl.release_repair_filing(
+            "k", "s", "sha",
+            run_headless_fn=lambda *a, **kw: seen_kwargs.update(kw) or completed(stdout=json.dumps({"released": True})),
+        )
+        self.assertEqual(seen_kwargs.get("timeout_seconds"), rfl.REPAIR_FILING_LEDGER_TIMEOUT_SECONDS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

pr-admin-bypass-land was getting killed by its own 240s tick timeout repeatedly on DO1.

It failed 4 times in under an hour. This stalled PR #11168's admin-bypass queue progress.

## Review Claim

Each repair-filing insert/release call inherited run_headless's general 30s timeout.

Measured live against the production DO1 owner: a single insert call took the full 30s before timing out.

Several such calls in one cron tick can exceed the worker's own 240s tick budget.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the repair-filing ledger's own insert/release calls get a shorter timeout.

run_headless's general default, and every other caller of it, is unchanged.

These calls are already best-effort — the caller already treats any failure as "skip this filing tick, retry next time."

## Slice Rationale

One review claim, one module (repair_filing_ledger.py) plus its test.

Isolated from the worker-level tick-timeout constant and every other caller of run_headless.

## Non-goals

No change to why the owner is slow to respond under load in the first place.

No change to run_headless's general default, the worker-level tick timeout, or any other headless_mutation call site.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_repair_filing_ledger`
- [x] `python3 -m unittest discover -s scripts -p "test_*.py"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
