### PR TITLE
[select short-id branch] Also match full/local -exp-<id> suffixes

### DIFF
--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -26,7 +26,6 @@ export type TaskStatus =
 export interface TaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
-  /** Short variant id from the spawning experimentVariants entry (e.g. "mine-02"), before workflow/pivot scoping is composed into the task id. */
   readonly variantLocalId?: string;
   readonly command?: string;
   readonly prompt?: string;

--- a/packages/workflow-core/src/resolve-reconciliation-experiment.ts
+++ b/packages/workflow-core/src/resolve-reconciliation-experiment.ts
@@ -12,6 +12,12 @@ export function resolveReconciliationExperiment(
     const dep = getTask(depId);
     if (!dep) continue;
     if (dep.config.variantLocalId === experimentId) return dep;
+    if (depId.endsWith(`-exp-${experimentId}`)) return dep;
+    const slash = depId.lastIndexOf('/');
+    const local = slash >= 0 ? depId.slice(slash + 1) : depId;
+    if (local === experimentId || local.endsWith(`-exp-${experimentId}`)) {
+      return dep;
+    }
   }
   return undefined;
 }

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -29,6 +29,7 @@ export type TaskStatus = typeof TASK_STATUSES[number];
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
+  readonly variantLocalId?: string;
   readonly command?: string;
   readonly prompt?: string;
   readonly experimentPrompt?: string;


### PR DESCRIPTION
Fallback when variantLocalId is missing so recon select still sets branch.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #11338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fallback in reconciliation dependency matching; no auth or data-path changes, though wrong matches could pick the wrong experiment branch in edge cases.
> 
> **Overview**
> Extends **reconciliation experiment resolution** so selecting a short experiment id still finds the winning dependency when `variantLocalId` was never copied onto the task config. After the existing direct lookup and `variantLocalId` match, `resolveReconciliationExperiment` now also accepts dependency ids whose full id or path-local segment equals the id or ends with `-exp-<experimentId>`.
> 
> Adds **`variantLocalId`** to `BaseTaskConfig` in `workflow-graph` so graph task configs stay aligned with the other task type packages. The long JSDoc on `variantLocalId` in `packages/graph` is removed (field unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de19322b7349ed30e19bf04d92dd90290fa87bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->