### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](1) Skip empty-diff review-stack publication in merge gate

### DIFF
--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -497,4 +497,93 @@ describe('publishAfterFixImpl integration (real git)', () => {
     expect(parsedError.failedBranch).toBe('invoker/t2');
     expect(Array.isArray(parsedError.conflictFiles)).toBe(true);
   }, REAL_GIT_TIMEOUT_MS);
+
+  it('skips make-pr review publication when the repaired branch has zero net diff vs base (Invoker repo)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'pub-fix-zero-diff-'));
+    const originDir = join(root, 'origin.git');
+    const hostDir = join(root, 'host');
+    const gateDir = join(root, 'gate');
+
+    try {
+      execSync(`git init --bare -b master "${originDir}"`, { stdio: 'pipe' });
+
+      execSync(`git clone "${originDir}" "${hostDir}"`, { stdio: 'pipe' });
+      git('config user.email "test@test.com"', hostDir);
+      git('config user.name "Test"', hostDir);
+      // The task's work and the fix are already present on master (e.g. an
+      // earlier merge already landed the identical content), so consolidating
+      // task branches on top produces zero net diff against master.
+      writeFileSync(join(hostDir, 'initial.txt'), 'initial');
+      writeFileSync(join(hostDir, 't1.txt'), 'task 1 work');
+      writeFileSync(join(hostDir, 'fix.txt'), 'claude fix');
+      git('add -A', hostDir);
+      git('commit -m "initial (already contains task 1 + fix content)"', hostDir);
+      git('push origin master', hostDir);
+
+      git('checkout -b invoker/t1', hostDir);
+      gitExec(['commit', '--allow-empty', '-m', 'task 1 (no-op, already on master)'], hostDir);
+      git('push origin invoker/t1', hostDir);
+      git('checkout master', hostDir);
+
+      execSync(`git clone "${originDir}" "${gateDir}"`, { stdio: 'pipe' });
+      git('config user.email "test@test.com"', gateDir);
+      git('config user.name "Test"', gateDir);
+      gitExec(['commit', '--allow-empty', '-m', 'claude fix (no-op, already on master)'], gateDir);
+      const fixCommit = git('rev-parse HEAD', gateDir);
+
+      const mergeTask: TaskState = {
+        id: '__merge__wf-int',
+        description: 'Merge gate',
+        status: 'running',
+        dependencies: ['t1'],
+        createdAt: new Date(),
+        config: { isMergeNode: true, workflowId: 'wf-int' } as any,
+        execution: { fixedIntegrationSha: fixCommit } as any,
+      };
+      const taskT1: TaskState = {
+        id: 't1',
+        description: 'Task 1',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: 'wf-int' } as any,
+        execution: { branch: 'invoker/t1' } as any,
+      };
+
+      const host = makeHost(hostDir, gateDir, [mergeTask, taskT1]);
+      (host.persistence as any).loadWorkflow = () => ({
+        id: 'wf-int',
+        onFinish: 'pull_request',
+        mergeMode: 'external_review',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        name: 'Integration Test',
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+      host.publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [{ url: 'https://github.com/example/pr/1', providerId: '1' }],
+        sessionId: 'session-1',
+        agentName: 'claude',
+      });
+
+      await publishAfterFixImpl(host, mergeTask);
+
+      expect(host.orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
+      // Zero net diff vs base: the make-pr skill must not be invoked, since
+      // there is nothing for it to review.
+      expect(host.publishReviewStackWithMakePrSkill).not.toHaveBeenCalled();
+      expect(host.orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-int', expect.objectContaining({
+        execution: expect.objectContaining({ branch: 'plan/feature' }),
+      }), expect.objectContaining({ generation: 0 }));
+      const reviewReadyCall = (host.orchestrator.setTaskReviewReady as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(reviewReadyCall?.[1]?.execution).not.toHaveProperty('reviewUrl');
+      expect(reviewReadyCall?.[1]?.execution).not.toHaveProperty('reviewGate');
+
+      git('fetch origin', hostDir);
+      const diffStat = gitSilent('diff --stat master origin/plan/feature', hostDir);
+      expect(diffStat).toBe('');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, REAL_GIT_TIMEOUT_MS);
 });

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -1545,6 +1545,23 @@ export async function publishAfterFixImpl(
       ? await resolveReviewBaseRef(host, consolidateDir, baseBranch)
       : { branchName: normalizeBranchForGithubCli(baseBranch), gitRef: baseBranch };
 
+    let skipReviewForEmptyDiff = false;
+    if (shouldPublishReview && isInvokerRepoUrl(workflow?.repoUrl)) {
+      const changedFiles = await listReviewableChangedFiles(host, consolidateDir, reviewBase.gitRef, featureBranch);
+      if (changedFiles.length === 0) {
+        logTaskProgress(host, task.id, 'info', 'Skipping review stack publication for empty Invoker branch', {
+          baseBranch: reviewBase.branchName,
+          featureBranch,
+        });
+        mergeTrace('PUBLISH_AFTER_FIX_REVIEW_PUBLISH_NOOP', {
+          taskId: task.id,
+          baseBranch: reviewBase.branchName,
+          featureBranch,
+        });
+        skipReviewForEmptyDiff = true;
+      }
+    }
+
     let fullSummary = summary;
     if (visualProof && host.runVisualProofCapture) {
       const slug = featureBranch.replace(/\//g, '-');
@@ -1554,7 +1571,7 @@ export async function publishAfterFixImpl(
       }
     }
 
-    if (shouldPublishReview) {
+    if (shouldPublishReview && !skipReviewForEmptyDiff) {
       const published = await publishReviewArtifactsForMerge(host, {
         workflowId,
         mergeNodeTaskId: task.id,


### PR DESCRIPTION
## Summary

The merge gate always routed a repaired branch into the review-stack publish call in `publishAfterFixImpl`, even when the branch ended up byte-identical to its review base.

That happens when a task's work already reached the base branch through a different path before the merge gate ran.

Routing an empty-diff branch into that call wastes a review-agent session and would surface a PR with nothing to review.

This change adds a changed-files check before the routing decision, for Invoker-repo workflows only.

## Review Claim

Approve adding a diff check that keeps `publishAfterFixImpl` from routing an empty-diff repaired branch into the review-stack publish call.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

When the repaired branch has one or more changed files against its review base, this change has no effect: `shouldPublishReview` still gates the same `publishReviewArtifactsForMerge` call as before, unconditionally. The new short-circuit only fires when `listReviewableChangedFiles` returns zero files, a case that previously invoked `publishReviewArtifactsForMerge` on a no-op branch.

## Slice Rationale

Single, self-contained change: one new branch-diff condition in `publishAfterFixImpl`, verified by its own added case. No other merge-gate behavior is touched.

## Non-goals

Does not change `publishReviewArtifactsForMerge` itself, the make-pr skill, or any non-Invoker-repo merge-gate behavior. Does not change poll/approval runtime behavior in `task-runner.ts`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine test -- publish-after-fix`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 83457cbd1`
- Post-revert steps: None
- Data migration? No

</details>

