### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](2) Fix $HOME/.invoker collision guard in case-2.17 e2e script

### DIFF
--- a/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+++ b/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
@@ -15,8 +15,6 @@ unset INVOKER_HEADLESS_STANDALONE
 
 TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-home.XXXXXX")"
 export HOME="$TMP_HOME"
-# Not "$HOME/.invoker": the profile launcher fail-closes on that exact path as a
-# production collision, even under a disposable test HOME (see with-invoker-development-profile.mjs).
 export INVOKER_DB_DIR="$HOME/.invoker-e2e"
 mkdir -p "$INVOKER_DB_DIR"
 git config --global --add safe.directory "$REPO_ROOT"

--- a/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+++ b/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
@@ -12,11 +12,13 @@ export INVOKER_DISABLE_EXCLUSIVE_LOCKING=1
 # Keep shared WAL here so sqlite diagnostics can coexist with the owner.
 export INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK=1
 unset INVOKER_HEADLESS_STANDALONE
-unset INVOKER_DB_DIR
 
 TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-home.XXXXXX")"
 export HOME="$TMP_HOME"
-mkdir -p "$HOME/.invoker"
+# Not "$HOME/.invoker": the profile launcher fail-closes on that exact path as a
+# production collision, even under a disposable test HOME (see with-invoker-development-profile.mjs).
+export INVOKER_DB_DIR="$HOME/.invoker-e2e"
+mkdir -p "$INVOKER_DB_DIR"
 git config --global --add safe.directory "$REPO_ROOT"
 export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-config.XXXXXX")"
 printf '{\n  "autoFixRetries": 1\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
@@ -24,7 +26,7 @@ printf '{\n  "autoFixRetries": 1\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
 OWNER_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.17-owner.XXXXXX")"
 SUBMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.17-submit.XXXXXX")"
 PLAN_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.17-plan.XXXXXX")"
-DB_PATH="$HOME/.invoker/invoker.db"
+DB_PATH="$INVOKER_DB_DIR/invoker.db"
 OWNER_PID=""
 
 cleanup() {
@@ -50,7 +52,7 @@ for i in $(seq 1 120); do
     cat "$OWNER_LOG"
     exit 1
   fi
-  if [ -S "$HOME/.invoker/ipc-transport.sock" ] \
+  if [ -S "$INVOKER_DB_DIR/ipc-transport.sock" ] \
     && ./run.sh --headless query queue --output json >/dev/null 2>&1; then
     READY=1
     break


### PR DESCRIPTION
## Summary

The 2.17 autofix e2e case unset `INVOKER_DB_DIR` and then reused the literal `$HOME/.invoker` path for its disposable sqlite/IPC directory.

Invoker's profile launcher fail-closes on that exact path as a production-database collision, even under a disposable test `$HOME`.

The case now exports `INVOKER_DB_DIR=$HOME/.invoker-e2e` and points every reference at that variable instead, so the launcher no longer treats the throwaway home as production.

## Review Claim

Approve rerouting this e2e-dry-run case's sqlite/IPC directory away from the literal `.invoker` name that the profile launcher treats as a production collision.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only this e2e case script's own temp-directory variable changes; no product code path or other script is touched.

## Slice Rationale

This is a single self-contained rename in one e2e-dry-run case script, kept separate from the sibling repro-script fix because the two files classify under different review units (`tooling-policy` vs `proof`).

## Non-goals

No product code changes. No new test coverage added. Does not touch `scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh`, which carries the matching fix for the sibling script and ships as its own PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the case-2.17 e2e shell harness changes; no product runtime or other scripts are modified.
> 
> **Overview**
> Fixes a CI regression in the **case 2.17** autofix e2e dry-run harness where the disposable test home used the literal `$HOME/.invoker` path for sqlite and the IPC socket.
> 
> The script now sets **`INVOKER_DB_DIR=$HOME/.invoker-e2e`**, creates that directory, and wires **`DB_PATH`** and the **mutation-readiness** socket check to that variable instead of unsetting `INVOKER_DB_DIR` and defaulting to `.invoker`. That avoids the profile launcher’s production-database collision fail-close on the standard profile path, even under a throwaway `HOME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980326d8affd2710f93abe5f0a80adddc6df162c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->