### PR TITLE
[Chaos L: Error Mask](1) Repro test for /invoke masking thrown errors

### DIFF
--- a/packages/app/src/__tests__/repro-invoke-error-mask.test.ts
+++ b/packages/app/src/__tests__/repro-invoke-error-mask.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Repro: Web /invoke masks thrown errors as "internal server error"
+ *
+ * Symptom: HTTP 200 `{ok:false,error:{message:"internal server error"}}` for
+ * validation/domain errors like get-events missing options, limit 0/101,
+ * approve/delete-task/edit-task-command on merge, set-workflow-merge-mode
+ * with invalid mode.
+ *
+ * Root cause: Uncaught exceptions without a `.code` property are caught and
+ * masked as "internal server error" to avoid leaking stack traces.
+ *
+ * Invariant: Validation/domain errors must surface code+message, not a
+ * generic mask. Known error types should map to specific codes.
+ *
+ * TODO(chaos-l-fix): These tests are marked it.fails because the current
+ * implementation masks validation errors as "internal server error".
+ *
+ * After the fix applies:
+ * - Known error types will be mapped to specific error codes
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { LocalBus } from '@invoker/transport';
+import { startWebBridge, type WebBridge } from '../web/web-bridge-server.js';
+
+describe('/invoke error handling', () => {
+  let bridge: WebBridge;
+  let port: number;
+  let token: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    token = 'test-token-' + Math.random().toString(36).slice(2);
+    tmpDir = mkdtempSync(join(tmpdir(), 'web-bridge-error-test-'));
+    mkdirSync(join(tmpDir, 'dist'));
+    writeFileSync(join(tmpDir, 'dist', 'index.html'), '<!DOCTYPE html><html><body>Test</body></html>');
+
+    const bus = new LocalBus();
+    bridge = startWebBridge({
+      token,
+      dispatch: async (channel, args) => {
+        if (channel === 'test:validation-error') {
+          throw new Error('Validation failed: limit must be between 1 and 100');
+        }
+        if (channel === 'test:not-found') {
+          throw new Error('Task not found: wf-123/task-456');
+        }
+        if (channel === 'test:invalid-operation') {
+          throw new Error('Cannot approve merge node directly');
+        }
+        if (channel === 'test:domain-error-with-code') {
+          const err = new Error('Task not found') as Error & { code: string };
+          err.code = 'TASK_NOT_FOUND';
+          throw err;
+        }
+        return { ok: true };
+      },
+      messageBus: bus,
+      persistence: {
+        getActivityLogs: () => [],
+        listWorkflows: () => [],
+      },
+      uiDistDir: join(tmpDir, 'dist'),
+      host: '127.0.0.1',
+      port: 0,
+    });
+    port = await bridge.whenReady;
+  });
+
+  afterAll(async () => {
+    await bridge?.close();
+  });
+
+  function invoke(channel: string, args: unknown[] = []): Promise<{ status: number; body: any }> {
+    return new Promise((resolve, reject) => {
+      const data = JSON.stringify({ channel, args });
+      const req = http.request({
+        hostname: '127.0.0.1',
+        port,
+        method: 'POST',
+        path: '/invoke',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': data.length,
+          'x-invoker-token': token,
+        },
+      }, (res) => {
+        let body = '';
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body });
+          }
+        });
+      });
+      req.on('error', reject);
+      req.write(data);
+      req.end();
+    });
+  }
+
+  it('returns error code when error has .code property', async () => {
+    const res = await invoke('test:domain-error-with-code');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.code).toBe('TASK_NOT_FOUND');
+  });
+
+  it.fails('should surface validation error message, not mask as internal server error', async () => {
+    const res = await invoke('test:validation-error');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.message).not.toBe('internal server error');
+    expect(res.body.error.message).toContain('Validation failed');
+  });
+
+  it.fails('should surface not-found error message', async () => {
+    const res = await invoke('test:not-found');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.message).not.toBe('internal server error');
+    expect(res.body.error.message).toContain('not found');
+  });
+
+  it.fails('should surface invalid operation error message', async () => {
+    const res = await invoke('test:invalid-operation');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.message).not.toBe('internal server error');
+    expect(res.body.error.message).toContain('Cannot approve');
+  });
+});

--- a/scripts/repro/repro-invoke-error-mask.sh
+++ b/scripts/repro/repro-invoke-error-mask.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: Web /invoke masks thrown errors as "internal server error"
+#
+# This script runs the invoke error handling test to demonstrate that:
+# 1. Validation/domain errors without .code are masked as "internal server error"
+# 2. Error messages are not surfaced to the client
+#
+# Before fix: Tests marked it.fails pass (errors masked)
+# After fix: Tests pass directly (errors surfaced with codes)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running invoke error handling test ==="
+pnpm --filter @invoker/app test -- --run repro-invoke-error-mask
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that web /invoke masks thrown errors as "internal server error".

Errors without a `.code` property get masked even when they have meaningful messages.

Tests are marked `it.fails` to show the bug exists on current master.

## Review Claim

Verify the test correctly demonstrates the error masking behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof slice only. Adds failing tests that document the current buggy behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-invoke-error-mask.sh`
- [x] `pnpm --filter @invoker/app test -- --run repro-invoke-error-mask`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

