### PR TITLE
db-reaper step 1: config schema and validation

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -898,6 +898,53 @@ describe('catstackDeploy config', () => {
   });
 });
 
+describe('dbReaper config', () => {
+  it('accepts omitted dbReaper block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts valid intervalMinutes and retention days', () => {
+    const config = validateInvokerConfig({
+      dbReaper: { intervalMinutes: 60, eventsRetentionDays: 14, syncJournalRetentionDays: 14 },
+    });
+    expect(config.dbReaper?.intervalMinutes).toBe(60);
+    expect(config.dbReaper?.eventsRetentionDays).toBe(14);
+    expect(config.dbReaper?.syncJournalRetentionDays).toBe(14);
+  });
+
+  it('accepts a non-positive retention day value as a disable signal', () => {
+    const config = validateInvokerConfig({
+      dbReaper: { eventsRetentionDays: 0, syncJournalRetentionDays: -1 },
+    });
+    expect(config.dbReaper?.eventsRetentionDays).toBe(0);
+    expect(config.dbReaper?.syncJournalRetentionDays).toBe(-1);
+  });
+
+  it('rejects intervalMinutes of 0', () => {
+    expect(() => validateInvokerConfig({
+      dbReaper: { intervalMinutes: 0 },
+    })).toThrow(/dbReaper.intervalMinutes must be an integer > 0/);
+  });
+
+  it('rejects non-integer intervalMinutes', () => {
+    expect(() => validateInvokerConfig({
+      dbReaper: { intervalMinutes: 1.5 },
+    })).toThrow(/dbReaper.intervalMinutes must be an integer > 0/);
+  });
+
+  it('rejects a non-integer eventsRetentionDays', () => {
+    expect(() => validateInvokerConfig({
+      dbReaper: { eventsRetentionDays: 1.5 },
+    })).toThrow(/dbReaper.eventsRetentionDays must be an integer/);
+  });
+
+  it('rejects a non-integer syncJournalRetentionDays', () => {
+    expect(() => validateInvokerConfig({
+      dbReaper: { syncJournalRetentionDays: 1.5 },
+    })).toThrow(/dbReaper.syncJournalRetentionDays must be an integer/);
+  });
+});
+
 describe('e2eAutoFix.targetRepos', () => {
   it('reads targetRepos from config', () => {
     expect(resolveE2eAutoFixTargetRepos({

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -3,6 +3,7 @@ import {
   normalizeGithubOwnerRepo,
   type AdminBypassE2eBabysitConfig,
   type CatstackDeployConfig,
+  type DbReaperConfig,
   type CrossRepoResearchConfig,
   type CrossRepoResearchSource,
   type InvokerConfig,
@@ -256,6 +257,34 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateDbReaperConfig(config: InvokerConfig): void {
+  const dbReaper = config.dbReaper;
+  if (dbReaper === undefined) return;
+  if (typeof dbReaper !== 'object' || dbReaper === null || Array.isArray(dbReaper)) {
+    throw new Error('dbReaper must be an object');
+  }
+  const typed = dbReaper as DbReaperConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('dbReaper.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.eventsRetentionDays !== undefined) {
+    if (typeof typed.eventsRetentionDays !== 'number' || !Number.isInteger(typed.eventsRetentionDays)) {
+      throw new Error('dbReaper.eventsRetentionDays must be an integer');
+    }
+  }
+  if (typed.syncJournalRetentionDays !== undefined) {
+    if (typeof typed.syncJournalRetentionDays !== 'number' || !Number.isInteger(typed.syncJournalRetentionDays)) {
+      throw new Error('dbReaper.syncJournalRetentionDays must be an integer');
+    }
+  }
+}
+
 function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {
   const adminBypassE2eBabysit = config.adminBypassE2eBabysit;
   if (adminBypassE2eBabysit === undefined) return;
@@ -318,6 +347,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateDbReaperConfig(config);
   validateAdminBypassE2eBabysitConfig(config);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -227,6 +227,12 @@ export interface CatstackDeployConfig {
 /** Default poll cadence when catstackDeploy.intervalMinutes is unset. */
 export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
 
+export interface DbReaperConfig {
+  intervalMinutes?: number;
+  eventsRetentionDays?: number;
+  syncJournalRetentionDays?: number;
+}
+
 /** Default catstack clone URL. */
 export const DEFAULT_CATSTACK_DEPLOY_REPO_URL = 'https://github.com/EdbertChan/catstack.git';
 
@@ -597,6 +603,7 @@ export interface InvokerConfig {
    */
   catstackDeploy?: CatstackDeployConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
+  dbReaper?: DbReaperConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },


### PR DESCRIPTION
## Summary

Step 1 of 3 for a new bounded-retention mechanism for `invoker.db`'s `events` and `sync_journal` tables (see step 2 for the worker itself and the production incident this addresses).

Adds a new optional config field for the upcoming worker's cadence and retention windows, plus its validation.

Unused by any running code until step 2 wires it into a worker.

## Review Claim

The new `dbReaper` config field and its validation function are purely additive and follow the exact same shape as the existing `catstackDeploy` config: an optional object, with optional integer fields and explicit range checks.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Purely additive: a new optional config field and its validator function. No existing config field, validation rule, or behavior changes.

## Slice Rationale

Config validation is its own review unit here, separate from the worker that will consume it (step 2) and its Workers display copy (step 3).

## Non-goals

No worker wiring yet (step 2). No display changes (step 3).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/config.test.ts` (7 new cases: omitted field, valid values, non-positive retention as a disable signal, and each rejection case)
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config typing and validation only; no runtime behavior or existing validation rules change.
> 
> **Overview**
> Introduces optional **`dbReaper`** on `InvokerConfig` for an upcoming worker that will bound retention on `invoker.db` **`events`** and **`sync_journal`** tables. The block supports **`intervalMinutes`** (must be a positive integer when set), **`eventsRetentionDays`**, and **`syncJournalRetentionDays`** (integers when set; **0 or negative** allowed as a disable signal for retention).
> 
> **`validateDbReaperConfig`** is hooked into **`validateInvokerConfig`** (same optional-object pattern as **`catstackDeploy`**). Seven unit tests cover omitted config, valid values, disable semantics, and rejection paths. **Nothing consumes this config at runtime yet** (worker wiring is a follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68eaeb6a0b5e9f15d18430b1afd1658effb74534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->