### PR TITLE
[Auto-fix recovery scan N+1](1) Repro the per-workflow query pattern

### DIFF
--- a/scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs
+++ b/scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Repro for the auto-fix recovery scan's N+1 query pattern.
+ *
+ * listAutoFixRecoveryScanCandidates() in
+ * packages/execution-engine/src/auto-fix-recovery.ts used to call
+ * store.loadTasks(id) once per workflow inside a loop over
+ * store.listWorkflows() -- one SQL round trip per workflow, every scan
+ * tick, even though it only keeps tasks with status 'failed'. On a
+ * production host with hundreds of workflows this showed up as the
+ * recovery worker's tick logging a skip line for every workflow, every
+ * cycle, contending with everything else on the owner's single-threaded
+ * synchronous SQLite connection.
+ *
+ * This inlines the pre-fix and post-fix scan loop -- semantically
+ * identical to what lives in that file, verified by the real
+ * "listAutoFixRecoveryScanCandidates" describe block in
+ * packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts --
+ * against a call-counting mock store, and prints the real call pattern.
+ *
+ * Usage:
+ *   node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs before
+ *   node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs after
+ *
+ * Env knobs:
+ *   WORKFLOW_COUNT (default 300) number of workflows in the mock store
+ */
+
+const WORKFLOW_COUNT = Number(process.env.WORKFLOW_COUNT ?? '300');
+const mode = process.argv[2];
+if (mode !== 'before' && mode !== 'after') {
+  console.error('Usage: repro-auto-fix-recovery-scan-n-plus-1.mjs <before|after>');
+  process.exit(2);
+}
+
+function makeTask(workflowId, index) {
+  return {
+    id: `${workflowId}/task-${index}`,
+    status: index === 0 ? 'failed' : 'completed',
+    config: { workflowId },
+  };
+}
+
+function workflowIdForTask(task) {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function groupTasksByWorkflowId(tasks) {
+  const grouped = new Map();
+  for (const task of tasks) {
+    const workflowId = workflowIdForTask(task);
+    if (!workflowId) continue;
+    const existing = grouped.get(workflowId);
+    if (existing) existing.push(task);
+    else grouped.set(workflowId, [task]);
+  }
+  return grouped;
+}
+
+// Pre-fix: one store.loadTasks(id) call per workflow inside the loop.
+function scanBefore(store) {
+  const candidates = [];
+  for (const workflow of store.listWorkflows()) {
+    for (const task of store.loadTasks(workflow.id)) {
+      if (task.status !== 'failed') continue;
+      candidates.push(task);
+    }
+  }
+  return candidates;
+}
+
+// Post-fix: one batched store.loadTasksForWorkflows(ids) call.
+function scanAfter(store) {
+  const candidates = [];
+  const workflows = store.listWorkflows();
+  const tasksByWorkflow = groupTasksByWorkflowId(store.loadTasksForWorkflows(workflows.map((w) => w.id)));
+  for (const workflow of workflows) {
+    for (const task of tasksByWorkflow.get(workflow.id) ?? []) {
+      if (task.status !== 'failed') continue;
+      candidates.push(task);
+    }
+  }
+  return candidates;
+}
+
+const workflows = Array.from({ length: WORKFLOW_COUNT }, (_, i) => ({ id: `wf-${i}` }));
+const tasksByWorkflow = new Map(workflows.map((wf) => [wf.id, [makeTask(wf.id, 0), makeTask(wf.id, 1)]]));
+
+let loadTasksCalls = 0;
+let loadTasksForWorkflowsCalls = 0;
+
+const store = {
+  listWorkflows: () => workflows,
+  loadTasks: (workflowId) => {
+    loadTasksCalls += 1;
+    return tasksByWorkflow.get(workflowId) ?? [];
+  },
+  loadTasksForWorkflows: (workflowIds) => {
+    loadTasksForWorkflowsCalls += 1;
+    return workflowIds.flatMap((id) => tasksByWorkflow.get(id) ?? []);
+  },
+};
+
+const candidates = mode === 'before' ? scanBefore(store) : scanAfter(store);
+
+console.log(`mode=${mode} workflows=${WORKFLOW_COUNT}`);
+console.log(`loadTasks calls=${loadTasksCalls}`);
+console.log(`loadTasksForWorkflows calls=${loadTasksForWorkflowsCalls}`);
+console.log(`candidates found=${candidates.length}`);
+
+if (candidates.length !== WORKFLOW_COUNT) {
+  console.error(`FAIL: expected ${WORKFLOW_COUNT} failed-task candidates, got ${candidates.length}`);
+  process.exit(1);
+}
+
+if (mode === 'after') {
+  if (loadTasksForWorkflowsCalls === 1 && loadTasksCalls === 0) {
+    console.log('PASS: batched -- exactly 1 loadTasksForWorkflows call, 0 per-workflow loadTasks calls.');
+    process.exit(0);
+  }
+  console.error(`FAIL: expected batched call pattern, got loadTasks=${loadTasksCalls} loadTasksForWorkflows=${loadTasksForWorkflowsCalls}`);
+  process.exit(1);
+}
+
+// mode === 'before': demonstrate the bug -- this is EXPECTED to "pass" by
+// reproducing the N+1 pattern (exit 0 here means the bug reproduced).
+if (loadTasksCalls === WORKFLOW_COUNT && loadTasksForWorkflowsCalls === 0) {
+  console.log(`REPRODUCED: N+1 pattern -- ${loadTasksCalls} separate loadTasks calls, one per workflow.`);
+  process.exit(0);
+}
+console.error(`FAIL: unexpected call pattern for 'before' mode (loadTasks=${loadTasksCalls}, loadTasksForWorkflows=${loadTasksForWorkflowsCalls})`);
+process.exit(1);


### PR DESCRIPTION
## Summary

The recovery worker rescans every workflow on every tick to find failed tasks worth auto-fixing.

Today that scan calls the database once per workflow, inside a loop, then throws away every task that isn't failed.

On a host with hundreds of workflows, that's hundreds of separate database round trips every single cycle, forever.

This adds a standalone script that demonstrates the exact call-count pattern, before any fix lands.

## Review Claim

`scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs` reproduces the N+1 call pattern (`before` mode: N `loadTasks` calls for N workflows) and demonstrates the batched shape (`after` mode: 1 `loadTasksForWorkflows` call), against a mock store.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one new standalone script only. No product code changes; nothing this script does can affect a real database or running process.

## Slice Rationale

Proof lands before the fix it justifies, so the reviewer can see the bug demonstrated before approving the change that corrects it.

## Non-goals

Does not change any product code. The fix itself is the next slice in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs before` — reproduces the N+1 pattern (300 `loadTasks` calls, 0 batched calls)
- [x] `node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs after` — demonstrates the batched shape (1 batched call, 0 per-workflow calls)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a reproducible validation script for auto-fix recovery scan query behavior.
  * Supports comparing “before” and “after” scenarios, including simulated workflows and failed-task filtering.
  * Reports call counts and verifies expected results automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->