### PR TITLE
[select short-id branch](3) Resolve variant id by field, not ID parsing

### DIFF
--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -26,6 +26,8 @@ export type TaskStatus =
 export interface TaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
+  /** Short variant id from the spawning experimentVariants entry (e.g. "mine-02"), before workflow/pivot scoping is composed into the task id. */
+  readonly variantLocalId?: string;
   readonly command?: string;
   readonly prompt?: string;
   readonly experimentPrompt?: string;

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -208,6 +208,7 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
     const nodeBase = {
       workflowId: nodeDef.workflowId,
       parentTask: nodeDef.parentTask,
+      variantLocalId: nodeDef.variantLocalId,
       experimentPrompt: nodeDef.experimentPrompt,
       prompt: nodeDef.prompt,
       command: nodeDef.command,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -546,6 +546,7 @@ export interface GraphMutationNodeDef {
   dependencies: string[];
   workflowId?: string;
   parentTask?: string;
+  variantLocalId?: string;
   experimentPrompt?: string;
   prompt?: string;
   command?: string;

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -415,6 +415,7 @@ export function handleSpawnExperimentsImpl(
     dependencies: [taskId, ...parentDepIds],
     workflowId: wfId,
     parentTask: taskId,
+    variantLocalId: v.localId,
     experimentPrompt: v.prompt,
     prompt: v.prompt,
     command: v.command,

--- a/packages/workflow-core/src/resolve-reconciliation-experiment.ts
+++ b/packages/workflow-core/src/resolve-reconciliation-experiment.ts
@@ -11,13 +11,7 @@ export function resolveReconciliationExperiment(
   for (const depId of recon.dependencies) {
     const dep = getTask(depId);
     if (!dep) continue;
-    if (depId === experimentId) return dep;
-    if (depId.endsWith(`-exp-${experimentId}`)) return dep;
-    const slash = depId.lastIndexOf('/');
-    const local = slash >= 0 ? depId.slice(slash + 1) : depId;
-    if (local === experimentId || local.endsWith(`-exp-${experimentId}`)) {
-      return dep;
-    }
+    if (dep.config.variantLocalId === experimentId) return dep;
   }
   return undefined;
 }

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -23,6 +23,7 @@ function planLocalFromActionId(actionId: string): string {
 
 export interface ParsedVariantDef {
   id: string;
+  localId: string;
   description: string;
   prompt?: string;
   command?: string;
@@ -152,6 +153,7 @@ export class ResponseHandler {
         const variants: ParsedVariantDef[] =
           dagMutation.spawnExperiments.variants.map((v) => ({
             id: `${pivotLocal}-exp-${v.id}`,
+            localId: v.id,
             description: v.description ?? `Experiment: ${v.id}`,
             prompt: v.prompt,
             command: v.command,


### PR DESCRIPTION
resolveReconciliationExperiment matched short variant ids against
dependency task ids via endsWith/slash-splitting, because the short
id was never stored on the task itself. Add TaskConfig.variantLocalId,
stamped when spawn_experiments creates each experiment task, and
resolve by equality against it instead of parsing the composite id.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mi99ayNHjPmhUH7NamNuyt

Depends-On: #11332

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconciliation winner resolution used by `selectExperiment`/`selectExperiments`; older persisted experiment tasks without `variantLocalId` may fail to resolve until respawned or migrated.
> 
> **Overview**
> Reconciliation and experiment selection no longer infer short variant ids by parsing scoped task ids (`endsWith`, slash segments, etc.). **Experiment tasks now carry an explicit `variantLocalId` on `TaskConfig`**, set when `spawn_experiments` is parsed and when graph mutation creates each variant node.
> 
> `resolveReconciliationExperiment` matches reconciliation dependencies with **`dep.config.variantLocalId === experimentId`** after the usual direct task-id lookup. Parsed spawn payloads expose both the composite variant id (`pivot-exp-…`) and the original **`localId`** from the worker mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c951b06a36ddeaf25bd5e3e50f0bd2e9fb569b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->