### PR TITLE
[Chaos M: no_op+onFinish](1) Repro test for mergeMode no_op skipping onFinish

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-noop-onfinish-mismatch.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-noop-onfinish-mismatch.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Repro: mergeMode: no_op skips onFinish: merge / pull_request
+ *
+ * Symptom: Plan with mergeMode: no_op and onFinish: pull_request/merge
+ * completes the workflow without merging or creating a PR.
+ * The master branch stays at the initial commit.
+ *
+ * Root cause: parsePlan does not validate that mergeMode: no_op
+ * requires onFinish: none. The combination is contradictory.
+ *
+ * Invariant: mergeMode: no_op must use onFinish: none, or load must
+ * reject the combination to prevent silent skipping of merge/PR.
+ *
+ * TODO(chaos-m-fix): These tests are marked it.fails because the current
+ * implementation accepts the contradictory combination.
+ *
+ * After the fix applies:
+ * - parsePlan will reject mergeMode: no_op with onFinish: merge/pull_request
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('mergeMode no_op + onFinish validation', () => {
+  it.fails('parsePlan should reject mergeMode: no_op with onFinish: merge', () => {
+    const yamlContent = `
+name: No-op merge mismatch
+repoUrl: git@github.com:example/repo.git
+mergeMode: no_op
+onFinish: merge
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject mergeMode: no_op with onFinish: pull_request', () => {
+    const yamlContent = `
+name: No-op PR mismatch
+repoUrl: git@github.com:example/repo.git
+mergeMode: no_op
+onFinish: pull_request
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept mergeMode: no_op with onFinish: none', () => {
+    const yamlContent = `
+name: Valid no-op
+repoUrl: git@github.com:example/repo.git
+mergeMode: no_op
+onFinish: none
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.mergeMode).toBe('no_op');
+    expect(plan.onFinish).toBe('none');
+  });
+
+  it('parsePlan should accept non-no_op mergeMode with onFinish: pull_request', () => {
+    const yamlContent = `
+name: Valid manual merge
+repoUrl: git@github.com:example/repo.git
+mergeMode: manual
+onFinish: pull_request
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.mergeMode).toBe('manual');
+    expect(plan.onFinish).toBe('pull_request');
+  });
+});

--- a/scripts/repro/repro-noop-onfinish-mismatch.sh
+++ b/scripts/repro/repro-noop-onfinish-mismatch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: mergeMode: no_op skips onFinish: merge / pull_request
+#
+# This script runs the no_op + onFinish validation test to demonstrate that:
+# 1. mergeMode: no_op with onFinish: merge/pull_request is accepted
+# 2. This causes the workflow to silently skip the merge/PR step
+#
+# Before fix: Tests marked it.fails pass (contradictory combo accepted)
+# After fix: Tests pass directly (contradictory combo refused at parse time)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running no_op + onFinish mismatch test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-noop-onfinish-mismatch
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that parsePlan accepts mergeMode: no_op with onFinish: merge or pull_request.

This contradictory combination causes the workflow to silently skip merge/PR.

Tests are marked `it.fails` to show the bug exists on current master.

## Review Claim

Verify the test correctly demonstrates the no_op + onFinish mismatch.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof slice only. Adds failing tests that document the current buggy behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-noop-onfinish-mismatch.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

