### PR TITLE
fix(ci): assign planning-submit-to-workflow-graph.spec.ts to a shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,6 +795,7 @@ jobs:
               e2e/invalid-task-workspace-visual.spec.ts
               e2e/persistence-lifecycle.spec.ts
               e2e/planning-review-scroll.spec.ts
+              e2e/planning-submit-to-workflow-graph.spec.ts
           - name: 3-of-9
             files: >-
               e2e/task-death-logs.spec.ts


### PR DESCRIPTION
PR #11326 added e2e/planning-submit-to-workflow-graph.spec.ts but never
added it to the Playwright shard matrix in ci.yml. The shard-inventory
guard (scripts/repro/repro-ci-playwright-shard-inventory.mjs) fails
closed on any unassigned CI-owned spec, so every playwright job —
all 9 numbered shards plus terminal-garbling and planning-chat-restore —
has failed at this guard step before a single test could run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application or test logic changes beyond which shard runs the spec.
> 
> **Overview**
> Registers **`e2e/planning-submit-to-workflow-graph.spec.ts`** in the Playwright job matrix under **`2-of-9`**, alongside other planning/persistence specs.
> 
> That spec was added earlier but left out of `ci.yml`, so **`Verify Playwright shard inventory`** (`repro-ci-playwright-shard-inventory.mjs`) treated it as unassigned and failed every Playwright matrix job before any tests ran.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8d7492344b3c1b3df7c0e1e99f632af4b2a59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->