### PR TITLE
(3) fix(chaos-b): handle 413 responses without poisoning keep-alive connections

### DIFF
--- a/packages/app/src/__tests__/web-bridge-413-keepalive.test.ts
+++ b/packages/app/src/__tests__/web-bridge-413-keepalive.test.ts
@@ -5,14 +5,10 @@
  * drops the socket. Next request on the same HTTP keep-alive agent:
  * "write ECONNRESET" / Connection reset by peer.
  *
- * TODO(chaos-b-fix): These tests are marked it.fails because the current
- * implementation uses req.destroy() after a 413 response, which severs the
- * TCP connection immediately and causes ECONNRESET on subsequent requests.
- *
- * After the fix applies:
- * - sendJson will send Connection: close header for 413 responses
- * - req.resume() will drain the body instead of req.destroy() dropping the socket
- * - These tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - sendJson sends Connection: close header for 413 responses
+ * - req.resume() drains the body instead of req.destroy() dropping the socket
+ * - Tests now pass because subsequent requests on the same agent succeed
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -96,7 +92,7 @@ describe('web-bridge 413 keep-alive handling', () => {
     rmSync(uiDistDir, { recursive: true, force: true });
   });
 
-  it.fails('413 response does not poison keep-alive connection', async () => {
+  it('413 response does not poison keep-alive connection', async () => {
     const deps = makeMinimalDeps(uiDistDir);
     bridge = startWebBridge(deps);
     const port = await bridge.whenReady;
@@ -140,7 +136,7 @@ describe('web-bridge 413 keep-alive handling', () => {
     }
   });
 
-  it.fails('413 response includes Connection: close header', async () => {
+  it('413 response includes Connection: close header', async () => {
     const deps = makeMinimalDeps(uiDistDir);
     bridge = startWebBridge(deps);
     const port = await bridge.whenReady;

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -102,12 +102,21 @@ function contentTypeFor(filePath: string): string {
   return CONTENT_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown, req?: IncomingMessage): void {
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  req?: IncomingMessage,
+  opts?: { forceClose?: boolean },
+): void {
   const payload = Buffer.from(JSON.stringify(body), 'utf8');
   const headers: Record<string, string> = {
     'content-type': 'application/json; charset=utf-8',
     vary: 'Accept-Encoding',
   };
+  if (opts?.forceClose) {
+    headers.connection = 'close';
+  }
   const accepted = typeof req?.headers['accept-encoding'] === 'string' ? req.headers['accept-encoding'] : '';
   let responseBody = payload;
   if (payload.length >= JSON_COMPRESSION_MIN_BYTES) {
@@ -196,8 +205,8 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
       total += (chunk as Buffer).length;
       if (total > MAX_INVOKE_BODY_BYTES) {
         aborted = true;
-        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } }, req);
-        req.destroy();
+        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } }, req, { forceClose: true });
+        req.resume();
         return;
       }
       chunks.push(chunk as Buffer);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix the 413 response handling in handleInvoke to not poison HTTP keep-alive connections.

Changes sendJson to accept a forceClose option that sets Connection: close header. Replaces req.destroy() with req.resume() to drain the request body cleanly.

This prevents ECONNRESET errors on subsequent requests using the same HTTP agent.

## Review Claim

Confirm the fix correctly handles 413 responses by sending Connection: close and draining the body.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only affects 413 response handling. The new Connection: close header tells clients to open a fresh connection. Using req.resume() drains pending data instead of forcibly closing.

## Slice Rationale

Stacked on the proof slice. This fix slice applies the behavior change and updates tests from it.fails to it.

## Non-goals

Does not change request body size limits. Does not modify other error response paths. Does not add new validation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `scripts/repro/repro-413-keepalive-reset.sh`

```
=== Running 413 keep-alive ECONNRESET test ===
 ✓ src/__tests__/web-bridge-413-keepalive.test.ts (2 tests) 41ms
   ✓ web-bridge 413 keep-alive handling > 413 response does not poison keep-alive connection
   ✓ web-bridge 413 keep-alive handling > 413 response includes Connection: close header
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

