### PR TITLE
[Chaos L: Error Mask](2) Add mapInvokeError to surface known errors

### DIFF
--- a/packages/app/src/__tests__/repro-invoke-error-mask.test.ts
+++ b/packages/app/src/__tests__/repro-invoke-error-mask.test.ts
@@ -12,12 +12,10 @@
  * Invariant: Validation/domain errors must surface code+message, not a
  * generic mask. Known error types should map to specific codes.
  *
- * TODO(chaos-l-fix): These tests are marked it.fails because the current
- * implementation masks validation errors as "internal server error".
- *
- * After the fix applies:
- * - Known error types will be mapped to specific error codes
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - Known error patterns are mapped to specific error codes
+ * - Validation, not-found, and invalid-operation errors are surfaced
+ * - Unknown errors are still masked to avoid leaking stack traces
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -113,27 +111,30 @@ describe('/invoke error handling', () => {
     expect(res.body.error.code).toBe('TASK_NOT_FOUND');
   });
 
-  it.fails('should surface validation error message, not mask as internal server error', async () => {
+  it('should surface validation error message with code', async () => {
     const res = await invoke('test:validation-error');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(false);
     expect(res.body.error.message).not.toBe('internal server error');
     expect(res.body.error.message).toContain('Validation failed');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
-  it.fails('should surface not-found error message', async () => {
+  it('should surface not-found error message with code', async () => {
     const res = await invoke('test:not-found');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(false);
     expect(res.body.error.message).not.toBe('internal server error');
     expect(res.body.error.message).toContain('not found');
+    expect(res.body.error.code).toBe('NOT_FOUND');
   });
 
-  it.fails('should surface invalid operation error message', async () => {
+  it('should surface invalid operation error message with code', async () => {
     const res = await invoke('test:invalid-operation');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(false);
     expect(res.body.error.message).not.toBe('internal server error');
     expect(res.body.error.message).toContain('Cannot approve');
+    expect(res.body.error.code).toBe('INVALID_OPERATION');
   });
 });

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -29,6 +29,29 @@ import type { WebInvokerDispatch } from './web-invoker-dispatch.js';
 const COOKIE_NAME = 'invoker_web';
 const MAX_INVOKE_BODY_BYTES = 1024 * 1024; // 1 MiB
 const MAX_SSE_CLIENTS = 64;
+
+interface MappedError {
+  message: string;
+  code: string;
+}
+
+const INVOKE_ERROR_PATTERNS: ReadonlyArray<[pattern: RegExp, code: string]> = [
+  [/^Validation failed:/i, 'VALIDATION_ERROR'],
+  [/not found/i, 'NOT_FOUND'],
+  [/^Cannot (approve|reject|delete|edit|cancel)/i, 'INVALID_OPERATION'],
+  [/is required|must be|must have|missing/i, 'VALIDATION_ERROR'],
+  [/limit must be/i, 'VALIDATION_ERROR'],
+  [/invalid (mode|value|option|argument)/i, 'INVALID_ARGUMENT'],
+];
+
+function mapInvokeError(message: string): MappedError | null {
+  for (const [pattern, code] of INVOKE_ERROR_PATTERNS) {
+    if (pattern.test(message)) {
+      return { message, code };
+    }
+  }
+  return null;
+}
 const SSE_PING_INTERVAL_MS = 20_000;
 const ACTIVITY_POLL_INTERVAL_MS = 2_000;
 const WORKFLOWS_SAFETY_POLL_INTERVAL_MS = 30_000;
@@ -235,6 +258,11 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
         return;
       }
       const errorMessage = err instanceof Error ? err.message : String(err);
+      const mappedError = mapInvokeError(errorMessage);
+      if (mappedError) {
+        sendJson(res, 200, { ok: false, error: mappedError }, req);
+        return;
+      }
       logger?.warn(`web invoke failed for ${parsed.channel}: ${errorMessage}`, {
         module: 'web-bridge',
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add mapInvokeError to classify error messages and surface them with codes.

Known patterns are mapped: not-found, invalid-operation, and similar.

Unknown errors remain masked to avoid leaking stack traces.

## Review Claim

Verify the error mapping logic correctly surfaces known error patterns.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds error classification. Unknown errors still masked for safety.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not surface stack traces. Only known patterns are mapped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-invoke-error-mask.sh`
- [x] `pnpm --filter @invoker/app test -- --run repro-invoke-error-mask`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

