### PR TITLE
[Chaos H: Reserved Prefix](2) Add hasReservedTaskIdPrefix check

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-reserved-task-id-prefix.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-reserved-task-id-prefix.test.ts
@@ -13,19 +13,16 @@
  * Invariant: `__merge__*` is reserved; plan-local ids must always be scoped;
  * a user task must not become the merge node or an unscoped experiment branch.
  *
- * TODO(chaos-h-fix): These tests are marked it.fails because the current
- * implementation accepts task ids with reserved prefixes.
- *
- * After the fix applies:
- * - parsePlan will reject task ids starting with reserved prefixes
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates that task ids don't start with reserved prefixes
+ * - Task ids starting with `__merge__` are rejected with a clear error
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('reserved task id prefix validation', () => {
-  it.fails('parsePlan should reject task id starting with __merge__', () => {
+  it('parsePlan should reject task id starting with __merge__', () => {
     const yamlContent = `
 name: Merge impersonation
 repoUrl: git@github.com:example/repo.git
@@ -38,7 +35,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task id exactly matching __merge__', () => {
+  it('parsePlan should reject task id exactly matching __merge__', () => {
     const yamlContent = `
 name: Exact merge impersonation
 repoUrl: git@github.com:example/repo.git
@@ -51,7 +48,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject task id with __merge__ prefix and workflow-like suffix', () => {
+  it('parsePlan should reject task id with __merge__ prefix and workflow-like suffix', () => {
     const yamlContent = `
 name: Workflow merge impersonation
 repoUrl: git@github.com:example/repo.git
@@ -90,5 +87,18 @@ tasks:
 
     const plan = parsePlan(yamlContent);
     expect(plan.tasks[0].id).toBe('_private_task');
+  });
+
+  it('parsePlan should reject task id attempting cross-workflow gate steal', () => {
+    const yamlContent = `
+name: Cross-workflow gate steal
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: "__merge__wf-1788115593379-67"
+    description: Task stealing another workflow gate
+    command: echo stolen-gate
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 });

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -20,6 +20,13 @@ export function isPathSafeId(id: string): boolean {
   return true;
 }
 
+const RESERVED_TASK_ID_PREFIXES = ['__merge__'] as const;
+
+export function hasReservedTaskIdPrefix(id: string): boolean {
+  if (!id || typeof id !== 'string') return false;
+  return RESERVED_TASK_ID_PREFIXES.some((prefix) => id.startsWith(prefix));
+}
+
 interface TaskWithDeps {
   id: string;
   dependencies: string[];
@@ -290,6 +297,11 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     if (!isPathSafeId(task.id)) {
       throw new PlanParseError(
         `Task id "${task.id}" contains unsafe characters. Task ids must not contain "..", "/", "\\", or start with ".".`,
+      );
+    }
+    if (hasReservedTaskIdPrefix(task.id)) {
+      throw new PlanParseError(
+        `Task id "${task.id}" uses a reserved prefix. Task ids must not start with "__merge__".`,
       );
     }
     if (seenTaskIds.has(task.id)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add hasReservedTaskIdPrefix check in the plan parser route.

Task ids starting with `__merge__` now throw a parse error.

This prevents reserved prefix ids from bypassing workflow scoping.

Includes test for cross-workflow gate steal (`__merge__<victimWfId>`).

## Review Claim

Verify the parsing route correctly throws for task ids with reserved prefix.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted plans with reserved ids.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not add other reserved prefixes. Only `__merge__` is reserved for now.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-reserved-task-id-prefix.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

