### PR TITLE
[Chaos H: Reserved Prefix](1) Repro test for __merge__ task id impersonation

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-reserved-task-id-prefix.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-reserved-task-id-prefix.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Repro: __merge__ task id impersonation
+ *
+ * Symptom: Plan task id `__merge__w3fake` bypassed ${workflowId}/ scoping.
+ * Fake node ran as a normal task (completed), created unscoped branch
+ * `experiment/__merge__w3fake/…`, AND a real gate `__merge__${workflowId}`
+ * was still created.
+ *
+ * Root cause: parsePlan does not validate that task ids don't use reserved
+ * prefixes like `__merge__`. The scopePlanTaskId function treats ids starting
+ * with `__merge__` as already-scoped merge nodes.
+ *
+ * Invariant: `__merge__*` is reserved; plan-local ids must always be scoped;
+ * a user task must not become the merge node or an unscoped experiment branch.
+ *
+ * TODO(chaos-h-fix): These tests are marked it.fails because the current
+ * implementation accepts task ids with reserved prefixes.
+ *
+ * After the fix applies:
+ * - parsePlan will reject task ids starting with reserved prefixes
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('reserved task id prefix validation', () => {
+  it.fails('parsePlan should reject task id starting with __merge__', () => {
+    const yamlContent = `
+name: Merge impersonation
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "__merge__w3fake"
+    description: Task impersonating merge node
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id exactly matching __merge__', () => {
+    const yamlContent = `
+name: Exact merge impersonation
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "__merge__"
+    description: Task with exact merge node id
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject task id with __merge__ prefix and workflow-like suffix', () => {
+    const yamlContent = `
+name: Workflow merge impersonation
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "__merge__wf-1234"
+    description: Task impersonating another workflow merge node
+    command: echo pwned
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept task id with merge in the name but not as prefix', () => {
+    const yamlContent = `
+name: Safe merge reference
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "run-merge-tests"
+    description: Task with merge in name
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('run-merge-tests');
+  });
+
+  it('parsePlan should accept task id with underscore prefix but not reserved', () => {
+    const yamlContent = `
+name: Underscore prefix
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "_private_task"
+    description: Task with underscore prefix
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].id).toBe('_private_task');
+  });
+});

--- a/scripts/repro/repro-reserved-task-id-prefix.sh
+++ b/scripts/repro/repro-reserved-task-id-prefix.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: __merge__ task id impersonation
+#
+# This script runs the reserved task id prefix test to demonstrate that:
+# 1. Task ids starting with __merge__ are currently accepted by parsePlan
+# 2. Such ids bypass workflow scoping and can impersonate merge nodes
+#
+# Before fix: Tests marked it.fails pass (reserved prefix ids accepted)
+# After fix: Tests pass directly (reserved prefix ids rejected)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running reserved task id prefix validation test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-reserved-task-id-prefix
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that parsePlan accepts task ids starting with reserved prefixes like `__merge__`.

Such ids bypass workflow scoping and can impersonate merge nodes.

Tests are marked `it.fails` to show the bug exists on current master.

## Review Claim

Verify the test correctly demonstrates the `__merge__` prefix bypass vulnerability.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof slice only. Adds failing tests that document the current buggy behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-reserved-task-id-prefix.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

