### PR TITLE
(5) proof(app): action graph snapshot slow with large event payloads

### DIFF
--- a/packages/app/src/__tests__/action-graph-large-payload.repro.test.ts
+++ b/packages/app/src/__tests__/action-graph-large-payload.repro.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import type { InvokerConfig } from '../config.js';
+
+describe('action graph snapshot with large payloads (ui-read-scale proof)', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it.fails('materializes full 1MB event payloads even though history truncates to 2KB', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ag-payload-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const largePayload = 'x'.repeat(1_000_000);
+
+    adapter.saveWorkflow({
+      id: 'wf-payload',
+      name: 'Large payload workflow',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    for (let t = 0; t < 5; t++) {
+      const taskId = `wf-payload/t${t}`;
+      adapter.saveTask('wf-payload', {
+        id: taskId,
+        description: `Running task ${t}`,
+        status: 'running',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: 'wf-payload' },
+        execution: { startedAt: new Date() },
+        taskStateVersion: 1,
+      });
+      for (let e = 0; e < 20; e++) {
+        adapter.logEvent(taskId, 'task.progress', { data: largePayload });
+      }
+    }
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const invokerConfig: InvokerConfig = {};
+    const started = performance.now();
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig,
+    });
+    const elapsedMs = performance.now() - started;
+
+    expect(snapshot.nodes.length).toBeGreaterThan(0);
+    expect(
+      elapsedMs,
+      `snapshot with 5 tasks × 20 events × 1MB payloads took ${elapsedMs.toFixed(1)}ms`,
+    ).toBeLessThan(50);
+  });
+
+  it('history entries are truncated to 2KB', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ag-truncate-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const largePayload = 'y'.repeat(10_000);
+
+    adapter.saveWorkflow({
+      id: 'wf-trunc',
+      name: 'Truncation test workflow',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    adapter.saveTask('wf-trunc', {
+      id: 'wf-trunc/t1',
+      description: 'Task with large event',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-trunc' },
+      execution: { startedAt: new Date() },
+      taskStateVersion: 1,
+    });
+    adapter.logEvent('wf-trunc/t1', 'task.progress', { data: largePayload });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig: {},
+    });
+
+    const taskNode = snapshot.nodes.find((n) => n.taskId === 'wf-trunc/t1');
+    expect(taskNode?.history).toHaveLength(1);
+    const historyMessage = taskNode?.history?.[0]?.message ?? '';
+    expect(historyMessage.length).toBeLessThanOrEqual(2100);
+    expect(historyMessage).toContain('truncated');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`buildCurrentActionGraphSnapshot` fetches events with `getEvents(taskId, 'desc', 20)` which retrieves full event payloads from SQLite.

With 1MB payloads per event, even 20 events per task causes slowdowns. The test with 5 tasks x 20 events x 1MB payloads takes ~900ms vs the <50ms budget.

The `compactHistory` function truncates payloads to 2KB for the UI, but the full payloads were already fetched from SQLite. The fix should avoid fetching large payloads when they'll just be truncated.

## Review Claim

The `it.fails` test proves that large event payloads slow the action graph snapshot even when they're truncated before use.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only: no production code changed. Test uses `it.fails` so CI stays green while the issue exists.

## Slice Rationale

Proof before fix: demonstrates the performance issue before the fix lands, so the fix PR can show the test passes with optimized payload handling.

## Non-goals

Does not fix the slow snapshot. Does not change the events query or truncation logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- --testNamePattern="action graph snapshot with large payloads"`

Both tests pass:
- `it.fails` demonstrates ~900ms with large payloads (expected <50ms fails)
- Truncation test verifies history entries are capped to ~2KB

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

