### PR TITLE
[Chaos G: Invoke Method](1) Repro test for GET/HEAD /invoke serving SPA HTML

### DIFF
--- a/packages/app/src/__tests__/repro-invoke-method-fallthrough.test.ts
+++ b/packages/app/src/__tests__/repro-invoke-method-fallthrough.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Repro: GET/HEAD /invoke serves SPA HTML
+ *
+ * Symptom: POST /invoke is RPC. PUT/OPTIONS correctly 405. Cookie GET /invoke
+ * returns 200 text/html SPA. Header-only GET returns 401 (static cookie check),
+ * not 405.
+ *
+ * Root cause: GET/HEAD requests to /invoke are not explicitly rejected as 405.
+ * They fall through to the static file handler which serves the SPA HTML.
+ *
+ * Invariant: /invoke is POST-only; other methods should return 405 before
+ * any static fallback.
+ *
+ * TODO(chaos-g-fix): These tests are marked it.fails because the current
+ * implementation serves GET /invoke as SPA HTML instead of returning 405.
+ *
+ * After the fix applies:
+ * - GET/HEAD /invoke will return 405 method_not_allowed
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { LocalBus } from '@invoker/transport';
+import { startWebBridge, type WebBridge } from '../web/web-bridge-server.js';
+
+describe('/invoke method validation', () => {
+  let bridge: WebBridge;
+  let port: number;
+  let token: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    token = 'test-token-' + Math.random().toString(36).slice(2);
+    tmpDir = mkdtempSync(join(tmpdir(), 'web-bridge-test-'));
+    mkdirSync(join(tmpDir, 'dist'));
+    writeFileSync(join(tmpDir, 'dist', 'index.html'), '<!DOCTYPE html><html><body>Test</body></html>');
+
+    const bus = new LocalBus();
+    bridge = startWebBridge({
+      token,
+      dispatch: async () => ({ ok: true }),
+      messageBus: bus,
+      persistence: {
+        getActivityLogs: () => [],
+        listWorkflows: () => [],
+      },
+      uiDistDir: join(tmpDir, 'dist'),
+      host: '127.0.0.1',
+      port: 0,
+    });
+    port = await bridge.whenReady;
+  });
+
+  afterAll(async () => {
+    await bridge?.close();
+  });
+
+  function makeRequest(method: string, path: string, cookie?: string): Promise<{ status: number; contentType: string; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: '127.0.0.1',
+        port,
+        method,
+        path,
+        headers: cookie ? { cookie } : {},
+      }, (res) => {
+        let body = '';
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            contentType: res.headers['content-type'] ?? '',
+            body,
+          });
+        });
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('POST /invoke without auth returns 401', async () => {
+    const res = await makeRequest('POST', '/invoke');
+    expect(res.status).toBe(401);
+  });
+
+  it('PUT /invoke returns 405 method not allowed', async () => {
+    const res = await makeRequest('PUT', '/invoke');
+    expect(res.status).toBe(405);
+  });
+
+  it('OPTIONS /invoke returns 405 method not allowed', async () => {
+    const res = await makeRequest('OPTIONS', '/invoke');
+    expect(res.status).toBe(405);
+  });
+
+  it.fails('GET /invoke without auth should return 405, not 401', async () => {
+    const res = await makeRequest('GET', '/invoke');
+    expect(res.status).toBe(405);
+  });
+
+  it.fails('GET /invoke with auth should return 405, not 200 HTML', async () => {
+    const cookie = `invoker_web_token=${token}`;
+    const res = await makeRequest('GET', '/invoke', cookie);
+    expect(res.status).toBe(405);
+    expect(res.contentType).not.toContain('text/html');
+  });
+
+  it.fails('HEAD /invoke with auth should return 405', async () => {
+    const cookie = `invoker_web_token=${token}`;
+    const res = await makeRequest('HEAD', '/invoke', cookie);
+    expect(res.status).toBe(405);
+  });
+});

--- a/scripts/repro/repro-invoke-method-fallthrough.sh
+++ b/scripts/repro/repro-invoke-method-fallthrough.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GET/HEAD /invoke serves SPA HTML
+#
+# This script runs the /invoke method validation test to demonstrate that:
+# 1. GET/HEAD requests to /invoke fall through to static file handler
+# 2. Instead of returning 405, they serve SPA HTML or check auth first
+#
+# Before fix: Tests marked it.fails pass (GET /invoke serves HTML)
+# After fix: Tests pass directly (GET/HEAD /invoke return 405)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running /invoke method validation test ==="
+pnpm --filter @invoker/app test -- --run repro-invoke-method-fallthrough
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that GET/HEAD requests to /invoke fall through to static.

Instead of returning 405, these requests serve SPA HTML or check auth first.

Tests use it.fails to prove the bug exists. The fix slice will flip them to regular it.

## Review Claim

Verify the test correctly reproduces non-POST /invoke being served as HTML.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No production code modified. Tests assert current behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. Fix is in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-invoke-method-fallthrough.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

