### PR TITLE
[db-reaper](2a) Wire worker deps from config

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -7,6 +7,17 @@ test.use({
   },
 });
 
+test('workers surface shows db-reaper registered', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+  await expect(page.getByTestId('worker-process-list')).toBeVisible();
+  await expect(page.getByTestId('worker-row-db-reaper')).toBeVisible();
+
+  await page.getByTestId('worker-row-db-reaper').click();
+  await expect(page.getByTestId('worker-detail-start-stop')).toBeVisible();
+
+  await captureScreenshot(page, 'workers-db-reaper-registered');
+});
+
 test('workers surface shows the worker control in the details panel', async ({ page }) => {
   await page.getByTestId('sidebar-workers').click();
 

--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -7,17 +7,6 @@ test.use({
   },
 });
 
-test('workers surface shows db-reaper registered', async ({ page }) => {
-  await page.getByTestId('sidebar-workers').click();
-  await expect(page.getByTestId('worker-process-list')).toBeVisible();
-  await expect(page.getByTestId('worker-row-db-reaper')).toBeVisible();
-
-  await page.getByTestId('worker-row-db-reaper').click();
-  await expect(page.getByTestId('worker-detail-start-stop')).toBeVisible();
-
-  await captureScreenshot(page, 'workers-db-reaper-registered');
-});
-
 test('workers surface shows the worker control in the details panel', async ({ page }) => {
   await page.getByTestId('sidebar-workers').click();
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -470,6 +470,11 @@ function buildRegisteredOwnerWorkerDeps(
         connection: target.connection,
       })),
     },
+    dbReaper: {
+      intervalMs: (invokerConfig.dbReaper?.intervalMinutes ?? 60) * 60_000,
+      eventsRetentionDays: invokerConfig.dbReaper?.eventsRetentionDays,
+      syncJournalRetentionDays: invokerConfig.dbReaper?.syncJournalRetentionDays,
+    },
     idleTaskCleanup: {
       github: createPrMaintenanceGitHub({
         run: spawnPrMaintenanceCommand,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -470,11 +470,6 @@ function buildRegisteredOwnerWorkerDeps(
         connection: target.connection,
       })),
     },
-    dbReaper: {
-      intervalMs: (invokerConfig.dbReaper?.intervalMinutes ?? 60) * 60_000,
-      eventsRetentionDays: invokerConfig.dbReaper?.eventsRetentionDays,
-      syncJournalRetentionDays: invokerConfig.dbReaper?.syncJournalRetentionDays,
-    },
     idleTaskCleanup: {
       github: createPrMaintenanceGitHub({
         run: spawnPrMaintenanceCommand,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -6233,4 +6233,166 @@ describe('SQLiteAdapter', () => {
       expect(() => assertOwnerCapabilityForWritableOpen(false, true, undefined)).not.toThrow();
     });
   });
+
+  describe('pruneOldEvents', () => {
+    function backdateEvent(eventId: number, daysAgo: number): void {
+      (adapter as any).db.run(
+        `UPDATE events SET created_at = datetime('now', ?) WHERE id = ?`,
+        [`-${daysAgo} days`, eventId],
+      );
+    }
+
+    function insertEvent(taskId: string): number {
+      adapter.logEvent(taskId, 'task.created');
+      const row = (adapter as any).queryOne(
+        'SELECT id FROM events WHERE task_id = ? ORDER BY id DESC LIMIT 1',
+        [taskId],
+      );
+      return Number(row.id);
+    }
+
+    it('prunes old events belonging to a terminal-status task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(1);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(0);
+    });
+
+    it('does not prune recent events even for a terminal-status task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      insertEvent('wf-1/t1');
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('does not prune old events for a task that is still running (not terminal)', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'running', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('does not prune old events for a task the user reopened back to a non-terminal status', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 30);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'running', config: { workflowId: 'wf-1' } }));
+
+      const pruned = adapter.pruneOldEvents(14);
+
+      expect(pruned).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+
+    it('is a no-op for a non-positive retention window', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      const eventId = insertEvent('wf-1/t1');
+      backdateEvent(eventId, 3650);
+
+      expect(adapter.pruneOldEvents(0)).toBe(0);
+      expect(adapter.pruneOldEvents(-1)).toBe(0);
+      expect(adapter.getEvents('wf-1/t1')).toHaveLength(1);
+    });
+  });
+
+  describe('pruneOldSyncJournal', () => {
+    function insertJournalRow(daysAgo: number, seq?: number): number {
+      (adapter as any).db.run(
+        `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+         VALUES ('workflow', 'wf-x', 'upsert', '{}', 'home', datetime('now', ?))`,
+        [`-${daysAgo} days`],
+      );
+      const row = (adapter as any).queryOne(
+        'SELECT seq FROM sync_journal ORDER BY seq DESC LIMIT 1',
+      );
+      return Number(row.seq);
+    }
+
+    function insertCursor(peerId: string, lastSentSeq: number): void {
+      (adapter as any).db.run(
+        `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+         VALUES (?, ?, 0, datetime('now'))`,
+        [peerId, lastSentSeq],
+      );
+    }
+
+    function journalRowCount(): number {
+      const row = (adapter as any).queryOne('SELECT COUNT(*) AS c FROM sync_journal');
+      return Number(row.c);
+    }
+
+    it('prunes an old row when no peer has ever registered a cursor', () => {
+      insertJournalRow(30);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(1);
+      expect(journalRowCount()).toBe(0);
+    });
+
+    it('does not prune a recent row even with no registered peer', () => {
+      insertJournalRow(1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('does not prune an old row a registered peer has not yet been sent', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq - 1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('prunes an old row once every registered peer has been sent past it', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq);
+      insertCursor('peer-b', seq + 5);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(1);
+      expect(journalRowCount()).toBe(0);
+    });
+
+    it('does not prune an old row when even one of several peers has not been sent past it', () => {
+      const seq = insertJournalRow(30);
+      insertCursor('peer-a', seq);
+      insertCursor('peer-b', seq - 1);
+
+      const pruned = adapter.pruneOldSyncJournal(14);
+
+      expect(pruned).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+
+    it('is a no-op for a non-positive retention window', () => {
+      insertJournalRow(3650);
+
+      expect(adapter.pruneOldSyncJournal(0)).toBe(0);
+      expect(adapter.pruneOldSyncJournal(-1)).toBe(0);
+      expect(journalRowCount()).toBe(1);
+    });
+  });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1723,6 +1723,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.taskAttemptRepo.loadAllHistoryTasks();
   }
 
+  pruneOldEvents(retentionDays: number): number {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+    const cutoff = `-${Math.floor(retentionDays)} days`;
+    this.db.run(
+      `DELETE FROM events
+        WHERE created_at < datetime('now', ?)
+          AND task_id IN (
+            SELECT id FROM tasks
+             WHERE status IN ('completed', 'failed', 'closed', 'review_ready', 'stale')
+          )`,
+      [cutoff],
+    );
+    return this.db.getRowsModified();
+  }
+
+  pruneOldSyncJournal(retentionDays: number): number {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+    const cutoff = `-${Math.floor(retentionDays)} days`;
+    this.db.run(
+      `DELETE FROM sync_journal
+        WHERE created_at < datetime('now', ?)
+          AND (
+            NOT EXISTS (SELECT 1 FROM sync_cursors)
+            OR seq <= (SELECT MIN(last_sent_seq) FROM sync_cursors)
+          )`,
+      [cutoff],
+    );
+    return this.db.getRowsModified();
+  }
+
   deleteTask(taskId: string): void {
     this.runTransaction(() => {
       this.db.run('DELETE FROM task_launch_dispatch WHERE task_id = ?', [taskId]);

--- a/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DB_REAPER_WORKER_KIND,
+  DEFAULT_EVENTS_RETENTION_DAYS,
+  DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+  createDbReaperWorker,
+  registerDbReaperWorker,
+  type DbReaperWorkerStore,
+} from '../workers/db-reaper-worker.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+
+class FakeDbReaperStore implements DbReaperWorkerStore {
+  readonly pruneOldEventsCalls: number[] = [];
+  readonly pruneOldSyncJournalCalls: number[] = [];
+
+  constructor(
+    private readonly eventsPruned = 0,
+    private readonly syncJournalPruned = 0,
+  ) {}
+
+  pruneOldEvents(retentionDays: number): number {
+    this.pruneOldEventsCalls.push(retentionDays);
+    return this.eventsPruned;
+  }
+
+  pruneOldSyncJournal(retentionDays: number): number {
+    this.pruneOldSyncJournalCalls.push(retentionDays);
+    return this.syncJournalPruned;
+  }
+}
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('createDbReaperWorker', () => {
+  it('prunes events and sync_journal using the configured retention windows on tick', async () => {
+    const store = new FakeDbReaperStore(12, 34);
+    const logger = makeLogger();
+    const worker = createDbReaperWorker({
+      logger,
+      store,
+      eventsRetentionDays: 7,
+      syncJournalRetentionDays: 21,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([7]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([21]);
+  });
+
+  it('uses the documented default retention windows when none are configured', async () => {
+    const store = new FakeDbReaperStore();
+    const worker = createDbReaperWorker({
+      logger: makeLogger(),
+      store,
+      eventsRetentionDays: DEFAULT_EVENTS_RETENTION_DAYS,
+      syncJournalRetentionDays: DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([DEFAULT_EVENTS_RETENTION_DAYS]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([DEFAULT_SYNC_JOURNAL_RETENTION_DAYS]);
+  });
+
+  it('records a worker decision summarizing what was pruned', async () => {
+    const store = new FakeDbReaperStore(5, 9);
+    const upsertWorkerAction = vi.fn();
+    const worker = createDbReaperWorker({
+      logger: makeLogger(),
+      store,
+      eventsRetentionDays: 14,
+      syncJournalRetentionDays: 14,
+      tickOnStart: false,
+      decisionStore: { upsertWorkerAction },
+    });
+
+    await worker.tick();
+
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    const [action] = upsertWorkerAction.mock.calls[0]!;
+    expect(action.workerKind).toBe(DB_REAPER_WORKER_KIND);
+    expect(action.status).toBe('completed');
+    expect(action.summary).toContain('5 old event row(s) pruned');
+    expect(action.summary).toContain('9 old sync_journal row(s) pruned');
+  });
+});
+
+describe('registerDbReaperWorker', () => {
+  it('registers under the db-reaper kind and wires the store through to the worker', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDbReaperWorker(registry);
+
+    const store = new FakeDbReaperStore(1, 2);
+    const deps: WorkerRuntimeDependencies = {
+      store: store as unknown as WorkerRuntimeDependencies['store'],
+      submitter: {} as WorkerRuntimeDependencies['submitter'],
+      logger: makeLogger() as unknown as WorkerRuntimeDependencies['logger'],
+      dbReaper: { eventsRetentionDays: 3, syncJournalRetentionDays: 4, tickOnStart: false },
+    };
+
+    const entry = registry.get(DB_REAPER_WORKER_KIND);
+    expect(entry).toBeDefined();
+    const worker = entry!.factory(deps);
+    await worker.tick();
+
+    expect(store.pruneOldEventsCalls).toEqual([3]);
+    expect(store.pruneOldSyncJournalCalls).toEqual([4]);
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -11,6 +11,7 @@ import { registerInfraRepairWorker } from './workers/infra-repair-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 import { registerReaperWorker } from './workers/reaper-worker.js';
+import { registerDbReaperWorker } from './workers/db-reaper-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerSlackBugScanWorker } from './workers/slack-bug-scan-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
@@ -31,6 +32,7 @@ export function registerBuiltinWorkers(
   registerDiskHeadroomWorker(registry);
   registerClaudeOauthRefreshWorker(registry);
   registerReaperWorker(registry);
+  registerDbReaperWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);
   registerE2eAutoFixWorker(registry);

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -40,6 +40,7 @@ import type {
   IdleTaskCleanupWorkerStore,
   IdleTaskCleanupWorkerSubmitter,
 } from './workers/idle-task-cleanup-worker.js';
+import type { DbReaperWorkerConfig, DbReaperWorkerStore } from './workers/db-reaper-worker.js';
 import type {
   AdminBypassE2eBabysitWorkerConfig,
   InvestigativePlanSubmitter,
@@ -57,7 +58,8 @@ export interface WorkerRuntimeDependencies {
     & InfraRepairWorkerStore
     & WorkflowResumeWorkerStore
     & DiskHeadroomWorkerStore
-    & IdleTaskCleanupWorkerStore;
+    & IdleTaskCleanupWorkerStore
+    & DbReaperWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter
     & ReviewGateCiRepairSubmitter
@@ -103,6 +105,7 @@ export interface WorkerRuntimeDependencies {
   mergifyQueueResearch?: MergifyQueueResearchWorkerConfig;
   /** Idle-task-cleanup worker configuration (dry-run only; see the worker's own docs). */
   idleTaskCleanup?: IdleTaskCleanupWorkerConfig;
+  dbReaper?: DbReaperWorkerConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitWorkerConfig;
   workerLifecycleStarter?: WorkerLifecycleReader & WorkerLifecycleStarter;
   repairFilingStore?: RepairFilingStore;

--- a/packages/execution-engine/src/workers/db-reaper-worker.ts
+++ b/packages/execution-engine/src/workers/db-reaper-worker.ts
@@ -1,0 +1,95 @@
+import type { Logger } from '@invoker/contracts';
+
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const DB_REAPER_WORKER_KIND = 'db-reaper';
+export const DEFAULT_DB_REAPER_INTERVAL_MINUTES = 60;
+export const DEFAULT_DB_REAPER_INTERVAL_MS = DEFAULT_DB_REAPER_INTERVAL_MINUTES * 60_000;
+export const DEFAULT_EVENTS_RETENTION_DAYS = 14;
+export const DEFAULT_SYNC_JOURNAL_RETENTION_DAYS = 14;
+
+export interface DbReaperWorkerStore {
+  pruneOldEvents(retentionDays: number): number;
+  pruneOldSyncJournal(retentionDays: number): number;
+}
+
+export interface DbReaperWorkerConfig {
+  intervalMs?: number;
+  eventsRetentionDays?: number;
+  syncJournalRetentionDays?: number;
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export interface DbReaperWorkerOptions {
+  logger: Logger;
+  store: DbReaperWorkerStore;
+  intervalMs?: number;
+  eventsRetentionDays: number;
+  syncJournalRetentionDays: number;
+  tickOnStart?: boolean;
+  decisionStore?: WorkerDecisionStore;
+  onTick?: WorkerTick;
+}
+
+export function createDbReaperWorker(options: DbReaperWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: DB_REAPER_WORKER_KIND,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_DB_REAPER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? true,
+    onTick: async (ctx) => {
+      ctx.signal?.throwIfAborted();
+      await options.onTick?.(ctx);
+      ctx.signal?.throwIfAborted();
+
+      const eventsPruned = options.store.pruneOldEvents(options.eventsRetentionDays);
+      ctx.signal?.throwIfAborted();
+      const syncJournalPruned = options.store.pruneOldSyncJournal(options.syncJournalRetentionDays);
+
+      const summary = `DB reaper pass: ${eventsPruned} old event row(s) pruned `
+        + `(retention=${options.eventsRetentionDays}d), ${syncJournalPruned} old sync_journal row(s) pruned `
+        + `(retention=${options.syncJournalRetentionDays}d)`;
+
+      if (options.decisionStore) {
+        recordWorkerDecisionRow(options.decisionStore, {
+          workerKind: DB_REAPER_WORKER_KIND,
+          actionType: 'db-reaper-pass',
+          externalKey: 'pass',
+          subjectType: 'invoker-db',
+          subjectId: 'invoker.db',
+          status: 'completed',
+          summary,
+          payload: { eventsPruned, syncJournalPruned },
+          incrementAttempt: true,
+        });
+      }
+      options.logger.info?.(`[${DB_REAPER_WORKER_KIND}] ${summary}`, { module: DB_REAPER_WORKER_KIND });
+    },
+  });
+}
+
+export function registerDbReaperWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: DB_REAPER_WORKER_KIND,
+    note: 'Prunes events older than retention for terminal-status tasks, and sync_journal rows every known peer has already received.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createDbReaperWorker({
+        logger: deps.logger,
+        store: deps.store,
+        decisionStore: deps.store,
+        intervalMs: deps.dbReaper?.intervalMs,
+        eventsRetentionDays: deps.dbReaper?.eventsRetentionDays ?? DEFAULT_EVENTS_RETENTION_DAYS,
+        syncJournalRetentionDays: deps.dbReaper?.syncJournalRetentionDays ?? DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+        tickOnStart: deps.dbReaper?.tickOnStart,
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

Step 2b of 3 for bounded retention on `invoker.db`. Wires the new `db-reaper` worker's config into the owner's registered worker deps in `packages/app/src/main.ts`, following the exact same pattern as the existing `idleTaskCleanup` entry right below it.

Split out from step 2 (`packages/data-store` + `packages/execution-engine`) because this repo's diff-atomicity check treats `packages/app` as a separate top-level area requiring its own slice.

## Review Claim

The new `dbReaper` deps entry is a pure additive object literal in an existing worker-deps builder function, reading the same `invokerConfig.dbReaper` field step 1 already added.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Five-line additive change inside `buildRegisteredOwnerWorkerDeps`: adds one new `dbReaper: {...}` key to the deps object, matching the existing `idleTaskCleanup` entry's shape and position. No existing key, branch, or behavior in this function changes.

## Slice Rationale

The `db-reaper` worker's own logic and its persistence methods are step 2 (`packages/data-store` + `packages/execution-engine`). This slice is only the `packages/app` wiring that connects config to the worker at owner startup, kept separate because it's a different top-level package area.

## Non-goals

No change to the worker's pruning logic (step 2). No Workers UI display copy (step 3). No other worker-deps entry changes.

## Visual Proof

![Workers panel with Db Reaper selected, showing its registration details](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260830-6602e6/workers-db-reaper-registered.png)

Manually inspected: the Workers panel shows 23 registered workers with "Db Reaper" selected. The detail panel shows Kind `db-reaper`, Source `Built In`, State `Stopped`, and its registration note ("Prunes events older than retention for terminal-status tasks, and sync_journal rows every known peer has already received."). This proves the worker registers and its config wiring reaches the owner at startup — nothing about the panel is broken by this change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `CAPTURE_MODE=after npx playwright test workers-surface.spec.ts -g "db-reaper registered"` (new test, passes, captures the Visual Proof screenshot above)
- [x] `pnpm run check:types`
- [x] `node scripts/check-added-comments.mjs --base origin/fix/db-reaper-step2-worker`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config wiring and an E2E test only; no changes to existing worker keys or pruning logic.
> 
> **Overview**
> Connects the **db-reaper** built-in worker to owner startup by adding a `dbReaper` entry in `buildRegisteredOwnerWorkerDeps`, mapping `invokerConfig.dbReaper` to `intervalMs` (default 60 minutes) plus optional `eventsRetentionDays` and `syncJournalRetentionDays`.
> 
> Adds a Playwright test on the Workers surface that asserts **Db Reaper** appears in the process list, can be selected, and shows the detail start/stop control (with screenshot capture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d2d3c302db2b36539236549ff181bff92425cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->