### PR TITLE
[Chaos D: Commandless Task](2) Reject tasks without command or prompt at parse time

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-commandless-task-accepted.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-commandless-task-accepted.test.ts
@@ -7,19 +7,16 @@
  * Root cause: parsePlan only validates id/description, not that at least one
  * of command|prompt is present. A task without either cannot run.
  *
- * TODO(chaos-d-fix): These tests are marked it.fails because the current
- * implementation accepts tasks with neither command nor prompt.
- *
- * After the fix applies:
- * - parsePlan will reject tasks that have neither command nor prompt
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates that each task has at least one of command|prompt
+ * - Tasks without either are rejected with a clear error message
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('command-less / prompt-less task validation', () => {
-  it.fails('parsePlan should reject task with neither command nor prompt', () => {
+  it('parsePlan should reject task with neither command nor prompt', () => {
     const yamlContent = `
 name: No action task
 repoUrl: git@github.com:example/repo.git
@@ -31,7 +28,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task with empty command and no prompt', () => {
+  it('parsePlan should reject task with empty command and no prompt', () => {
     const yamlContent = `
 name: Empty command task
 repoUrl: git@github.com:example/repo.git
@@ -44,7 +41,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task with whitespace-only command and no prompt', () => {
+  it('parsePlan should reject task with whitespace-only command and no prompt', () => {
     const yamlContent = `
 name: Whitespace command task
 repoUrl: git@github.com:example/repo.git

--- a/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Repro: Path-traversal task id accepted
+ *
+ * Symptom: Task id `../etc/passwd` stored as `wf-…/../etc/passwd`.
+ * Task ids are concatenated into workflow-scoped paths without sanitizing.
+ *
+ * Root cause: parsePlan does not validate task ids for path-unsafe characters.
+ * Task ids with `..`, `/`, or `\` can escape the intended directory scope.
+ *
+ * TODO(chaos-e-fix): These tests are marked it.fails because the current
+ * implementation accepts task ids with path traversal characters.
+ *
+ * After the fix applies:
+ * - parsePlan will reject task ids containing path-unsafe characters
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('path-traversal task id validation', () => {
+  it.fails('parsePlan should reject task id with ".." path traversal', () => {
+    const yamlContent = `
+name: Path traversal task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "../etc/passwd"
+    description: Task with path traversal in id
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id with forward slash', () => {
+    const yamlContent = `
+name: Forward slash task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "foo/bar"
+    description: Task with forward slash in id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id with backslash', () => {
+    const yamlContent = `
+name: Backslash task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "foo\\bar"
+    description: Task with backslash in id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id starting with dot', () => {
+    const yamlContent = `
+name: Dot prefix task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: ".hidden-task"
+    description: Task starting with dot
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept task id with safe characters', () => {
+    const yamlContent = `
+name: Safe task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "safe-task_123"
+    description: Task with safe characters
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('safe-task_123');
+  });
+
+  it('parsePlan should accept task id with hyphen and underscore', () => {
+    const yamlContent = `
+name: Special chars task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "my-task_v2"
+    description: Task with hyphen and underscore
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('my-task_v2');
+  });
+});

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -278,6 +278,13 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     if (!task.description || typeof task.description !== 'string') {
       throw new PlanParseError(`Task "${task.id}" must have a "description" field`);
     }
+    const hasCommand = typeof task.command === 'string' && task.command.trim() !== '';
+    const hasPrompt = typeof task.prompt === 'string' && task.prompt.trim() !== '';
+    if (!hasCommand && !hasPrompt) {
+      throw new PlanParseError(
+        `Task "${task.id}" must have at least one of "command" or "prompt". A task without either cannot run.`,
+      );
+    }
     assertNoLegacyRoutingKeys(`Task "${task.id}"`, task as object);
     if (hasOwn(task as object, 'autoFix')) {
       throw new PlanParseError(`Task "${task.id}" uses "autoFix", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`);

--- a/scripts/repro/repro-path-traversal-task-id.sh
+++ b/scripts/repro/repro-path-traversal-task-id.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: Path-traversal task id accepted
+#
+# This script runs the path-traversal task id test to demonstrate that:
+# 1. Task ids with "..", "/", or "\\" are currently accepted by parsePlan
+# 2. Such ids can escape intended directory scope when concatenated to paths
+#
+# Before fix: Tests marked it.fails pass (underlying test fails, showing the bug)
+# After fix: Tests pass directly (path-unsafe task ids are rejected)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running path-traversal task id validation test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-path-traversal-task-id
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add validation in parsePlan to require at least one of command or prompt.

Tasks with neither cannot run and would stay pending forever, blocking merge.

The check validates that the field exists as a non-empty string.

## Review Claim

Verify the validation correctly rejects tasks missing both command and prompt.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Adds input validation at parse time. Rejects previously-accepted invalid plans.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not change runtime behavior. Rejection happens at load time only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-commandless-task-accepted.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid tasks without a command or prompt are now rejected with a clear validation error.
  - Empty and whitespace-only commands are no longer accepted as runnable tasks.

- **Tests**
  - Added coverage for invalid task definitions.
  - Added validation checks for unsafe task identifiers, including path traversal patterns, and confirmed that standard identifiers remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->