### PR TITLE
[admin-bypass-repair-bot-thread-pr-11168-72fcdf3](1) Parse nested JSON from wrapped publisher output

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -380,6 +380,65 @@ describe('make-pr stack publish body contract', () => {
     // The caller validates this empty body and falls through to the next agent.
     expect(validateReviewStackPrBody(parsed[0]?.body ?? '').length).toBeGreaterThan(0);
   });
+
+  it('parses JSON wrapped in a ```json fenced code block despite the no-fences instruction', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```json\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('parses JSON wrapped in a bare ``` fenced code block', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = '```\n' + payload + '\n```';
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts a JSON object surrounded by commentary the agent added despite instructions', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = `Here is the published review stack:\n${payload}\nLet me know if you need anything else.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts balanced JSON when surrounding commentary and quoted strings contain braces', () => {
+    const title = 'Keep } inside an escaped "quote" and { inside the string';
+    const payload = JSON.stringify({
+      artifacts: [{ id: 'a', url: 'https://x/1', title }],
+    });
+    const raw = `Preparing {draft} output.\n${payload}\nFinished with } commentary.`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.title).toBe(title);
+  });
+
+  it('does not let a valid-JSON decoy in leading commentary shadow the real artifacts payload', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    // "{}" is itself valid, parseable JSON -- a naive first-match scanner
+    // would stop here and never reach the real payload below it.
+    const raw = `Status: {}\nHere is the published review stack:\n${payload}`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('extracts nested artifact JSON from an invalid enclosing brace span', () => {
+    const payload = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const raw = `Note: {payload follows: ${payload}}`;
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe('a');
+  });
+
+  it('still throws "must output JSON" for genuinely non-JSON output', () => {
+    expect(() => parseMakePrStackPublishResult('I could not publish the PR stack.')).toThrow(
+      'make-pr stack publisher must output JSON',
+    );
+  });
 });
 
 // ── resolveSkillPathViaAgent ─────────────────────────────

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -406,12 +406,59 @@ function normalizeReviewArtifactProviderId(url: string, providerId: string | und
   return providerId;
 }
 
+function extractJsonPayload(raw: string): string {
+  const trimmed = raw.trim();
+  let lastValid: string | undefined;
+  for (let start = 0; start < trimmed.length; start += 1) {
+    if (trimmed[start] !== '{') continue;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let end = start; end < trimmed.length; end += 1) {
+      const character = trimmed[end];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === '{') {
+        depth += 1;
+      } else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = trimmed.slice(start, end + 1);
+          try {
+            JSON.parse(candidate);
+            lastValid = candidate;
+            start = end;
+          } catch {}
+          break;
+        }
+      }
+    }
+  }
+  return lastValid ?? trimmed;
+}
+
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.trim());
   } catch {
-    throw new Error('make-pr stack publisher must output JSON');
+    try {
+      parsed = JSON.parse(extractJsonPayload(raw));
+    } catch {
+      throw new Error('make-pr stack publisher must output JSON');
+    }
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {


### PR DESCRIPTION
## Summary

Publisher output parsing now accepts artifact JSON nested inside an invalid outer brace block.

Direct JSON handling and downstream artifact checks remain unchanged.

## Workflow Summary

admin-bypass-repair-bot-thread-pr-11168-72fcdf3 — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1788111704082-1/repair | Resolve bot review thread on PR #11168 | completed |
| wf-1788111704082-1/safe-push | Safely push PR #11168 only if its head did not move | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1788111704082-1/repair — Resolve bot review thread on PR #11168

### wf-1788111704082-1/safe-push — Safely push PR #11168 only if its head did not move
.../src/__tests__/pr-authoring.test.ts             | 59 ++++++++++++++++++++++
 packages/execution-engine/src/pr-authoring.ts      | 49 +++++++++++++++++-
 2 files changed, 107 insertions(+), 1 deletion(-)

</details>

## Review Claim

Publisher output parsing accepts a valid nested artifact object after an invalid enclosing candidate while preserving the existing artifact checks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Assumptions: unconfirmed because publication is headless. Direct JSON still parses first, and artifact ordering, dependencies, required bodies, provider IDs, branches, and malformed-output errors remain unchanged.

## Slice Rationale

The parser fallback and its directly affected cases stay together because both define acceptance at the same publisher-output boundary.

## Non-goals

No prompt schema, artifact shape, GitHub mutation, user interface, or unrelated behavior changes.

## Architecture

### Before

```mermaid
graph TD
    A["publisher emits wrapped output"] --> B["try exact JSON first"]
    B --> C["inspect an enclosing object candidate"]
    C --> D["skip a nested artifact object when the enclosing candidate is invalid"]
```

### After

```mermaid
graph TD
    A["publisher emits wrapped output"] --> B["try exact JSON first"]
    B --> C["inspect balanced object candidates"]
    C --> D["parse the last valid candidate"]
    D --> E["run unchanged artifact checks"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-authoring.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .invoker-pr-body.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 07e32a539d0eae790aed23304b768c816242133c`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Heuristic JSON extraction could mis-identify the payload if an agent emits multiple valid JSON objects, but impact is limited to parsing publisher agent stdout before existing artifact validation runs.
> 
> **Overview**
> **`parseMakePrStackPublishResult`** no longer requires the agent response to be bare JSON. When a direct `JSON.parse` on the trimmed string fails, it runs **`extractJsonPayload`**, which scans for brace-balanced `{…}` spans (respecting strings and escapes), keeps each substring that `JSON.parse` accepts, and uses the **last** valid object so leading decoys like `{}` do not win over the real `artifacts` payload.
> 
> That makes the make-pr stack publish path tolerate common instruction violations—markdown fences, surrounding commentary, and braces inside quoted fields—while still throwing **`make-pr stack publisher must output JSON`** for prose-only replies. Matching unit tests were added for fences, commentary, nested extraction, and the decoy case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e32a539d0eae790aed23304b768c816242133c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->