### PR TITLE
[Chaos K: baseBranch](2) Apply isValidGitRef check to baseBranch

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-nonexistent-basebranch.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-nonexistent-basebranch.test.ts
@@ -11,19 +11,16 @@
  * Invariant: baseBranch must be a valid git ref format at parse time.
  * Missing refs should fail closed at load, not after leaf work is done.
  *
- * TODO(chaos-k-fix): These tests are marked it.fails because the current
- * implementation accepts invalid baseBranch values.
- *
- * After the fix applies:
- * - parsePlan will validate baseBranch as a valid git ref
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates baseBranch with isValidGitRef()
+ * - Invalid baseBranch values are rejected with a clear error message
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('baseBranch validation', () => {
-  it.fails('parsePlan should reject baseBranch with path traversal', () => {
+  it('parsePlan should reject baseBranch with path traversal', () => {
     const yamlContent = `
 name: Base escape test
 repoUrl: git@github.com:example/repo.git
@@ -37,7 +34,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject baseBranch with empty string', () => {
+  it('parsePlan should reject baseBranch with empty string', () => {
     const yamlContent = `
 name: Empty base test
 repoUrl: git@github.com:example/repo.git
@@ -51,7 +48,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject baseBranch with trailing slash', () => {
+  it('parsePlan should reject baseBranch with trailing slash', () => {
     const yamlContent = `
 name: Trailing slash base test
 repoUrl: git@github.com:example/repo.git
@@ -65,7 +62,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject baseBranch with control characters', () => {
+  it('parsePlan should reject baseBranch with control characters', () => {
     const yamlContent = `
 name: Control char base test
 repoUrl: git@github.com:example/repo.git

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -312,6 +312,19 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     }
   }
 
+  if (raw.baseBranch !== undefined) {
+    if (typeof raw.baseBranch !== 'string') {
+      throw new PlanParseError('Plan "baseBranch" must be a string when provided.');
+    }
+    const trimmed = raw.baseBranch.trim();
+    if (trimmed === '' || !isValidGitRef(trimmed)) {
+      throw new PlanParseError(
+        `Plan "baseBranch" value "${raw.baseBranch}" is not a valid git ref. ` +
+        'Refs must not be empty, contain "..", start/end with "/", or contain control characters.',
+      );
+    }
+  }
+
   if (scratch && raw.poolId) {
     throw new PlanParseError('Plan sets "poolId" but has "scratch: true" — scratch plans never use execution pools.');
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply isValidGitRef to baseBranch in the plan parser route.

Refs with path traversal, empty slugs, or control characters now throw.

This prevents invalid base branch names from causing runtime failures.

## Review Claim

Verify the parsing route correctly throws for invalid baseBranch values.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted plans with invalid refs.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not check that the branch exists on the remote. Format only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-nonexistent-basebranch.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

