### PR TITLE
[PR-maintenance lock probe](1) False positive under owner load

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -27,9 +27,11 @@ import {
   createPrAutoLabelWorker,
   createPrDuplicateCloseWorker,
   createPrOrphanRepairWorker,
+  probePrMaintenanceLock,
   registerPrMaintenanceWorkers,
   type PrMaintenanceLockProbeOptions,
 } from '../workers/pr-maintenance-workers.js';
+import { chmodSync } from 'node:fs';
 
 type SpawnCall = {
   command: string;
@@ -130,6 +132,37 @@ describe('PR maintenance workers', () => {
     tmpRoot = mkdtempSync(join(tmpdir(), 'invoker-pr-maintenance-test-'));
     return tmpRoot;
   }
+
+  it(
+    'probePrMaintenanceLock treats a spawnSync timeout as not-held, not as a genuine lock holder',
+    async () => {
+      // Real repro, no mocking: `flock -n` is non-blocking and always returns
+      // immediately regardless of the lock's state, so the only way the probe's
+      // spawnSync call can hit its own timeout is if the child process itself
+      // never got scheduled (e.g. the owner is under heavy CPU load) -- which
+      // says nothing about whether the lock is actually held. This installs a
+      // real, slow `flock` shim ahead of the real one on PATH so the probe's
+      // spawnSync call genuinely times out, then asserts it does not falsely
+      // report the lock as held.
+      const repoRoot = makeRepoRoot();
+      const lockPath = join(repoRoot, 'pr-crons.lock');
+      const fakeBinDir = join(repoRoot, 'fake-bin');
+      const { mkdirSync, writeFileSync: writeFile } = await import('node:fs');
+      mkdirSync(fakeBinDir, { recursive: true });
+      const fakeFlockPath = join(fakeBinDir, 'flock');
+      writeFile(fakeFlockPath, '#!/bin/bash\nsleep 5\n');
+      chmodSync(fakeFlockPath, 0o755);
+
+      const result = probePrMaintenanceLock({
+        lockPath,
+        env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ''}` },
+      });
+
+      expect(result.held).toBe(false);
+      expect(result.reason).toBe('probe-timeout');
+    },
+    8_000,
+  );
 
   it('spawns the admin-bypass shell entrypoint with the configured cwd and env', async () => {
     const repoRoot = makeRepoRoot();

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -270,6 +270,9 @@ export function probePrMaintenanceLock(options: PrMaintenanceLockProbeOptions): 
     timeout: 3_000,
     killSignal: 'SIGKILL',
   });
+  if (flockProbe.signal === 'SIGKILL' || (flockProbe.error && (flockProbe.error as NodeJS.ErrnoException).code === 'ETIMEDOUT')) {
+    return { held: false, reason: 'probe-timeout' };
+  }
   if (!flockProbe.error || (flockProbe.error as NodeJS.ErrnoException).code !== 'ENOENT') {
     return flockProbe.status === 0
       ? { held: false }


### PR DESCRIPTION
## Summary

`pr-admin-bypass-land` shares one lock file with three sibling PR-maintenance workers so only one runs at a time.

Before running, each worker asks a quick probe: is the lock free right now? That probe used a 3-second timeout.

Under heavy load, the probe process itself sometimes couldn't start in time. The code then wrongly reported "lock held," even though nothing held it.

Tonight this made `pr-admin-bypass-land` pass on every single tick for 50+ minutes straight, while admin-bypass PRs sat untouched.

The fix: only treat a real `flock` refusal as "held." Treat the probe's own timeout as "unknown, assume free" instead.

The worker's actual script still does its own real lock check before running, so this stays safe either way.

## Review Claim

`probePrMaintenanceLock` no longer reports the shared PR-maintenance lock as held when its own timeout kills the probe process; it only reports held on a genuine `flock` refusal.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A probe timeout can only make the worker try to run when it otherwise wouldn't have. If the lock is genuinely held, the worker's own script (`scripts/cron-pr-lib.sh`'s `cron_lock`) still does a real, blocking-free `flock -n 9` before doing any work and exits cleanly if contended — that check is untouched by this PR. So this change can never cause two PR-maintenance operations to run concurrently; the worst case it removes is a worker passing on a tick it didn't need to pass on.

## Slice Rationale

One isolated behavior fix, one file's logic plus its regression test. No other PR-maintenance behavior touched.

## Non-goals

Does not change the real `flock` lock in `scripts/cron-pr-lib.sh`. Does not change any worker's scheduling interval or attempt-count handling. Does not address why the owner was under CPU load in the first place.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- pr-maintenance-workers` — new repro test fails on pre-fix code (`expected true to be false`, confirmed by stashing the source fix and re-running), passes after the fix; full file: 18/18 pass
- [x] `pnpm --filter @invoker/execution-engine build` — builds clean, no type errors

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e8833f2007`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance lock detection when the lock probe times out.
  * Prevented timed-out probes from being incorrectly reported as an active lock holder.
  * Timeout cases now clearly indicate that the lock status could not be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->