### PR TITLE
fix(execution-engine): accept absolute local paths as cloneable repoUrl

### DIFF
--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -223,6 +223,7 @@ describe('isCloneableRepoUrl', () => {
     ['ssh://git@github.com/owner/repo.git', true],
     ['file:///home/user/repo.git', true],
     ['owner/repo', true],
+    ['/tmp/invoker-repro-fixture/repro-repo', true],
     ['.', false],
     ['..', false],
     ['./repo', false],

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, unlinkSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
@@ -49,6 +49,7 @@ export function isCloneableRepoUrl(repoUrl: string): boolean {
   if (trimmed.startsWith(SSH_PREFIX)) return true;
   if (trimmed.startsWith(FILE_PREFIX)) return true;
   if (GITHUB_SHORTHAND_PATTERN.test(trimmed)) return true;
+  if (isAbsolute(trimmed)) return true;
   return false;
 }
 


### PR DESCRIPTION
PR #11266 added isCloneableRepoUrl() to reject invalid repoUrl values
before WorktreeExecutor attempts a clone. Its allowlist covered https/http,
git@host:, ssh://, file://, and owner/repo shorthand, but not a bare
absolute filesystem path — even though git natively clones one with no
scheme needed. At least 5 repro scripts pass their disposable git fixture
directory as repoUrl this way (a plain $TMP_DIR/repro-repo path), and all
of them now fail every task at startup with "invalid repoUrl".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation widen in execution-engine preflight only; relative paths and other rejections are unchanged.
> 
> **Overview**
> **`isCloneableRepoUrl`** now treats **bare absolute filesystem paths** as valid `repoUrl` values (via `path.isAbsolute`), alongside existing URL forms (`https://`, `git@`, `file://`, `owner/repo`, etc.).
> 
> That unblocks workflows and repro scripts that point at a local git directory (e.g. `$TMP/repro-repo`) without a scheme—previously they failed at **`WorktreeExecutor.start()`** with **invalid repoUrl** even though `git clone` accepts such paths.
> 
> A parameterized test case documents the expected behavior for a fixture-style absolute path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56de7da4bb44fa4bfd4a40af418351ec4b4e8e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->