### PR TITLE
[DB reaper incremental vacuum](2) Reclaim freed pages via incremental vacuum

### DIFF
--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -283,6 +283,24 @@ function validateDbReaperConfig(config: InvokerConfig): void {
       throw new Error('dbReaper.syncJournalRetentionDays must be an integer');
     }
   }
+  if (typed.vacuumFreelistThresholdPages !== undefined) {
+    if (
+      typeof typed.vacuumFreelistThresholdPages !== 'number'
+      || !Number.isInteger(typed.vacuumFreelistThresholdPages)
+      || typed.vacuumFreelistThresholdPages <= 0
+    ) {
+      throw new Error('dbReaper.vacuumFreelistThresholdPages must be an integer > 0');
+    }
+  }
+  if (typed.vacuumMaxPagesPerTick !== undefined) {
+    if (
+      typeof typed.vacuumMaxPagesPerTick !== 'number'
+      || !Number.isInteger(typed.vacuumMaxPagesPerTick)
+      || typed.vacuumMaxPagesPerTick <= 0
+    ) {
+      throw new Error('dbReaper.vacuumMaxPagesPerTick must be an integer > 0');
+    }
+  }
 }
 
 function validateAdminBypassE2eBabysitConfig(config: InvokerConfig): void {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -231,6 +231,8 @@ export interface DbReaperConfig {
   intervalMinutes?: number;
   eventsRetentionDays?: number;
   syncJournalRetentionDays?: number;
+  vacuumFreelistThresholdPages?: number;
+  vacuumMaxPagesPerTick?: number;
 }
 
 /** Default catstack clone URL. */

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -6481,4 +6481,65 @@ describe('SQLiteAdapter', () => {
       expect(journalRowCount()).toBe(1);
     });
   });
+
+  describe('getFreelistPageCount / runIncrementalVacuum', () => {
+    function induceFragmentation(): void {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/t1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      for (let i = 0; i < 2_000; i += 1) {
+        adapter.logEvent('wf-1/t1', 'task.created', { padding: 'x'.repeat(500) });
+      }
+      (adapter as any).db.run('DELETE FROM events WHERE task_id = ?', ['wf-1/t1']);
+    }
+
+    it('returns 0 on a fresh database with no dead pages', () => {
+      expect(adapter.getFreelistPageCount()).toBe(0);
+    });
+
+    it('is a safe no-op while auto_vacuum is still the default NONE, even with real fragmentation', () => {
+      induceFragmentation();
+      const freelistBefore = adapter.getFreelistPageCount();
+      expect(freelistBefore).toBeGreaterThan(0);
+
+      const reclaimed = adapter.runIncrementalVacuum(10_000);
+
+      expect(reclaimed).toBe(0);
+      expect(adapter.getFreelistPageCount()).toBe(freelistBefore);
+    });
+
+    it('reclaims real freelist pages once auto_vacuum is switched to INCREMENTAL', () => {
+      (adapter as any).nativeDb.exec('PRAGMA auto_vacuum = INCREMENTAL');
+      (adapter as any).nativeDb.exec('VACUUM');
+      induceFragmentation();
+      const freelistBefore = adapter.getFreelistPageCount();
+      expect(freelistBefore).toBeGreaterThan(0);
+
+      const reclaimed = adapter.runIncrementalVacuum(freelistBefore + 1_000);
+
+      expect(reclaimed).toBeGreaterThan(0);
+      expect(adapter.getFreelistPageCount()).toBeLessThan(freelistBefore);
+    });
+
+    it('caps reclaimed pages at the requested maxPages', () => {
+      (adapter as any).nativeDb.exec('PRAGMA auto_vacuum = INCREMENTAL');
+      (adapter as any).nativeDb.exec('VACUUM');
+      induceFragmentation();
+      const freelistBefore = adapter.getFreelistPageCount();
+      expect(freelistBefore).toBeGreaterThan(5);
+
+      const reclaimed = adapter.runIncrementalVacuum(5);
+
+      expect(reclaimed).toBeLessThanOrEqual(5);
+      expect(adapter.getFreelistPageCount()).toBe(freelistBefore - reclaimed);
+    });
+
+    it('is a no-op for a non-positive maxPages', () => {
+      (adapter as any).nativeDb.exec('PRAGMA auto_vacuum = INCREMENTAL');
+      (adapter as any).nativeDb.exec('VACUUM');
+      induceFragmentation();
+
+      expect(adapter.runIncrementalVacuum(0)).toBe(0);
+      expect(adapter.runIncrementalVacuum(-1)).toBe(0);
+    });
+  });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1754,6 +1754,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.db.getRowsModified();
   }
 
+  getFreelistPageCount(): number {
+    const row = this.nativeDb.prepare('PRAGMA freelist_count').get() as { freelist_count?: number } | undefined;
+    return Number(row?.freelist_count ?? 0);
+  }
+
+  runIncrementalVacuum(maxPages: number): number {
+    if (!Number.isFinite(maxPages) || maxPages <= 0) return 0;
+    const autoVacuumRow = this.nativeDb.prepare('PRAGMA auto_vacuum').get() as { auto_vacuum?: number } | undefined;
+    if (Number(autoVacuumRow?.auto_vacuum ?? 0) === 0) return 0;
+    const before = this.getFreelistPageCount();
+    this.nativeDb.exec(`PRAGMA incremental_vacuum(${Math.floor(maxPages)})`);
+    const after = this.getFreelistPageCount();
+    return Math.max(0, before - after);
+  }
+
   deleteTask(taskId: string): void {
     this.runTransaction(() => {
       this.db.run('DELETE FROM task_launch_dispatch WHERE task_id = ?', [taskId]);

--- a/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/db-reaper-worker.test.ts
@@ -14,10 +14,13 @@ import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.j
 class FakeDbReaperStore implements DbReaperWorkerStore {
   readonly pruneOldEventsCalls: number[] = [];
   readonly pruneOldSyncJournalCalls: number[] = [];
+  readonly runIncrementalVacuumCalls: number[] = [];
 
   constructor(
     private readonly eventsPruned = 0,
     private readonly syncJournalPruned = 0,
+    private readonly freelistPages = 0,
+    private readonly pagesVacuumed = 0,
   ) {}
 
   pruneOldEvents(retentionDays: number): number {
@@ -28,6 +31,15 @@ class FakeDbReaperStore implements DbReaperWorkerStore {
   pruneOldSyncJournal(retentionDays: number): number {
     this.pruneOldSyncJournalCalls.push(retentionDays);
     return this.syncJournalPruned;
+  }
+
+  getFreelistPageCount(): number {
+    return this.freelistPages;
+  }
+
+  runIncrementalVacuum(maxPages: number): number {
+    this.runIncrementalVacuumCalls.push(maxPages);
+    return this.pagesVacuumed;
   }
 }
 
@@ -51,6 +63,44 @@ describe('createDbReaperWorker', () => {
 
     expect(store.pruneOldEventsCalls).toEqual([7]);
     expect(store.pruneOldSyncJournalCalls).toEqual([21]);
+  });
+
+  it('does not run incremental vacuum when the freelist is below the configured threshold', async () => {
+    const store = new FakeDbReaperStore(0, 0, 500, 0);
+    const worker = createDbReaperWorker({
+      logger: makeLogger(),
+      store,
+      eventsRetentionDays: 7,
+      syncJournalRetentionDays: 21,
+      vacuumFreelistThresholdPages: 1_000,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.runIncrementalVacuumCalls).toEqual([]);
+  });
+
+  it('runs incremental vacuum with the configured page cap once the freelist exceeds the threshold', async () => {
+    const store = new FakeDbReaperStore(0, 0, 15_000, 800);
+    const logger = makeLogger();
+    const worker = createDbReaperWorker({
+      logger,
+      store,
+      eventsRetentionDays: 7,
+      syncJournalRetentionDays: 21,
+      vacuumFreelistThresholdPages: 10_000,
+      vacuumMaxPagesPerTick: 2_500,
+      tickOnStart: false,
+    });
+
+    await worker.tick();
+
+    expect(store.runIncrementalVacuumCalls).toEqual([2_500]);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('800 freelist page(s) reclaimed'),
+      expect.anything(),
+    );
   });
 
   it('uses the documented default retention windows when none are configured', async () => {

--- a/packages/execution-engine/src/workers/db-reaper-worker.ts
+++ b/packages/execution-engine/src/workers/db-reaper-worker.ts
@@ -10,16 +10,22 @@ export const DEFAULT_DB_REAPER_INTERVAL_MINUTES = 60;
 export const DEFAULT_DB_REAPER_INTERVAL_MS = DEFAULT_DB_REAPER_INTERVAL_MINUTES * 60_000;
 export const DEFAULT_EVENTS_RETENTION_DAYS = 14;
 export const DEFAULT_SYNC_JOURNAL_RETENTION_DAYS = 14;
+export const DEFAULT_VACUUM_FREELIST_THRESHOLD_PAGES = 10_000;
+export const DEFAULT_VACUUM_MAX_PAGES_PER_TICK = 2_000;
 
 export interface DbReaperWorkerStore {
   pruneOldEvents(retentionDays: number): number;
   pruneOldSyncJournal(retentionDays: number): number;
+  getFreelistPageCount(): number;
+  runIncrementalVacuum(maxPages: number): number;
 }
 
 export interface DbReaperWorkerConfig {
   intervalMs?: number;
   eventsRetentionDays?: number;
   syncJournalRetentionDays?: number;
+  vacuumFreelistThresholdPages?: number;
+  vacuumMaxPagesPerTick?: number;
   tickOnStart?: boolean;
   store?: WorkerDecisionStore;
   onTick?: WorkerTick;
@@ -31,6 +37,8 @@ export interface DbReaperWorkerOptions {
   intervalMs?: number;
   eventsRetentionDays: number;
   syncJournalRetentionDays: number;
+  vacuumFreelistThresholdPages?: number;
+  vacuumMaxPagesPerTick?: number;
   tickOnStart?: boolean;
   decisionStore?: WorkerDecisionStore;
   onTick?: WorkerTick;
@@ -50,10 +58,19 @@ export function createDbReaperWorker(options: DbReaperWorkerOptions): WorkerRunt
       const eventsPruned = options.store.pruneOldEvents(options.eventsRetentionDays);
       ctx.signal?.throwIfAborted();
       const syncJournalPruned = options.store.pruneOldSyncJournal(options.syncJournalRetentionDays);
+      ctx.signal?.throwIfAborted();
+
+      const vacuumThreshold = options.vacuumFreelistThresholdPages ?? DEFAULT_VACUUM_FREELIST_THRESHOLD_PAGES;
+      const vacuumMaxPages = options.vacuumMaxPagesPerTick ?? DEFAULT_VACUUM_MAX_PAGES_PER_TICK;
+      const freelistPages = options.store.getFreelistPageCount();
+      const pagesVacuumed = freelistPages > vacuumThreshold
+        ? options.store.runIncrementalVacuum(vacuumMaxPages)
+        : 0;
 
       const summary = `DB reaper pass: ${eventsPruned} old event row(s) pruned `
         + `(retention=${options.eventsRetentionDays}d), ${syncJournalPruned} old sync_journal row(s) pruned `
-        + `(retention=${options.syncJournalRetentionDays}d)`;
+        + `(retention=${options.syncJournalRetentionDays}d), ${pagesVacuumed} freelist page(s) reclaimed `
+        + `(freelist was ${freelistPages}, threshold=${vacuumThreshold})`;
 
       if (options.decisionStore) {
         recordWorkerDecisionRow(options.decisionStore, {
@@ -64,7 +81,7 @@ export function createDbReaperWorker(options: DbReaperWorkerOptions): WorkerRunt
           subjectId: 'invoker.db',
           status: 'completed',
           summary,
-          payload: { eventsPruned, syncJournalPruned },
+          payload: { eventsPruned, syncJournalPruned, pagesVacuumed, freelistPages },
           incrementAttempt: true,
         });
       }
@@ -78,7 +95,7 @@ export function registerDbReaperWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: DB_REAPER_WORKER_KIND,
-    note: 'Prunes events older than retention for terminal-status tasks, and sync_journal rows every known peer has already received.',
+    note: 'Prunes events older than retention for terminal-status tasks, sync_journal rows every known peer has already received, and reclaims freelist space via incremental vacuum once auto_vacuum is enabled.',
     source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createDbReaperWorker({
@@ -88,6 +105,8 @@ export function registerDbReaperWorker(
         intervalMs: deps.dbReaper?.intervalMs,
         eventsRetentionDays: deps.dbReaper?.eventsRetentionDays ?? DEFAULT_EVENTS_RETENTION_DAYS,
         syncJournalRetentionDays: deps.dbReaper?.syncJournalRetentionDays ?? DEFAULT_SYNC_JOURNAL_RETENTION_DAYS,
+        vacuumFreelistThresholdPages: deps.dbReaper?.vacuumFreelistThresholdPages,
+        vacuumMaxPagesPerTick: deps.dbReaper?.vacuumMaxPagesPerTick,
         tickOnStart: deps.dbReaper?.tickOnStart,
       }),
   });


### PR DESCRIPTION
## Summary

`db-reaper` prunes old rows, but SQLite never shrinks the file afterward on its own — pruned space just becomes a permanent hole.

Confirmed live on DO1: 119,423 of 499,222 pages (~489MB, 24% of a 2.0GB file) are free and unreclaimed.

A boot that only needs the small workflows/tasks tables took 12 minutes 19 seconds — consistent with paging through a badly fragmented file.

This adds a bounded, incremental reclaim step to `db-reaper`, using SQLite's own built-in mechanism for this instead of a risky full rewrite.

## Review Claim

`db-reaper` calls a new `runIncrementalVacuum` step once `getFreelistPageCount()` exceeds a configurable threshold, capped at a configurable page count per tick. `PRAGMA incremental_vacuum` is a documented no-op while `auto_vacuum` is the default `NONE`, so this ships inert until an operator explicitly converts the database.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This never touches a database still in the default `auto_vacuum = NONE` mode — confirmed by a real test that induces fragmentation and shows `runIncrementalVacuum` returns 0 and changes nothing. It only does real work after an explicit, separate one-time conversion (a maintenance script, not this PR). Even once active, it reclaims a bounded number of pages per tick (`vacuumMaxPagesPerTick`), not an unbounded rewrite — confirmed by a test that caps reclaim at the requested limit.

## Slice Rationale

The mechanism itself: `SQLiteAdapter.getFreelistPageCount()`/`runIncrementalVacuum()` plus the `db-reaper` worker tick logic that calls them. App-level config wiring (`main.ts`) is its own follow-on slice, since it's a distinct package boundary from data-store/execution-engine.

## Non-goals

Does not run the one-time `auto_vacuum` mode conversion — that's a separate, explicit maintenance action (an earlier fix, `7883e7979b`, deliberately treated any VACUUM-class action on live data as its own decision, not something a worker does silently). Does not change `eventsRetentionDays`/`syncJournalRetentionDays` pruning behavior. Does not address the deeper "should events live in a separate file" question raised alongside this fix. Does not wire the new config fields through `main.ts` — that's the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter -t "getFreelistPageCount|runIncrementalVacuum"` — 5 new tests against a real SQLite database with induced fragmentation: returns 0 on a fresh DB; safe no-op while auto_vacuum is NONE even with real dead pages; real reclaim once switched to INCREMENTAL; reclaim capped at maxPages; no-op for non-positive maxPages. All pass; full `sqlite-adapter` suite (520 tests) unaffected.
- [x] `pnpm --filter @invoker/execution-engine test -- db-reaper-worker` — 2 new tests prove the freelist-threshold gate: skips vacuum below threshold, calls it with the configured page cap above threshold. 6/6 pass.
- [x] `pnpm --filter @invoker/data-store build`, `pnpm --filter @invoker/execution-engine build` — both build clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — this PR never mutates the database itself; only the separate manual conversion script does, and it's not run automatically.

</details>
