### PR TITLE
feat(bench): add UI read scale benchmarks with INVOKER_BENCH_SCALE

### DIFF
--- a/packages/app/src/__tests__/ui-read-scale-bench.test.ts
+++ b/packages/app/src/__tests__/ui-read-scale-bench.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+import type { InvokerConfig } from '../config.js';
+import { getEventsPage } from '../get-events-page.js';
+
+const CHEAP_IPC_P95_BUDGET_MS = 200;
+const ACTION_GRAPH_P95_BUDGET_MS = 100;
+
+const CI_WORKFLOW_COUNT = 200;
+const CI_EVENTS_PER_TASK = 250;
+const CI_TASKS_PER_WORKFLOW = 5;
+
+function parseBenchScale(): { workflowCount: number; eventsPerTask: number; tasksPerWorkflow: number } {
+  const scale = process.env.INVOKER_BENCH_SCALE?.toLowerCase();
+  if (!scale) {
+    return { workflowCount: CI_WORKFLOW_COUNT, eventsPerTask: CI_EVENTS_PER_TASK, tasksPerWorkflow: CI_TASKS_PER_WORKFLOW };
+  }
+  if (scale === '2g' || scale === '2gb') {
+    return { workflowCount: 800, eventsPerTask: 1000, tasksPerWorkflow: 10 };
+  }
+  if (scale === '1g' || scale === '1gb') {
+    return { workflowCount: 400, eventsPerTask: 500, tasksPerWorkflow: 8 };
+  }
+  if (scale === '500m' || scale === '500mb') {
+    return { workflowCount: 200, eventsPerTask: 400, tasksPerWorkflow: 6 };
+  }
+  return { workflowCount: CI_WORKFLOW_COUNT, eventsPerTask: CI_EVENTS_PER_TASK, tasksPerWorkflow: CI_TASKS_PER_WORKFLOW };
+}
+
+interface BenchStats {
+  min: number;
+  max: number;
+  p50: number;
+  p95: number;
+  samples: number[];
+}
+
+function computeStats(samples: number[]): BenchStats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const min = sorted[0]!;
+  const max = sorted[sorted.length - 1]!;
+  const p50 = sorted[Math.floor(sorted.length * 0.5)]!;
+  const p95 = sorted[Math.floor(sorted.length * 0.95)]!;
+  return { min, max, p50, p95, samples };
+}
+
+function benchmark(
+  fn: () => void,
+  opts: { warmup?: number; iterations?: number } = {},
+): BenchStats {
+  const warmup = opts.warmup ?? 3;
+  const iterations = opts.iterations ?? 20;
+  for (let i = 0; i < warmup; i += 1) fn();
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const started = performance.now();
+    fn();
+    samples.push(performance.now() - started);
+  }
+  return computeStats(samples);
+}
+
+interface SeedManyWorkflowsResult {
+  workflowIds: string[];
+  totalTasks: number;
+  totalEvents: number;
+}
+
+function seedManyWorkflows(
+  adapter: SQLiteAdapter,
+  opts: { workflowCount: number; tasksPerWorkflow: number; eventsPerTask: number },
+): SeedManyWorkflowsResult {
+  const workflowIds: string[] = [];
+  let totalTasks = 0;
+  let totalEvents = 0;
+
+  adapter.runInTransaction(() => {
+    for (let w = 0; w < opts.workflowCount; w += 1) {
+      const workflowId = `wf-bench-${w}`;
+      workflowIds.push(workflowId);
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: `Bench workflow ${w}`,
+        status: w % 10 === 0 ? 'running' : 'completed',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      });
+
+      for (let t = 0; t < opts.tasksPerWorkflow; t += 1) {
+        const taskId = `${workflowId}/t${t}`;
+        adapter.saveTask(workflowId, {
+          id: taskId,
+          description: `Task ${t} of workflow ${w}`,
+          status: t === 0 && w % 10 === 0 ? 'running' : 'completed',
+          dependencies: [],
+          createdAt: new Date('2026-07-01T00:00:00.000Z'),
+          config: {},
+          execution: {},
+          taskStateVersion: 1,
+        });
+        totalTasks += 1;
+
+        for (let e = 0; e < opts.eventsPerTask; e += 1) {
+          adapter.logEvent(taskId, 'bench.event', { idx: e });
+          totalEvents += 1;
+        }
+      }
+    }
+  });
+
+  return { workflowIds, totalTasks, totalEvents };
+}
+
+describe('ui-read-scale-bench', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+  const scale = parseBenchScale();
+  const isLargeScale = scale.workflowCount > CI_WORKFLOW_COUNT;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('listWorkflows p95 stays under 200ms with many workflows', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-list-wf-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedManyWorkflows(adapter, {
+      workflowCount: scale.workflowCount,
+      tasksPerWorkflow: 1,
+      eventsPerTask: 10,
+    });
+    expect(seeded.workflowIds.length).toBe(scale.workflowCount);
+
+    let result: ReturnType<SQLiteAdapter['listWorkflows']> | undefined;
+    const stats = benchmark(() => { result = adapter!.listWorkflows(); });
+
+    expect(result!.length).toBe(scale.workflowCount);
+    expect(
+      stats.p95,
+      `listWorkflows p95=${stats.p95.toFixed(1)}ms max=${stats.max.toFixed(1)}ms (workflows=${scale.workflowCount})`,
+    ).toBeLessThan(CHEAP_IPC_P95_BUDGET_MS);
+  });
+
+  it('paginated getEvents p95 stays under 200ms on fat event table', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-get-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: scale.eventsPerTask * scale.tasksPerWorkflow,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+    expect(seeded.eventCount).toBeGreaterThanOrEqual(1000);
+
+    let result: ReturnType<typeof getEventsPage> | undefined;
+    const stats = benchmark(() => {
+      result = getEventsPage(adapter!, taskId, { limit: 20, sortBy: 'desc' });
+    });
+
+    expect(result!.length).toBe(20);
+    expect(
+      stats.p95,
+      `getEvents(limit:20) p95=${stats.p95.toFixed(1)}ms max=${stats.max.toFixed(1)}ms (events=${seeded.eventCount})`,
+    ).toBeLessThan(CHEAP_IPC_P95_BUDGET_MS);
+  });
+
+  it('syncAllFromDb + getAllTasks p95 stays under 200ms', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-sync-all-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedManyWorkflows(adapter, {
+      workflowCount: scale.workflowCount,
+      tasksPerWorkflow: scale.tasksPerWorkflow,
+      eventsPerTask: 10,
+    });
+    expect(seeded.totalTasks).toBe(scale.workflowCount * scale.tasksPerWorkflow);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+
+    let tasks: ReturnType<Orchestrator['getAllTasks']> | undefined;
+    const stats = benchmark(() => {
+      orchestrator.syncAllFromDb();
+      tasks = orchestrator.getAllTasks();
+    });
+
+    expect(tasks!.length).toBe(seeded.totalTasks);
+    expect(
+      stats.p95,
+      `syncAllFromDb+getAllTasks p95=${stats.p95.toFixed(1)}ms max=${stats.max.toFixed(1)}ms (tasks=${seeded.totalTasks})`,
+    ).toBeLessThan(CHEAP_IPC_P95_BUDGET_MS);
+  });
+
+  it('buildCurrentActionGraphSnapshot p95 stays under 100ms on hitch fixture', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-ag-snapshot-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 40,
+      eventsPerTask: scale.eventsPerTask,
+      actionsPerKind: 20,
+    });
+    expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const invokerConfig: InvokerConfig = {};
+    let snapshot: ReturnType<typeof buildCurrentActionGraphSnapshot> | undefined;
+    const stats = benchmark(() => {
+      snapshot = buildCurrentActionGraphSnapshot({
+        orchestrator,
+        persistence: adapter!,
+        invokerConfig,
+      });
+    });
+
+    expect(snapshot!.nodes.length).toBeGreaterThan(0);
+    expect(
+      stats.p95,
+      `actionGraphSnapshot p95=${stats.p95.toFixed(1)}ms max=${stats.max.toFixed(1)}ms (events=${seeded.eventCount})`,
+    ).toBeLessThan(ACTION_GRAPH_P95_BUDGET_MS);
+  });
+
+  it('buildCurrentActionGraphSnapshot p95 stays under 100ms with 200 workflows × 250 events (sidebar cardinality)', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-ag-sidebar-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedManyWorkflows(adapter, {
+      workflowCount: scale.workflowCount,
+      tasksPerWorkflow: 2,
+      eventsPerTask: scale.eventsPerTask,
+    });
+    expect(seeded.workflowIds.length).toBe(scale.workflowCount);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const invokerConfig: InvokerConfig = {};
+    let snapshot: ReturnType<typeof buildCurrentActionGraphSnapshot> | undefined;
+    const stats = benchmark(() => {
+      snapshot = buildCurrentActionGraphSnapshot({
+        orchestrator,
+        persistence: adapter!,
+        invokerConfig,
+      });
+    });
+
+    expect(snapshot!.nodes.length).toBeGreaterThan(0);
+    expect(
+      stats.p95,
+      `actionGraphSnapshot p95=${stats.p95.toFixed(1)}ms max=${stats.max.toFixed(1)}ms (workflows=${scale.workflowCount}, events=${seeded.totalEvents})`,
+    ).toBeLessThan(ACTION_GRAPH_P95_BUDGET_MS);
+  });
+
+  it.skipIf(!isLargeScale)('reports DB size for large-scale benchmark', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-db-size-'));
+    const dbPath = join(tmpDir, 'invoker.db');
+    adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+
+    seedManyWorkflows(adapter, {
+      workflowCount: scale.workflowCount,
+      tasksPerWorkflow: scale.tasksPerWorkflow,
+      eventsPerTask: scale.eventsPerTask,
+    });
+
+    const stat = statSync(dbPath);
+    const sizeMB = stat.size / (1024 * 1024);
+    console.info(`[ui-read-scale-bench] DB size: ${sizeMB.toFixed(1)} MB (scale=${process.env.INVOKER_BENCH_SCALE})`);
+    expect(sizeMB).toBeGreaterThan(10);
+  });
+});
+
+describe('unbounded getEvents proof', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded adapter.getEvents(taskId) is expensive on large event tables', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bench-unbounded-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const unboundedStats = benchmark(() => { adapter!.getEvents(taskId); }, { warmup: 1, iterations: 5 });
+    const boundedStats = benchmark(
+      () => { getEventsPage(adapter!, taskId, { limit: 20, sortBy: 'desc' }); },
+      { warmup: 1, iterations: 5 },
+    );
+
+    expect(unboundedStats.p50).toBeGreaterThan(boundedStats.p50 * 2);
+    expect(boundedStats.p95).toBeLessThan(50);
+  });
+
+  it('SQLiteAdapter.getEvents(taskId) 1-arg overload still exists and is unbounded', () => {
+    expect(typeof SQLiteAdapter.prototype.getEvents).toBe('function');
+    expect(SQLiteAdapter.prototype.getEvents.length).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add committed UI-read scale benchmarks to guard against SQLite performance regressions as the database grows toward 2GB.

The benchmarks time several hot paths with warmup and compute min/p50/p95/max statistics. Assertions match the budgets in the responsiveness invariant doc.

CI default stays small by reusing existing fixture scale (200 workflows × 5 tasks × 250 events). The INVOKER_BENCH_SCALE env flag enables local 2GB-scale testing.

Also includes a proof test showing the unbounded getEvents 1-arg overload is expensive on large tables. Production code uses the bounded version.

## Review Claim

Approve adding a benchmark test file that gates UI read performance at the budgets documented in ui-action-responsiveness-invariant.md.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only a new test file under packages/app/src/__tests__/. No production code changes. The benchmarks use isolated temp SQLite databases and clean up after each test.

## Slice Rationale

Tooling-only: benchmarks and proof tests belong together since they all measure and assert performance characteristics. No behavior change to split out.

## Non-goals

- Does not change production code.
- Does not add 2GB fixtures to git.
- Does not remove the 1-arg getEvents overload (it's test-only and useful for test convenience).
- Does not touch chaos-submit #11342–#11375, demo-control, or web-freshness #11379–#11380.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments` — passes, no disallowed comments
- [x] `pnpm --filter @invoker/app test -- ui-read-scale-bench` — 7 passed, 1 skipped (large-scale DB size report)
- [ ] CI scale (default): `pnpm --filter @invoker/app test -- ui-read-scale-bench`
- [ ] 2GB local scale: `INVOKER_BENCH_SCALE=2g pnpm --filter @invoker/app test -- ui-read-scale-bench`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8261e010-ed1c-4e23-b1e1-4dcc91b1922f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8261e010-ed1c-4e23-b1e1-4dcc91b1922f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

