### PR TITLE
[DB reaper incremental vacuum](1) Config schema

### DIFF
--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -283,6 +283,24 @@ function validateDbReaperConfig(config: InvokerConfig): void {
       throw new Error('dbReaper.syncJournalRetentionDays must be an integer');
     }
   }
+  if (typed.vacuumFreelistThresholdPages !== undefined) {
+    if (
+      typeof typed.vacuumFreelistThresholdPages !== 'number'
+      || !Number.isInteger(typed.vacuumFreelistThresholdPages)
+      || typed.vacuumFreelistThresholdPages <= 0
+    ) {
+      throw new Error('dbReaper.vacuumFreelistThresholdPages must be an integer > 0');
+    }
+  }
+  if (typed.vacuumMaxPagesPerTick !== undefined) {
+    if (
+      typeof typed.vacuumMaxPagesPerTick !== 'number'
+      || !Number.isInteger(typed.vacuumMaxPagesPerTick)
+      || typed.vacuumMaxPagesPerTick <= 0
+    ) {
+      throw new Error('dbReaper.vacuumMaxPagesPerTick must be an integer > 0');
+    }
+  }
 }
 
 function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -231,6 +231,8 @@ export interface DbReaperConfig {
   intervalMinutes?: number;
   eventsRetentionDays?: number;
   syncJournalRetentionDays?: number;
+  vacuumFreelistThresholdPages?: number;
+  vacuumMaxPagesPerTick?: number;
 }
 
 /** Default catstack clone URL. */


### PR DESCRIPTION
## Summary

`db-reaper` prunes old rows, but SQLite never reclaims the space they leave behind on its own.

The next slice fixes that with an incremental-vacuum step. This slice only adds its two config fields and their validation, first.

## Review Claim

`dbReaper.vacuumFreelistThresholdPages` and `dbReaper.vacuumMaxPagesPerTick` are added to `InvokerConfig` and validated, following the exact pattern already used for `dbReaper.eventsRetentionDays`.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Both fields are optional and unread by any code in this slice — setting or omitting them changes nothing about current behavior. Validation only rejects a non-positive-integer value; a well-formed config passes through unchanged.

## Slice Rationale

Config schema lands before the worker logic that reads it, so the next slice's diff is pure behavior with no schema noise mixed in.

## Non-goals

Does not add the incremental-vacuum logic itself — that's the next slice. Does not change any other `dbReaper` field's validation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build` — builds clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
