### PR TITLE
[Chaos N: executionAgent](1) Repro test for shell metacharacter injection

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-executionagent-injection.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-executionagent-injection.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Repro: executionAgent not validated at parse time for injection chars
+ *
+ * Symptom: executionAgent values with injection characters (semicolons,
+ * newlines, shell metacharacters) are stored as-is. While runtime agent
+ * lookup may fail, malformed values reach the persistence layer.
+ *
+ * Root cause: parsePlan only trims executionAgent, no validation for
+ * dangerous characters or format. The agent registry check happens
+ * later in the headless-run flow, not at parse time.
+ *
+ * Invariant: executionAgent must be a valid identifier at parse time.
+ * Values with newlines, semicolons, or other shell metacharacters
+ * should be rejected immediately to avoid injection risks.
+ *
+ * TODO(chaos-n-fix): These tests are marked it.fails because the current
+ * implementation does not validate executionAgent format at parse time.
+ *
+ * After the fix applies:
+ * - parsePlan will reject executionAgent values with dangerous characters
+ * - Tests will pass and should be changed from it.fails to it
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('executionAgent format validation', () => {
+  it.fails('parsePlan should reject executionAgent with semicolon (shell injection)', () => {
+    const yamlContent = `
+name: Injection test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: "claude; id"
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject executionAgent with newline', () => {
+    const yamlContent = `
+name: Newline test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: "claude\\nid"
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject executionAgent with backtick (command substitution)', () => {
+    const yamlContent = `
+name: Backtick test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: "claude\`id\`"
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it.fails('parsePlan should reject executionAgent with $() (command substitution)', () => {
+    const yamlContent = `
+name: Command sub test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: "claude$(id)"
+`;
+
+    expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
+  });
+
+  it('parsePlan should accept valid executionAgent names', () => {
+    const yamlContent = `
+name: Valid agent test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: claude
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].executionAgent).toBe('claude');
+  });
+
+  it('parsePlan should accept executionAgent with hyphen', () => {
+    const yamlContent = `
+name: Hyphen agent test
+repoUrl: git@github.com:example/repo.git
+tasks:
+  - id: task1
+    description: Test task
+    command: echo test
+    executionAgent: my-custom-agent
+`;
+
+    const plan = parsePlan(yamlContent);
+    expect(plan.tasks[0].executionAgent).toBe('my-custom-agent');
+  });
+});

--- a/scripts/repro/repro-executionagent-injection.sh
+++ b/scripts/repro/repro-executionagent-injection.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: executionAgent not validated at parse time for injection chars
+#
+# This script runs the executionAgent injection test to demonstrate that:
+# 1. executionAgent values with shell metacharacters are accepted at parse
+# 2. Values like "claude; id" are stored without validation
+#
+# Before fix: Tests marked it.fails pass (injection chars accepted)
+# After fix: Tests pass directly (injection chars refused at parse time)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Running executionAgent injection test ==="
+pnpm --filter @invoker/workflow-core test -- --run repro-executionagent-injection
+
+echo ""
+echo "=== Test completed ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add test demonstrating that parsePlan accepts executionAgent values with shell metacharacters.

Values like "claude; id" or "claude`id`" are stored without format checks.

Tests are marked `it.fails` to show the bug exists on current master.

## Review Claim

Verify the test correctly demonstrates the executionAgent injection issue.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof slice only. Adds failing tests that document the current buggy behavior.

## Slice Rationale

Proof comes before fix per review-compression ordering rules.

## Non-goals

Does not fix the bug. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-executionagent-injection.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

