### PR TITLE
[CI regression: 37249e1-required-fast-mergify-admin-requeue-repro-babysit-pr-body](1) Mock async-repair submit command in stale-base repro

### DIFF
--- a/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
+++ b/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
@@ -18,7 +18,7 @@ fail() {
 
 export HOME="$TMP/home"
 WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
-mkdir -p "$WORK_PARENT" "$TMP/state"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
 export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
@@ -117,6 +117,20 @@ state = {
 Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
 PY
 : > "$LEDGER_PATH"
+
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC, which this hermetic repro never provides. Mock
+# it (same pattern as repro-babysit-pr-body-human-split.sh) -- this repro only
+# pins the routing decision (repair_check vs. rebase) and the resulting
+# ledger row, not what a real repair attempt does with the checked-out PR.
+cat > "$TMP/bin/submit-async.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="${1:?plan path required}"
+test -f "$plan_path"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
 
 run_worker() {
   python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 7727 2>&1


### PR DESCRIPTION
<!-- invoker-ci-regression-watch: first-bad-sha=37249e16eee56fa153e1562a932fdd34d87b4309; job=required-fast / Mergify Admin Requeue; test=repro-babysit-pr-body-human-split-bkjb8r -->

## Summary

CI job `required-fast / Mergify Admin Requeue` went red at 37249e16 in run 33203077649. The failing probe was `repro-babysit-stale-base-skips-agent-repair.sh` in the suite's auto-run repro set.

The repro is hermetic, but `submit_async_repair_plan`'s default path shells out to a live Invoker owner over IPC, which the repro never provides. The repair leg died there.

This slice mocks the async-repair submission step through `INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD`, matching the sibling babysit repro's existing approach.

The repro still pins what it exists to pin: the `repair_check`-versus-`rebase` decision and the resulting ledger row, not what a real repair attempt does.

## Review Claim

The stale-base repro stubs its async-repair submission step so the hermetic run no longer depends on a live Invoker owner over IPC, restoring `required-fast / Mergify Admin Requeue` to green.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only `scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh` changes. No product code, no other CI job, and no other repro script is touched, so other CI jobs and product behavior stay unchanged.

## Slice Rationale

One proof slice for the repaired CI job: the failing repro's root cause and its deterministic local proof, with no product or policy files mixed in.

## Non-goals

- No product code changes.
- No test weakening: the repro still asserts the `repair_check` routing decision and the resulting ledger row.
- No changes to other repro scripts, the suite runner, or snapshots.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh` — exit 0
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` — exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 44068f99b`
- Post-revert steps: None; the repro returns to failing whenever no live Invoker owner IPC endpoint is available.
- Data migration? No

</details>
