### PR TITLE
(2) proof(chaos-b): 413 response poisons HTTP keep-alive connections

### DIFF
--- a/packages/app/src/__tests__/web-bridge-413-keepalive.test.ts
+++ b/packages/app/src/__tests__/web-bridge-413-keepalive.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Repro: 413 then keep-alive ECONNRESET
+ *
+ * Symptom: POST /invoke body > 1 MiB returns 413 correctly, then req.destroy()
+ * drops the socket. Next request on the same HTTP keep-alive agent:
+ * "write ECONNRESET" / Connection reset by peer.
+ *
+ * TODO(chaos-b-fix): These tests are marked it.fails because the current
+ * implementation uses req.destroy() after a 413 response, which severs the
+ * TCP connection immediately and causes ECONNRESET on subsequent requests.
+ *
+ * After the fix applies:
+ * - sendJson will send Connection: close header for 413 responses
+ * - req.resume() will drain the body instead of req.destroy() dropping the socket
+ * - These tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { request as httpRequest, Agent } from 'node:http';
+import type { MessageBus } from '@invoker/transport';
+import { startWebBridge, type WebBridge, type WebBridgeDeps } from '../web/web-bridge-server.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function makeMinimalDeps(uiDistDir: string): WebBridgeDeps {
+  const mockMessageBus: Pick<MessageBus, 'subscribe'> = {
+    subscribe: () => () => {},
+  };
+
+  const mockPersistence = {
+    getActivityLogs: () => [],
+    listWorkflows: () => [],
+  };
+
+  return {
+    dispatch: async () => ({ ok: true }),
+    messageBus: mockMessageBus,
+    persistence: mockPersistence as any,
+    uiDistDir,
+    token: 'test-token',
+    host: '127.0.0.1',
+    port: 0,
+  };
+}
+
+function createMinimalUiDist(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'web-bridge-413-test-'));
+  writeFileSync(join(dir, 'web.html'), '<html><body>Test</body></html>');
+  return dir;
+}
+
+function httpPost(options: {
+  hostname: string;
+  port: number;
+  path: string;
+  body: string;
+  headers?: Record<string, string>;
+  agent?: Agent;
+}): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: options.hostname,
+        port: options.port,
+        path: options.path,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+        agent: options.agent,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body }));
+      }
+    );
+    req.on('error', reject);
+    req.write(options.body);
+    req.end();
+  });
+}
+
+describe('web-bridge 413 keep-alive handling', () => {
+  let uiDistDir: string;
+  let bridge: WebBridge;
+
+  beforeEach(async () => {
+    uiDistDir = createMinimalUiDist();
+  });
+
+  afterEach(async () => {
+    await bridge?.close();
+    rmSync(uiDistDir, { recursive: true, force: true });
+  });
+
+  it.fails('413 response does not poison keep-alive connection', async () => {
+    const deps = makeMinimalDeps(uiDistDir);
+    bridge = startWebBridge(deps);
+    const port = await bridge.whenReady;
+
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+
+    try {
+      const oversizeBody = JSON.stringify({
+        channel: 'invoker:test',
+        args: [{ data: 'x'.repeat(2 * 1024 * 1024) }],
+      });
+
+      const res1 = await httpPost({
+        hostname: '127.0.0.1',
+        port,
+        path: '/invoke',
+        body: oversizeBody,
+        headers: { 'x-invoker-token': 'test-token' },
+        agent,
+      });
+
+      expect(res1.statusCode).toBe(413);
+
+      const smallBody = JSON.stringify({
+        channel: 'invoker:get-status',
+        args: [],
+      });
+
+      const res2 = await httpPost({
+        hostname: '127.0.0.1',
+        port,
+        path: '/invoke',
+        body: smallBody,
+        headers: { 'x-invoker-token': 'test-token' },
+        agent,
+      });
+
+      expect(res2.statusCode).toBe(200);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  it.fails('413 response includes Connection: close header', async () => {
+    const deps = makeMinimalDeps(uiDistDir);
+    bridge = startWebBridge(deps);
+    const port = await bridge.whenReady;
+
+    const oversizeBody = JSON.stringify({
+      channel: 'invoker:test',
+      args: [{ data: 'x'.repeat(2 * 1024 * 1024) }],
+    });
+
+    const responseHeaders = await new Promise<Record<string, string | string[] | undefined>>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/invoke',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-invoker-token': 'test-token',
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve(res.headers));
+        }
+      );
+      req.on('error', reject);
+      req.write(oversizeBody);
+      req.end();
+    });
+
+    expect(responseHeaders.connection?.toString().toLowerCase()).toBe('close');
+  });
+});

--- a/scripts/repro/repro-413-keepalive-reset.sh
+++ b/scripts/repro/repro-413-keepalive-reset.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: 413 then keep-alive ECONNRESET
+#
+# This script runs the 413 keep-alive test to verify that:
+# 1. A 413 response includes Connection: close header
+# 2. A subsequent request on the same HTTP agent does not fail with ECONNRESET
+#
+# Before fix: Second request fails with ECONNRESET because req.destroy() dropped the socket
+# After fix: Second request succeeds because we use req.resume() and Connection: close
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running 413 keep-alive ECONNRESET test ==="
+pnpm --filter @invoker/app test -- --run web-bridge-413
+
+echo ""
+echo "=== Test passed: 413 response correctly handles keep-alive connections ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a regression test demonstrating that 413 responses poison HTTP keep-alive connections.

The current implementation calls req.destroy() after sending a 413 response for oversized request bodies. This severs the TCP connection immediately, causing ECONNRESET on subsequent requests using the same HTTP agent.

Tests are marked it.fails to demonstrate the bug exists on current master.

## Review Claim

Confirm the test correctly reproduces the 413 keep-alive ECONNRESET bug.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only a test file and a repro script. No production code is modified. The test exercises existing web-bridge behavior without side effects.

## Slice Rationale

Proof slices demonstrate the bug before the fix. The fix slice will change the tests from it.fails to it.

## Non-goals

Does not fix the 413 handling. Does not modify web-bridge-server.ts production code. Does not change request body limits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `scripts/repro/repro-413-keepalive-reset.sh`

```
=== Running 413 keep-alive ECONNRESET test ===
 ✓ src/__tests__/web-bridge-413-keepalive.test.ts (2 tests) 43ms
   ✓ (it.fails) web-bridge 413 keep-alive handling > 413 response does not poison keep-alive connection
   ✓ (it.fails) web-bridge 413 keep-alive handling > 413 response includes Connection: close header
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

