### PR TITLE
fix(execution-engine): mock a non-empty diff in the publishAfterFix review-stack tests

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2998,6 +2998,7 @@ describe('TaskRunner', () => {
         }
         // merge-base --is-ancestor exits non-zero when branch is NOT an ancestor of HEAD
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
+        if (args[0] === 'diff' && args[1] === '--name-only') return 'src/example.ts';
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';


### PR DESCRIPTION
## Summary

`required-fast / Vitest Workspace` has been red on every master run because
two `publishAfterFix` tests broke when PR #11305 shipped.

#11305 added a check that avoids publishing a review stack when the
consolidated feature branch has an empty diff against base, by running
`git diff --name-only` in the gate clone. `setupPublishAfterFix`'s shared
git-response fixture returns `''` for any unmatched call, including `diff`,
so both tests looked like an empty-diff branch and hit the new no-op path
instead of the review-publish path they exist to exercise.

## Review Claim

Add a `diff --name-only` case to the shared git-response fixture returning a
non-empty file, matching what these tests actually intend to simulate: a
real consolidated change that should publish a review stack.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change: one new branch in a test helper's git-response fixture.
No product code changes; `packages/execution-engine/src/merge-runner.ts`
(where the #11305 empty-diff check lives) is untouched.

## Slice Rationale

This PR touches only the `task-runner-fix-publish-and-ssh.test.ts` fixture
gap. Kept apart from the unrelated `worktree-executor.test.ts` fix (different
root cause, its own PR) so each fix is independently reviewable and
revertible.

## Non-goals

No change to the #11305 empty-diff behavior itself — that behavior is
intentional (it avoids opening empty/no-op review PRs) and neither of these
two tests exercises it either way.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/task-runner-fix-publish-and-ssh.test.ts` — fails before this change (one test finds zero calls on its mock, the other hits an undefined-property error reading the review gate), passes after (110 tests passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a shared mock; no production behavior is modified.
> 
> **Overview**
> **Fixes `publishAfterFix` test fixtures** so they exercise review publication instead of the empty-diff skip introduced when the gate clone calls `git diff --name-only`.
> 
> The shared `setupPublishAfterFix` helper’s `execGitIn` mock used to fall through to `''` for unmatched git commands. That made `listReviewableChangedFiles` see zero changed files, so Invoker review-stack and related `publishAfterFix` tests never reached `publishReviewStackWithMakePrSkill` or the normal `createReview` path.
> 
> The helper now returns `'src/example.ts'` when git is invoked with `diff --name-only`, simulating at least one reviewable file in the gate workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66a982de87acae203acdf96d69a2d05d37cf429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->