### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](1) Fix $HOME/.invoker collision guard in recreate-task repro

### DIFF
--- a/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
@@ -20,7 +20,9 @@ done
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-recreate-task-queue.XXXXXX")"
 HOME_DIR="$TMP_DIR/home"
-DB_DIR="$HOME_DIR/.invoker"
+# Not "$HOME_DIR/.invoker": the profile launcher fail-closes on that exact path as a
+# production collision, even under a disposable test HOME (see with-invoker-development-profile.mjs).
+DB_DIR="$HOME_DIR/.invoker-repro"
 PLAN_PATH="$TMP_DIR/repro-plan.yaml"
 CONFIG_PATH="$DB_DIR/config.json"
 REPO_FIXTURE_DIR="$TMP_DIR/repro-repo"


### PR DESCRIPTION
## Summary

The recreate-task repro script pointed its disposable sqlite/IPC directory at the literal `.invoker` name under its temp `$HOME_DIR`.

Invoker's profile launcher fail-closes on that exact path as a production-database collision, even under a disposable test `$HOME`.

The script now uses `$HOME_DIR/.invoker-repro` instead, so the launcher no longer treats the throwaway home as production.

## Review Claim

Approve rerouting this repro script's sqlite/IPC directory away from the literal `.invoker` name that the profile launcher treats as a production collision.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the repro script's own temp-directory variable changes; no product code path or other script is touched.

## Slice Rationale

This is a single self-contained rename in one repro script, kept separate from the sibling e2e-dry-run case fix because the two files classify under different review units (`proof` vs `tooling-policy`).

## Non-goals

No product code changes. No new test coverage added. Does not touch `scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh`, which carries the matching fix for the sibling script and ships as its own PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

