### PR TITLE
fix(workflow-core): skip cascade task refresh when nothing is downstream

### DIFF
--- a/packages/app/src/__tests__/retry-task-cascade-refresh-cost.test.ts
+++ b/packages/app/src/__tests__/retry-task-cascade-refresh-cost.test.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+
+/**
+ * Reproduces DO1's real invoker:retry-task dispatch cost, matching the
+ * proven live shape: 687 workflows (676 with a non-terminal task), 2,702
+ * tasks, 85% pending. cascadeInvalidationToDownstream() unconditionally
+ * calls refreshFromDb() -- reloading every task in every workflow the
+ * orchestrator has ever tracked -- before checking whether the target
+ * workflow has any downstream dependents at all. Most retried tasks (no
+ * cross-workflow externalDependencies) have zero downstream workflows, so
+ * that reload is pure waste on the common path.
+ */
+
+const WORKFLOW_COUNT = 687;
+
+describe('retryTask cascade pays a full active-workflow refresh even with no downstream', () => {
+  let dbDir: string | undefined;
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+    dbDir = undefined;
+  });
+
+  it(
+    'cascadeInvalidationToDownstream cost for a workflow with zero downstream dependents',
+    async () => {
+      dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-retry-cascade-'));
+      const dbPath = path.join(dbDir, 'invoker.db');
+
+      // Real DO1 task rows average ~8KB (description ~4.8KB, prompt ~3KB) --
+      // measured directly against the live DB. Synthetic 1-char fields
+      // understate row-materialization cost, so match the real size here.
+      const realisticDescription = 'x'.repeat(4800);
+      const realisticPrompt = 'y'.repeat(3000);
+      const realisticSummary = 'z'.repeat(700);
+
+      const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+          const wfId = `wf-seed-${i}`;
+          const nowIso = new Date().toISOString();
+          seedAdapter.saveWorkflow({
+            id: wfId,
+            name: wfId,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+            // No externalDependencies -- matches the common DO1 case: most
+            // workflows have zero cross-workflow dependents.
+          } as any);
+
+          const createdAt = new Date();
+          const isActive = i % 100 !== 0; // ~99% active, matching 676/687 real ratio
+          for (let t = 0; t < 4; t += 1) {
+            seedAdapter.saveTask(wfId, {
+              id: `${wfId}/t${t}`,
+              description: realisticDescription,
+              prompt: realisticPrompt,
+              summary: realisticSummary,
+              status: isActive && t === 3 ? 'pending' : 'completed',
+              dependencies: t > 0 ? [`${wfId}/t${t - 1}`] : [],
+              createdAt,
+              config: { workflowId: wfId },
+              execution: isActive && t === 3 ? {} : { exitCode: 0 },
+            } as TaskState);
+          }
+        }
+      } finally {
+        seedAdapter.close();
+      }
+
+      const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        const orchestrator = new Orchestrator({
+          persistence: bootAdapter as any,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 200,
+        });
+
+        // Match real production boot: syncAllFromDb() populates
+        // activeWorkflowIds for every tracked workflow, exactly like the
+        // long-running DO1 owner has accumulated over its lifetime.
+        orchestrator.syncAllFromDb();
+
+        const targetTaskId = 'wf-seed-1/t3';
+        const cascadeStart = performance.now();
+        const affected = orchestrator.cascadeInvalidationToDownstream('wf-seed-1');
+        const cascadeMs = performance.now() - cascadeStart;
+
+        // wf-seed-1 has no externalDependencies pointing to it, so nothing
+        // downstream -- the common case for a plain retryTask.
+        expect(affected).toEqual([]);
+        // eslint-disable-next-line no-console
+        console.log(`cascadeInvalidationToDownstream (zero downstream) took ${cascadeMs.toFixed(1)}ms for ${WORKFLOW_COUNT} tracked workflows`);
+        // Before the fix this paid a full refreshFromDb() (~87ms measured
+        // pre-fix for this seed) even with nothing downstream to process;
+        // after the fix, only the cheap listWorkflows() lookup runs.
+        expect(cascadeMs, `cascadeMs=${cascadeMs} for ${WORKFLOW_COUNT} tracked workflows, zero downstream`).toBeLessThan(60);
+      } finally {
+        bootAdapter.close();
+      }
+    },
+    30_000,
+  );
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4138,9 +4138,9 @@ export class Orchestrator {
    * `fixReject`, `none`) skip the cascade per `MUTATION_POLICIES`.
    */
   cascadeInvalidationToDownstream(workflowId: string): TaskState[] {
-    this.refreshFromDb();
     const downstreamWorkflowIds = this.collectDownstreamWorkflowIds(workflowId);
     if (downstreamWorkflowIds.length === 0) return [];
+    this.refreshFromDb();
 
     this.logger.info('[orchestrator] cascadeInvalidationToDownstream', {
       upstreamWorkflowId: workflowId,


### PR DESCRIPTION
## Summary

`retryTask`/`recreateTask` always run a `cascadeAcrossWorkflows` stage, which unconditionally reloaded every task in every workflow the orchestrator has ever tracked before even checking whether the target workflow has any downstream dependents.

Most retried tasks have no cross-workflow `externalDependencies`, so that reload is pure waste on the common path.

This does not explain DO1's full observed retry-task slowness — real timing marks show most dispatches cost 15-45s, this fix's own repro shows the reload itself only accounts for tens of milliseconds. It's a real, separately-provable inefficiency, not the dominant cause.

## Review Claim

`cascadeInvalidationToDownstream` now checks for downstream workflows (a cheap `listWorkflows()`-only lookup) before paying for a full active-workflow task reload, instead of always reloading first.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`collectDownstreamWorkflowIds()` only reads `persistence.listWorkflows()` — it never touches the in-memory task graph `refreshFromDb()` populates, so reordering the two calls cannot change which downstream workflows are found. When there genuinely are downstream workflows, `refreshFromDb()` still runs before they're processed, unchanged. Confirmed by the full `@invoker/workflow-core` suite (979/979, including the cross-workflow-cascade and external-dependency-deadlock tests) passing unmodified.

## Slice Rationale

One function, one change: reorder two existing calls inside `cascadeInvalidationToDownstream`. The repro test lives in `packages/app` (not `workflow-core`) because it needs a real on-disk `SQLiteAdapter` boot, matching this repo's existing pattern for this class of fix (see the cold-boot-large-db test).

## Non-goals

Does not explain or fix DO1's actual dominant retry-task cost (15-45s typical, up to several minutes for at least one task) — that remains unproven and unfixed. Does not change `refreshFromDb()`'s own implementation. Does not change behavior for workflows that do have downstream dependents.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- retry-task-cascade-refresh-cost` — real on-disk SQLite, 687 workflows matching DO1's live shape, ~8KB average task row size matching DO1's real measured average. `cascadeInvalidationToDownstream` for a workflow with zero downstream dependents: ~87ms before this fix, ~40ms after (measured directly, both numbers real).
- [x] `pnpm --filter @invoker/workflow-core test` — 979/979 pass, 3 pre-existing skips, including `cross-workflow-cascade.test.ts`, `cross-workflow-cascade-command-service-e2e.test.ts`, `repro-permanent-external-dependency-deadlock.test.ts`.
- [x] `pnpm --filter @invoker/workflow-core build`, `pnpm --filter @invoker/app build` — both build clean.
- [x] `node scripts/check-added-comments.mjs` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

---

**Note:** this PR was drafted by an autonomous fork investigating tonight's Invoker drain-speed incident. The Safety Invariant above was fork-proposed, not human-confirmed — please give it a second look before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single reorder inside one method; downstream detection does not use the in-memory graph, and the full refresh still runs when dependents exist.
> 
> **Overview**
> **`retryTask` / recreate-style invalidations** always run cross-workflow cascade logic; on the common path (no workflows depend on the retried workflow) the orchestrator was still calling **`refreshFromDb()`** first, reloading every task in every tracked workflow before discovering there was nothing to cascade.
> 
> **`cascadeInvalidationToDownstream`** now resolves downstream workflow IDs via the existing **`listWorkflows()`**-only dependency graph first and **returns immediately** when the list is empty. **`refreshFromDb()`** runs only when there are real downstream workflows to cancel and reset—unchanged behavior for that case.
> 
> Adds an **`@invoker/app`** integration test that seeds ~687 workflows with DO1-like row sizes and asserts cascade time stays under 60ms with zero downstream (documented ~87ms pre-fix). This targets tens-of-ms waste, not the separate multi-second retry dispatch issue called out in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fed57bd16abd39bf90d9f126222942123ce20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->