### PR TITLE
[Chaos M: no_op+onFinish](2) Enforce onFinish: none for mergeMode: no_op

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-noop-onfinish-mismatch.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-noop-onfinish-mismatch.test.ts
@@ -11,19 +11,16 @@
  * Invariant: mergeMode: no_op must use onFinish: none, or load must
  * reject the combination to prevent silent skipping of merge/PR.
  *
- * TODO(chaos-m-fix): These tests are marked it.fails because the current
- * implementation accepts the contradictory combination.
- *
- * After the fix applies:
- * - parsePlan will reject mergeMode: no_op with onFinish: merge/pull_request
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now throws for mergeMode: no_op with onFinish: merge/pull_request
+ * - The contradictory combination is refused at parse time
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('mergeMode no_op + onFinish validation', () => {
-  it.fails('parsePlan should reject mergeMode: no_op with onFinish: merge', () => {
+  it('parsePlan should reject mergeMode: no_op with onFinish: merge', () => {
     const yamlContent = `
 name: No-op merge mismatch
 repoUrl: git@github.com:example/repo.git
@@ -38,7 +35,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject mergeMode: no_op with onFinish: pull_request', () => {
+  it('parsePlan should reject mergeMode: no_op with onFinish: pull_request', () => {
     const yamlContent = `
 name: No-op PR mismatch
 repoUrl: git@github.com:example/repo.git

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -283,6 +283,12 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   if (scratch && raw.mergeMode !== undefined && raw.mergeMode !== 'no_op') {
     throw new PlanParseError('Plan with "scratch: true" must use mergeMode: "no_op" (or omit it) — there is no repo/branch to merge.');
   }
+  if (raw.mergeMode === 'no_op' && onFinish !== 'none') {
+    throw new PlanParseError(
+      `Plan with "mergeMode: no_op" must use "onFinish: none". Got onFinish: "${onFinish}". ` +
+      'The no_op mode skips merging, so onFinish: merge/pull_request would silently do nothing.',
+    );
+  }
   const mergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
   const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add check that mergeMode: no_op requires onFinish: none.

The incompatible combination would silently drop the merge/PR step.

Plans with mergeMode: no_op and onFinish: merge/pull_request now throw.

## Review Claim

Verify the parsing route correctly throws for the incompatible combination.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted combos.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not change no_op semantics. Only enforces onFinish must be none.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-noop-onfinish-mismatch.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

