### PR TITLE
[Chaos N: executionAgent](2) Add isValidAgentName check for shell metacharacters

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-executionagent-injection.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-executionagent-injection.test.ts
@@ -13,19 +13,16 @@
  * Values with newlines, semicolons, or other shell metacharacters
  * should be rejected immediately to avoid injection risks.
  *
- * TODO(chaos-n-fix): These tests are marked it.fails because the current
- * implementation does not validate executionAgent format at parse time.
- *
- * After the fix applies:
- * - parsePlan will reject executionAgent values with dangerous characters
- * - Tests will pass and should be changed from it.fails to it
+ * Fix applied:
+ * - parsePlan now validates executionAgent with isValidAgentName()
+ * - Values with shell metacharacters are rejected at parse time
  */
 
 import { describe, it, expect } from 'vitest';
 import { parsePlan, PlanParseError } from '../plan-parser.js';
 
 describe('executionAgent format validation', () => {
-  it.fails('parsePlan should reject executionAgent with semicolon (shell injection)', () => {
+  it('parsePlan should reject executionAgent with semicolon (shell injection)', () => {
     const yamlContent = `
 name: Injection test
 repoUrl: git@github.com:example/repo.git
@@ -39,7 +36,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject executionAgent with newline', () => {
+  it('parsePlan should reject executionAgent with newline', () => {
     const yamlContent = `
 name: Newline test
 repoUrl: git@github.com:example/repo.git
@@ -53,7 +50,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject executionAgent with backtick (command substitution)', () => {
+  it('parsePlan should reject executionAgent with backtick (command substitution)', () => {
     const yamlContent = `
 name: Backtick test
 repoUrl: git@github.com:example/repo.git
@@ -67,7 +64,7 @@ tasks:
     expect(() => parsePlan(yamlContent)).toThrow(PlanParseError);
   });
 
-  it.fails('parsePlan should reject executionAgent with $() (command substitution)', () => {
+  it('parsePlan should reject executionAgent with $() (command substitution)', () => {
     const yamlContent = `
 name: Command sub test
 repoUrl: git@github.com:example/repo.git

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -29,6 +29,14 @@ export function hasReservedTaskIdPrefix(id: string): boolean {
 
 const RESERVED_GIT_REFS = ['HEAD', 'FETCH_HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'CHERRY_PICK_HEAD'] as const;
 
+export function isValidAgentName(name: string): boolean {
+  if (!name || typeof name !== 'string') return false;
+  if (name.trim() === '') return false;
+  if (/[;\n\r`$(){}|&<>]/.test(name)) return false;
+  if (/[\x00-\x1f\x7f]/.test(name)) return false;
+  return true;
+}
+
 export function isValidGitRef(ref: string): boolean {
   if (!ref || typeof ref !== 'string') return false;
   if (ref.trim() === '') return false;
@@ -426,7 +434,16 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       featureBranch: task.featureBranch,
       dockerImage: task.dockerImage,
       poolId: task.poolId,
-      executionAgent: task.executionAgent?.trim() || undefined,
+      executionAgent: (() => {
+        const agent = task.executionAgent?.trim();
+        if (agent && !isValidAgentName(agent)) {
+          throw new PlanParseError(
+            `Task "${task.id}" executionAgent "${task.executionAgent}" contains invalid characters. ` +
+            'Agent names must not contain shell metacharacters (;$`|&<>), newlines, or control characters.',
+          );
+        }
+        return agent || undefined;
+      })(),
       executionModel: task.executionModel?.trim() || undefined,
       maxTurns: task.maxTurns,
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add isValidAgentName check for executionAgent in the plan parser route.

Agent names with semicolons, newlines, backticks, or $() now throw.

This prevents shell metacharacters from reaching the persistence layer.

## Review Claim

Verify the parsing route correctly throws for agent names with shell metacharacters.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds check at parse time. Throws for previously-accepted agent names.

## Slice Rationale

Fix follows proof per review-compression ordering rules.

## Non-goals

Does not change agent registry lookup. Only enforces character format.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-executionagent-injection.sh`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60685c3-070b-4c53-bd64-0aa3e85012e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60685c3-070b-4c53-bd64-0aa3e85012e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

