### PR TITLE
Add bounded retention for events and sync_journal (db-reaper worker)

### DIFF
--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -3,6 +3,7 @@ import {
   normalizeGithubOwnerRepo,
   type AdminBypassE2eBabysitConfig,
   type CatstackDeployConfig,
+  type DbReaperConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
   type InvokerConfig,
@@ -256,6 +257,34 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateDbReaperConfig(config: InvokerConfig): void {
+  const dbReaper = config.dbReaper;
+  if (dbReaper === undefined) return;
+  if (typeof dbReaper !== 'object' || dbReaper === null || Array.isArray(dbReaper)) {
+    throw new Error('dbReaper must be an object');
+  }
+  const typed = dbReaper as DbReaperConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('dbReaper.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.eventsRetentionDays !== undefined) {
+    if (typeof typed.eventsRetentionDays !== 'number' || !Number.isInteger(typed.eventsRetentionDays)) {
+      throw new Error('dbReaper.eventsRetentionDays must be an integer');
+    }
+  }
+  if (typed.syncJournalRetentionDays !== undefined) {
+    if (typeof typed.syncJournalRetentionDays !== 'number' || !Number.isInteger(typed.syncJournalRetentionDays)) {
+      throw new Error('dbReaper.syncJournalRetentionDays must be an integer');
+    }
+  }
+}
+
 function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {
   const adminBypassE2eBabysit = config.adminBypassE2eBabysit;
   if (adminBypassE2eBabysit === undefined) return;
@@ -318,6 +347,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateDbReaperConfig(config);
   validateAdminBypassE2eBabysitConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -228,11 +228,8 @@ export interface CatstackDeployConfig {
 export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
 
 export interface DbReaperConfig {
-  /** Poll cadence in minutes. Default: 60. */
   intervalMinutes?: number;
-  /** Days of events to keep for terminal-status tasks. Default: 14. <= 0 disables events pruning. */
   eventsRetentionDays?: number;
-  /** Days of sync_journal rows to keep. Default: 14. <= 0 disables sync_journal pruning. */
   syncJournalRetentionDays?: number;
 }
 
@@ -606,7 +603,6 @@ export interface InvokerConfig {
    */
   catstackDeploy?: CatstackDeployConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
-  /** DB-reaper worker: events/sync_journal retention cadence and windows. */
   dbReaper?: DbReaperConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -227,6 +227,15 @@ export interface CatstackDeployConfig {
 /** Default poll cadence when catstackDeploy.intervalMinutes is unset. */
 export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
 
+export interface DbReaperConfig {
+  /** Poll cadence in minutes. Default: 60. */
+  intervalMinutes?: number;
+  /** Days of events to keep for terminal-status tasks. Default: 14. <= 0 disables events pruning. */
+  eventsRetentionDays?: number;
+  /** Days of sync_journal rows to keep. Default: 14. <= 0 disables sync_journal pruning. */
+  syncJournalRetentionDays?: number;
+}
+
 /** Default catstack clone URL. */
 export const DEFAULT_CATSTACK_DEPLOY_REPO_URL = 'https://github.com/EdbertChan/catstack.git';
 
@@ -597,6 +606,8 @@ export interface InvokerConfig {
    */
   catstackDeploy?: CatstackDeployConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
+  /** DB-reaper worker: events/sync_journal retention cadence and windows. */
+  dbReaper?: DbReaperConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -470,6 +470,11 @@ function buildRegisteredOwnerWorkerDeps(
         connection: target.connection,
       })),
     },
+    dbReaper: {
+      intervalMs: (invokerConfig.dbReaper?.intervalMinutes ?? 60) * 60_000,
+      eventsRetentionDays: invokerConfig.dbReaper?.eventsRetentionDays,
+      syncJournalRetentionDays: invokerConfig.dbReaper?.syncJournalRetentionDays,
+    },
     idleTaskCleanup: {
       github: createPrMaintenanceGitHub({
         run: spawnPrMaintenanceCommand,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -6233,4 +6233,166 @@ describe('SQLiteAdapter', () => {
       expect(() => assertOwnerCapabilityForWritableOpen(false, true, undefined)).not.toThrow();
     });
   });
+
+  describe('pruneOldEvents', () => {
+    function backdateEvent(eventId: number, daysAgo: number): void {
+      (adapter as any).db.run(
+        `UPDATE events SET created_at = datetime('now', ?) WHERE id = ?`,
+        [`-${daysAgo} days`, eventId],
+      );
+    }
+
+    function insertEvent(taskId: string): number {
+      adapter.logEvent(taskId, 'task.created');
+      const row = (adapter as any).queryOne(
+        'SELECT id FROM events WHERE task_id = ? ORDER BY id DESC LIMIT 1',
+        [taskId],
+      );
+      return Number(row.id);
+    }
+
+    it('prunes old events belonging to a terminal-status task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(1);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(0);
+    });
+
+    it('does not prune recent events even for a terminal-status task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      insertEvent('wf-1/t1');
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('does not prune old events for a task that is still running (not terminal)', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'running', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('does not prune old events for a task the user reopened back to a non-terminal status', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'running', config: { workflowId: 'wf-1' } }));
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('is a no-op for a non-positive retention window', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 3650);
+
+      expect(adapter.pruneOldEvents(0)).toBe(0);
+      expect(adapter.pruneOldEvents(-1)).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+  });
+
+  describe('pruneOldSyncJournal', () => {
+    function insertJournalRow(daysAgo: number, seq?: number): number {
+      (adapter as any).db.run(
+        `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+         VALUES ('workflow', 'wf-x', 'upsert', '{}', 'home', datetime('now', ?))`,
+        [`-${daysAgo} days`],
+      );
+      const row = (adapter as any).queryOne(
+        'SELECT seq FROM sync_journal ORDER BY seq DESC LIMIT 1',
+      );
+      return Number(row.seq);
+    }
+
+    function insertCursor(peerId: string, lastSentSeq: number): void {
+      (adapter as any).db.run(
+        `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+         VALUES (?, ?, 0, datetime('now'))`,
+        [peerId, lastSentSeq],
+      );
+    }
+
+    function journalRowCount(): number {
+      const row = (adapter as any).queryOne('SELECT COUNT(*) AS c FROM sync_journal');
+      return Number(row.c);
+    }
+
+    it('prunes an old row when no peer has ever registered a cursor', () => {
+      insertJournalRow(30);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(1);
+      expect(journalRowCount()).toBe(0);
+    });
+
+    it('does not prune a recent row even with no registered peer', () => {
+      insertJournalRow(1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('does not prune an old row a registered peer has not yet been sent', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq - 1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('prunes an old row once every registered peer has been sent past it', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq);
+      insertCursor('peer-b', seq + 5);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(1);
+      expect(journalRowCount()).toBe(0);
+    });
+
+    it('does not prune an old row when even one of several peers has not been sent past it', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq);
+      insertCursor('peer-b', seq - 1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('is a no-op for a non-positive retention window', () => {
+      insertJournalRow(3650);
+
+      expect(adapter.pruneOldSyncJournal(0)).toBe(0);
+      expect(adapter.pruneOldSyncJournal(-1)).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+  });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1723,6 +1723,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.taskAttemptRepo.loadAllHistoryTasks();
   }
 
+  pruneOldEvents(retentionDays: number): number {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+    const cutoff = `-${Math.floor(retentionDays)} days`;
+    this.db.run(
+      `DELETE FROM events
+        WHERE created_at < datetime('now', ?)
+          AND task_id IN (
+            SELECT id FROM tasks
+             WHERE status IN ('completed', 'failed', 'closed', 'review_ready', 'stale')
+          )`,
+      [cutoff],
+    );
+    return this.db.getRowsModified();
+  }
+
+  pruneOldSyncJournal(retentionDays: number): number {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+    const cutoff = `-${Math.floor(retentionDays)} days`;
+    this.db.run(
+      `DELETE FROM sync_journal
+        WHERE created_at < datetime('now', ?)
+          AND (
+            NOT EXISTS (SELECT 1 FROM sync_cursors)
+            OR seq <= (SELECT MIN(last_sent_seq) FROM sync_cursors)
+          )`,
+      [cutoff],
+    );
+    return this.db.getRowsModified();
+  }
+
   deleteTask(taskId: string): void {
     this.runTransaction(() => {
       this.db.run('DELETE FROM task_launch_dispatch WHERE task_id = ?', [taskId]);

--- a/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DB_REAPER_WORKER_KIND,
+  DEFAULT_EVENTS_RETENTION_DAYS,
+  DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+  createDbReaperWorker,
+  registerDbReaperWorker,
+  type DbReaperWorkerStore,
+} from '../workers/db-reaper-worker.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+
+class FakeDbReaperStore implements DbReaperWorkerStore {
+  readonly pruneOldEventsCalls: number[] = [];
+  readonly pruneOldSyncJournalCalls: number[] = [];
+
+  constructor(
+    private readonly eventsPruned = 0,
+    private readonly syncJournalPruned = 0,
+  ) {}
+
+  pruneOldEvents(retentionDays: number): number {
+    this.pruneOldEventsCalls.push(retentionDays);
+    return this.eventsPruned;
+  }
+
+  pruneOldSyncJournal(retentionDays: number): number {
+    this.pruneOldSyncJournalCalls.push(retentionDays);
+    return this.syncJournalPruned;
+  }
+}
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('createDbReaperWorker', () => {
+  it('prunes events and sync_journal using the configured retention windows on tick', async () => {
+    const store = new FakeDbReaperStore(12, 34);
+    const logger = makeLogger();
+    const worker = createDbReaperWorker({
+      logger,
+      store,
+      eventsRetentionDays: 7,
+      syncJournalRetentionDays: 21,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([7]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([21]);
+  });
+
+  it('uses the documented default retention windows when none are configured', async () => {
+    const store = new FakeDbReaperStore();
+    const worker = createDbReaperWorker({
+      logger: makeLogger(),
+      store,
+      eventsRetentionDays: DEFAULT_EVENTS_RETENTION_DAYS,
+      syncJournalRetentionDays: DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([DEFAULT_EVENTS_RETENTION_DAYS]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([DEFAULT_SYNC_JOURNAL_RETENTION_DAYS]);
+  });
+
+  it('records a worker decision summarizing what was pruned', async () => {
+    const store = new FakeDbReaperStore(5, 9);
+    const upsertWorkerAction = vi.fn();
+    const worker = createDbReaperWorker({
+      logger: makeLogger(),
+      store,
+      eventsRetentionDays: 14,
+      syncJournalRetentionDays: 14,
+      tickOnStart: false,
+      decisionStore: { upsertWorkerAction },
+    });
+
+    await worker.tick();
+
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    const [action] = upsertWorkerAction.mock.calls[0]!;
+    expect(action.workerKind).toBe(DB_REAPER_WORKER_KIND);
+    expect(action.status).toBe('completed');
+    expect(action.summary).toContain('5 old event row(s) pruned');
+    expect(action.summary).toContain('9 old sync_journal row(s) pruned');
+  });
+});
+
+describe('registerDbReaperWorker', () => {
+  it('registers under the db-reaper kind and wires the store through to the worker', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDbReaperWorker(registry);
+
+    const store = new FakeDbReaperStore(1, 2);
+    const deps: WorkerRuntimeDependencies = {
+      store: store as unknown as WorkerRuntimeDependencies['store'],
+      submitter: {} as WorkerRuntimeDependencies['submitter'],
+      logger: makeLogger() as unknown as WorkerRuntimeDependencies['logger'],
+      dbReaper: { eventsRetentionDays: 3, syncJournalRetentionDays: 4, tickOnStart: false },
+    };
+
+    const entry = registry.get(DB_REAPER_WORKER_KIND);
+    expect(entry).toBeDefined();
+    const worker = entry!.factory(deps);
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([3]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([4]);
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -11,6 +11,7 @@ import { registerInfraRepairWorker } from './workers/infra-repair-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 import { registerReaperWorker } from './workers/reaper-worker.js';
+import { registerDbReaperWorker } from './workers/db-reaper-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerSlackBugScanWorker } from './workers/slack-bug-scan-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
@@ -31,6 +32,7 @@ export function registerBuiltinWorkers(
   registerDiskHeadroomWorker(registry);
   registerClaudeOauthRefreshWorker(registry);
   registerReaperWorker(registry);
+  registerDbReaperWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);
   registerE2eAutoFixWorker(registry);

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -105,7 +105,6 @@ export interface WorkerRuntimeDependencies {
   mergifyQueueResearch?: MergifyQueueResearchWorkerConfig;
   /** Idle-task-cleanup worker configuration (dry-run only; see the worker's own docs). */
   idleTaskCleanup?: IdleTaskCleanupWorkerConfig;
-  /** DB-reaper worker configuration (events/sync_journal retention). */
   dbReaper?: DbReaperWorkerConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitWorkerConfig;
   workerLifecycleStarter?: WorkerLifecycleReader & WorkerLifecycleStarter;

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -40,6 +40,7 @@ import type {
   IdleTaskCleanupWorkerStore,
   IdleTaskCleanupWorkerSubmitter,
 } from './workers/idle-task-cleanup-worker.js';
+import type { DbReaperWorkerConfig, DbReaperWorkerStore } from './workers/db-reaper-worker.js';
 import type {
   AdminBypassE2eBabysitWorkerConfig,
   InvestigativePlanSubmitter,
@@ -57,7 +58,8 @@ export interface WorkerRuntimeDependencies {
     & InfraRepairWorkerStore
     & WorkflowResumeWorkerStore
     & DiskHeadroomWorkerStore
-    & IdleTaskCleanupWorkerStore;
+    & IdleTaskCleanupWorkerStore
+    & DbReaperWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter
     & ReviewGateCiRepairSubmitter
@@ -103,6 +105,8 @@ export interface WorkerRuntimeDependencies {
   mergifyQueueResearch?: MergifyQueueResearchWorkerConfig;
   /** Idle-task-cleanup worker configuration (dry-run only; see the worker's own docs). */
   idleTaskCleanup?: IdleTaskCleanupWorkerConfig;
+  /** DB-reaper worker configuration (events/sync_journal retention). */
+  dbReaper?: DbReaperWorkerConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitWorkerConfig;
   workerLifecycleStarter?: WorkerLifecycleReader & WorkerLifecycleStarter;
   repairFilingStore?: RepairFilingStore;

--- a/packages/execution-engine/src/workers/db-reaper-worker.ts
+++ b/packages/execution-engine/src/workers/db-reaper-worker.ts
@@ -1,0 +1,99 @@
+import type { Logger } from '@invoker/contracts';
+
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const DB_REAPER_WORKER_KIND = 'db-reaper';
+export const DEFAULT_DB_REAPER_INTERVAL_MINUTES = 60;
+export const DEFAULT_DB_REAPER_INTERVAL_MS = DEFAULT_DB_REAPER_INTERVAL_MINUTES * 60_000;
+export const DEFAULT_EVENTS_RETENTION_DAYS = 14;
+export const DEFAULT_SYNC_JOURNAL_RETENTION_DAYS = 14;
+
+export interface DbReaperWorkerStore {
+  pruneOldEvents(retentionDays: number): number;
+  pruneOldSyncJournal(retentionDays: number): number;
+}
+
+export interface DbReaperWorkerConfig {
+  /** Poll cadence in milliseconds. Defaults to one hour. */
+  intervalMs?: number;
+  /** Days of events to keep for terminal-status tasks. <= 0 disables events pruning. */
+  eventsRetentionDays?: number;
+  /** Days of sync_journal rows to keep. <= 0 disables sync_journal pruning. */
+  syncJournalRetentionDays?: number;
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export interface DbReaperWorkerOptions {
+  logger: Logger;
+  store: DbReaperWorkerStore;
+  intervalMs?: number;
+  eventsRetentionDays: number;
+  syncJournalRetentionDays: number;
+  tickOnStart?: boolean;
+  decisionStore?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export function createDbReaperWorker(options: DbReaperWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: DB_REAPER_WORKER_KIND,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_DB_REAPER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? true,
+    onTick: async (ctx) => {
+      ctx.signal?.throwIfAborted();
+      await options.onTick?.(ctx);
+      ctx.signal?.throwIfAborted();
+
+      const eventsPruned = options.store.pruneOldEvents(options.eventsRetentionDays);
+      ctx.signal?.throwIfAborted();
+      const syncJournalPruned = options.store.pruneOldSyncJournal(options.syncJournalRetentionDays);
+
+      const summary = `DB reaper pass: ${eventsPruned} old event row(s) pruned `
+        + `(retention=${options.eventsRetentionDays}d), ${syncJournalPruned} old sync_journal row(s) pruned `
+        + `(retention=${options.syncJournalRetentionDays}d)`;
+
+      if (options.decisionStore) {
+        recordWorkerDecisionRow(options.decisionStore, {
+          workerKind: DB_REAPER_WORKER_KIND,
+          actionType: 'db-reaper-pass',
+          externalKey: 'pass',
+          subjectType: 'invoker-db',
+          subjectId: 'invoker.db',
+          status: 'completed',
+          summary,
+          payload: { eventsPruned, syncJournalPruned },
+          incrementAttempt: true,
+        });
+      }
+      options.logger.info?.(`[${DB_REAPER_WORKER_KIND}] ${summary}`, { module: DB_REAPER_WORKER_KIND });
+    },
+  });
+}
+
+/** Register the built-in db-reaper worker (bounded events/sync_journal retention). */
+export function registerDbReaperWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: DB_REAPER_WORKER_KIND,
+    note: 'Prunes events older than retention for terminal-status tasks, and sync_journal rows every known peer has already received.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createDbReaperWorker({
+        logger: deps.logger,
+        store: deps.store,
+        decisionStore: deps.store,
+        intervalMs: deps.dbReaper?.intervalMs,
+        eventsRetentionDays: deps.dbReaper?.eventsRetentionDays ?? DEFAULT_EVENTS_RETENTION_DAYS,
+        syncJournalRetentionDays: deps.dbReaper?.syncJournalRetentionDays ?? DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+        tickOnStart: deps.dbReaper?.tickOnStart,
+      }),
+  });
+  return registry;
+}

--- a/packages/execution-engine/src/workers/db-reaper-worker.ts
+++ b/packages/execution-engine/src/workers/db-reaper-worker.ts
@@ -17,11 +17,8 @@ export interface DbReaperWorkerStore {
 }
 
 export interface DbReaperWorkerConfig {
-  /** Poll cadence in milliseconds. Defaults to one hour. */
   intervalMs?: number;
-  /** Days of events to keep for terminal-status tasks. <= 0 disables events pruning. */
   eventsRetentionDays?: number;
-  /** Days of sync_journal rows to keep. <= 0 disables sync_journal pruning. */
   syncJournalRetentionDays?: number;
   tickOnStart?: boolean;
   store?: WorkerDecisionStore;
@@ -76,7 +73,6 @@ export function createDbReaperWorker(options: DbReaperWorkerOptions): WorkerRunt
   });
 }
 
-/** Register the built-in db-reaper worker (bounded events/sync_journal retention). */
 export function registerDbReaperWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {

--- a/packages/ui/src/__tests__/worker-display.test.ts
+++ b/packages/ui/src/__tests__/worker-display.test.ts
@@ -17,4 +17,12 @@ describe('getWorkerDisplayCopy', () => {
       noActionText: 'No catstack-deploy runs recorded yet.',
     });
   });
+
+  it('returns dedicated display copy for the db-reaper worker', () => {
+    expect(getWorkerDisplayCopy('db-reaper')).toEqual({
+      name: 'DB reaper',
+      idleText: 'Idle. Prunes old events for terminal-status tasks and fully-sent sync_journal rows on an interval.',
+      noActionText: 'No db-reaper runs recorded yet.',
+    });
+  });
 });

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -134,6 +134,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No catstack-deploy runs recorded yet.',
     };
   }
+  if (kind === 'db-reaper') {
+    return {
+      name: 'DB reaper',
+      idleText: 'Idle. Prunes old events for terminal-status tasks and fully-sent sync_journal rows on an interval.',
+      noActionText: 'No db-reaper runs recorded yet.',
+    };
+  }
   if (kind === 'admin-bypass-e2e-babysit') {
     return {
       name: 'Admin-bypass/e2e babysit',


### PR DESCRIPTION
## Summary
`invoker.db` reached 1.5GB in production, dominated by two tables with no bounded retention: `events` (855MB, 1.6M rows in just 4 days — cleared only when the owning task is deleted, and tasks are rarely deleted) and `sync_journal` (555MB, 101K rows — cleared only per-entity after one specific peer syncs it, with no bulk sweep). This DB growth is the confirmed root cause of a real production incident: DO1's owner cold-boot time grew past even a 20-minute watchdog timeout, and the owner was killed mid-boot, causing an outage.

## Review claim
`SQLiteAdapter.pruneOldEvents`/`pruneOldSyncJournal` delete only rows that are provably safe to delete (an old event on a *currently terminal-status* task; an old sync_journal row every *currently registered* peer has already been sent, or age-only when no peer has ever registered), and a new `db-reaper` worker runs them hourly via the standard registry/config/resolver/Workers-UI pattern already used by every other built-in worker in this repo.

## Review lane
behavior

## Review unit
One conceptual unit: a new bounded-retention mechanism for two specific tables, wired through the existing worker infrastructure.

## Safety invariant
`pruneOldEvents` never touches a task whose *current* status is non-terminal (pending/queued/running/fixing_with_ai/needs_input/blocked/awaiting_approval), even if the events themselves are old — covered by a test where a task is completed, has old events, then reopened to `running`, and the events survive. `pruneOldSyncJournal` never deletes a row past what every currently-registered peer's `last_sent_seq` cursor has actually reached — covered by a multi-peer test where one lagging peer blocks deletion. Both functions are no-ops for a non-positive retention window.

## Slice rationale
Touches 4 layers (persistence, domain/worker, app config wiring, UI display copy) but is one indivisible feature — splitting it into a stack would mean landing a worker with no config surface or a config surface for a worker that doesn't exist yet. Standalone waiver: this mirrors today's other two production fixes (#11290, #11293), which also landed as single PRs given the operational urgency of an active production incident.

## Architectural effect
Adds one new built-in worker (`db-reaper`) alongside the existing `reaper` (filesystem-focused) worker — deliberately separate rather than extending `reaper`, since `reaper` has no DB/persistence dependency today and every other DB-touching worker in this repo (e.g. `idle-task-cleanup`) is its own dedicated worker with a narrow `Store` interface, not a `reaper` extension.

## Non-goals
No change to the `activity_log` table's existing separate retention mechanism (`pruneActivityLog`, already bounded by row count). No change to the sync/replication protocol itself. No backfill/one-time cleanup script — the worker itself performs the (idempotent, safe-by-construction) cleanup on its normal interval once deployed.

## Test plan
- `packages/data-store/src/__tests__/sqlite-adapter.test.ts`: 11 new tests for `pruneOldEvents`/`pruneOldSyncJournal`, including the two false-positive-protection cases described in Safety invariant above. Full `data-store` suite: 512/512 pass.
- `packages/execution-engine/src/__tests__/db-reaper-worker.test.ts`: 4 new tests (tick wiring, defaults, decision recording, registry wiring).
- `packages/ui/src/__tests__/worker-display.test.ts`: 1 new test for the Workers UI copy.
- `pnpm run check:types` (the exact command CI's `quality / TypeScript Types` job runs): clean, zero errors.

## Revert plan
Revert this commit; the two new adapter methods and the worker are additive and touch no existing code paths (the two existing per-entity `DELETE FROM events`/`sync_journal` cleanups in `sqlite-adapter.ts`/`sync-merge.ts` are untouched).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduled DELETEs on core persistence tables can remove audit/sync history if retention or terminal-status guards are wrong; behavior is heavily tested but still touches production SQLite under load.
> 
> **Overview**
> Adds a **`db-reaper`** built-in worker to cap SQLite growth from unbounded **`events`** and **`sync_journal`** tables, addressing production DB bloat that slowed owner cold-boot.
> 
> **`SQLiteAdapter`** gains **`pruneOldEvents`** (deletes aged events only when the task’s **current** status is terminal) and **`pruneOldSyncJournal`** (deletes aged journal rows only after every registered peer’s **`last_sent_seq`** has passed them, or by age when no cursors exist). The worker runs on a configurable interval (default **60** minutes) with default **14**-day retention for both tables unless overridden.
> 
> **`InvokerConfig.dbReaper`** exposes **`intervalMinutes`**, **`eventsRetentionDays`**, and **`syncJournalRetentionDays`**, with validation in **`config-validation`** and wiring in **`main.ts`**. The worker registers with other built-ins, extends **`WorkerRuntimeDependencies`**, records a decision summary each pass, and gets Workers UI display copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49143a7ae8bd8e97abc144c1b1b19ca89fd04567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->