### PR TITLE
[Chaos F: Owner Timeout](1) Repro test for timeout misclassified as dead owner

### DIFF
--- a/packages/app/src/__tests__/repro-delegation-timeout-vs-dead-owner.test.ts
+++ b/packages/app/src/__tests__/repro-delegation-timeout-vs-dead-owner.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Repro: Concurrent CLI headless run false "owner not running"
+ *
+ * Symptom: Two overlapping `electron --headless run` against a live owner:
+ * one hit `[delegation] timeout channel=headless.run timeoutMs=5000` then
+ * `Mutation command "run" requires a running owner process.` The other succeeded.
+ * Owner stayed up, writer lock stayed with the owner pid.
+ *
+ * Root cause: 5s headless.run timeout is mapped to "owner not running" instead
+ * of "owner busy/timeout". A busy owner is not a dead owner.
+ *
+ * Invariant: A live owner must not be reported dead because an IPC/delegation
+ * wait timed out.
+ *
+ * TODO(chaos-f-fix): These tests are marked it.fails because the current
+ * implementation does not export isTimeout/isNoHandler helpers that callers
+ * can use to distinguish timeout from no-handler outcomes.
+ *
+ * After the fix applies:
+ * - isTimeout and isNoHandler will be exported from headless-delegation
+ * - Callers can distinguish timeout (owner busy) from no-handler (owner dead)
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isDelegated,
+  type DelegationOutcome,
+} from '../headless-delegation.js';
+
+describe('delegation timeout vs dead owner classification', () => {
+  it('isDelegated correctly identifies delegated outcomes', () => {
+    const timeout: DelegationOutcome = { kind: 'timeout' };
+    const noHandler: DelegationOutcome = { kind: 'no-handler' };
+    const delegated: DelegationOutcome = { kind: 'delegated' };
+
+    expect(isDelegated(timeout)).toBe(false);
+    expect(isDelegated(noHandler)).toBe(false);
+    expect(isDelegated(delegated)).toBe(true);
+  });
+
+  it.fails('isTimeout and isNoHandler should be exported for caller-side distinction', async () => {
+    const mod = await import('../headless-delegation.js') as Record<string, unknown>;
+
+    expect(typeof mod.isTimeout).toBe('function');
+    expect(typeof mod.isNoHandler).toBe('function');
+
+    const timeout: DelegationOutcome = { kind: 'timeout' };
+    const noHandler: DelegationOutcome = { kind: 'no-handler' };
+
+    expect((mod.isTimeout as (o: DelegationOutcome) => boolean)(timeout)).toBe(true);
+    expect((mod.isTimeout as (o: DelegationOutcome) => boolean)(noHandler)).toBe(false);
+    expect((mod.isNoHandler as (o: DelegationOutcome) => boolean)(timeout)).toBe(false);
+    expect((mod.isNoHandler as (o: DelegationOutcome) => boolean)(noHandler)).toBe(true);
+  });
+});

--- a/scripts/repro/repro-delegation-timeout-vs-dead-owner.sh
+++ b/scripts/repro/repro-delegation-timeout-vs-dead-owner.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: Concurrent CLI headless run false "owner not running"
+#
+# This script runs the delegation timeout classification test to demonstrate that:
+# 1. Delegation timeout is not distinguished from "no owner" at the API level
+# 2. Callers cannot differentiate busy owner (timeout) from dead owner (no-handler)
+#
+# Before fix: Tests marked it.fails pass (isTimeout/isNoHandler not exported)
+# After fix: Tests pass directly (helpers exported for caller-side distinction)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running delegation timeout classification test ==="
+pnpm --filter @invoker/app test -- --run repro-delegation-timeout-vs-dead-owner
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that isTimeout and isNoHandler are not exported.

Without these helpers, callers cannot distinguish a timeout from no-handler.

A busy owner (timeout) is misreported as dead (no owner running).

## Review Claim

Verify the test correctly shows missing type guards for delegation outcomes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No production code modified. Tests assert current behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. Fix is in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-delegation-timeout-vs-dead-owner.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

