### PR TITLE
[Chaos G: Invoke Method](2) Reject non-POST /invoke with 405 method not allowed

### DIFF
--- a/packages/app/src/__tests__/repro-invoke-method-fallthrough.test.ts
+++ b/packages/app/src/__tests__/repro-invoke-method-fallthrough.test.ts
@@ -11,12 +11,9 @@
  * Invariant: /invoke is POST-only; other methods should return 405 before
  * any static fallback.
  *
- * TODO(chaos-g-fix): These tests are marked it.fails because the current
- * implementation serves GET /invoke as SPA HTML instead of returning 405.
- *
- * After the fix applies:
- * - GET/HEAD /invoke will return 405 method_not_allowed
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - /invoke path now checks method first
+ * - Non-POST requests to /invoke return 405 method_not_allowed
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -98,19 +95,19 @@ describe('/invoke method validation', () => {
     expect(res.status).toBe(405);
   });
 
-  it.fails('GET /invoke without auth should return 405, not 401', async () => {
+  it('GET /invoke without auth returns 405', async () => {
     const res = await makeRequest('GET', '/invoke');
     expect(res.status).toBe(405);
   });
 
-  it.fails('GET /invoke with auth should return 405, not 200 HTML', async () => {
+  it('GET /invoke with auth returns 405', async () => {
     const cookie = `invoker_web_token=${token}`;
     const res = await makeRequest('GET', '/invoke', cookie);
     expect(res.status).toBe(405);
     expect(res.contentType).not.toContain('text/html');
   });
 
-  it.fails('HEAD /invoke with auth should return 405', async () => {
+  it('HEAD /invoke with auth returns 405', async () => {
     const cookie = `invoker_web_token=${token}`;
     const res = await makeRequest('HEAD', '/invoke', cookie);
     expect(res.status).toBe(405);

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -276,7 +276,11 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
         const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
         const pathname = url.pathname;
 
-        if (method === 'POST' && pathname === '/invoke') {
+        if (pathname === '/invoke') {
+          if (method !== 'POST') {
+            sendJson(res, 405, { error: 'method_not_allowed' });
+            return;
+          }
           if (!cookieValid(req) && !headerValid(req)) {
             sendJson(res, 401, { error: 'unauthorized' });
             return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Move method check before auth check for /invoke endpoint.

Non-POST requests now return 405 immediately.

They no longer fall through to static file handling or auth validation.

## Review Claim

Verify /invoke correctly returns 405 for non-POST methods.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Changes request handling order only. POST /invoke behavior unchanged.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not change POST /invoke behavior. Does not add CORS headers.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-invoke-method-fallthrough.sh`
- [x] `pnpm --filter @invoker/app test -- --run repro-invoke-method-fallthrough`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

