### PR TITLE
[Ready-task blocker lookup](1) Batch external-dependency checks

### DIFF
--- a/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
+++ b/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
@@ -17,8 +17,10 @@ import type { TaskState } from '@invoker/workflow-core';
  */
 
 const WORKFLOW_COUNT = 687;
+const TASK_COUNT = 2702;
 const ACTIVE_WORKFLOW_COUNT = 676;
 const REPEATED_CALLS = 20;
+const EXTRA_COMPLETED_TASK_COUNT = TASK_COUNT - (WORKFLOW_COUNT * 3);
 
 describe('orchestrator repeated startExecution() during backlog drain', () => {
   let dbDir: string | undefined;
@@ -68,12 +70,26 @@ describe('orchestrator repeated startExecution() during backlog drain', () => {
             execution: { exitCode: 0 },
           } as TaskState);
 
+          let readyTaskDependency = `${wfId}/b`;
+          if (i < EXTRA_COMPLETED_TASK_COUNT) {
+            readyTaskDependency = `${wfId}/extra-completed`;
+            seedAdapter.saveTask(wfId, {
+              id: readyTaskDependency,
+              description: realisticDescription,
+              status: 'completed',
+              dependencies: [`${wfId}/b`],
+              createdAt,
+              config: { workflowId: wfId },
+              execution: { exitCode: 0 },
+            } as TaskState);
+          }
+
           const isActive = i < ACTIVE_WORKFLOW_COUNT;
           seedAdapter.saveTask(wfId, {
             id: `${wfId}/c`,
             description: realisticDescription,
             status: isActive ? 'pending' : 'completed',
-            dependencies: [`${wfId}/b`],
+            dependencies: [readyTaskDependency],
             createdAt,
             config: { workflowId: wfId },
             execution: isActive ? {} : { exitCode: 0 },
@@ -92,6 +108,9 @@ describe('orchestrator repeated startExecution() during backlog drain', () => {
         });
 
         orchestrator.syncAllFromDb();
+        expect(orchestrator.getAllTasks()).toHaveLength(TASK_COUNT);
+        expect(orchestrator.getExecutableReadyTasks({ alreadyRefreshed: true }))
+          .toHaveLength(ACTIVE_WORKFLOW_COUNT);
 
         // Simulate the real DO1 backlog drain: one startExecution() call
         // per queued workflow-mutation intent, back to back, with nothing

--- a/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
+++ b/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+
+/**
+ * Reproduces DO1's real proven shape (queried live, 2026-08-30): 687
+ * workflows, 2702 tasks, 676 workflows with at least one ready pending
+ * task. Unlike orchestrator-cold-boot-large-db.test.ts (a single boot
+ * call), this drives repeated startExecution() calls -- the real DO1
+ * shape: one call per queued workflow-mutation intent during backlog
+ * catch-up (43 queued intents were observed live).
+ */
+
+const WORKFLOW_COUNT = 687;
+const ACTIVE_WORKFLOW_COUNT = 676;
+const REPEATED_CALLS = 20;
+
+describe('orchestrator repeated startExecution() during backlog drain', () => {
+  let dbDir: string | undefined;
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+    dbDir = undefined;
+  });
+
+  it(
+    `completes ${REPEATED_CALLS} back-to-back startExecution() calls in bounded time for a ${WORKFLOW_COUNT}-workflow / ${ACTIVE_WORKFLOW_COUNT}-active-ready DB`,
+    async () => {
+      dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-drain-repro-'));
+      const dbPath = path.join(dbDir, 'invoker.db');
+
+      const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+          const wfId = `wf-seed-${i}`;
+          const nowIso = new Date().toISOString();
+          seedAdapter.saveWorkflow({
+            id: wfId,
+            name: wfId,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          } as any);
+
+          const createdAt = new Date();
+          const realisticDescription = `Fix CI failure in job "required-fast-extra" for workflow ${wfId}: `
+            + 'the merge queue job failed with a dependency install error. '.repeat(3);
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/a`,
+            description: realisticDescription,
+            status: 'completed',
+            dependencies: [],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: { exitCode: 0 },
+          } as TaskState);
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/b`,
+            description: realisticDescription,
+            status: 'completed',
+            dependencies: [`${wfId}/a`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: { exitCode: 0 },
+          } as TaskState);
+
+          const isActive = i < ACTIVE_WORKFLOW_COUNT;
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/c`,
+            description: realisticDescription,
+            status: isActive ? 'pending' : 'completed',
+            dependencies: [`${wfId}/b`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: isActive ? {} : { exitCode: 0 },
+          } as TaskState);
+        }
+      } finally {
+        seedAdapter.close();
+      }
+
+      const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        const orchestrator = new Orchestrator({
+          persistence: bootAdapter as any,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 1000,
+        });
+
+        orchestrator.syncAllFromDb();
+
+        // Simulate the real DO1 backlog drain: one startExecution() call
+        // per queued workflow-mutation intent, back to back, with nothing
+        // completing in between (matching a fresh boot with a backlog of
+        // already-ready tasks nobody has drained yet).
+        const perCallMs: number[] = [];
+        for (let call = 0; call < REPEATED_CALLS; call += 1) {
+          const start = performance.now();
+          orchestrator.startExecution({ limit: 0 });
+          perCallMs.push(performance.now() - start);
+        }
+
+        const totalMs = perCallMs.reduce((a, b) => a + b, 0);
+        const avgMs = totalMs / REPEATED_CALLS;
+        console.log(`per-call ms: ${perCallMs.map((n) => n.toFixed(1)).join(', ')}`);
+        console.log(`total=${totalMs.toFixed(1)}ms avg=${avgMs.toFixed(1)}ms over ${REPEATED_CALLS} calls`);
+
+        // Each call should be well under a second once the N+1 is fixed.
+        // Before the fix, this scales with ACTIVE_WORKFLOW_COUNT per call
+        // (one uncached loadWorkflow() per ready task) and is expected to
+        // fail this bound.
+        expect(avgMs, `avgMs=${avgMs} per call over ${REPEATED_CALLS} calls (${ACTIVE_WORKFLOW_COUNT} ready tasks/call)`).toBeLessThan(500);
+      } finally {
+        bootAdapter.close();
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3418,13 +3418,24 @@ export class Orchestrator {
   }
 
   getExecutableReadyTasks(opts?: { alreadyRefreshed?: boolean; includeStaged?: boolean }): TaskState[] {
+    const allWorkflows = this.persistence.listWorkflows();
     const stagedWorkflowIds = opts?.includeStaged
       ? new Set<string>()
-      : new Set(this.persistence.listWorkflows().filter((workflow) => workflow.staged === true).map((workflow) => workflow.id));
+      : new Set(allWorkflows.filter((workflow) => workflow.staged === true).map((workflow) => workflow.id));
+    const workflowLookup = new Map(allWorkflows.map((workflow) => [workflow.id, workflow]));
+    const workflowBlockerCache = new Map<string, string | undefined>();
+    const isExternallyBlocked = (task: TaskState): boolean => {
+      const workflowId = task.config.workflowId;
+      if (!workflowId) return false;
+      if (!workflowBlockerCache.has(workflowId)) {
+        workflowBlockerCache.set(workflowId, this.getWorkflowDependencyBlocker(workflowId, workflowLookup));
+      }
+      return workflowBlockerCache.get(workflowId) !== undefined;
+    };
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => !task.config.workflowId || !stagedWorkflowIds.has(task.config.workflowId))
-      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+      .filter((task) => !isExternallyBlocked(task));
     const readyTasksById = new Map(readyTasks.map((task) => [task.id, task]));
     return getPendingLaunchQueueSnapshotImpl(
       this as unknown as SchedulerDomainHost,
@@ -4041,14 +4052,21 @@ export class Orchestrator {
     return tasks.find((t) => t.id === scopedId || t.id === normalizedTaskId);
   }
 
-  private getWorkflowExternalDependencies(workflowId: string): ExternalDependency[] {
-    const workflow = this.persistence.loadWorkflow?.(workflowId)
+  private getWorkflowExternalDependencies(
+    workflowId: string,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): ExternalDependency[] {
+    const workflow = workflowLookup?.get(workflowId)
+      ?? this.persistence.loadWorkflow?.(workflowId)
       ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
     return workflow?.externalDependencies ?? [];
   }
 
-  private getWorkflowDependencyBlocker(workflowId: string): string | undefined {
-    const deps = this.getWorkflowExternalDependencies(workflowId);
+  private getWorkflowDependencyBlocker(
+    workflowId: string,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): string | undefined {
+    const deps = this.getWorkflowExternalDependencies(workflowId, workflowLookup);
     if (!deps || deps.length === 0) return undefined;
 
     for (const dep of deps) {
@@ -4075,10 +4093,13 @@ export class Orchestrator {
     return undefined;
   }
 
-  private getExternalDependencyBlocker(task: TaskState): string | undefined {
+  private getExternalDependencyBlocker(
+    task: TaskState,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): string | undefined {
     const workflowId = task.config.workflowId;
     if (!workflowId) return undefined;
-    return this.getWorkflowDependencyBlocker(workflowId);
+    return this.getWorkflowDependencyBlocker(workflowId, workflowLookup);
   }
 
   private collectWorkflowDependencyEdges(): Map<string, Set<string>> {


### PR DESCRIPTION
## Summary

`getExecutableReadyTasks()` checked each ready task's external-dependency blocker via its own `persistence.loadWorkflow()` call — a fresh query plus rollup, once per task.

A live CPU profile on DO1 proved 38%+ of drain CPU time sits in that exact chain. A sibling function already caches this same check; this one never got the fix.

## Review Claim

`getExecutableReadyTasks()` now reuses one batched `listWorkflows()` call (already made for staged-workflow filtering) to resolve external-dependency blockers, instead of one `loadWorkflow()` call per ready task.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Behavior is unchanged: the same blocker logic (`getWorkflowDependencyBlocker`) runs against the same workflow data, just sourced from an already-fetched batch instead of a fresh per-task query. All 979 existing `@invoker/workflow-core` tests pass unmodified. Fork-drafted, not human-confirmed — please double-check this reasoning.

## Slice Rationale

Single, self-contained fix to one function and its two private helpers, matching this repo's existing N+1 remediation pattern (see the `loadTasksForWorkflows` comment a few hundred lines above this diff, and `getQueueStatus`'s own `workflowBlockerCache`).

## Non-goals

**This does not close the gap to DO1's real observed slowness.** A local repro at DO1's exact proven scale (687 workflows, 676 with a ready task, matching realistic task-description sizes) shows this fix improves `startExecution()` from ~196ms/call to ~157-161ms/call — a real, reproducible ~20% win, but nowhere near DO1's actual observed 70-170 *seconds* per `start-ready` intent, or 6-32 *minutes* per `retry-task` intent (both proven via real `durationMs` values in DO1's own logs). Isolating `syncAllFromDb()`'s repeated-per-call reload cost separately measured ~61ms/call at this scale — also real, but small next to the production gap.

**What remains unproven and is NOT fixed here:**
- The dominant cause of DO1's multi-minute-per-intent durations is still unidentified. This fix removes one confirmed, real inefficiency; it is not a claim that it resolves the production incident.
- `invoker:retry-task` (proven to run 6-32+ minutes per intent on DO1, worse than `start-ready`) was not investigated in this pass at all.
- Real DO1 row payload sizes (agent prompts, fix context, experiment results) are likely far larger than this repro's synthetic ~600-byte task descriptions; a bigger real per-row marshaling cost was flagged by the live profiler (`v8::Object::New`, `ColumnToValue`) but not separately isolated here.
- Concurrency effects from DO1's ~30 simultaneously "running" intents and their periodic lease-heartbeat timers are not modeled by this repro's clean serial loop.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] New repro: `pnpm --filter @invoker/app test -- orchestrator-repeated-start-execution-drain` — seeds a real on-disk SQLite DB at DO1's exact proven shape (687 workflows / 2702 tasks / 676 active-ready), drives 20 back-to-back `startExecution()` calls (matching a real backlog drain). Before this fix: avg 196.4ms/call. After: avg 160.9ms/call. Both runs' raw per-call numbers are in the test's console output.
- [x] `pnpm --filter @invoker/workflow-core test` — 979 tests pass, 3 skipped (pre-existing), no regressions.
- [x] `pnpm --filter @invoker/workflow-core build` — builds clean.
- [ ] Full `pnpm --filter @invoker/app test` — running at PR publish time; see CI status.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved execution backlog processing by reducing repeated workflow and dependency lookups.
  * Preserved existing task-blocking behavior while making ready-task selection more efficient.

* **Tests**
  * Added a workload test covering repeated execution starts across hundreds of workflows and thousands of tasks.
  * Verified that backlog-drain calls maintain an average response time under 500 ms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only performance path in ready-task selection; blocker rules and data sources are preserved, with a targeted regression test at production-like scale.
> 
> **Overview**
> **`getExecutableReadyTasks()`** no longer triggers a per-ready-task `loadWorkflow()` when filtering on cross-workflow external-dependency blockers. It reuses the single **`listWorkflows()`** result already fetched for staged-workflow filtering, builds a **`workflowLookup`** map, and caches blocker results **per workflow** while scanning ready tasks.
> 
> Private helpers **`getWorkflowExternalDependencies`**, **`getWorkflowDependencyBlocker`**, and **`getExternalDependencyBlocker`** accept an optional **`workflowLookup`** so blocker evaluation can read workflow metadata from that batch instead of hitting persistence again. Scheduling semantics are unchanged—the same blocker logic runs on the same data.
> 
> Adds **`orchestrator-repeated-start-execution-drain.test.ts`**, which seeds a large SQLite DB (687 workflows / ~676 ready tasks), runs **20** back-to-back **`startExecution({ limit: 0 })`** calls, and asserts average latency stays **under 500 ms** to guard against N+1 regression during backlog drain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6a4895d65f94102cf1ba7e4d90c38990168ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->