### PR TITLE
[WebBridge requestWorkflowsPush](1) Wire through the missing property

### DIFF
--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -270,6 +270,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
   return {
     whenReady: bridge.whenReady,
     broadcast: bridge.broadcast,
+    requestWorkflowsPush: bridge.requestWorkflowsPush,
     get port(): number {
       return bridge!.port;
     },


### PR DESCRIPTION
## Summary

`startHeadlessWebSurface`'s returned object is missing `requestWorkflowsPush`, a property the underlying bridge object already provides.

An earlier PR (#11380) added this property to the shared shape without wiring it through here.

This left a required compile-check job failing for every open PR on master.

## Review Claim

The returned handle now passes `requestWorkflowsPush` through, delegating to the already-constructed underlying bridge object, matching the existing pattern for `whenReady`/`broadcast`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

One-line addition delegating to a method the underlying `bridge` object already provides and already calls internally at the TASK_DELTA subscription a few lines above. No new logic, no behavior change beyond making an existing capability reachable through the returned handle.

## Slice Rationale

Single-file, single-line fix for a compile error blocking the entire merge queue. No reason to split further.

## Non-goals

Does not address the separate `UI Vitest` failure currently also blocking the queue (duplicate "Beta Empty Workflow" button match) — that already has an open fix, PR #11384.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` — fails before this change (confirmed via the actual failing CI log on PR #11428/#11429/#11431/#11433, all currently blocked by the same missing property). Exits 0 after this change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
