### PR TITLE
[Chaos K: baseBranch](1) Repro test for invalid baseBranch accepted

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-nonexistent-basebranch.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-nonexistent-basebranch.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Repro: Nonexistent baseBranch accepted
+ *
+ * Symptom: `baseBranch: definitely-does-not-exist-w3` loads without error.
+ * Leaf task completes, but merge node fails with "Branch not found on remote".
+ * Work is done before the error surfaces.
+ *
+ * Root cause: baseBranch is not validated as a valid git ref at parse time.
+ * Invalid or nonexistent refs are accepted, causing failures only at runtime.
+ *
+ * Invariant: baseBranch must be a valid git ref format at parse time.
+ * Missing refs should fail closed at load, not after leaf work is done.
+ *
+ * TODO(chaos-k-fix): These tests are marked it.fails because the current
+ * implementation accepts invalid baseBranch values.
+ *
+ * After the fix applies:
+ * - parsePlan will validate baseBranch as a valid git ref
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('baseBranch validation', () => {
+  it.fails('parsePlan should reject baseBranch with path traversal', () => {
+    const yamlContent = `
+name: Base escape test
+repoUrl: git@github.com:example/repo.git
+baseBranch: "../escape-branch"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject baseBranch with empty string', () => {
+    const yamlContent = `
+name: Empty base test
+repoUrl: git@github.com:example/repo.git
+baseBranch: ""
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject baseBranch with trailing slash', () => {
+    const yamlContent = `
+name: Trailing slash base test
+repoUrl: git@github.com:example/repo.git
+baseBranch: "refs/heads/"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject baseBranch with control characters', () => {
+    const yamlContent = `
+name: Control char base test
+repoUrl: git@github.com:example/repo.git
+baseBranch: "branch\x00name"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept valid baseBranch', () => {
+    const yamlContent = `
+name: Valid base test
+repoUrl: git@github.com:example/repo.git
+baseBranch: "main"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.baseBranch).toBe('main');
+  });
+
+  it('parsePlan should accept baseBranch with slashes', () => {
+    const yamlContent = `
+name: Feature base test
+repoUrl: git@github.com:example/repo.git
+baseBranch: "feature/my-branch"
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.baseBranch).toBe('feature/my-branch');
+  });
+});

--- a/scripts/repro/repro-nonexistent-basebranch.sh
+++ b/scripts/repro/repro-nonexistent-basebranch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: Nonexistent baseBranch accepted
+#
+# This script runs the baseBranch validation test to demonstrate that:
+# 1. Invalid baseBranch values (path traversal, empty, control chars) are accepted
+# 2. The error surfaces only at runtime, after leaf work is done
+#
+# Before fix: Tests marked it.fails pass (invalid baseBranch accepted)
+# After fix: Tests pass directly (invalid baseBranch rejected at parse time)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running baseBranch validation test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-nonexistent-basebranch
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that parsePlan accepts invalid baseBranch values.

Path traversal, empty strings, and control characters are currently allowed.

Tests are marked `it.fails` to show the bug exists on current master.

## Review Claim

Verify the test correctly demonstrates the baseBranch bypass.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof slice only. Adds failing tests that document the current buggy behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-nonexistent-basebranch.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

