### PR TITLE
[db-reaper](3) Workers display copy

### DIFF
--- a/packages/ui/src/__tests__/worker-display.test.ts
+++ b/packages/ui/src/__tests__/worker-display.test.ts
@@ -17,4 +17,12 @@ describe('getWorkerDisplayCopy', () => {
       noActionText: 'No catstack-deploy runs recorded yet.',
     });
   });
+
+  it('returns dedicated display copy for the db-reaper worker', () => {
+    expect(getWorkerDisplayCopy('db-reaper')).toEqual({
+      name: 'DB reaper',
+      idleText: 'Idle. Prunes old events for terminal-status tasks and fully-sent sync_journal rows on an interval.',
+      noActionText: 'No db-reaper runs recorded yet.',
+    });
+  });
 });

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -134,6 +134,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No catstack-deploy runs recorded yet.',
     };
   }
+  if (kind === 'db-reaper') {
+    return {
+      name: 'DB reaper',
+      idleText: 'Idle. Prunes old events for terminal-status tasks and fully-sent sync_journal rows on an interval.',
+      noActionText: 'No db-reaper runs recorded yet.',
+    };
+  }
   if (kind === 'admin-bypass-e2e-babysit') {
     return {
       name: 'Admin-bypass/e2e babysit',


### PR DESCRIPTION
## Summary

Step 3 of 3 for the `db-reaper` worker: adds its Workers panel display copy in `packages/ui/src/lib/worker-display.ts`, following the exact same pattern as the existing `catstack-deploy` entry right above it.

Replaces the generic kebab-to-title-case fallback name ("Db Reaper") with dedicated copy ("DB reaper") plus an idle-state description and a no-runs-yet message.

## Review Claim

The new `db-reaper` branch in `getWorkerDisplayCopy` returns a fixed name/idleText/noActionText object, matching the shape and style of every other entry in this function.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely additive: one new `if (kind === 'db-reaper')` branch returning a fixed display object. No existing branch, ordering, or fallback logic in `getWorkerDisplayCopy` changes.

## Slice Rationale

Display copy is its own review unit here, separate from the worker's actual logic (step 2) and the config/app wiring that activates it (step 1, step 2a).

## Non-goals

No change to the worker's pruning logic. No change to any other worker's display copy. No change to the fallback path used by workers without dedicated copy.

## Visual Proof

![Workers panel showing the dedicated "DB reaper" display name, idle description, and registration details](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260830-fadefa/workers-db-reaper-registered.png)

Manually inspected: the detail panel title now reads "DB reaper" (previously showed as the generic fallback "Db Reaper" before this slice) with Kind `db-reaper`, Source `Built In`, State `Stopped`. The dedicated copy is live and rendering correctly with no layout regression to the surrounding panel.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/worker-display.test.ts` (3 tests)
- [x] `pnpm --filter @invoker/ui build`
- [x] `CAPTURE_MODE=after npx playwright test workers-surface.spec.ts -g "db-reaper registered"` (re-run against the new copy, captures the Visual Proof screenshot above)
- [x] `pnpm run check:types`
- [x] `node scripts/check-added-comments.mjs --base origin/fix/db-reaper-step2b-app-wiring`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only string mapping with no changes to worker behavior, routing, or other workers' copy.
> 
> **Overview**
> Adds dedicated Workers panel copy for the **`db-reaper`** kind so it no longer falls through to the generic **`formatWorkerValue`** name ("Db Reaper") and default idle/no-action strings.
> 
> **`getWorkerDisplayCopy`** now returns **"DB reaper"** with idle text describing interval pruning of terminal-task events and fully-sent **`sync_journal`** rows, plus a **"No db-reaper runs recorded yet."** empty-state message—same pattern as **`catstack-deploy`**. A unit test locks the returned object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c916ba869d19c8c380ac36f341e7f7640bbf12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “DB reaper” worker description, including its idle status and no-action messaging.
  * Displays that the worker periodically prunes eligible task events and synchronization records.

* **Tests**
  * Added coverage to verify the DB reaper display text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->