### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](1) Fix worker-registry and worktree-executor test drift

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -23,6 +23,7 @@ import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { CLAUDE_OAUTH_REFRESH_WORKER_KIND } from '../workers/claude-oauth-refresh-worker.js';
 import { INFRA_REPAIR_WORKER_KIND } from '../workers/infra-repair-worker.js';
 import { REAPER_WORKER_KIND } from '../workers/reaper-worker.js';
+import { DB_REAPER_WORKER_KIND } from '../workers/db-reaper-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
@@ -87,6 +88,7 @@ describe('worker registry', () => {
       DISK_HEADROOM_WORKER_KIND,
       CLAUDE_OAUTH_REFRESH_WORKER_KIND,
       REAPER_WORKER_KIND,
+      DB_REAPER_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -647,10 +647,10 @@ describe('WorktreeExecutor', () => {
       executor.onComplete(handle, (res) => resolve(res));
     });
 
-    // When kill sends SIGTERM, simulate process exit
-    const origKill = process.kill;
-    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
-      // Simulate the process closing after receiving the signal
+    // When kill sends SIGTERM, simulate process exit. The mocked pid does
+    // not lead a real process group, so killProcessGroup falls back to
+    // child.kill() rather than process.kill(-pid) — mock that fallback.
+    vi.mocked(taskProcess.kill).mockImplementation((_signal?) => {
       setTimeout(() => taskProcess.emit('close', null, 'SIGTERM'), 0);
       return true;
     });
@@ -665,8 +665,6 @@ describe('WorktreeExecutor', () => {
         (call[1] as string[])?.includes('remove'),
     );
     expect(removeCalls.length).toBe(0);
-
-    vi.mocked(process.kill).mockRestore();
   });
 
   it('kill returns when process close already fired during finalization', async () => {
@@ -715,16 +713,15 @@ describe('WorktreeExecutor', () => {
 
     expect(taskProcesses).toHaveLength(2);
 
-    // Simulate processes closing when SIGTERM is sent
-    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
-      for (const tp of taskProcesses) {
-        if (!(tp as any)._closed) {
-          (tp as any)._closed = true;
-          setTimeout(() => tp.emit('close', null, 'SIGTERM'), 0);
-        }
-      }
-      return true;
-    });
+    // Simulate processes closing when SIGTERM is sent. The mocked pids do
+    // not lead real process groups, so killProcessGroup falls back to
+    // child.kill() rather than process.kill(-pid) — mock that fallback.
+    for (const tp of taskProcesses) {
+      vi.mocked(tp.kill).mockImplementation((_signal?) => {
+        setTimeout(() => tp.emit('close', null, 'SIGTERM'), 0);
+        return true;
+      });
+    }
 
     await executor.destroyAll();
 
@@ -736,8 +733,6 @@ describe('WorktreeExecutor', () => {
         (call[1] as string[])?.includes('remove'),
     );
     expect(removeCalls.length).toBe(0);
-
-    vi.mocked(process.kill).mockRestore();
   });
 
 


### PR DESCRIPTION
## Summary

Two tests in `packages/execution-engine` were drifting out of sync with the code they cover, blocking the merge gate.

`worker-registry.test.ts` never learned about the `db-reaper` worker that landed separately on master. Its expected worker kinds array was missing `DB_REAPER_WORKER_KIND`.

`worktree-executor.test.ts` mocked the global `process.kill` to simulate SIGTERM delivery. Production `killProcessGroup` falls back to the per-child `child.kill()` call for a mocked pid, so the global mock never fired.

This slice only updates the two test files so they match current production behavior. No product code changes.

## Review Claim

Approve updating `worker-registry.test.ts` to include `DB_REAPER_WORKER_KIND` and updating `worktree-executor.test.ts` to mock the per-instance `child.kill()` fallback instead of the global `process.kill`, so both tests pass against current master.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

Only test files change; no production module is touched. The two updated assertions cover the same behavior as before (worker kind registration, and SIGTERM-triggered process cleanup) — only the mocking mechanism used to observe that behavior changed. Other suites and product behavior are unaffected.

## Slice Rationale

This is one cleanup slice: bringing two drifted tests back in line with code already on master, kept separate from any behavior or feature work.

## Non-goals

- No product code changes.
- No new test coverage beyond restoring these two tests to a passing state.
- No changes to other worker-registry or worktree-executor test cases.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- worker-registry` — 6/6 passed
- [x] `pnpm --filter @invoker/execution-engine test -- worktree-executor -t "kill terminates process without removing worktree|destroyAll kills processes without removing worktrees"` — 2/2 passed

Note: `worktree-executor.test.ts` has one unrelated pre-existing failure (`times out hung provision commands and terminates their process group`, expects `process.kill` called with `-12345`) confirmed present on `origin/master` before this change and untouched by this diff.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9bd03a7c5`
- Post-revert steps: None
- Data migration? No

</details>
