### PR TITLE
[Add a config-driven live toggle for the pr-jailbreak-land worker](1) worker wiring

### DIFF
--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -85,6 +85,7 @@ export interface PrMaintenanceWorkerConfig {
   repoRoot?: string;
   /** Environment overrides passed to the shell entrypoint. `undefined` removes a variable. */
   env?: EnvOverrides;
+  jailbreakLive?: boolean;
   /** Poll cadence for PR-maintenance workers. Defaults to five minutes. */
   intervalMs?: number;
   /**
@@ -212,6 +213,12 @@ export function registerPrJailbreakLandWorker(
       createPrJailbreakLandWorker({
         logger: deps.logger,
         ...deps.prMaintenance,
+        env: {
+          ...deps.prMaintenance?.env,
+          INVOKER_JAILBREAK_LIVE: deps.prMaintenance?.jailbreakLive
+            ? '1'
+            : deps.prMaintenance?.env?.INVOKER_JAILBREAK_LIVE,
+        },
         store: deps.store,
         startDelayMs: 3 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),


### PR DESCRIPTION
## Summary

Adds a typed `jailbreakLive` setting to PR-maintenance worker configuration.

Only the jailbreak-land factory maps the setting to `INVOKER_JAILBREAK_LIVE=1` for its spawned process.

Unset and false values preserve explicit environment overrides. Sibling worker factories do not receive a new live-mode variable.

## Review Claim

Approve the worker-specific configuration path that enables live mode only for the spawned `pr-jailbreak-land` process.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`jailbreakLive` defaults to unset. When unset or false, explicit environment overrides are preserved, and the four sibling worker factories receive no new live-mode variable.

## Slice Rationale

This slice contains one configuration field and its only consumer. The `packages/app` configuration surface remains a later stacked workflow.

## Non-goals

No changes to the landing script, worker desired state, runner-exhaustion thresholds, tests, or the `packages/app` configuration surface.

## Architecture

### Before

```mermaid
graph LR
    A["Shared PR-maintenance configuration"] --> B["pr-jailbreak-land factory"]
    B --> C["Spawned process receives only shared environment overrides"]
```

### After

```mermaid
graph LR
    A["Shared PR-maintenance configuration"] --> B["pr-jailbreak-land factory reads jailbreakLive"]
    B --> C["Spawned process receives INVOKER_JAILBREAK_LIVE=1 when enabled"]
    A --> D["Sibling factories ignore jailbreakLive"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-maintenance-workers.test.ts`
- [x] `pnpm run check:comments`
- [x] `bash scripts/scrub-handoff-artifacts.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: None
- Data migration? No

</details>
