### PR TITLE
fix(execution-engine): mock the process-group kill fallback in the provision-timeout test

### DIFF
--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -583,7 +583,6 @@ describe('WorktreeExecutor', () => {
     });
     mockPool(provisionedExecutor);
 
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => true);
     try {
       const startPromise = provisionedExecutor.start(makeRequest());
       const rejection = expect(startPromise).rejects.toThrow('provision command timed out after 25ms');
@@ -596,10 +595,11 @@ describe('WorktreeExecutor', () => {
       await vi.advanceTimersByTimeAsync(25 + SIGKILL_TIMEOUT_MS);
 
       await rejection;
-      expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
-      expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGKILL');
+      // The mocked pid does not lead a real process group, so killProcessGroup
+      // falls back to child.kill() rather than process.kill(-pid).
+      expect(provisionProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(provisionProcess.kill).toHaveBeenCalledWith('SIGKILL');
     } finally {
-      killSpy.mockRestore();
       if (previousTimeout === undefined) {
         delete process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;
       } else {


### PR DESCRIPTION
## Summary

`required-fast / Vitest Workspace` has been red on every master run because
one WorktreeExecutor test still asserts the pre-hardening kill behavior.

PR #10531 made `killProcessGroup` check a process's real group id via `ps`
before signaling the whole group, falling back to a direct child signal when
that check fails, as it always does for a mocked test process.

PR #11321 already updated two sibling tests in this same file for that new
behavior, but missed a third one.

## Review Claim

Update the provision-timeout test to assert on the mocked child process's
own signal calls instead of the top-level process signal call, matching the
pattern #11321 already established for the other two tests broken by the
same #10531 change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change, one assertion target swapped for another in a single
`it()` block. No product code changes; `packages/execution-engine/src/base-executor.ts`
and `process-utils.ts` are untouched.

## Slice Rationale

This PR touches only the one remaining test broken by the #10531 process-id
check. Kept apart from the other `required-fast / Vitest Workspace` failure
(`task-runner-fix-publish-and-ssh.test.ts`, an unrelated root cause covered
in its own PR) so each fix is independently reviewable and revertible.

## Non-goals

No change to `killProcessGroup`'s real runtime behavior. No change to the
other two already-fixed tests in this file.

**Consolidation signal:** this is the third instance of `worktree-executor.test.ts`
tests broken by the same #10531 hardening (2 already fixed by #11321, this is
the last one). No further follow-up needed — after this PR, no test in the
file still asserts the pre-#10531 top-level signal call.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/worktree-executor.test.ts` — fails before this change with zero matching calls on the old assertion target, passes after (96 tests passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
