### PR TITLE
[Auto-fix recovery scan N+1](2) Batch per-workflow task loads

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -11,6 +11,7 @@ import {
   AUTO_FIX_WORKER_KIND,
   collectValidatedAutoFixRecoveryCandidates,
   createAutoFixRecoveryTick,
+  listAutoFixRecoveryScanCandidates,
   shouldRecreateMergeGateInsteadOfAutoFix,
 } from '../auto-fix-recovery.js';
 import { autoFixBareRetryExternalKey, autoFixRetryCapExternalKey } from '../auto-fix-retry-cap.js';
@@ -181,6 +182,53 @@ describe('collectValidatedAutoFixRecoveryCandidates', () => {
       'debug.auto-fix',
       expect.objectContaining({ phase: 'worker-autofix-skip', reason: 'admin-bypass-excluded' }),
     );
+  });
+});
+
+describe('listAutoFixRecoveryScanCandidates', () => {
+  it('batches task loads across workflows in one call instead of one call per workflow', () => {
+    const workflowCount = 50;
+    const workflows = Array.from({ length: workflowCount }, (_, i) => ({ id: `wf-${i}` }));
+    const tasksByWorkflow = new Map(
+      workflows.map((wf) => [
+        wf.id,
+        [makeFailedTask({ id: `${wf.id}/build`, config: { workflowId: wf.id, command: 'pnpm build' } })],
+      ]),
+    );
+    let loadTasksCalls = 0;
+    let loadTasksForWorkflowsCalls = 0;
+    const store = {
+      listWorkflows: vi.fn(() => workflows),
+      loadTasks: vi.fn((workflowId: string) => {
+        loadTasksCalls += 1;
+        return tasksByWorkflow.get(workflowId) ?? [];
+      }),
+      loadTasksForWorkflows: vi.fn((workflowIds: string[]) => {
+        loadTasksForWorkflowsCalls += 1;
+        return workflowIds.flatMap((id) => tasksByWorkflow.get(id) ?? []);
+      }),
+      listWorkflowMutationIntents: vi.fn(() => []),
+    };
+
+    const candidates = listAutoFixRecoveryScanCandidates({ store });
+
+    expect(candidates).toHaveLength(workflowCount);
+    expect(loadTasksForWorkflowsCalls).toBe(1);
+    expect(loadTasksCalls).toBe(0);
+  });
+
+  it('falls back to per-workflow loadTasks when loadTasksForWorkflows is not implemented', () => {
+    const task = makeFailedTask();
+    const store = {
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn((workflowId: string) => (workflowId === 'wf-1' ? [task] : [])),
+      listWorkflowMutationIntents: vi.fn(() => []),
+    };
+
+    const candidates = listAutoFixRecoveryScanCandidates({ store });
+
+    expect(candidates).toHaveLength(1);
+    expect(store.loadTasks).toHaveBeenCalledWith('wf-1');
   });
 });
 

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -95,6 +95,7 @@ export interface AutoFixRecoveryStore {
   listWorkflows(): ReadonlyArray<{ id: string; name?: string }>;
   loadWorkflow?(workflowId: string): { name?: string | null } | undefined;
   loadTasks(workflowId: string): TaskState[];
+  loadTasksForWorkflows?(workflowIds: string[]): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents(
     workflowId?: string,
@@ -240,14 +241,34 @@ export function listAutoFixRecoveryScanCandidates(
   options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
 ): AutoFixRecoveryCandidate[] {
   const candidates: AutoFixRecoveryCandidate[] = [];
-  for (const workflow of options.store.listWorkflows()) {
-    for (const task of options.store.loadTasks(workflow.id)) {
+  const workflows = options.store.listWorkflows();
+  const tasksByWorkflow = options.store.loadTasksForWorkflows
+    ? groupTasksByWorkflowId(options.store.loadTasksForWorkflows(workflows.map((workflow) => workflow.id)))
+    : undefined;
+  for (const workflow of workflows) {
+    const tasks = tasksByWorkflow ? (tasksByWorkflow.get(workflow.id) ?? []) : options.store.loadTasks(workflow.id);
+    for (const task of tasks) {
       if (task.status !== 'failed') continue;
       const candidate = candidateFromTask(task);
       if (candidate) candidates.push(candidate);
     }
   }
   return candidates;
+}
+
+function groupTasksByWorkflowId(tasks: TaskState[]): Map<string, TaskState[]> {
+  const grouped = new Map<string, TaskState[]>();
+  for (const task of tasks) {
+    const workflowId = workflowIdForTask(task);
+    if (!workflowId) continue;
+    const existing = grouped.get(workflowId);
+    if (existing) {
+      existing.push(task);
+    } else {
+      grouped.set(workflowId, [task]);
+    }
+  }
+  return grouped;
 }
 
 function retryBudgetForTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): number {

--- a/scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs
+++ b/scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Repro for the auto-fix recovery scan's N+1 query pattern.
+ *
+ * listAutoFixRecoveryScanCandidates() in
+ * packages/execution-engine/src/auto-fix-recovery.ts used to call
+ * store.loadTasks(id) once per workflow inside a loop over
+ * store.listWorkflows() -- one SQL round trip per workflow, every scan
+ * tick, even though it only keeps tasks with status 'failed'. On a
+ * production host with hundreds of workflows this showed up as the
+ * recovery worker's tick logging a skip line for every workflow, every
+ * cycle, contending with everything else on the owner's single-threaded
+ * synchronous SQLite connection.
+ *
+ * This inlines the pre-fix and post-fix scan loop -- semantically
+ * identical to what lives in that file, verified by the real
+ * "listAutoFixRecoveryScanCandidates" describe block in
+ * packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts --
+ * against a call-counting mock store, and prints the real call pattern.
+ *
+ * Usage:
+ *   node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs before
+ *   node scripts/repro/repro-auto-fix-recovery-scan-n-plus-1.mjs after
+ *
+ * Env knobs:
+ *   WORKFLOW_COUNT (default 300) number of workflows in the mock store
+ */
+
+const WORKFLOW_COUNT = Number(process.env.WORKFLOW_COUNT ?? '300');
+const mode = process.argv[2];
+if (mode !== 'before' && mode !== 'after') {
+  console.error('Usage: repro-auto-fix-recovery-scan-n-plus-1.mjs <before|after>');
+  process.exit(2);
+}
+
+function makeTask(workflowId, index) {
+  return {
+    id: `${workflowId}/task-${index}`,
+    status: index === 0 ? 'failed' : 'completed',
+    config: { workflowId },
+  };
+}
+
+function workflowIdForTask(task) {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function groupTasksByWorkflowId(tasks) {
+  const grouped = new Map();
+  for (const task of tasks) {
+    const workflowId = workflowIdForTask(task);
+    if (!workflowId) continue;
+    const existing = grouped.get(workflowId);
+    if (existing) existing.push(task);
+    else grouped.set(workflowId, [task]);
+  }
+  return grouped;
+}
+
+// Pre-fix: one store.loadTasks(id) call per workflow inside the loop.
+function scanBefore(store) {
+  const candidates = [];
+  for (const workflow of store.listWorkflows()) {
+    for (const task of store.loadTasks(workflow.id)) {
+      if (task.status !== 'failed') continue;
+      candidates.push(task);
+    }
+  }
+  return candidates;
+}
+
+// Post-fix: one batched store.loadTasksForWorkflows(ids) call.
+function scanAfter(store) {
+  const candidates = [];
+  const workflows = store.listWorkflows();
+  const tasksByWorkflow = groupTasksByWorkflowId(store.loadTasksForWorkflows(workflows.map((w) => w.id)));
+  for (const workflow of workflows) {
+    for (const task of tasksByWorkflow.get(workflow.id) ?? []) {
+      if (task.status !== 'failed') continue;
+      candidates.push(task);
+    }
+  }
+  return candidates;
+}
+
+const workflows = Array.from({ length: WORKFLOW_COUNT }, (_, i) => ({ id: `wf-${i}` }));
+const tasksByWorkflow = new Map(workflows.map((wf) => [wf.id, [makeTask(wf.id, 0), makeTask(wf.id, 1)]]));
+
+let loadTasksCalls = 0;
+let loadTasksForWorkflowsCalls = 0;
+
+const store = {
+  listWorkflows: () => workflows,
+  loadTasks: (workflowId) => {
+    loadTasksCalls += 1;
+    return tasksByWorkflow.get(workflowId) ?? [];
+  },
+  loadTasksForWorkflows: (workflowIds) => {
+    loadTasksForWorkflowsCalls += 1;
+    return workflowIds.flatMap((id) => tasksByWorkflow.get(id) ?? []);
+  },
+};
+
+const candidates = mode === 'before' ? scanBefore(store) : scanAfter(store);
+
+console.log(`mode=${mode} workflows=${WORKFLOW_COUNT}`);
+console.log(`loadTasks calls=${loadTasksCalls}`);
+console.log(`loadTasksForWorkflows calls=${loadTasksForWorkflowsCalls}`);
+console.log(`candidates found=${candidates.length}`);
+
+if (candidates.length !== WORKFLOW_COUNT) {
+  console.error(`FAIL: expected ${WORKFLOW_COUNT} failed-task candidates, got ${candidates.length}`);
+  process.exit(1);
+}
+
+if (mode === 'after') {
+  if (loadTasksForWorkflowsCalls === 1 && loadTasksCalls === 0) {
+    console.log('PASS: batched -- exactly 1 loadTasksForWorkflows call, 0 per-workflow loadTasks calls.');
+    process.exit(0);
+  }
+  console.error(`FAIL: expected batched call pattern, got loadTasks=${loadTasksCalls} loadTasksForWorkflows=${loadTasksForWorkflowsCalls}`);
+  process.exit(1);
+}
+
+// mode === 'before': demonstrate the bug -- this is EXPECTED to "pass" by
+// reproducing the N+1 pattern (exit 0 here means the bug reproduced).
+if (loadTasksCalls === WORKFLOW_COUNT && loadTasksForWorkflowsCalls === 0) {
+  console.log(`REPRODUCED: N+1 pattern -- ${loadTasksCalls} separate loadTasks calls, one per workflow.`);
+  process.exit(0);
+}
+console.error(`FAIL: unexpected call pattern for 'before' mode (loadTasks=${loadTasksCalls}, loadTasksForWorkflows=${loadTasksForWorkflowsCalls})`);
+process.exit(1);


### PR DESCRIPTION
## Summary

The recovery worker rescans every workflow on every tick to find failed tasks worth auto-fixing.

Before this change, that scan called the database once per workflow, inside a loop. With 300+ workflows, that's 300+ separate round trips, every single cycle, forever.

Tonight this contributed to the owner falling badly behind: worker ticks delayed by minutes, IPC queries timing out, under a large backlog.

The fix replaces the per-workflow loop with one batched database call that already existed in this codebase for the exact same class of problem (`loadTasksForWorkflows`, added for a near-identical scheduler N+1 in #8502).

## Review Claim

`listAutoFixRecoveryScanCandidates` makes one batched `loadTasksForWorkflows` call instead of one `loadTasks` call per workflow, with identical results, when the store provides it; falls back to the old per-workflow path unchanged otherwise.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new store method is optional (`loadTasksForWorkflows?`). A store that doesn't implement it (existing test mocks, any future caller) keeps using the exact old per-workflow `loadTasks` path with no behavior change. The real production store (`SQLiteAdapter`, wired as `persistence` in `main.ts`) already implements `loadTasksForWorkflows` — it was added for a prior, separate fix (#8502) and is otherwise unused by this scan today.

## Slice Rationale

One isolated performance fix to one scan function, landing after the repro slice that demonstrates the bug it corrects. No changes to auto-fix decision logic, retry policy, or which tasks get selected — only how their task rows are loaded.

## Non-goals

Does not touch the four sibling call sites with the same per-workflow-loadTasks shape found via class-search (`headless-command-classification.ts`, `metadata-setter.ts`, `recovery-worker-observability.ts`, `worker-control.ts`) — none of them run on this worker's hot, constantly-ticking path, so they're lower urgency and out of scope here. Does not change how many workflows the e2e-autofix watcher creates per CI regression (a separate, larger design question).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- auto-fix-recovery` — new test proves the batched call pattern (1 `loadTasksForWorkflows` call, 0 `loadTasks` calls, across 50 workflows) fails on pre-fix code (confirmed via `git stash`, real pasted output) and passes after; a second new test proves the fallback path still works when the store doesn't implement the batched method; 12/12 pass
- [x] `pnpm --filter @invoker/execution-engine build` and `pnpm --filter @invoker/app build` — both build clean
- [x] `pnpm --filter @invoker/app test -- auto-fix-recovery` — 18/18 pass, unaffected

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
