### PR TITLE
(5) fix(chaos-c): reject cyclic task dependencies in plan parser and orchestrator

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-cyclic-deps-accepted.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-cyclic-deps-accepted.test.ts
@@ -5,13 +5,10 @@
  * Tasks stay `pending` forever. `__merge__` becomes `review_ready` with deps: [].
  * Rollup `review_ready` with 2 tasks still pending.
  *
- * TODO(chaos-c-fix): These tests are marked it.fails because the current
- * implementation does not detect cycles in parsePlan or loadPlan.
- *
- * After the fix applies:
- * - parsePlan will detect cycles using Kahn's algorithm
- * - loadPlan will also detect cycles before any state mutation
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now detects cycles using Kahn's algorithm
+ * - loadPlan also detects cycles before any state mutation
+ * - Cyclic plans are rejected with a clear error message
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -123,11 +120,11 @@ tasks:
     dependencies: [task-a]
 `;
 
-  it.fails('parsePlan should reject cyclic dependencies', () => {
+  it('parsePlan should reject cyclic dependencies', () => {
     expect(() => parsePlan(cyclicPlanYaml)).toThrow(PlanParseError);
   });
 
-  it.fails('loadPlan should reject cyclic dependencies', () => {
+  it('loadPlan should reject cyclic dependencies', () => {
     const plan: PlanDefinition = {
       name: 'Cyclic deps',
       repoUrl: 'git@github.com:example/repo.git',
@@ -140,7 +137,7 @@ tasks:
     expect(() => orchestrator.loadPlan(plan)).toThrow(/cycle/i);
   });
 
-  it.fails('loadPlan should reject self-referential dependencies', () => {
+  it('loadPlan should reject self-referential dependencies', () => {
     const plan: PlanDefinition = {
       name: 'Self-referential',
       repoUrl: 'git@github.com:example/repo.git',
@@ -152,7 +149,7 @@ tasks:
     expect(() => orchestrator.loadPlan(plan)).toThrow(/cycle/i);
   });
 
-  it.fails('loadPlan should reject transitive cycles (a->b->c->a)', () => {
+  it('loadPlan should reject transitive cycles (a->b->c->a)', () => {
     const plan: PlanDefinition = {
       name: 'Transitive cycle',
       repoUrl: 'git@github.com:example/repo.git',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -595,6 +595,55 @@ function isReviewReadyLikeGatePolicy(gatePolicy: ExternalGatePolicy): boolean {
   return gatePolicy === 'review_ready' || gatePolicy === 'ci_failed';
 }
 
+interface TaskWithDeps {
+  id: string;
+  dependencies?: string[];
+}
+
+function detectDependencyCycleInPlan(tasks: TaskWithDeps[]): string | null {
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const adjacency = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const task of tasks) {
+    adjacency.set(task.id, []);
+    inDegree.set(task.id, 0);
+  }
+
+  for (const task of tasks) {
+    for (const dep of task.dependencies ?? []) {
+      if (!taskIds.has(dep)) continue;
+      adjacency.get(dep)!.push(task.id);
+      inDegree.set(task.id, inDegree.get(task.id)! + 1);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [id, degree] of inDegree) {
+    if (degree === 0) queue.push(id);
+  }
+
+  let processed = 0;
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    processed++;
+    for (const neighbor of adjacency.get(id)!) {
+      const newDegree = inDegree.get(neighbor)! - 1;
+      inDegree.set(neighbor, newDegree);
+      if (newDegree === 0) queue.push(neighbor);
+    }
+  }
+
+  if (processed < tasks.length) {
+    const cycleNodes = tasks
+      .filter((t) => inDegree.get(t.id)! > 0)
+      .map((t) => t.id);
+    return `Cycle detected in task dependencies involving: ${cycleNodes.join(', ')}. Task dependencies must form a directed acyclic graph (DAG).`;
+  }
+
+  return null;
+}
+
 export {
   findMatchingExecutorRoutingRule,
   assertExecutorRoutingConforms,
@@ -1432,6 +1481,11 @@ export class Orchestrator {
           conflictingWorkflows,
         );
       }
+    }
+
+    const cycleError = detectDependencyCycleInPlan(plan.tasks);
+    if (cycleError) {
+      throw new Error(cycleError);
     }
 
     // ── Pass 1: validate all tasks, build TaskState objects ──

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -9,6 +9,55 @@ export class PlanParseError extends Error {
   }
 }
 
+interface TaskWithDeps {
+  id: string;
+  dependencies: string[];
+}
+
+function detectDependencyCycle(tasks: TaskWithDeps[]): string | null {
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const adjacency = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const task of tasks) {
+    adjacency.set(task.id, []);
+    inDegree.set(task.id, 0);
+  }
+
+  for (const task of tasks) {
+    for (const dep of task.dependencies) {
+      if (!taskIds.has(dep)) continue;
+      adjacency.get(dep)!.push(task.id);
+      inDegree.set(task.id, inDegree.get(task.id)! + 1);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [id, degree] of inDegree) {
+    if (degree === 0) queue.push(id);
+  }
+
+  let processed = 0;
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    processed++;
+    for (const neighbor of adjacency.get(id)!) {
+      const newDegree = inDegree.get(neighbor)! - 1;
+      inDegree.set(neighbor, newDegree);
+      if (newDegree === 0) queue.push(neighbor);
+    }
+  }
+
+  if (processed < tasks.length) {
+    const cycleNodes = tasks
+      .filter((t) => inDegree.get(t.id)! > 0)
+      .map((t) => t.id);
+    return `Cycle detected in task dependencies involving: ${cycleNodes.join(', ')}. Task dependencies must form a directed acyclic graph (DAG).`;
+  }
+
+  return null;
+}
+
 export interface RawExperimentVariant {
   id?: string;
   description?: string;
@@ -281,6 +330,11 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       maxTurns: task.maxTurns,
     };
   });
+
+  const cycleError = detectDependencyCycle(tasks);
+  if (cycleError) {
+    throw new PlanParseError(cycleError);
+  }
 
   return applyPlanDefinitionDefaults({
     name: raw.name,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add cycle detection using Kahn's algorithm to both parsePlan and loadPlan.

The detectDependencyCycle function builds an in-degree map and processes tasks in topological order. If any tasks remain unprocessed (in-degree > 0), a cycle exists and an error is thrown listing the involved task IDs.

This prevents loading plans with cyclic dependencies that would cause tasks to pend forever.

## Review Claim

Confirm the cycle detection correctly identifies cyclic, self-referential, and transitive dependency cycles.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Cycle detection runs at plan load time before any state mutation. A rejected plan has no side effects. Valid DAGs (no cycles) are unaffected.

## Slice Rationale

Stacked on the proof slice. This fix slice adds cycle detection and updates tests from it.fails to it.

## Non-goals

Does not modify task scheduling or execution. Does not add runtime cycle detection. Does not change external dependency validation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `scripts/repro/repro-cyclic-deps-accepted.sh`

```
=== Running cyclic dependency detection test ===
 ✓ src/__tests__/repro-cyclic-deps-accepted.test.ts (5 tests) 15ms
   ✓ cyclic dependency detection > parsePlan should reject cyclic dependencies
   ✓ cyclic dependency detection > loadPlan should reject cyclic dependencies
   ✓ cyclic dependency detection > loadPlan should reject self-referential dependencies
   ✓ cyclic dependency detection > loadPlan should reject transitive cycles
   ✓ cyclic dependency detection > loadPlan should accept valid DAG (no cycles)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

