### PR TITLE
fix(dev-profile-guard): use the real OS home for the production-collision check

### DIFF
--- a/scripts/test-development-profile-guard.mjs
+++ b/scripts/test-development-profile-guard.mjs
@@ -61,6 +61,16 @@ const collision = spawnSync(process.execPath, [launcher, '--print-env'], {
 });
 if (collision.status === 0 || !collision.stderr.includes('production profile')) failures.push('production collision did not fail closed');
 
+const sandboxedHome = join('/tmp', 'invoker-development-profile-sandboxed-home');
+const sandboxedNonCollision = spawnSync(process.execPath, [launcher, '--print-env'], {
+  cwd: root,
+  encoding: 'utf8',
+  env: { ...process.env, HOME: sandboxedHome, INVOKER_DB_DIR: join(sandboxedHome, '.invoker') },
+});
+if (sandboxedNonCollision.status !== 0) {
+  failures.push(`a caller's own sandboxed $HOME/.invoker was rejected as a production collision: ${sandboxedNonCollision.stderr.trim()}`);
+}
+
 const explicitResourcePaths = Object.fromEntries(
   profileResourceKeys.map((key) => [key, join('/tmp', 'invoker-development-profile-override', key.toLowerCase())]),
 );

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from 'node:crypto';
 import { realpathSync } from 'node:fs';
-import { homedir, platform } from 'node:os';
+import { homedir, platform, userInfo } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -50,8 +50,19 @@ function resolveValue(name, value) {
   return name.endsWith('_PORT') ? String(value) : resolve(String(value));
 }
 
+function realHomeDir() {
+  // Unlike os.homedir(), userInfo().homedir ignores an overridden $HOME —
+  // needed so a caller's own sandboxed $HOME/.invoker isn't mistaken for
+  // the real production namespace this guard protects.
+  try {
+    return userInfo().homedir;
+  } catch {
+    return homedir();
+  }
+}
+
 function assertNoProductionCollision(env) {
-  const homeDir = homedir();
+  const homeDir = realHomeDir();
   const productionHome = join(homeDir, '.invoker');
   const forbidden = new Map([
     ['INVOKER_DB_DIR', productionHome],


### PR DESCRIPTION
scripts/electron.cjs wraps every launch through
with-invoker-development-profile.mjs, whose production-collision check
compared INVOKER_DB_DIR against os.homedir() + '/.invoker'. os.homedir()
follows an overridden $HOME, so a caller that sandboxes its own $HOME and
points INVOKER_DB_DIR at $HOME/.invoker inside it (the same layout the
real default profile uses) gets flagged as colliding with production and
refused. Two required e2e-proof scripts do exactly that and both spawn a
real owner process through this wrapper, so the guard blocked their owner
from starting.

os.userInfo().homedir reads the OS user database directly and ignores an
overridden $HOME, so it reflects the actual production home this guard
is meant to protect, without weakening the real collision check for an
interactive developer who has not overridden $HOME.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to dev-launcher env validation and its test script; production runtime paths are unchanged except fixing false rejects for sandboxed `$HOME`.
> 
> **Overview**
> The development profile launcher was **false-positive blocking** callers that sandbox `$HOME` and set `INVOKER_DB_DIR` to `$HOME/.invoker`, because the production-collision check used `os.homedir()`, which follows an overridden `$HOME` and treated that layout as the real production namespace.
> 
> **Production collision detection** now resolves the protected home via a new `realHomeDir()` helper that prefers `os.userInfo().homedir` (OS user record, ignores `$HOME`), with `homedir()` as fallback.
> 
> The guard test script adds a regression case: launcher `--print-env` must succeed when `HOME` and `INVOKER_DB_DIR` both live under a temporary sandbox path, while the existing check that real production `INVOKER_DB_DIR` still fails closed is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5fd8b77cf2efe9724333ed75b320c285259812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->