### PR TITLE
fix(e2e): point the shared startPlan fixture at startReady, not start

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -449,7 +449,7 @@ export async function injectTaskStates(
 
 /** Start the loaded plan via the IPC bridge. */
 export async function startPlan(page: Page): Promise<void> {
-  await page.evaluate(() => window.invoker.start());
+  await page.evaluate(() => window.invoker.startReady());
 }
 
 /** Get all current tasks via the IPC bridge. */


### PR DESCRIPTION
PR #9907 made every plan loaded through invoker:load-plan staged by
default; only invoker:start-ready activates a staged workflow before
computing ready tasks. The shared startPlan() e2e fixture still called
window.invoker.start(), which never got a workflow past staged, so the
loaded plan sat pending forever. This matches the real UI's own "Start
ready work" button, which already calls startReady.

startPlan() is used by 15 spec files, so this one fixture fix covers
all of them instead of 15 separate patches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change with no production runtime impact.
> 
> **Overview**
> Updates the shared **`startPlan()`** E2E helper so it calls **`window.invoker.startReady()`** instead of **`window.invoker.start()`**.
> 
> After staged-by-default plan loading, **`start()`** no longer moves a workflow out of staged, so specs that relied on this fixture could leave plans stuck in **pending**. **`startReady()`** matches production **“Start ready work”** and activates ready tasks. Because **`startPlan()`** is shared across many specs, this single fixture change fixes that behavior everywhere it is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f9f4ce197c7fe1d90bdd49ed1b34fd2beefa2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan startup behavior by ensuring loaded plans begin only after the application is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->