### PR TITLE
[Chaos E: Path Traversal](2) Reject path-unsafe task ids and plan names at parse time

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-commandless-task-accepted.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-commandless-task-accepted.test.ts
@@ -7,19 +7,16 @@
  * Root cause: parsePlan only validates id/description, not that at least one
  * of command|prompt is present. A task without either cannot run.
  *
- * TODO(chaos-d-fix): These tests are marked it.fails because the current
- * implementation accepts tasks with neither command nor prompt.
- *
- * After the fix applies:
- * - parsePlan will reject tasks that have neither command nor prompt
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates that each task has at least one of command|prompt
+ * - Tasks without either are rejected with a clear error message
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('command-less / prompt-less task validation', () => {
-  it.fails('parsePlan should reject task with neither command nor prompt', () => {
+  it('parsePlan should reject task with neither command nor prompt', () => {
     const yamlContent = `
 name: No action task
 repoUrl: git@github.com:example/repo.git
@@ -31,7 +28,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task with empty command and no prompt', () => {
+  it('parsePlan should reject task with empty command and no prompt', () => {
     const yamlContent = `
 name: Empty command task
 repoUrl: git@github.com:example/repo.git
@@ -44,7 +41,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task with whitespace-only command and no prompt', () => {
+  it('parsePlan should reject task with whitespace-only command and no prompt', () => {
     const yamlContent = `
 name: Whitespace command task
 repoUrl: git@github.com:example/repo.git

--- a/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
@@ -7,19 +7,16 @@
  * Root cause: parsePlan does not validate task ids for path-unsafe characters.
  * Task ids with `..`, `/`, or `\` can escape the intended directory scope.
  *
- * TODO(chaos-e-fix): These tests are marked it.fails because the current
- * implementation accepts task ids with path traversal characters.
- *
- * After the fix applies:
- * - parsePlan will reject task ids containing path-unsafe characters
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates task ids with isPathSafeId()
+ * - Task ids containing "..", "/", "\", or starting with "." are rejected
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('path-traversal task id validation', () => {
-  it.fails('parsePlan should reject task id with ".." path traversal', () => {
+  it('parsePlan should reject task id with ".." path traversal', () => {
     const yamlContent = `
 name: Path traversal task
 repoUrl: git@github.com:example/repo.git
@@ -32,7 +29,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task id with forward slash', () => {
+  it('parsePlan should reject task id with forward slash', () => {
     const yamlContent = `
 name: Forward slash task
 repoUrl: git@github.com:example/repo.git
@@ -45,12 +42,12 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task id with backslash', () => {
+  it('parsePlan should reject task id with backslash', () => {
     const yamlContent = `
 name: Backslash task
 repoUrl: git@github.com:example/repo.git
 tasks:
-  - id: "foo\\bar"
+  - id: 'foo\\bar'
     description: Task with backslash in id
     command: echo test
 `;
@@ -58,7 +55,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task id starting with dot', () => {
+  it('parsePlan should reject task id starting with dot', () => {
     const yamlContent = `
 name: Dot prefix task
 repoUrl: git@github.com:example/repo.git
@@ -97,5 +94,167 @@ tasks:
 
     const plan = parsePlan(yamlContent);
     expect(plan.tasks[0].id).toBe('my-task_v2');
+  });
+
+  it('parsePlan should reject task id with absolute path', () => {
+    const yamlContent = `
+name: Absolute path task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "/tmp/w3-escape"
+    description: Task with absolute path in id
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject task id with RTL override character', () => {
+    const yamlContent = `
+name: RTL task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "task\u202Ename"
+    description: Task with RTL override in id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject experimentVariant id with path traversal', () => {
+    const yamlContent = `
+name: Variant escape task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "pivot-task"
+    description: Pivot task with malicious variant
+    command: echo test
+    pivot: true
+    experimentVariants:
+      - id: "../etc/passwd"
+        description: Malicious variant
+        command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject experimentVariant id starting with dot', () => {
+    const yamlContent = `
+name: Hidden variant task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "pivot-task"
+    description: Pivot task with hidden variant
+    command: echo test
+    pivot: true
+    experimentVariants:
+      - id: ".hidden"
+        description: Hidden variant
+        command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept experimentVariant id with safe characters', () => {
+    const yamlContent = `
+name: Safe variant task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "pivot-task"
+    description: Pivot task with safe variant
+    command: echo test
+    pivot: true
+    experimentVariants:
+      - id: "variant-v1"
+        description: Safe variant
+        command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].experimentVariants![0].id).toBe('variant-v1');
+  });
+
+  it('parsePlan should reject task id that is exactly ".."', () => {
+    const yamlContent = `
+name: Double dot task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: ".."
+    description: Task with .. as id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject task id that is exactly "."', () => {
+    const yamlContent = `
+name: Single dot task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "."
+    description: Task with . as id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject task id that is whitespace only', () => {
+    const yamlContent = `
+name: Whitespace task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "   "
+    description: Task with whitespace-only id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+});
+
+describe('path-traversal plan name validation', () => {
+  it('parsePlan should reject plan name with ".." path traversal', () => {
+    const yamlContent = `
+name: "../etc/passwd"
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: safe-task
+    description: Safe task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should reject plan name with forward slash', () => {
+    const yamlContent = `
+name: "foo/bar"
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: safe-task
+    description: Safe task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept plan name with safe characters', () => {
+    const yamlContent = `
+name: "My Safe Plan 2026"
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: safe-task
+    description: Safe task
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.name).toBe('My Safe Plan 2026');
   });
 });

--- a/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-path-traversal-task-id.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Repro: Path-traversal task id accepted
+ *
+ * Symptom: Task id `../etc/passwd` stored as `wf-…/../etc/passwd`.
+ * Task ids are concatenated into workflow-scoped paths without sanitizing.
+ *
+ * Root cause: parsePlan does not validate task ids for path-unsafe characters.
+ * Task ids with `..`, `/`, or `\` can escape the intended directory scope.
+ *
+ * TODO(chaos-e-fix): These tests are marked it.fails because the current
+ * implementation accepts task ids with path traversal characters.
+ *
+ * After the fix applies:
+ * - parsePlan will reject task ids containing path-unsafe characters
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('path-traversal task id validation', () => {
+  it.fails('parsePlan should reject task id with ".." path traversal', () => {
+    const yamlContent = `
+name: Path traversal task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "../etc/passwd"
+    description: Task with path traversal in id
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id with forward slash', () => {
+    const yamlContent = `
+name: Forward slash task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "foo/bar"
+    description: Task with forward slash in id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id with backslash', () => {
+    const yamlContent = `
+name: Backslash task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "foo\\bar"
+    description: Task with backslash in id
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id starting with dot', () => {
+    const yamlContent = `
+name: Dot prefix task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: ".hidden-task"
+    description: Task starting with dot
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept task id with safe characters', () => {
+    const yamlContent = `
+name: Safe task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "safe-task_123"
+    description: Task with safe characters
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('safe-task_123');
+  });
+
+  it('parsePlan should accept task id with hyphen and underscore', () => {
+    const yamlContent = `
+name: Special chars task
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "my-task_v2"
+    description: Task with hyphen and underscore
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('my-task_v2');
+  });
+});

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -278,6 +278,13 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     if (!task.description || typeof task.description !== 'string') {
       throw new PlanParseError(`Task "${task.id}" must have a "description" field`);
     }
+    const hasCommand = typeof task.command === 'string' && task.command.trim() !== '';
+    const hasPrompt = typeof task.prompt === 'string' && task.prompt.trim() !== '';
+    if (!hasCommand && !hasPrompt) {
+      throw new PlanParseError(
+        `Task "${task.id}" must have at least one of "command" or "prompt". A task without either cannot run.`,
+      );
+    }
     assertNoLegacyRoutingKeys(`Task "${task.id}"`, task as object);
     if (hasOwn(task as object, 'autoFix')) {
       throw new PlanParseError(`Task "${task.id}" uses "autoFix", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`);

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -9,6 +9,17 @@ export class PlanParseError extends Error {
   }
 }
 
+export function isPathSafeId(id: string): boolean {
+  if (!id || typeof id !== 'string') return false;
+  if (id.trim() === '') return false;
+  if (id.startsWith('.')) return false;
+  if (id.includes('..')) return false;
+  if (id.includes('/')) return false;
+  if (id.includes('\\')) return false;
+  if (/[\x00-\x1f\x7f\u200e\u200f\u202a-\u202e\u2066-\u2069]/.test(id)) return false;
+  return true;
+}
+
 interface TaskWithDeps {
   id: string;
   dependencies: string[];
@@ -206,6 +217,11 @@ export function parsePlan(yamlContent: string): PlanDefinition {
 
   if (!raw || typeof raw !== 'object') throw new PlanParseError('Plan must be a YAML object');
   if (!raw.name || typeof raw.name !== 'string') throw new PlanParseError('Plan must have a "name" field');
+  if (!isPathSafeId(raw.name)) {
+    throw new PlanParseError(
+      `Plan name "${raw.name}" contains unsafe characters. Plan names must not contain "..", "/", "\\", or start with ".".`,
+    );
+  }
   if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
     throw new PlanParseError('Plan must have a non-empty "tasks" array');
   }
@@ -271,6 +287,11 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       throw new PlanParseError(`Task at index ${index} must be an object with an "id" field`);
     }
     if (!task.id || typeof task.id !== 'string') throw new PlanParseError(`Task at index ${index} must have an "id" field`);
+    if (!isPathSafeId(task.id)) {
+      throw new PlanParseError(
+        `Task id "${task.id}" contains unsafe characters. Task ids must not contain "..", "/", "\\", or start with ".".`,
+      );
+    }
     if (seenTaskIds.has(task.id)) {
       throw new PlanParseError(`Duplicate task id "${task.id}". Task ids must be unique within a plan.`);
     }
@@ -322,12 +343,21 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       prompt: task.prompt,
       dependencies: task.dependencies ?? [],
       pivot: task.pivot,
-      experimentVariants: task.experimentVariants?.map((variant) => ({
-        id: variant.id ?? '',
-        description: variant.description ?? '',
-        prompt: variant.prompt,
-        command: variant.command,
-      })),
+      experimentVariants: task.experimentVariants?.map((variant, variantIndex) => {
+        const variantId = variant.id ?? '';
+        if (variantId && !isPathSafeId(variantId)) {
+          throw new PlanParseError(
+            `Task "${task.id}" experimentVariants[${variantIndex}] id "${variantId}" contains unsafe characters. ` +
+            'Variant ids must not contain "..", "/", "\\", control characters, or start with ".".',
+          );
+        }
+        return {
+          id: variantId,
+          description: variant.description ?? '',
+          prompt: variant.prompt,
+          command: variant.command,
+        };
+      }),
       requiresManualApproval: task.requiresManualApproval,
       featureBranch: task.featureBranch,
       dockerImage: task.dockerImage,

--- a/scripts/repro/repro-path-traversal-task-id.sh
+++ b/scripts/repro/repro-path-traversal-task-id.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: Path-traversal task id accepted
+#
+# This script runs the path-traversal task id test to demonstrate that:
+# 1. Task ids with "..", "/", or "\\" are currently accepted by parsePlan
+# 2. Such ids can escape intended directory scope when concatenated to paths
+#
+# Before fix: Tests marked it.fails pass (underlying test fails, showing the bug)
+# After fix: Tests pass directly (path-unsafe task ids are rejected)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running path-traversal task id validation test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-path-traversal-task-id
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add isPathSafeId check for task ids and plan names in the parsing route.

Ids with path traversal (`..`), slashes, control characters, or starting with `.` throw.

Extended to cover experimentVariant ids, absolute paths, RTL override characters, and exact `..`, `.`, whitespace-only ids.

## Review Claim

Verify the parsing route correctly throws for path-unsafe ids and names.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted plans with unsafe ids.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not sanitize ids at runtime. Only throws at parse time.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-path-traversal-task-id.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

