### PR TITLE
(4) fix(data-store): add default limit to 1-arg getEvents overload

### DIFF
--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { SQLiteAdapter, GET_EVENTS_DEFAULT_LIMIT } from '../sqlite-adapter.js';
 
-describe('unbounded getEvents (ui-read-scale proof)', () => {
+describe('getEvents default limit (ui-read-scale)', () => {
   let tmpDir: string;
   let adapter: SQLiteAdapter;
 
   beforeEach(async () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'unbounded-events-'));
+    tmpDir = mkdtempSync(join(tmpdir(), 'bounded-events-'));
     adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
     adapter.saveWorkflow({
       id: 'wf-1',
@@ -35,18 +35,17 @@ describe('unbounded getEvents (ui-read-scale proof)', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it.fails('1-arg getEvents overload has no LIMIT and returns entire event history', () => {
-    const eventCount = 50_000;
+  it('1-arg getEvents overload applies GET_EVENTS_DEFAULT_LIMIT', () => {
+    const eventCount = GET_EVENTS_DEFAULT_LIMIT + 5000;
     for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i, data: 'x'.repeat(100) });
+      adapter.logEvent('wf-1/t1', 'task.progress', { i });
     }
 
     const events = adapter.getEvents('wf-1/t1');
-    expect(events).toHaveLength(eventCount);
-    expect(events.length).toBeLessThan(1000);
+    expect(events).toHaveLength(GET_EVENTS_DEFAULT_LIMIT);
   });
 
-  it('bounded getEvents with limit works correctly', () => {
+  it('bounded getEvents with explicit limit works correctly', () => {
     const eventCount = 1000;
     for (let i = 0; i < eventCount; i++) {
       adapter.logEvent('wf-1/t1', 'task.progress', { i });
@@ -56,4 +55,7 @@ describe('unbounded getEvents (ui-read-scale proof)', () => {
     expect(events).toHaveLength(100);
   });
 
+  it('GET_EVENTS_DEFAULT_LIMIT is exported and equals 10000', () => {
+    expect(GET_EVENTS_DEFAULT_LIMIT).toBe(10_000);
+  });
 });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -445,7 +445,6 @@ export interface PersistenceAdapter {
 
   // Events (audit trail)
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
-  /** Unbounded history — internal/tests only. Public IPC must use the limited overload. */
   getEvents(taskId: string): TaskEvent[];
   getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
   /** Bounded, newest-first lookup — prefer this over a full getEvents(taskId) scan when only recent events of one type are needed. */

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -107,7 +107,8 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
-// activity_log is capped to its most recent rows so the DB file stays bounded; 0 disables.
+export const GET_EVENTS_DEFAULT_LIMIT = 10_000;
+
 const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
 const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000; // prune at most once per N writes
 
@@ -1953,15 +1954,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
     beforeId?: number,
   ): TaskEvent[] {
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    if (limit === undefined) {
-      const rows = this.queryAll(
-        `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy}`,
-        [taskId],
-      );
-      return rows.map((row: any) => this.rowToTaskEvent(row));
-    }
-    if (limit <= 0) return [];
-    const pageLimit = Math.floor(limit);
+    const effectiveLimit = limit ?? GET_EVENTS_DEFAULT_LIMIT;
+    if (effectiveLimit <= 0) return [];
+    const pageLimit = Math.floor(effectiveLimit);
     if (beforeId !== undefined) {
       const rows = this.queryAll(
         `SELECT * FROM events WHERE task_id = ? AND id < ? ORDER BY id ${orderBy} LIMIT ?`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `getEvents(taskId)` 1-arg overload executed an unbounded `SELECT`, returning potentially millions of events. At 2.74M events this took 19.1s in scale benchmarks.

This fix applies `GET_EVENTS_DEFAULT_LIMIT` (10000) when no limit is specified. The 4-arg overload with explicit limit is preferred for new code.

## Review Claim

The default limit prevents unbounded queries while maintaining backward compatibility for existing callers that expect reasonable event counts.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Existing callers that use the 1-arg overload with <10k events see no change. Callers with >10k events now get a bounded result (safer than OOM/timeout). The public IPC path via `getEventsPage` already required explicit limits.

## Slice Rationale

Fix after proof: the proof PR (#11422) demonstrated the unbounded behavior. This PR flips the test to verify the default limit is applied.

## Non-goals

Does not remove the 1-arg overload (would break tests/backward compat). Does not migrate existing callers to explicit limits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- --testPathPattern="unbounded-get-events"`

Tests verify:
- 1-arg overload applies GET_EVENTS_DEFAULT_LIMIT (10000)
- Bounded 4-arg overload works correctly
- GET_EVENTS_DEFAULT_LIMIT is exported

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

