### PR TITLE
[Chaos A: Planning Worktree Cap](2) Cap planning worktrees by counting on-disk directories

### DIFF
--- a/packages/execution-engine/src/__tests__/repro-planning-worktree-cap-softrelease.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-planning-worktree-cap-softrelease.test.ts
@@ -9,14 +9,11 @@
  * the worktree from disk, so later creates see <maxWorktrees and keep minting
  * new directories/sessions.
  *
- * TODO(chaos-a-fix): These tests are marked it.fails because the current
- * implementation only checks in-memory activeWorktrees, not on-disk planning
- * worktrees. The limit is not enforced for planning sessions that call
- * softRelease() immediately after acquire.
- *
- * After the fix applies:
- * - RepoPool will count on-disk planning worktrees when enforcing maxWorktrees
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - RepoPool now counts on-disk planning worktrees when enforcing maxWorktrees
+ * - For branches starting with invoker/planning/, the limit is checked against
+ *   the git worktree list, not just in-memory activeWorktrees
+ * - Tests now pass because on-disk count stays <= maxWorktrees
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -24,7 +21,7 @@ import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync } from 'nod
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { RepoPool } from '../repo-pool.js';
+import { RepoPool, ResourceLimitError } from '../repo-pool.js';
 import { parseGitWorktreePorcelain } from '../worktree-discovery.js';
 
 function createTempRepo(): string {
@@ -73,7 +70,7 @@ describe('planning worktree cap with softRelease', () => {
     rmSync(localRepoUrl, { recursive: true, force: true });
   });
 
-  it.fails('sequential acquire+softRelease should not exceed maxWorktrees on disk', async () => {
+  it('sequential acquire+softRelease should not exceed maxWorktrees on disk', async () => {
     const MAX_WORKTREES = 6;
     const SESSIONS_TO_CREATE = 15;
 
@@ -84,20 +81,33 @@ describe('planning worktree cap with softRelease', () => {
     });
 
     const clonePath = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
+    let succeeded = 0;
+    let rejected = 0;
 
     for (let i = 0; i < SESSIONS_TO_CREATE; i++) {
       const sessionId = `session-${i}`;
       const branch = resolvePlanningWorktreeBranch(sessionId);
-      const acquired = await pool.acquireWorktree(localRepoUrl, branch, undefined, sessionId);
-      acquired.softRelease();
+      try {
+        const acquired = await pool.acquireWorktree(localRepoUrl, branch, undefined, sessionId);
+        acquired.softRelease();
+        succeeded++;
+      } catch (err) {
+        if (err instanceof ResourceLimitError) {
+          rejected++;
+        } else {
+          throw err;
+        }
+      }
     }
 
     const onDiskCount = countPlanningWorktrees(clonePath);
 
     expect(onDiskCount).toBeLessThanOrEqual(MAX_WORKTREES);
+    expect(succeeded).toBe(MAX_WORKTREES);
+    expect(rejected).toBe(SESSIONS_TO_CREATE - MAX_WORKTREES);
   });
 
-  it.fails('concurrent acquire+softRelease should not exceed maxWorktrees on disk', async () => {
+  it('concurrent acquire+softRelease should not exceed maxWorktrees on disk', async () => {
     const MAX_WORKTREES = 6;
     const CONCURRENT_SESSIONS = 25;
 
@@ -122,12 +132,17 @@ describe('planning worktree cap with softRelease', () => {
     );
 
     const succeeded = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter(
+      (r) => r.status === 'rejected' && r.reason instanceof ResourceLimitError
+    );
     const onDiskCount = countPlanningWorktrees(clonePath);
 
     expect(onDiskCount).toBeLessThanOrEqual(MAX_WORKTREES);
+    expect(succeeded.length).toBeLessThanOrEqual(MAX_WORKTREES);
+    expect(rejected.length).toBeGreaterThanOrEqual(CONCURRENT_SESSIONS - MAX_WORKTREES);
   });
 
-  it.fails('live planning worktree count should not exceed maxWorktrees', async () => {
+  it('live planning worktree count should not exceed maxWorktrees', async () => {
     const MAX_WORKTREES = 6;
     const SESSIONS_TO_CREATE = 20;
 
@@ -143,8 +158,14 @@ describe('planning worktree cap with softRelease', () => {
     for (let i = 0; i < SESSIONS_TO_CREATE; i++) {
       const sessionId = `tracked-session-${i}`;
       const branch = resolvePlanningWorktreeBranch(sessionId);
-      const acquired = await pool.acquireWorktree(localRepoUrl, branch, undefined, sessionId);
-      acquired.softRelease();
+      try {
+        const acquired = await pool.acquireWorktree(localRepoUrl, branch, undefined, sessionId);
+        acquired.softRelease();
+      } catch (err) {
+        if (!(err instanceof ResourceLimitError)) {
+          throw err;
+        }
+      }
 
       const currentOnDisk = countPlanningWorktrees(clonePath);
       if (currentOnDisk > maxOnDiskObserved) {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -8,9 +8,11 @@ import { planManagedWorktree } from './managed-worktree-controller.js';
 import {
   abbrevRefMatchesBranch,
   canonicalPathForComparison,
+  countPlanningWorktreesFromPorcelain,
   findContentHashCollisions,
   findManagedWorktreeByContent,
   findManagedWorktreeForBranch,
+  isPlanningBranch,
   pathIsUnderManagedPrefixes,
   parseGitWorktreePorcelain,
   parseExperimentBranch,
@@ -799,17 +801,42 @@ export class RepoPool {
     const clonePath = await this.ensureCloneUnqueued(repoUrl);
     bench('RepoPool.doAcquireWorktree.ensureCloneUnqueued.after', { clonePath });
     const repoKey = this.repoKey(repoUrl);
-    const active = this.activeWorktrees.get(repoKey) ?? new Set();
-    bench('RepoPool.doAcquireWorktree.activeWorktreeCount', { activeCount: active.size, maxWorktrees: this.maxWorktrees });
-    if (active.size >= this.maxWorktrees) {
-      throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
+
+    let porcelain = '';
+    try {
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.before', { clonePath });
+      porcelain = await this.execGit(['worktree', 'list', '--porcelain'], clonePath);
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.after', { clonePath });
+    } catch {
+      porcelain = '';
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.failed', { clonePath });
     }
 
-    // DB-backed lease: additive to the in-memory Set above, never a way to
-    // grant more capacity than it already allows. Skipped (not a hard
-    // failure) when persistence or a holder id isn't supplied, so every
-    // existing no-persistence caller (all current repo-pool.test.ts cases)
-    // behaves exactly as before.
+    const active = this.activeWorktrees.get(repoKey) ?? new Set();
+    const isPlanning = isPlanningBranch(branch);
+    const planningWorktreeCount = isPlanning ? countPlanningWorktreesFromPorcelain(porcelain) : 0;
+    const branchAlreadyExists = parseGitWorktreePorcelain(porcelain).some((e) => e.branch === branch);
+
+    bench('RepoPool.doAcquireWorktree.worktreeCount', {
+      activeCount: active.size,
+      planningWorktreeCount,
+      branchAlreadyExists,
+      isPlanning,
+      maxWorktrees: this.maxWorktrees,
+    });
+
+    if (isPlanning) {
+      if (!branchAlreadyExists && planningWorktreeCount >= this.maxWorktrees) {
+        throw new ResourceLimitError(
+          `Planning worktree limit reached for ${repoUrl}: ${planningWorktreeCount}/${this.maxWorktrees} on disk`,
+        );
+      }
+    } else {
+      if (active.size >= this.maxWorktrees) {
+        throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
+      }
+    }
+
     let leaseHolderId: string | undefined = opts?.leaseHolderId;
     if (this.leasePersistence && leaseHolderId) {
       let claimed = true;
@@ -848,16 +875,6 @@ export class RepoPool {
           : `${clonePath}/worktrees`,
       ),
     ];
-
-    let porcelain = '';
-    try {
-      bench('RepoPool.doAcquireWorktree.gitWorktreeList.before', { clonePath });
-      porcelain = await this.execGit(['worktree', 'list', '--porcelain'], clonePath);
-      bench('RepoPool.doAcquireWorktree.gitWorktreeList.after', { clonePath });
-    } catch {
-      porcelain = '';
-      bench('RepoPool.doAcquireWorktree.gitWorktreeList.failed', { clonePath });
-    }
 
     const allowReuse = opts?.forceFresh !== true;
     bench('RepoPool.doAcquireWorktree.findReuseCandidates.before', { allowReuse });

--- a/packages/execution-engine/src/worktree-discovery.ts
+++ b/packages/execution-engine/src/worktree-discovery.ts
@@ -47,6 +47,17 @@ export function canonicalPathForComparison(p: string): string {
   }
 }
 
+const PLANNING_BRANCH_PREFIX = 'invoker/planning/';
+
+export function isPlanningBranch(branch: string | undefined): boolean {
+  return branch?.startsWith(PLANNING_BRANCH_PREFIX) ?? false;
+}
+
+export function countPlanningWorktreesFromPorcelain(porcelain: string): number {
+  const entries = parseGitWorktreePorcelain(porcelain);
+  return entries.filter((e) => isPlanningBranch(e.branch)).length;
+}
+
 /** True if `worktreePath` is exactly `prefix` or a descendant (Invoker-owned tree). */
 export function pathIsUnderManagedPrefixes(worktreePath: string, managedPathPrefixes: string[]): boolean {
   const nw = canonicalPathForComparison(worktreePath);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the planning worktree cap bypass by counting on-disk worktrees for invoker/planning/* branches.

Before this fix, softRelease() freed the in-memory activeWorktrees slot but left the directory on disk. Subsequent acquires saw fewer than maxWorktrees in memory and created more directories.

This allowed unlimited planning worktrees to accumulate.

Now RepoPool checks the git worktree list for invoker/planning/* branches. If on-disk planning worktrees reach maxWorktrees and the requested branch does not already exist, it throws ResourceLimitError.

## Review Claim

Reviewer approves that counting on-disk planning worktrees when checking maxWorktrees correctly bounds live planning sessions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The fix adds an additional capacity check for planning branches only. Non-planning branches continue using the existing in-memory activeWorktrees check. Existing branch reuse is not affected since the check allows acquiring a branch that already exists on disk.

## Slice Rationale

Fix follows proof per stack ordering rules. The proof slice demonstrated the bug; this slice closes the softRelease hole.

## Non-goals

Does not change non-planning worktree capacity logic. Does not modify softRelease() itself. Does not add cleanup or garbage collection for existing worktrees.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run repro-planning-worktree-cap-softrelease`
- [x] `pnpm --filter @invoker/execution-engine test -- --run worktree-discovery`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, reverts to unbounded planning worktree behavior
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Planning worktree limits are now enforced using worktrees present on disk.
  * Existing planning branches can be reused without incorrectly exceeding capacity.
  * Worktree acquisition now correctly rejects requests when the planning limit is reached.
  * Failures while reading worktree details no longer prevent acquisition checks from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->