### PR TITLE
(8) fix(data-store): add listWorkflowsPaged for bounded workflow queries

### DIFF
--- a/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
@@ -74,7 +74,7 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
     expect(memoryDelta).toBeLessThan(1_000_000);
   });
 
-  it.fails('sidebar should have a bounded workflow list option', () => {
+  it('listWorkflowsPaged returns bounded results with pagination metadata', () => {
     for (let i = 0; i < 500; i++) {
       adapter.saveWorkflow({
         id: `wf-${i}`,
@@ -85,7 +85,37 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
       });
     }
 
-    const hasListWorkflowsPaged = typeof (adapter as any).listWorkflowsPaged === 'function';
-    expect(hasListWorkflowsPaged).toBe(true);
+    const page1 = adapter.listWorkflowsPaged({ limit: 100 });
+    expect(page1.workflows).toHaveLength(100);
+    expect(page1.total).toBe(500);
+    expect(page1.hasMore).toBe(true);
+
+    const page2 = adapter.listWorkflowsPaged({ limit: 100, offset: 100 });
+    expect(page2.workflows).toHaveLength(100);
+    expect(page2.hasMore).toBe(true);
+
+    const lastPage = adapter.listWorkflowsPaged({ limit: 100, offset: 400 });
+    expect(lastPage.workflows).toHaveLength(100);
+    expect(lastPage.hasMore).toBe(false);
+  });
+
+  it('listWorkflowsPaged respects limit at scale without loading all rows', () => {
+    for (let i = 0; i < 5000; i++) {
+      adapter.saveWorkflow({
+        id: `wf-${i}`,
+        name: `Workflow ${i}`,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    const started = performance.now();
+    const result = adapter.listWorkflowsPaged({ limit: 50 });
+    const elapsed = performance.now() - started;
+
+    expect(result.workflows).toHaveLength(50);
+    expect(result.total).toBe(5000);
+    expect(elapsed).toBeLessThan(500);
   });
 });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -173,6 +173,17 @@ export interface WorkflowReadOptions {
   includeDeleted?: boolean;
 }
 
+export interface WorkflowPagedOptions extends WorkflowReadOptions {
+  limit: number;
+  offset?: number;
+}
+
+export interface WorkflowPagedResult {
+  workflows: Workflow[];
+  total: number;
+  hasMore: boolean;
+}
+
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
  * node. The PR↔workflow link lives only on the `__merge__<workflowId>` task
@@ -399,6 +410,7 @@ export interface PersistenceAdapter {
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'staged' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
   listWorkflows(options?: WorkflowReadOptions): Workflow[];
+  listWorkflowsPaged?(options: WorkflowPagedOptions): WorkflowPagedResult;
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node.
    * When `repo` is set (owner/repo), prefer URL matches for that repo; bare

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -47,6 +47,8 @@ import type {
   ReviewGateLookup,
   Workflow,
   WorkflowReadOptions,
+  WorkflowPagedOptions,
+  WorkflowPagedResult,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -1219,6 +1221,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     return this.workflowRepo.listWorkflows(options);
+  }
+
+  listWorkflowsPaged(options: WorkflowPagedOptions): WorkflowPagedResult {
+    return this.workflowRepo.listWorkflowsPaged(options);
   }
 
   findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -28,6 +28,8 @@ import type {
   ReviewGateLookup,
   Workflow,
   WorkflowReadOptions,
+  WorkflowPagedOptions,
+  WorkflowPagedResult,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -236,6 +238,38 @@ export class SqliteWorkflowRepository {
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
     return rows.map((row) => this.rowToWorkflow(row, rollups.get(String(row.id))));
+  }
+
+  listWorkflowsPaged(options: WorkflowPagedOptions): WorkflowPagedResult {
+    const { limit, offset = 0, includeDeleted } = options;
+    const whereClause = includeDeleted ? '' : 'WHERE deleted_at IS NULL';
+
+    const countRow = this.exec.queryOne(
+      `SELECT COUNT(*) AS total FROM workflows ${whereClause}`,
+    );
+    const total = Number(countRow?.total ?? 0);
+
+    if (limit <= 0 || offset >= total) {
+      return { workflows: [], total, hasMore: false };
+    }
+
+    const rows = this.exec.queryAll(
+      `SELECT * FROM workflows
+        ${whereClause}
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?`,
+      [limit, offset],
+    );
+
+    const workflowIds = rows.map((row) => String(row.id));
+    const rollups = this.loadWorkflowRollups(workflowIds);
+    const workflows = rows.map((row) => this.rowToWorkflow(row, rollups.get(String(row.id))));
+
+    return {
+      workflows,
+      total,
+      hasMore: offset + workflows.length < total,
+    };
   }
 
   findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`listWorkflows` and `loadWorkflowTaskSnapshot` execute `SELECT * FROM workflows` with no LIMIT, materializing all rows into JS. At 1.83M workflows this took ~20.9s; at 3.64M workflows it OOMed (~4GB heap).

This fix adds `listWorkflowsPaged(options)` that uses SQL `LIMIT`/`OFFSET` for bounded queries. Returns `{ workflows, total, hasMore }` for pagination.

## Review Claim

The new `listWorkflowsPaged` method provides a bounded alternative to the unbounded `listWorkflows` for sidebar/UI callers.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The existing `listWorkflows` is preserved for backward compatibility. New `listWorkflowsPaged` is additive and opt-in. Callers that need all workflows (e.g. orchestrator sync) continue using `listWorkflows`.

## Slice Rationale

Fix after proof: the proof PR (#11426) demonstrated the unbounded SELECT behavior. This PR adds a bounded alternative via pagination.

## Non-goals

Does not migrate existing callers to `listWorkflowsPaged`. Does not add cursor-based pagination (offset-based is simpler and sufficient for sidebar). Does not modify `loadWorkflowTaskSnapshot` (that's used for orchestrator full sync where pagination doesn't apply).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test src/__tests__/unbounded-workflow-select.repro.test.ts`

All 5 tests pass:
- 3 `it.fails` tests prove unbounded behavior in existing methods
- `listWorkflowsPaged returns bounded results with pagination metadata` - verifies limit/offset/hasMore
- `listWorkflowsPaged respects limit at scale without loading all rows` - 5k workflows, limit 50, <500ms

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db88b65-3ea8-4c8d-9644-03ed0edc0fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

