### PR TITLE
[admin-bypass-repair-bot-thread-pr-11428-26c2178](1) Batch ready-task blocker lookups

### DIFF
--- a/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
+++ b/packages/app/src/__tests__/orchestrator-repeated-start-execution-drain.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+
+/**
+ * Reproduces DO1's real proven shape (queried live, 2026-08-30): 687
+ * workflows, 2702 tasks, 676 workflows with at least one ready pending
+ * task. Unlike orchestrator-cold-boot-large-db.test.ts (a single boot
+ * call), this drives repeated startExecution() calls -- the real DO1
+ * shape: one call per queued workflow-mutation intent during backlog
+ * catch-up (43 queued intents were observed live).
+ */
+
+const WORKFLOW_COUNT = 687;
+const TASK_COUNT = 2702;
+const ACTIVE_WORKFLOW_COUNT = 676;
+const REPEATED_CALLS = 20;
+const EXTRA_COMPLETED_TASK_COUNT = TASK_COUNT - (WORKFLOW_COUNT * 3);
+
+describe('orchestrator repeated startExecution() during backlog drain', () => {
+  let dbDir: string | undefined;
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+    dbDir = undefined;
+  });
+
+  it(
+    `completes ${REPEATED_CALLS} back-to-back startExecution() calls in bounded time for a ${WORKFLOW_COUNT}-workflow / ${ACTIVE_WORKFLOW_COUNT}-active-ready DB`,
+    async () => {
+      dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-drain-repro-'));
+      const dbPath = path.join(dbDir, 'invoker.db');
+
+      const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+          const wfId = `wf-seed-${i}`;
+          const nowIso = new Date().toISOString();
+          seedAdapter.saveWorkflow({
+            id: wfId,
+            name: wfId,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          } as any);
+
+          const createdAt = new Date();
+          const realisticDescription = `Fix CI failure in job "required-fast-extra" for workflow ${wfId}: `
+            + 'the merge queue job failed with a dependency install error. '.repeat(3);
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/a`,
+            description: realisticDescription,
+            status: 'completed',
+            dependencies: [],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: { exitCode: 0 },
+          } as TaskState);
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/b`,
+            description: realisticDescription,
+            status: 'completed',
+            dependencies: [`${wfId}/a`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: { exitCode: 0 },
+          } as TaskState);
+
+          let readyTaskDependency = `${wfId}/b`;
+          if (i < EXTRA_COMPLETED_TASK_COUNT) {
+            readyTaskDependency = `${wfId}/extra-completed`;
+            seedAdapter.saveTask(wfId, {
+              id: readyTaskDependency,
+              description: realisticDescription,
+              status: 'completed',
+              dependencies: [`${wfId}/b`],
+              createdAt,
+              config: { workflowId: wfId },
+              execution: { exitCode: 0 },
+            } as TaskState);
+          }
+
+          const isActive = i < ACTIVE_WORKFLOW_COUNT;
+          seedAdapter.saveTask(wfId, {
+            id: `${wfId}/c`,
+            description: realisticDescription,
+            status: isActive ? 'pending' : 'completed',
+            dependencies: [readyTaskDependency],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: isActive ? {} : { exitCode: 0 },
+          } as TaskState);
+        }
+      } finally {
+        seedAdapter.close();
+      }
+
+      const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        const orchestrator = new Orchestrator({
+          persistence: bootAdapter as any,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 1000,
+        });
+
+        orchestrator.syncAllFromDb();
+        expect(orchestrator.getAllTasks()).toHaveLength(TASK_COUNT);
+        expect(orchestrator.getExecutableReadyTasks({ alreadyRefreshed: true }))
+          .toHaveLength(ACTIVE_WORKFLOW_COUNT);
+
+        // Simulate the real DO1 backlog drain: one startExecution() call
+        // per queued workflow-mutation intent, back to back, with nothing
+        // completing in between (matching a fresh boot with a backlog of
+        // already-ready tasks nobody has drained yet).
+        const perCallMs: number[] = [];
+        for (let call = 0; call < REPEATED_CALLS; call += 1) {
+          const start = performance.now();
+          orchestrator.startExecution({ limit: 0 });
+          perCallMs.push(performance.now() - start);
+        }
+
+        const totalMs = perCallMs.reduce((a, b) => a + b, 0);
+        const avgMs = totalMs / REPEATED_CALLS;
+        console.log(`per-call ms: ${perCallMs.map((n) => n.toFixed(1)).join(', ')}`);
+        console.log(`total=${totalMs.toFixed(1)}ms avg=${avgMs.toFixed(1)}ms over ${REPEATED_CALLS} calls`);
+
+        // Each call should be well under a second once the N+1 is fixed.
+        // Before the fix, this scales with ACTIVE_WORKFLOW_COUNT per call
+        // (one uncached loadWorkflow() per ready task) and is expected to
+        // fail this bound.
+        expect(avgMs, `avgMs=${avgMs} per call over ${REPEATED_CALLS} calls (${ACTIVE_WORKFLOW_COUNT} ready tasks/call)`).toBeLessThan(500);
+      } finally {
+        bootAdapter.close();
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3418,13 +3418,24 @@ export class Orchestrator {
   }
 
   getExecutableReadyTasks(opts?: { alreadyRefreshed?: boolean; includeStaged?: boolean }): TaskState[] {
+    const allWorkflows = this.persistence.listWorkflows();
     const stagedWorkflowIds = opts?.includeStaged
       ? new Set<string>()
-      : new Set(this.persistence.listWorkflows().filter((workflow) => workflow.staged === true).map((workflow) => workflow.id));
+      : new Set(allWorkflows.filter((workflow) => workflow.staged === true).map((workflow) => workflow.id));
+    const workflowLookup = new Map(allWorkflows.map((workflow) => [workflow.id, workflow]));
+    const workflowBlockerCache = new Map<string, string | undefined>();
+    const isExternallyBlocked = (task: TaskState): boolean => {
+      const workflowId = task.config.workflowId;
+      if (!workflowId) return false;
+      if (!workflowBlockerCache.has(workflowId)) {
+        workflowBlockerCache.set(workflowId, this.getWorkflowDependencyBlocker(workflowId, workflowLookup));
+      }
+      return workflowBlockerCache.get(workflowId) !== undefined;
+    };
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => !task.config.workflowId || !stagedWorkflowIds.has(task.config.workflowId))
-      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+      .filter((task) => !isExternallyBlocked(task));
     const readyTasksById = new Map(readyTasks.map((task) => [task.id, task]));
     return getPendingLaunchQueueSnapshotImpl(
       this as unknown as SchedulerDomainHost,
@@ -4041,14 +4052,21 @@ export class Orchestrator {
     return tasks.find((t) => t.id === scopedId || t.id === normalizedTaskId);
   }
 
-  private getWorkflowExternalDependencies(workflowId: string): ExternalDependency[] {
-    const workflow = this.persistence.loadWorkflow?.(workflowId)
+  private getWorkflowExternalDependencies(
+    workflowId: string,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): ExternalDependency[] {
+    const workflow = workflowLookup?.get(workflowId)
+      ?? this.persistence.loadWorkflow?.(workflowId)
       ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
     return workflow?.externalDependencies ?? [];
   }
 
-  private getWorkflowDependencyBlocker(workflowId: string): string | undefined {
-    const deps = this.getWorkflowExternalDependencies(workflowId);
+  private getWorkflowDependencyBlocker(
+    workflowId: string,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): string | undefined {
+    const deps = this.getWorkflowExternalDependencies(workflowId, workflowLookup);
     if (!deps || deps.length === 0) return undefined;
 
     for (const dep of deps) {
@@ -4075,10 +4093,13 @@ export class Orchestrator {
     return undefined;
   }
 
-  private getExternalDependencyBlocker(task: TaskState): string | undefined {
+  private getExternalDependencyBlocker(
+    task: TaskState,
+    workflowLookup?: Map<string, { externalDependencies?: ExternalDependency[] }>,
+  ): string | undefined {
     const workflowId = task.config.workflowId;
     if (!workflowId) return undefined;
-    return this.getWorkflowDependencyBlocker(workflowId);
+    return this.getWorkflowDependencyBlocker(workflowId, workflowLookup);
   }
 
   private collectWorkflowDependencyEdges(): Map<string, Set<string>> {


### PR DESCRIPTION
## Summary

The ready-task path now shares one workflow snapshot across external-dependency blocker checks. It preserves blocker decisions while avoiding repeated persistence calls.

## Review Claim

Approve per-call workflow metadata reuse in `getExecutableReadyTasks()` while preserving external-dependency blocker decisions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The same `getWorkflowDependencyBlocker()` logic evaluates the same workflow metadata. Only the lookup source changes from repeated loads to the snapshot already fetched by the caller.

## Slice Rationale

The helper plumbing is inseparable from caller-level reuse, and the production-scale guard directly covers the same performance boundary.

## Non-goals

- This does not claim to eliminate all production backlog latency.
- This does not change retry-task behavior, workflow persistence schemas, or user-visible UI.
- This does not alter external-dependency satisfaction rules.

## Architecture

### Before

Before, `getExecutableReadyTasks()` loaded workflow metadata separately while checking ready tasks.

### After

After, it takes one workflow snapshot and caches blocker results per workflow for that call.

## Workflow Summary

admin-bypass-repair-bot-thread-pr-11428-26c2178 — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1788129356944-1/repair | Resolve bot review thread on PR #11428 | completed |
| wf-1788129356944-1/safe-push | Safely push PR #11428 only if its head did not move | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1788129356944-1/repair — Resolve bot review thread on PR #11428
...estrator-repeated-start-execution-drain.test.ts | 142 +++++++++++++++++++++
packages/workflow-core/src/orchestrator.ts         |  37 ++++--
2 files changed, 171 insertions(+), 8 deletions(-)

### wf-1788129356944-1/safe-push — Safely push PR #11428 only if its head did not move
...estrator-repeated-start-execution-drain.test.ts | 142 +++++++++++++++++++++
packages/workflow-core/src/orchestrator.ts         |  37 ++++--
2 files changed, 171 insertions(+), 8 deletions(-)

</details>

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- orchestrator-repeated-start-execution-drain` — 1 test passed.
- [x] `pnpm --filter @invoker/workflow-core test` — 979 tests passed, 3 skipped.
- [x] `pnpm --filter @invoker/workflow-core build` — ESM and DTS builds passed.
- [x] `pnpm run check:comments` — no disallowed added comments.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: None
- Data migration? No

</details>
