### PR TITLE
Apply approved fix for Review gate for CI regression: 195e2a4-fleet-195e2a4

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -23,6 +23,7 @@ import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { CLAUDE_OAUTH_REFRESH_WORKER_KIND } from '../workers/claude-oauth-refresh-worker.js';
 import { INFRA_REPAIR_WORKER_KIND } from '../workers/infra-repair-worker.js';
 import { REAPER_WORKER_KIND } from '../workers/reaper-worker.js';
+import { DB_REAPER_WORKER_KIND } from '../workers/db-reaper-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
@@ -87,6 +88,7 @@ describe('worker registry', () => {
       DISK_HEADROOM_WORKER_KIND,
       CLAUDE_OAUTH_REFRESH_WORKER_KIND,
       REAPER_WORKER_KIND,
+      DB_REAPER_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -647,10 +647,10 @@ describe('WorktreeExecutor', () => {
       executor.onComplete(handle, (res) => resolve(res));
     });
 
-    // When kill sends SIGTERM, simulate process exit
-    const origKill = process.kill;
-    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
-      // Simulate the process closing after receiving the signal
+    // When kill sends SIGTERM, simulate process exit. The mocked pid does
+    // not lead a real process group, so killProcessGroup falls back to
+    // child.kill() rather than process.kill(-pid) — mock that fallback.
+    vi.mocked(taskProcess.kill).mockImplementation((_signal?) => {
       setTimeout(() => taskProcess.emit('close', null, 'SIGTERM'), 0);
       return true;
     });
@@ -665,8 +665,6 @@ describe('WorktreeExecutor', () => {
         (call[1] as string[])?.includes('remove'),
     );
     expect(removeCalls.length).toBe(0);
-
-    vi.mocked(process.kill).mockRestore();
   });
 
   it('kill returns when process close already fired during finalization', async () => {
@@ -715,16 +713,15 @@ describe('WorktreeExecutor', () => {
 
     expect(taskProcesses).toHaveLength(2);
 
-    // Simulate processes closing when SIGTERM is sent
-    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
-      for (const tp of taskProcesses) {
-        if (!(tp as any)._closed) {
-          (tp as any)._closed = true;
-          setTimeout(() => tp.emit('close', null, 'SIGTERM'), 0);
-        }
-      }
-      return true;
-    });
+    // Simulate processes closing when SIGTERM is sent. The mocked pids do
+    // not lead real process groups, so killProcessGroup falls back to
+    // child.kill() rather than process.kill(-pid) — mock that fallback.
+    for (const tp of taskProcesses) {
+      vi.mocked(tp.kill).mockImplementation((_signal?) => {
+        setTimeout(() => tp.emit('close', null, 'SIGTERM'), 0);
+        return true;
+      });
+    }
 
     await executor.destroyAll();
 
@@ -736,8 +733,6 @@ describe('WorktreeExecutor', () => {
         (call[1] as string[])?.includes('remove'),
     );
     expect(removeCalls.length).toBe(0);
-
-    vi.mocked(process.kill).mockRestore();
   });
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes with no production code in this diff.
> 
> **Overview**
> Updates **execution-engine** tests so they match current built-in worker registration and how task processes are terminated in tests.
> 
> The worker registry test now expects **`DB_REAPER_WORKER_KIND`** in the list returned by `registerBuiltinWorkers`, immediately after the existing reaper worker.
> 
> **Worktree executor** kill/`destroyAll` tests no longer simulate shutdown by spying on **`process.kill`**. They mock each mock child’s **`kill`** instead, matching production behavior where **`killProcessGroup`** uses **`child.kill()`** when the child’s PID is not a real process group leader (as with test doubles). Comments document that rationale; redundant **`process.kill`** restore calls are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b3f3c30921d694d16432a916a265307880c80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated worker registry coverage to include the database reaper worker.
  * Improved process termination test coverage by validating child-process shutdown behavior in fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->