### PR TITLE
fix(ui): scope the Beta Empty Workflow click to the sidebar rail list

### DIFF
--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
@@ -226,7 +226,7 @@ describe('Browser-surface camera (component)', () => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Alpha Empty Workflow');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Beta Empty Workflow/ }));
+    fireEvent.click(within(screen.getByTestId('workflows-rail-list')).getByRole('button', { name: /Beta Empty Workflow/ }));
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Beta Empty Workflow');
     });


### PR DESCRIPTION
WorkflowNode also renders with role="button" and the workflow's name
as accessible text, so getByRole('button', { name: /Beta Empty
Workflow/ }) against the whole screen now matches both the sidebar
row and the graph node once both are on screen at the same time,
throwing a multiple-elements error instead of clicking the intended
sidebar row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only query scoping; no production UI or behavior changes.
> 
> **Overview**
> Fixes a flaky/failing assertion in the browser-surface camera regression test by clicking **Beta Empty Workflow** only inside the workflows sidebar rail, not anywhere on the page.
> 
> The test now imports `within` from Testing Library and uses `within(screen.getByTestId('workflows-rail-list')).getByRole('button', { name: /Beta Empty Workflow/ })` instead of a document-wide `getByRole`, because graph `WorkflowNode` elements also expose the same button name and caused a multiple-matches error once both sidebar and graph were visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dfbc4e244461237b619d709cbc5ef3c3f19db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->