### PR TITLE
[Chaos F: Owner Timeout](2) Distinguish delegation timeout from dead owner

### DIFF
--- a/packages/app/src/__tests__/repro-delegation-timeout-vs-dead-owner.test.ts
+++ b/packages/app/src/__tests__/repro-delegation-timeout-vs-dead-owner.test.ts
@@ -12,19 +12,16 @@
  * Invariant: A live owner must not be reported dead because an IPC/delegation
  * wait timed out.
  *
- * TODO(chaos-f-fix): These tests are marked it.fails because the current
- * implementation does not export isTimeout/isNoHandler helpers that callers
- * can use to distinguish timeout from no-handler outcomes.
- *
- * After the fix applies:
- * - isTimeout and isNoHandler will be exported from headless-delegation
+ * Fix applied:
+ * - isTimeout and isNoHandler are now exported from headless-delegation
  * - Callers can distinguish timeout (owner busy) from no-handler (owner dead)
- * - Tests will pass and should be changed from it.fails to it
  */
 
 import { describe, it, expect } from 'vitest';
 import {
   isDelegated,
+  isTimeout,
+  isNoHandler,
   type DelegationOutcome,
 } from '../headless-delegation.js';
 
@@ -39,18 +36,17 @@ describe('delegation timeout vs dead owner classification', () => {
     expect(isDelegated(delegated)).toBe(true);
   });
 
-  it.fails('isTimeout and isNoHandler should be exported for caller-side distinction', async () => {
-    const mod = await import('../headless-delegation.js') as Record<string, unknown>;
-
-    expect(typeof mod.isTimeout).toBe('function');
-    expect(typeof mod.isNoHandler).toBe('function');
-
+  it('isTimeout and isNoHandler distinguish timeout from no-handler', () => {
     const timeout: DelegationOutcome = { kind: 'timeout' };
     const noHandler: DelegationOutcome = { kind: 'no-handler' };
+    const delegated: DelegationOutcome = { kind: 'delegated' };
 
-    expect((mod.isTimeout as (o: DelegationOutcome) => boolean)(timeout)).toBe(true);
-    expect((mod.isTimeout as (o: DelegationOutcome) => boolean)(noHandler)).toBe(false);
-    expect((mod.isNoHandler as (o: DelegationOutcome) => boolean)(timeout)).toBe(false);
-    expect((mod.isNoHandler as (o: DelegationOutcome) => boolean)(noHandler)).toBe(true);
+    expect(isTimeout(timeout)).toBe(true);
+    expect(isTimeout(noHandler)).toBe(false);
+    expect(isTimeout(delegated)).toBe(false);
+
+    expect(isNoHandler(timeout)).toBe(false);
+    expect(isNoHandler(noHandler)).toBe(true);
+    expect(isNoHandler(delegated)).toBe(false);
   });
 });

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -31,9 +31,16 @@ export type DelegationOutcome =
   | { kind: 'no-handler' }
   | { kind: 'protocol-error'; message: string };
 
-/** Type guard: returns true when the delegation was accepted by the owner. */
 export function isDelegated(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'delegated' } {
   return outcome.kind === 'delegated';
+}
+
+export function isTimeout(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'timeout' } {
+  return outcome.kind === 'timeout';
+}
+
+export function isNoHandler(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'no-handler' } {
+  return outcome.kind === 'no-handler';
 }
 
 function delegationLog(message: string): void {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -54,6 +54,8 @@ export {
   WORKFLOW_DELEGATION_TIMEOUT_MS,
   delegationTimeoutMs,
   isDelegated,
+  isTimeout,
+  isNoHandler,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -155,6 +155,7 @@ import { assertAllWorkerMutationChannelsRegistered, buildWorkerMutationHandlers 
 import {
   runHeadless,
   isDelegated,
+  isTimeout,
   tryDelegateRun,
   tryDelegateResume,
   resolveDelegationTimeoutMs,
@@ -164,6 +165,7 @@ import {
   createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   type HeadlessDeps,
+  type DelegationOutcome,
 } from './headless.js';
 import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
@@ -1030,25 +1032,25 @@ async function tryDelegateHeadlessMutationToBus(
   args: string[],
   bus: MessageBus,
   command: string | undefined,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack));
+    return tryDelegateRun(planPath, bus, waitForApproval, noTrack);
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack));
+    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
   }
   const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(args);
-  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
+  return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
 async function tryDelegateHeadlessMutationToExistingOwner(
   args: string[],
   command: string | undefined,
-): Promise<'delegated' | 'no-compatible-owner' | 'failed'> {
+): Promise<'delegated' | 'no-compatible-owner' | 'timeout' | 'failed'> {
   let delegationBus = new IpcBus(undefined, { allowServe: false });
   try {
     await delegationBus.ready();
@@ -1058,9 +1060,10 @@ async function tryDelegateHeadlessMutationToExistingOwner(
         : EXISTING_HEADLESS_MUTATION_OWNER_REFRESH_TIMEOUT_MS;
       const owner = await discoverOwner(delegationBus, timeoutMs);
       if (isStandaloneCapable(owner)) {
-        return await tryDelegateHeadlessMutationToBus(args, delegationBus, command)
-          ? 'delegated'
-          : 'failed';
+        const outcome = await tryDelegateHeadlessMutationToBus(args, delegationBus, command);
+        if (isDelegated(outcome)) return 'delegated';
+        if (isTimeout(outcome)) return 'timeout';
+        return 'failed';
       }
       if (attempt === 0) {
         delegationBus.disconnect();
@@ -1157,26 +1160,31 @@ function startHeadlessMode(): void {
         try {
           await delegationBus.ready();
 
-          const delegated = await tryDelegateHeadlessMutationToBus(cliArgs, delegationBus, command);
-          if (delegated) {
-            // Successfully delegated to owner
+          const outcome = await tryDelegateHeadlessMutationToBus(cliArgs, delegationBus, command);
+          if (isDelegated(outcome)) {
             delegationBus.disconnect();
             await flushStdoutAndStderr();
             process.exit(process.exitCode ?? 0);
-            return; // Guard: process.exit() may not halt in Electron async context
+            return;
           }
 
-          // Delegation failed: no owner handler available.
           delegationBus.disconnect();
-          process.stderr.write(
-            `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
-            `\n${BOLD}Options:${RESET}\n` +
-            `  1. Start the interactive process: ${BOLD}electron dist/main.js${RESET}\n` +
-            `  2. Run in standalone mode: ${BOLD}INVOKER_HEADLESS_STANDALONE=1 electron dist/main.js --headless ${cliArgs.join(' ')}${RESET}\n` +
-            `\nStandalone mode opens a writable database. Only use it when no other process is accessing the database.\n`
-          );
+          if (isTimeout(outcome)) {
+            process.stderr.write(
+              `${RED}Error:${RESET} Mutation command "${command}" timed out waiting for the owner process.\n` +
+              `The owner may be busy processing another request. Try again in a moment.\n`,
+            );
+          } else {
+            process.stderr.write(
+              `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
+              `\n${BOLD}Options:${RESET}\n` +
+              `  1. Start the interactive process: ${BOLD}electron dist/main.js${RESET}\n` +
+              `  2. Run in standalone mode: ${BOLD}INVOKER_HEADLESS_STANDALONE=1 electron dist/main.js --headless ${cliArgs.join(' ')}${RESET}\n` +
+              `\nStandalone mode opens a writable database. Only use it when no other process is accessing the database.\n`,
+            );
+          }
           process.exit(1);
-          return; // Guard: process.exit() may not halt in Electron async context
+          return;
         } catch (err) {
           process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
           delegationBus.disconnect();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Export isTimeout and isNoHandler helpers from headless-delegation.

Update main.ts to show different error messages for timeout vs no-handler.

Timeout now says "timed out waiting for owner" instead of "requires running owner".

## Review Claim

Verify the error message correctly distinguishes timeout from missing owner.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Changes error message text only. No functional change to delegation behavior.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not change timeout duration. Does not retry on timeout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-delegation-timeout-vs-dead-owner.sh`
- [x] `pnpm --filter @invoker/app test -- --run repro-delegation-timeout-vs-dead-owner`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

