### PR TITLE
[Stack onto upstream](1) Classify workflow-chain-submit skill paths as tooling-policy

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -281,6 +281,7 @@ export function classifyReviewUnitsForPath(filePath) {
     path === 'skills/make-pr/SKILL.md'
     || path.startsWith('skills/chat-submit/')
     || path.startsWith('skills/plan-to-invoker/')
+    || path.startsWith('skills/workflow-chain-submit/')
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -40,6 +40,7 @@ const stillToolingPolicy = [
   'skills/chat-submit/scripts/check-contract.sh',
   'skills/plan-to-invoker/SKILL.md',
   'skills/plan-to-invoker/references/local-vs-remote-mcp.md',
+  'skills/workflow-chain-submit/SKILL.md',
   'skills/land-stack/SKILL.md',
   'skills/visual-proof/SKILL.md',
   'skills/prove-it/SKILL.md',

--- a/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
@@ -281,6 +281,7 @@ export function classifyReviewUnitsForPath(filePath) {
     path === 'skills/make-pr/SKILL.md'
     || path.startsWith('skills/chat-submit/')
     || path.startsWith('skills/plan-to-invoker/')
+    || path.startsWith('skills/workflow-chain-submit/')
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'


### PR DESCRIPTION
## Summary

This slice only classifies `skills/workflow-chain-submit/` under tooling-policy.

That keeps later chain-submit skill edits in the same review unit as the submit scripts.

## Review Claim

Approve treating workflow-chain-submit skill paths as tooling-policy, matching chat-submit and plan-to-invoker.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Assumptions: unconfirmed — Classification-only change; no runtime behavior change.

## Slice Rationale

Land the path classification first so the next stack slice can edit that skill without a docs-unit conflict against master rules.

## Non-goals

No validator, chain script, or skill prose changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9aea291bc6`
- Post-revert steps: None
- Data migration? No

</details>
