### PR TITLE
(3) proof(data-store): unbounded getEvents 1-arg overload returns entire table

### DIFF
--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+describe('unbounded getEvents (ui-read-scale proof)', () => {
+  let tmpDir: string;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'unbounded-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'Test Workflow',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-1', {
+      id: 'wf-1/t1',
+      description: 'Task with many events',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+      taskStateVersion: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.fails('1-arg getEvents overload has no LIMIT and returns entire event history', () => {
+    const eventCount = 50_000;
+    for (let i = 0; i < eventCount; i++) {
+      adapter.logEvent('wf-1/t1', 'task.progress', { i, data: 'x'.repeat(100) });
+    }
+
+    const events = adapter.getEvents('wf-1/t1');
+    expect(events).toHaveLength(eventCount);
+    expect(events.length).toBeLessThan(1000);
+  });
+
+  it('bounded getEvents with limit works correctly', () => {
+    const eventCount = 1000;
+    for (let i = 0; i < eventCount; i++) {
+      adapter.logEvent('wf-1/t1', 'task.progress', { i });
+    }
+
+    const events = adapter.getEvents('wf-1/t1', 'desc', 100);
+    expect(events).toHaveLength(100);
+  });
+
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `getEvents(taskId)` 1-arg overload executes `SELECT * FROM events WHERE task_id=? ORDER BY id` with no LIMIT.

On tasks with many events (e.g. 50k+ progress logs), this returns the entire history in one call. At 2.74M events this took 19.1s in the scale bench.

The `it.fails` test demonstrates the unbounded behavior.

## Review Claim

The `it.fails` test proves the 1-arg `getEvents` overload has no limit and returns the entire event history.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only: no production code changed. Test uses `it.fails` so CI stays green while the bug exists.

## Slice Rationale

Proof before fix: demonstrates the unbounded query before the fix lands, so the fix PR can update the test to show the limit is enforced.

## Non-goals

Does not fix the unbounded query. Does not change callers.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- --testPathPattern="unbounded-get-events"`

Both tests pass:
- `it.fails` test confirms unbounded behavior
- Bounded 3-arg overload works correctly

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

