### PR TITLE
Remove O(N) debug log flood blocking the event loop on every task completion

### DIFF
--- a/packages/workflow-core/src/state-machine.ts
+++ b/packages/workflow-core/src/state-machine.ts
@@ -50,15 +50,6 @@ export class TaskStateMachine {
     const ready: string[] = [];
 
     for (const task of this.graph.getAllNodes()) {
-      // Log merge nodes specifically to trace why they're skipped/included
-      if (task.config?.isMergeNode) {
-        const depStatuses = task.dependencies.map(depId => {
-          const dep = this.graph.getNode(depId);
-          return `${depId}=${dep?.status ?? 'NOT_FOUND'}`;
-        });
-        console.log(`[state-machine] findNewlyReadyTasks(${completedTaskId}): merge node "${task.id}" status=${task.status} deps=[${depStatuses.join(', ')}] hasDep=${task.dependencies.includes(completedTaskId)}`);
-      }
-
       if (task.status !== 'pending' && task.status !== 'blocked') continue;
       if (!task.dependencies.includes(completedTaskId)) continue;
 


### PR DESCRIPTION
## Summary

`findNewlyReadyTasks()` runs on every task completion anywhere in the system and loops over the entire in-memory task graph to route newly-unblocked tasks forward.

A debug trace added 2026-03-21 (`caa1d74cb1`, "merge-gate tracing") logged every merge node found during that routing pass, regardless of relevance to the completed task.

It stayed in place ever since. `console.log` to a redirected file is synchronous in Node, blocking the event loop on every routing pass once the graph grew enough merge nodes.

## Review Claim

The excised lines are a debug trace with no coupling to the readiness-determination routing logic below them, and that logic's tested behavior is unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Only the debug-logging lines are gone. `findNewlyReadyTasks`'s actual return value and routing control flow are unchanged.

## Slice Rationale

Single, isolated excision of a dead debug trace from one routing function; no other files or logic touched.

## Non-goals

No behavior change. No change to the readiness-determination routing algorithm, no change to how `findNewlyReadyTasks` is called, no changes to the underlying stuck/failed workflow backlog that this trace was logging about.

## Evidence

Confirmed live on the production DO1 owner (2026-08-29, ~21:40 UTC): the owner process sat at a sustained ~85% CPU for its entire ~20+ minute uptime, well past its cold-boot window.

A recent 2000-line slice of `gui.log` contained the same `[state-machine] findNewlyReadyTasks(...)` trace line for the same permanently-blocked merge node 136 times, another 96 times, another 83 times — all logging the exact same never-changing `status=pending` dependency.

A basic IPC call (`query workflows`) intermittently took 30s+ to dispatch against this same, otherwise-idle owner. This was directly blocking real work: PR #11168's bot-review-thread repair (`submit_async_repair_plan`) was timing out at 30s trying to reach the owner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test` (906 passed, 0 regressions)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 982539a057d`
- Post-revert steps: None
- Data migration? No

</details>
