### PR TITLE
Bound the infra-repair worker's per-task pool-member lookup

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2980,6 +2980,41 @@ describe('SQLiteAdapter', () => {
       expect(second[0]!.eventType).toBe(`event-${29 - 10}`);
     });
 
+    it('getRecentEventsOfType returns only the matching type, newest first, bounded by limit', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.logEvent('t1', 'task.executor.selected', { poolMemberId: 'target-1' });
+      adapter.logEvent('t1', 'debug.noise', {});
+      adapter.logEvent('t1', 'task.executor.selected', { poolMemberId: 'target-2' });
+      adapter.logEvent('t1', 'debug.noise', {});
+      adapter.logEvent('t1', 'task.executor.selected', { poolMemberId: 'target-3' });
+
+      const latestTwo = adapter.getRecentEventsOfType('t1', 'task.executor.selected', 2);
+      expect(latestTwo.map((event) => JSON.parse(event.payload!).poolMemberId)).toEqual([
+        'target-3',
+        'target-2',
+      ]);
+
+      expect(adapter.getRecentEventsOfType('t1', 'task.executor.selected', 0)).toEqual([]);
+      expect(adapter.getRecentEventsOfType('t1', 'no-such-type', 5)).toEqual([]);
+    });
+
+    it('uses an index lookup for getRecentEventsOfType instead of a full task-history scan', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const planRows = (adapter as any).db
+        .prepare('EXPLAIN QUERY PLAN SELECT * FROM events WHERE task_id = ? AND event_type = ? ORDER BY id DESC LIMIT ?')
+        .all('t1', 'task.executor.selected', 20) as Array<{ detail: string }>;
+      const detail = planRows.map((row) => row.detail).join('\n');
+
+      // Either the (task_id, id) or (event_type, id) index keeps this bounded;
+      // the invariant under test is "indexed SEARCH", not a specific index name.
+      expect(detail).toContain('SEARCH events USING INDEX');
+      expect(detail).not.toContain('SCAN events');
+      expect(detail).not.toContain('USE TEMP B-TREE');
+    });
+
     it('lists recent task events across tasks by event type', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1'));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -436,6 +436,8 @@ export interface PersistenceAdapter {
   /** Unbounded history — internal/tests only. Public IPC must use the limited overload. */
   getEvents(taskId: string): TaskEvent[];
   getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
+  /** Bounded, newest-first lookup — prefer this over a full getEvents(taskId) scan when only recent events of one type are needed. */
+  getRecentEventsOfType?(taskId: string, eventType: string, limit: number): TaskEvent[];
   getEventsByTypes?(eventTypes: readonly string[], sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
   countEventsByTypes?(eventTypes: readonly string[]): Array<{
     eventType: string;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1954,6 +1954,22 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row: any) => this.rowToTaskEvent(row));
   }
 
+  /**
+   * Bounded, newest-first lookup for a single task_id + event_type pair.
+   * Prefer this over a full getEvents(taskId) scan when a caller only needs
+   * the most recent occurrences of one event type (e.g. walking back through
+   * `task.executor.selected` attempts) — it stays cheap even when the task
+   * has accumulated a large unrelated event history (debug/progress logs).
+   */
+  getRecentEventsOfType(taskId: string, eventType: string, limit: number): TaskEvent[] {
+    if (limit <= 0) return [];
+    const rows = this.queryAll(
+      'SELECT * FROM events WHERE task_id = ? AND event_type = ? ORDER BY id DESC LIMIT ?',
+      [taskId, eventType, Math.floor(limit)],
+    );
+    return rows.map((row: any) => this.rowToTaskEvent(row));
+  }
+
   getEventsByTypes(
     eventTypes: readonly string[],
     sortBy: 'asc' | 'desc' = 'desc',

--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -784,7 +784,7 @@ describe('conflict-resolver fail-fast workspace invariant', () => {
       const host: ConflictResolverHost = {
         ...makeHost(task),
         persistence: {
-          getEvents: () => [
+          getRecentEventsOfType: () => [
             {
               id: 1,
               taskId: task.id,

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -103,7 +103,7 @@ function makeHarness(
     loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
     loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
     updateTask,
-    getEvents: vi.fn(() => []),
+    getRecentEventsOfType: vi.fn(() => []),
     getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
     upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
       const existing = actions.get(`${write.workerKind}:${write.externalKey}`);

--- a/packages/execution-engine/src/__tests__/oauth-session-expired-infra-repair.e2e.test.ts
+++ b/packages/execution-engine/src/__tests__/oauth-session-expired-infra-repair.e2e.test.ts
@@ -117,6 +117,13 @@ class MemoryPersistence {
     return this.events.get(taskId) ?? [];
   }
 
+  getRecentEventsOfType(taskId: string, eventType: string, limit: number): TaskEventRecord[] {
+    return (this.events.get(taskId) ?? [])
+      .filter((event) => event.eventType === eventType)
+      .slice(-limit)
+      .reverse();
+  }
+
   saveAttempt(attempt: { nodeId: string }): void {
     const list = this.attempts.get(attempt.nodeId) ?? [];
     list.push(attempt);
@@ -246,7 +253,8 @@ describe('oauth-session-expired infra repair with a dummy repo', () => {
       store: {
         listWorkflows: () => persistence.listWorkflows(),
         loadTasks: (workflowId: string) => persistence.loadTasks(workflowId),
-        getEvents: (taskId: string) => persistence.getEvents(taskId) as never,
+        getRecentEventsOfType: (taskId: string, eventType: string, limit: number) =>
+          persistence.getRecentEventsOfType(taskId, eventType, limit) as never,
         getWorkerAction: (workerKind: string, externalKey: string) =>
           actions.get(`${workerKind}:${externalKey}`),
         upsertWorkerAction: (write: WorkerActionWrite) => {

--- a/packages/execution-engine/src/__tests__/resolve-selected-remote-target-id-cost.test.ts
+++ b/packages/execution-engine/src/__tests__/resolve-selected-remote-target-id-cost.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { Workflow } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import { resolveSelectedRemoteTargetId } from '../conflict-resolver.js';
+import type { ConflictResolverHost } from '../conflict-resolver.js';
+
+/**
+ * Repro for the infra-repair worker's per-tick, per-failed-SSH-task scan:
+ * resolveSelectedRemoteTargetId used to fall back to an unbounded
+ * getEvents(taskId) full-history scan (no LIMIT) to find the task's last
+ * `task.executor.selected` event. On a task with a large accumulated event
+ * history (debug/progress logs), that scan alone showed up 1,057 times in a
+ * 15-minute DO1 production window, blocking node:sqlite's single-threaded
+ * event loop. It must now stay bounded regardless of history size.
+ */
+describe('resolveSelectedRemoteTargetId bounded event lookup', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('resolves the latest poolMemberId quickly even with a large unrelated event history', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-resolve-remote-target-cost-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const workflow: Workflow = {
+      id: 'wf-1',
+      name: 'Test Workflow',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    adapter.saveWorkflow(workflow);
+    const task: TaskState = {
+      id: 'wf-1/t1',
+      description: 'ssh task',
+      status: 'failed',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { runnerKind: 'ssh' },
+      execution: {},
+      taskStateVersion: 1,
+    };
+    adapter.saveTask('wf-1', task);
+
+    adapter.logEvent('wf-1/t1', 'task.executor.selected', { poolMemberId: 'stale-target' });
+    for (let index = 0; index < 20_000; index += 1) {
+      adapter.logEvent('wf-1/t1', 'debug.progress', { index });
+    }
+    adapter.logEvent('wf-1/t1', 'task.executor.selected', { poolMemberId: 'current-target' });
+
+    const host = { persistence: adapter } as unknown as ConflictResolverHost;
+    const runnableTask = { ...task, execution: {} } as unknown as ReturnType<Orchestrator['getTask']> & {};
+
+    const startedMs = performance.now();
+    const resolved = resolveSelectedRemoteTargetId(host, 'wf-1/t1', runnableTask);
+    const elapsedMs = performance.now() - startedMs;
+
+    expect(resolved).toBe('current-target');
+    expect(elapsedMs).toBeLessThan(25);
+  });
+});

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -324,14 +324,20 @@ export function buildRemoteAgentCommand(
   return { shellCommand: cmd, sessionId };
 }
 
+/** How many recent `task.executor.selected` events to check for a usable poolMemberId before giving up. */
+const RECENT_EXECUTOR_SELECTED_EVENTS_TO_CHECK = 20;
+
 export function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId: string, task: ReturnType<Orchestrator['getTask']> & {}): string | undefined {
   const direct = (task.config as { poolMemberId?: string }).poolMemberId;
   if (direct) return direct;
 
-  const events = host.persistence.getEvents?.(taskId) ?? [];
-  for (let i = events.length - 1; i >= 0; i--) {
-    const event = events[i];
-    if (event?.eventType !== 'task.executor.selected' || !event.payload) continue;
+  const events = host.persistence.getRecentEventsOfType?.(
+    taskId,
+    'task.executor.selected',
+    RECENT_EXECUTOR_SELECTED_EVENTS_TO_CHECK,
+  ) ?? [];
+  for (const event of events) {
+    if (!event.payload) continue;
     try {
       const payload = JSON.parse(event.payload) as { poolMemberId?: unknown };
       if (typeof payload.poolMemberId === 'string' && payload.poolMemberId.trim()) {

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -98,7 +98,8 @@ export interface InfraRepairWorkerStore {
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   updateTask?(taskId: string, changes: TaskStateChanges): void;
-  getEvents?(taskId: string): TaskEvent[];
+  /** Bounded, newest-first lookup — see SQLiteAdapter.getRecentEventsOfType. */
+  getRecentEventsOfType?(taskId: string, eventType: string, limit: number): TaskEvent[];
   getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -370,11 +371,11 @@ export function classifyGenericSshInfraFailure(errorText: unknown): InfraRepairR
 }
 
 function resolveRemoteTargetId(
-  store: Pick<InfraRepairWorkerStore, 'getEvents'>,
+  store: Pick<InfraRepairWorkerStore, 'getRecentEventsOfType'>,
   task: TaskState,
 ): string | undefined {
   return resolveSelectedRemoteTargetId(
-    { persistence: { getEvents: store.getEvents?.bind(store) } } as unknown as ConflictResolverHost,
+    { persistence: { getRecentEventsOfType: store.getRecentEventsOfType?.bind(store) } } as unknown as ConflictResolverHost,
     task.id,
     task,
   );


### PR DESCRIPTION
## Summary

The infra-repair worker's per-tick pass over failed SSH tasks looks up each
task's last-selected pool member by reading its complete event history, with
no row cap.

node:sqlite blocks the whole process while a query runs, so a full-history
read on a task with thousands of rows stalls everything else waiting on it.

On DO1 this single query shape fired over a thousand times in a
fifteen-minute window, one call alone returning over 8,000 rows.

The lookup now reads only the most recent handful of
`task.executor.selected` events for that task, through an indexed query
instead of a full table read.

## Review Claim

The bounded lookup returns the same pool-member id as the old unbounded read
for this path (same event, same payload), while touching at most a fixed
number of rows regardless of how large a task's event history has grown.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`resolveSelectedRemoteTargetId` keeps its existing fallback behavior — if the
newest `task.executor.selected` event lacks a usable pool-member id, it walks
backward through recent events of that same kind until it finds one, exactly
as before. The only change is that "recent" is now a bounded window (the last
20) read through an index instead of the task's complete, unbounded history.

## Slice Rationale

Scoped to the one call site that reached the process-wide unbounded query in
production (the infra-repair worker's pool-member lookup, via
conflict-resolver's shared helper, also used by the SSH publish-fix path in
task-runner.ts). It adds one narrow persistence method for that access
pattern and updates that call site and its test doubles. It does not touch
the paginated event-history readers used elsewhere, which were already
confirmed bounded before this change.

## Non-goals

List what this slice explicitly does not change.

- Does not change the infra-repair worker's per-tick full task scan/candidate
  list itself (a separate, already-flagged "poll every failed SSH task every
  60s forever" behavior) — this only removes the worst per-candidate query
  cost inside that scan.
- Does not add caching or backoff across ticks.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test` — 314/314 passed, including two
      new cases: "getRecentEventsOfType returns only the matching type,
      newest first, bounded by limit" and "uses an index lookup for
      getRecentEventsOfType instead of a full task-history scan" (asserts
      `EXPLAIN QUERY PLAN` shows an indexed SEARCH, never a SCAN or USE TEMP
      B-TREE)
- [x] `cd packages/execution-engine && pnpm test` — 1,777 passed / 1 skipped
      / 3 failed; all 3 failures reproduce identically on unmodified
      `origin/master` via `git stash` + targeted `vitest run -t`
      (`task-runner-fix-publish-and-ssh.test.ts` x2,
      `worktree-executor.test.ts` x1 — pre-existing, unrelated flakes)
- [x] New `resolve-selected-remote-target-id-cost.test.ts`: seeds a real
      SQLiteAdapter-backed task with 20,001 events (one stale
      `task.executor.selected`, 20,000 unrelated noise events, one current
      `task.executor.selected`) and asserts the lookup still returns the
      current pool member in under 25ms
- [x] `cd packages/data-store && pnpm build` — tsup + DTS typecheck clean
- [x] `cd packages/execution-engine && pnpm build` — tsup + DTS typecheck
      clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — the new method is additive/optional on the
  persistence interface, so reverting drops cleanly back to the prior
  unbounded call.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote pool members are resolved for failed SSH infra repair; behavior is intended to match within a fixed recent window, but mis-tuning the limit could miss older valid selections on unusual histories.
> 
> **Overview**
> Fixes a production SQLite hotspot where **infra-repair** (and shared **`resolveSelectedRemoteTargetId`**) loaded a task’s **entire** event history to find the latest `task.executor.selected` pool member—expensive on noisy tasks and blocking the single-threaded DB.
> 
> Adds optional **`getRecentEventsOfType`** on the persistence layer (SQLite: `task_id` + `event_type`, newest-first, `LIMIT`) and switches the resolver to walk at most the **last 20** matching events instead of an unbounded scan. **`InfraRepairWorkerStore`** and test doubles follow the same API.
> 
> Tests cover correctness, **`EXPLAIN QUERY PLAN`** index use, and a ~20k-event cost case (&lt;25ms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb5f9023213883362cc61cd60186b1f5772ba1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->