### PR TITLE
[CI regression: 390bb7f-required-fast-vitest-workspace-repro-normalize-pycache](1) Add missing worker kinds to worker-registry test

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -26,10 +26,12 @@ import { REAPER_WORKER_KIND } from '../workers/reaper-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
+import { WORKER_SESSION_MINE_WORKER_KIND } from '../workers/worker-session-mine-worker.js';
 import { SLACK_BUG_SCAN_WORKER_KIND } from '../workers/slack-bug-scan-worker.js';
 import { IDLE_TASK_CLEANUP_WORKER_KIND } from '../workers/idle-task-cleanup-worker.js';
 import { CROSS_REPO_RESEARCH_WORKER_KIND } from '../workers/cross-repo-research-worker.js';
 import { CATSTACK_DEPLOY_WORKER_KIND } from '../workers/catstack-deploy-worker.js';
+import { ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND } from '../workers/admin-bypass-e2e-babysit-worker.js';
 import { MERGIFY_QUEUE_RESEARCH_WORKER_KIND } from '../workers/mergify-queue-research-worker.js';
 
 const silentLogger = {
@@ -92,10 +94,12 @@ describe('worker registry', () => {
       PR_JAILBREAK_LAND_WORKER_KIND,
       PR_AUTO_LABEL_WORKER_KIND,
       E2E_AUTOFIX_WORKER_KIND,
+      WORKER_SESSION_MINE_WORKER_KIND,
       SLACK_BUG_SCAN_WORKER_KIND,
       IDLE_TASK_CLEANUP_WORKER_KIND,
       CROSS_REPO_RESEARCH_WORKER_KIND,
       CATSTACK_DEPLOY_WORKER_KIND,
+      ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
       MERGIFY_QUEUE_RESEARCH_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
@@ -113,10 +117,12 @@ describe('worker registry', () => {
     expect(registry.get(PR_JAILBREAK_LAND_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_AUTO_LABEL_WORKER_KIND)).toBeDefined();
     expect(registry.get(E2E_AUTOFIX_WORKER_KIND)).toBeDefined();
+    expect(registry.get(WORKER_SESSION_MINE_WORKER_KIND)).toBeDefined();
     expect(registry.get(SLACK_BUG_SCAN_WORKER_KIND)).toBeDefined();
     expect(registry.get(IDLE_TASK_CLEANUP_WORKER_KIND)).toBeDefined();
     expect(registry.get(CROSS_REPO_RESEARCH_WORKER_KIND)).toBeDefined();
     expect(registry.get(CATSTACK_DEPLOY_WORKER_KIND)).toBeDefined();
+    expect(registry.get(ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND)).toBeDefined();
     expect(registry.get(MERGIFY_QUEUE_RESEARCH_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {


### PR DESCRIPTION
## Summary

CI job `required-fast / Vitest Workspace` was red on master starting at commit `390bb7f83545ff13784aecb0ea811c055b2ce666`.

The root cause is `packages/execution-engine/src/__tests__/worker-registry.test.ts` asserting an exact expected list of registered worker kinds.

Two worker kinds, `WORKER_SESSION_MINE_WORKER_KIND` and `ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND`, were registered elsewhere on master without this test's expected list being updated.

This slice adds both kinds to the test's expected list so the assertion matches the live registry again.

## Review Claim

Approve adding the two missing worker kinds to `worker-registry.test.ts`'s expected list so the suite reflects the current registry contents.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The change only edits test expectations in one file; it adds no runtime code and does not alter worker registration behavior, so no other CI job or product behavior is affected.

## Slice Rationale

This is the entire root-cause fix for the failing CI job; there is no product-code change to slice apart from the test-expectation update itself, so it stays in its own proof-only slice.

## Non-goals

Does not change worker registration logic, add new workers, or touch any file other than the affected test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
