### PR TITLE
[Chaos I](1) Add isValidGitRef check for featureBranch

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-featurebranch-validation.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-featurebranch-validation.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Repro: featureBranch must be a safe git ref
+ *
+ * Symptoms:
+ * - Emoji-only `🔥` and name `..` slug to `featureBranch: "plan/"` (empty slug)
+ * - Explicit `featureBranch: ../w3-escape-branch` stored unsanitized
+ *
+ * Root cause: parsePlan does not validate featureBranch as a valid git ref.
+ * Invalid refs can cause git operations to fail or behave unexpectedly.
+ *
+ * Invariant: featureBranch must be a valid git ref - no empty slugs,
+ * trailing slashes, path escapes, or control characters.
+ *
+ * Fix applied:
+ * - parsePlan now validates featureBranch with isValidGitRef()
+ * - Invalid refs are rejected with a clear error message
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError, isValidGitRef } from '../plan-parser.js';
+
+describe('featureBranch validation', () => {
+  describe('isValidGitRef helper', () => {
+    it('rejects empty string', () => {
+      expect(isValidGitRef('')).toBe(false);
+    });
+
+    it('rejects whitespace-only', () => {
+      expect(isValidGitRef('   ')).toBe(false);
+    });
+
+    it('rejects path traversal with ..', () => {
+      expect(isValidGitRef('../escape')).toBe(false);
+      expect(isValidGitRef('foo/../bar')).toBe(false);
+    });
+
+    it('rejects leading slash', () => {
+      expect(isValidGitRef('/absolute')).toBe(false);
+    });
+
+    it('rejects trailing slash', () => {
+      expect(isValidGitRef('plan/')).toBe(false);
+      expect(isValidGitRef('feature/test/')).toBe(false);
+    });
+
+    it('rejects double slash', () => {
+      expect(isValidGitRef('foo//bar')).toBe(false);
+    });
+
+    it('rejects hidden component', () => {
+      expect(isValidGitRef('.hidden')).toBe(false);
+      expect(isValidGitRef('foo/.hidden')).toBe(false);
+    });
+
+    it('rejects .lock suffix', () => {
+      expect(isValidGitRef('branch.lock')).toBe(false);
+    });
+
+    it('rejects reflog syntax', () => {
+      expect(isValidGitRef('branch@{1}')).toBe(false);
+    });
+
+    it('rejects backslash', () => {
+      expect(isValidGitRef('foo\\bar')).toBe(false);
+    });
+
+    it('rejects control characters', () => {
+      expect(isValidGitRef('foo\x00bar')).toBe(false);
+      expect(isValidGitRef('foo\x1fbar')).toBe(false);
+    });
+
+    it('rejects special git characters', () => {
+      expect(isValidGitRef('foo~bar')).toBe(false);
+      expect(isValidGitRef('foo^bar')).toBe(false);
+      expect(isValidGitRef('foo:bar')).toBe(false);
+      expect(isValidGitRef('foo?bar')).toBe(false);
+      expect(isValidGitRef('foo*bar')).toBe(false);
+      expect(isValidGitRef('foo[bar')).toBe(false);
+    });
+
+    it('accepts valid branch names', () => {
+      expect(isValidGitRef('main')).toBe(true);
+      expect(isValidGitRef('feature/test')).toBe(true);
+      expect(isValidGitRef('plan/my-feature')).toBe(true);
+      expect(isValidGitRef('fix-123')).toBe(true);
+    });
+
+    it('rejects flag-like refs starting with hyphen', () => {
+      expect(isValidGitRef('-u')).toBe(false);
+      expect(isValidGitRef('-d')).toBe(false);
+      expect(isValidGitRef('--force')).toBe(false);
+    });
+
+    it('rejects reserved git refs', () => {
+      expect(isValidGitRef('HEAD')).toBe(false);
+      expect(isValidGitRef('FETCH_HEAD')).toBe(false);
+      expect(isValidGitRef('ORIG_HEAD')).toBe(false);
+      expect(isValidGitRef('MERGE_HEAD')).toBe(false);
+    });
+
+    it('rejects remote-prefixed refs', () => {
+      expect(isValidGitRef('origin/master')).toBe(false);
+      expect(isValidGitRef('upstream/main')).toBe(false);
+      expect(isValidGitRef('remote/feature')).toBe(false);
+    });
+
+    it('rejects refs/heads/.. path escape', () => {
+      expect(isValidGitRef('refs/heads/..')).toBe(false);
+      expect(isValidGitRef('refs/heads/../etc')).toBe(false);
+    });
+  });
+
+  describe('parsePlan featureBranch validation', () => {
+    it('rejects featureBranch with path traversal', () => {
+      const yamlContent = `
+name: Escape test
+repoUrl: git@github.com:example/repo.git
+featureBranch: "../w3-escape-branch"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+      expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+    });
+
+    it('rejects featureBranch with trailing slash (empty slug)', () => {
+      const yamlContent = `
+name: Empty slug test
+repoUrl: git@github.com:example/repo.git
+featureBranch: "plan/"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+      expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+    });
+
+    it('rejects empty featureBranch', () => {
+      const yamlContent = `
+name: Empty branch test
+repoUrl: git@github.com:example/repo.git
+featureBranch: ""
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+      expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+    });
+
+    it('accepts valid featureBranch', () => {
+      const yamlContent = `
+name: Valid branch test
+repoUrl: git@github.com:example/repo.git
+featureBranch: "feature/my-branch"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+      const plan = parsePlan(yamlContent);
+      expect(plan.featureBranch).toBe('feature/my-branch');
+    });
+
+    it('uses default featureBranch when not provided', () => {
+      const yamlContent = `
+name: Default branch test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+      const plan = parsePlan(yamlContent);
+      expect(plan.featureBranch).toBe('plan/default-branch-test');
+    });
+  });
+});

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -27,6 +27,26 @@ export function hasReservedTaskIdPrefix(id: string): boolean {
   return RESERVED_TASK_ID_PREFIXES.some((prefix) => id.startsWith(prefix));
 }
 
+const RESERVED_GIT_REFS = ['HEAD', 'FETCH_HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'CHERRY_PICK_HEAD'] as const;
+
+export function isValidGitRef(ref: string): boolean {
+  if (!ref || typeof ref !== 'string') return false;
+  if (ref.trim() === '') return false;
+  if (ref.includes('..')) return false;
+  if (ref.startsWith('/') || ref.endsWith('/')) return false;
+  if (ref.includes('//')) return false;
+  if (ref.startsWith('.') || ref.includes('/.')) return false;
+  if (ref.endsWith('.lock')) return false;
+  if (ref.includes('@{')) return false;
+  if (ref.includes('\\')) return false;
+  if (/[\x00-\x1f\x7f~^:?*\[]/.test(ref)) return false;
+  if (ref.startsWith('-')) return false;
+  if (RESERVED_GIT_REFS.includes(ref as typeof RESERVED_GIT_REFS[number])) return false;
+  if (/^(origin|upstream|remote)\//.test(ref)) return false;
+  if (ref.startsWith('refs/') && ref.includes('..')) return false;
+  return true;
+}
+
 interface TaskWithDeps {
   id: string;
   dependencies: string[];
@@ -277,6 +297,19 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       throw new PlanParseError('Plan "intermediateRepoUrl" must be a non-empty string when provided.');
     }
     raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
+  }
+
+  if (raw.featureBranch !== undefined) {
+    if (typeof raw.featureBranch !== 'string') {
+      throw new PlanParseError('Plan "featureBranch" must be a string when provided.');
+    }
+    const trimmed = raw.featureBranch.trim();
+    if (trimmed === '' || !isValidGitRef(trimmed)) {
+      throw new PlanParseError(
+        `Plan "featureBranch" value "${raw.featureBranch}" is not a valid git ref. ` +
+        'Refs must not be empty, contain "..", start/end with "/", or contain control characters.',
+      );
+    }
   }
 
   if (scratch && raw.poolId) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add isValidGitRef check for featureBranch in the plan parser route.

Refs with path traversal, empty slugs, or control characters now throw.

Extended to also cover flag-like refs (-u), reserved refs (HEAD), and remote-prefixed refs.

## Review Claim

Verify the parsing route correctly throws for invalid featureBranch values.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted plans with invalid refs.

## Slice Rationale

Combined proof+fix as this is a validation-only change.

## Non-goals

Does not resolve refs against the remote. Only format checks at parse time.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- --run repro-featurebranch-validation`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

