### PR TITLE
(1) proof(data-store): SQL variables limit crash at >32766 workflows

### DIFF
--- a/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
+++ b/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const SQLITE_MAX_VARIABLE_NUMBER = 32766;
+const WORKFLOW_COUNT_ABOVE_LIMIT = SQLITE_MAX_VARIABLE_NUMBER + 100;
+
+describe('SQL variables limit (ui-read-scale proof)', () => {
+  let tmpDir: string;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'sql-vars-repro-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.fails('loadWorkflowTaskSnapshot throws "too many SQL variables" at >32766 workflows', async () => {
+    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+      adapter.saveWorkflow({
+        id: `wf-${i}`,
+        name: `Workflow ${i}`,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      adapter.saveTask(`wf-${i}`, {
+        id: `wf-${i}/t0`,
+        description: `Task ${i}`,
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: `wf-${i}` },
+        execution: {},
+        taskStateVersion: 1,
+      });
+    }
+
+    const snapshot = adapter.loadWorkflowTaskSnapshot();
+    expect(snapshot.workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
+  });
+
+  it.fails('listWorkflows → loadWorkflowRollups throws at >32766 workflows', async () => {
+    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+      adapter.saveWorkflow({
+        id: `wf-${i}`,
+        name: `Workflow ${i}`,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    const workflows = adapter.listWorkflows();
+    expect(workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
+  });
+
+  it.fails('loadTasksForWorkflows throws at >32766 workflow IDs', async () => {
+    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+      adapter.saveWorkflow({
+        id: `wf-${i}`,
+        name: `Workflow ${i}`,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    const workflowIds = Array.from({ length: WORKFLOW_COUNT_ABOVE_LIMIT }, (_, i) => `wf-${i}`);
+    const tasks = adapter.loadTasksForWorkflows(workflowIds);
+    expect(tasks).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`loadWorkflowTaskSnapshot`, `listWorkflows`, and `loadTasksForWorkflows` build `WHERE workflow_id IN (?,?,?,...)` clauses with one placeholder per workflow.

Node's sqlite module has `MAX_VARIABLE_NUMBER = 32766`. At 33k+ workflows these queries throw "too many SQL variables."

This proof adds `it.fails` tests that confirm the crash at scale. The follow-up fix will chunk large IN clauses.

## Review Claim

The `it.fails` tests reproduce the SQL variables limit crash documented in the ui-read-scale bench findings.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only: no production code changed. Tests use `it.fails` so CI stays green while the bug exists.

## Slice Rationale

Proof before fix: demonstrates the crash before the chunking fix lands, so the fix PR can flip `it.fails` to `it` and show the tests pass.

## Non-goals

Does not fix the crash. Does not add large-scale fixtures to git.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- --testNamePattern="SQL variables limit"`

All three tests pass (as `it.fails` confirming the bug exists).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

