### PR TITLE
perf(lifecycle): scope DB refresh to single workflow in task-scoped mutations

### DIFF
--- a/packages/workflow-core/src/__tests__/lifecycle-full-reload-regression.test.ts
+++ b/packages/workflow-core/src/__tests__/lifecycle-full-reload-regression.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Orchestrator, type OrchestratorPersistence } from '../orchestrator.js';
+import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import { computeWorkflowRollup } from '@invoker/workflow-graph';
+import { InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+/**
+ * Regression test: lifecycle mutations (retryTask, recreateTask, etc.) should
+ * NOT reload the entire database on every call. They should scope their refresh
+ * to the workflow(s) they actually operate on.
+ *
+ * Before the fix: retryTaskImpl, recreateTaskImpl, and siblings called
+ * `host.refreshFromDb()` which reloads ALL tasks from ALL active workflows.
+ * With 687 workflows and 2702 tasks, each retryTask call took 15–45s.
+ *
+ * After the fix: these functions use `host.refreshWorkflowFromDb(workflowId)`
+ * to reload only the affected workflow's tasks.
+ */
+
+const WORKFLOW_COUNT = 90;
+const TASKS_PER_WORKFLOW = 30;
+
+interface TestWorkflow {
+  id: string;
+  name: string;
+  status?: string;
+  createdAt: string;
+  updatedAt: string;
+  repoUrl?: string;
+}
+
+class TestPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, TestWorkflow>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  private attempts = new Map<string, Attempt[]>();
+  loadTasksForWorkflowsCalls: string[][] = [];
+
+  saveWorkflow(workflow: { id: string; name: string; repoUrl?: string }): void {
+    const now = new Date().toISOString();
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      status: 'pending',
+      repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  updateWorkflow(workflowId: string, changes: Partial<TestWorkflow>): void {
+    const existing = this.workflows.get(workflowId);
+    if (!existing) return;
+    this.workflows.set(workflowId, { ...existing, ...changes });
+  }
+
+  loadWorkflow(workflowId: string): TestWorkflow | undefined {
+    return this.workflows.get(workflowId);
+  }
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...changes.config },
+      execution: { ...entry.task.execution, ...changes.execution },
+    } as TaskState;
+  }
+
+  listWorkflows() {
+    return Array.from(this.workflows.values()).map((workflow) => ({
+      ...workflow,
+      status: computeWorkflowRollup(this.loadTasks(workflow.id)).status,
+    }));
+  }
+
+  loadTasks(workflowId: string): TaskState[] {
+    return Array.from(this.tasks.values())
+      .filter((e) => e.workflowId === workflowId)
+      .map((e) => e.task);
+  }
+
+  loadTasksForWorkflows(workflowIds: string[]): TaskState[] {
+    this.loadTasksForWorkflowsCalls.push([...workflowIds]);
+    const wfSet = new Set(workflowIds);
+    return Array.from(this.tasks.values())
+      .filter((e) => wfSet.has(e.workflowId))
+      .map((e) => e.task);
+  }
+
+  loadWorkflowTaskSnapshot() {
+    const tasksByWorkflowId = new Map<string, TaskState[]>();
+    for (const entry of this.tasks.values()) {
+      const arr = tasksByWorkflowId.get(entry.workflowId) ?? [];
+      arr.push(entry.task);
+      tasksByWorkflowId.set(entry.workflowId, arr);
+    }
+    return {
+      workflows: Array.from(this.workflows.values()),
+      tasks: Array.from(this.tasks.values()).map((e) => e.task),
+      tasksByWorkflowId,
+    };
+  }
+
+  logEvent(_taskId: string, _eventType: string, _payload?: unknown): void {}
+
+  saveAttempt(attempt: Attempt): void {
+    const list = this.attempts.get(attempt.nodeId) ?? [];
+    list.push(attempt);
+    this.attempts.set(attempt.nodeId, list);
+  }
+
+  loadAttempts(nodeId: string): Attempt[] {
+    return this.attempts.get(nodeId) ?? [];
+  }
+
+  loadAttempt(attemptId: string): Attempt | undefined {
+    for (const list of this.attempts.values()) {
+      const found = list.find((a) => a.id === attemptId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    for (const list of this.attempts.values()) {
+      const idx = list.findIndex((a) => a.id === attemptId);
+      if (idx !== -1) {
+        list[idx] = { ...list[idx], ...changes } as Attempt;
+        return;
+      }
+    }
+  }
+
+  deleteAllWorkflows(): void {
+    this.workflows.clear();
+    this.tasks.clear();
+  }
+}
+
+function seedLargeDatabase(persistence: TestPersistence): void {
+  const nowIso = new Date().toISOString();
+  for (let w = 0; w < WORKFLOW_COUNT; w++) {
+    const wfId = `wf-${w}`;
+    persistence.saveWorkflow({
+      id: wfId,
+      name: `Workflow ${w}`,
+      repoUrl: 'memory://test-repo',
+    });
+
+    for (let t = 0; t < TASKS_PER_WORKFLOW; t++) {
+      const taskId = `${wfId}/task-${t}`;
+      const deps = t > 0 ? [`${wfId}/task-${t - 1}`] : [];
+      const task: TaskState = {
+        id: taskId,
+        description: `Task ${t} in workflow ${w}`,
+        status: t === TASKS_PER_WORKFLOW - 1 ? 'failed' : 'completed',
+        dependencies: deps,
+        createdAt: new Date(),
+        config: {
+          workflowId: wfId,
+          runnerKind: 'command',
+          command: 'echo test',
+        },
+        execution: t === TASKS_PER_WORKFLOW - 1 ? { exitCode: 1 } : { exitCode: 0 },
+        taskStateVersion: 1,
+      } as TaskState;
+      persistence.saveTask(wfId, task);
+    }
+  }
+}
+
+describe('lifecycle full-reload regression', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retryTask should NOT call loadTasksForWorkflows for all workflows', async () => {
+    const persistence = new TestPersistence();
+    seedLargeDatabase(persistence);
+
+    const orchestrator = new Orchestrator({
+      persistence: persistence as OrchestratorPersistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 10,
+    });
+
+    orchestrator.syncAllFromDb();
+    persistence.loadTasksForWorkflowsCalls = [];
+
+    const targetTaskId = 'wf-0/task-29';
+    const targetTask = orchestrator.getTask(targetTaskId);
+    expect(targetTask).toBeDefined();
+    expect(targetTask?.status).toBe('failed');
+
+    const t0 = performance.now();
+    orchestrator.retryTask(targetTaskId);
+    const elapsed = performance.now() - t0;
+
+    expect(
+      persistence.loadTasksForWorkflowsCalls.length,
+      `retryTask should NOT call loadTasksForWorkflows (full-reload), got ${persistence.loadTasksForWorkflowsCalls.length} calls`,
+    ).toBe(0);
+
+    expect(elapsed, `retryTask took ${elapsed.toFixed(0)}ms, budget is 100ms`).toBeLessThan(100);
+  });
+
+  it('draining 90 retry-task calls should complete within 10s', async () => {
+    const persistence = new TestPersistence();
+    seedLargeDatabase(persistence);
+
+    const orchestrator = new Orchestrator({
+      persistence: persistence as OrchestratorPersistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 10,
+    });
+
+    orchestrator.syncAllFromDb();
+
+    const failedTasks = orchestrator.getAllTasks().filter((t) => t.status === 'failed');
+    expect(failedTasks.length).toBe(WORKFLOW_COUNT);
+
+    const t0 = performance.now();
+    for (const task of failedTasks) {
+      orchestrator.retryTask(task.id);
+    }
+    const elapsed = performance.now() - t0;
+
+    expect(
+      elapsed,
+      `Draining ${WORKFLOW_COUNT} retry-task calls took ${elapsed.toFixed(0)}ms, budget is 10000ms`,
+    ).toBeLessThan(10_000);
+  });
+
+  it('recreateTask should scope refresh to the target workflow only', async () => {
+    const persistence = new TestPersistence();
+    seedLargeDatabase(persistence);
+
+    const orchestrator = new Orchestrator({
+      persistence: persistence as OrchestratorPersistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 10,
+    });
+
+    orchestrator.syncAllFromDb();
+    persistence.loadTasksForWorkflowsCalls = [];
+
+    const targetTaskId = 'wf-5/task-29';
+    const t0 = performance.now();
+    orchestrator.recreateTask(targetTaskId);
+    const elapsed = performance.now() - t0;
+
+    expect(
+      persistence.loadTasksForWorkflowsCalls.length,
+      `recreateTask should NOT call loadTasksForWorkflows (full-reload), got ${persistence.loadTasksForWorkflowsCalls.length} calls`,
+    ).toBe(0);
+
+    expect(elapsed, `recreateTask took ${elapsed.toFixed(0)}ms, budget is 100ms`).toBeLessThan(100);
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -261,7 +261,7 @@ export interface ExecutionResourceLeaseReleaseRow {
 export type TaskLaunchReadiness =
   | { ready: true; task: TaskState }
   | { ready: false; reason: string; task?: TaskState };
-export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean; activePersistedAttempts?: number };
+export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean; activePersistedAttempts?: number; alreadyRefreshed?: boolean };
 export type StartExecutionOptions = { limit?: number };
 
 export interface OrchestratorPersistence {

--- a/packages/workflow-core/src/orchestrator/lifecycle.ts
+++ b/packages/workflow-core/src/orchestrator/lifecycle.ts
@@ -106,7 +106,7 @@ export interface LifecycleHost {
   ): string;
   buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
   touchWorkflow(workflowId: string): void;
-  autoStartReadyTasks(taskIds: string[], priority?: number): TaskState[];
+  autoStartReadyTasks(taskIds: string[], priority?: number, opts?: { alreadyRefreshed?: boolean }): TaskState[];
   getExternalDependencyBlocker(task: TaskState): string | undefined;
   cancelActiveBeforeInvalidation(scope: 'task' | 'workflow', id: string): string[];
   cancelActiveCandidates(candidates: readonly TaskState[], scope: 'task' | 'workflow'): string[];
@@ -259,7 +259,13 @@ export function resetSubgraphToPendingImpl(
 }
 
 export function retryTaskImpl(host: LifecycleHost, taskId: string): TaskState[] {
-  host.refreshFromDb();
+  const existingTask = host.stateGetTask(taskId);
+  const workflowId = existingTask?.config.workflowId;
+  if (workflowId) {
+    host.refreshWorkflowFromDb(workflowId);
+  } else {
+    host.refreshFromDb();
+  }
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   const id = task.id;
@@ -331,7 +337,7 @@ export function retryTaskImpl(host: LifecycleHost, taskId: string): TaskState[] 
   const isReady = readyTasks.some((t) => t.id === id);
   host.logger.info('[orchestrator] retryTask ready check', { taskId: id, ready: isReady });
   if (isReady) {
-    const started = host.autoStartReadyTasks([id], EXPEDITED_PRIORITY);
+    const started = host.autoStartReadyTasks([id], EXPEDITED_PRIORITY, { alreadyRefreshed: true });
     if (started.some((t) => t.id === id)) return started;
 
     const current = host.stateGetTask(id);
@@ -431,7 +437,7 @@ export function retryWorkflowImpl(host: LifecycleHost, workflowId: string): Task
       return !!task
         && task.config.workflowId === workflowId;
     });
-  const started = host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY);
+  const started = host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY, { alreadyRefreshed: true });
   const retryEndMs = Date.now();
   host.logger.info('[orchestrator] retryWorkflow timing', {
     workflowId,
@@ -450,7 +456,13 @@ export function retryWorkflowImpl(host: LifecycleHost, workflowId: string): Task
  * ready tasks within that affected subgraph.
  */
 export function recreateTaskImpl(host: LifecycleHost, taskId: string): TaskState[] {
-  host.refreshFromDb();
+  const existingTask = host.stateGetTask(taskId);
+  const workflowId = existingTask?.config.workflowId;
+  if (workflowId) {
+    host.refreshWorkflowFromDb(workflowId);
+  } else {
+    host.refreshFromDb();
+  }
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
@@ -508,7 +520,7 @@ export function applyRecreateResetImpl(host: LifecycleHost, plan: InvalidationPl
     .map((t) => t.id)
     .filter((id) => toResetSet.has(id));
   host.lastInvalidationPlan = withSchedulerEnqueueCandidates(plan, readyIds);
-  return host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY);
+  return host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY, { alreadyRefreshed: true });
 }
 
 /**
@@ -517,7 +529,13 @@ export function applyRecreateResetImpl(host: LifecycleHost, plan: InvalidationPl
  * Calling it on a leaf is a no-op.
  */
 export function recreateDownstreamImpl(host: LifecycleHost, taskId: string): TaskState[] {
-  host.refreshFromDb();
+  const existingTask = host.stateGetTask(taskId);
+  const workflowId = existingTask?.config.workflowId;
+  if (workflowId) {
+    host.refreshWorkflowFromDb(workflowId);
+  } else {
+    host.refreshFromDb();
+  }
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
@@ -568,7 +586,7 @@ export function bumpWorkflowGenerationImpl(host: LifecycleHost, workflowId: stri
  * Used when a rebase conflicts and the entire DAG needs to re-execute.
  */
 export function recreateWorkflowImpl(host: LifecycleHost, workflowId: string): TaskState[] {
-  host.refreshFromDb();
+  host.refreshWorkflowFromDb(workflowId);
 
   const allTasks = host.stateMachine.getAllTasks().filter(
     (t) => t.config.workflowId === workflowId,
@@ -656,7 +674,7 @@ export function recreateWorkflowImpl(host: LifecycleHost, workflowId: string): T
     .filter((id) => host.stateGetTask(id)?.config.workflowId === workflowId);
   plan = withSchedulerEnqueueCandidates(plan, readyIds);
   host.lastInvalidationPlan = plan;
-  return host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY);
+  return host.autoStartReadyTasks(readyIds, EXPEDITED_PRIORITY, { alreadyRefreshed: true });
 }
 
 /**

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -236,7 +236,7 @@ export function autoStartReadyTasksImpl(
   host: SchedulerDomainHost,
   taskIds: string[],
   priority: number = 0,
-  opts?: LaunchReadinessOptions,
+  opts?: LaunchReadinessOptions & { alreadyRefreshed?: boolean },
 ): TaskState[] {
   const candidateJobs: TaskJob[] = [];
   for (const taskId of taskIds) {
@@ -393,10 +393,12 @@ export function getLocalDependencyBlockerImpl(host: SchedulerDomainHost, task: T
   return undefined;
 }
 
-export function drainSchedulerImpl(host: SchedulerDomainHost, opts?: LaunchReadinessOptions): TaskState[] {
+export function drainSchedulerImpl(host: SchedulerDomainHost, opts?: LaunchReadinessOptions & { alreadyRefreshed?: boolean }): TaskState[] {
   // Refresh once for the whole drain pass, not once per dequeued job below
   // (see planPendingLaunchQueue for the same reasoning).
-  host.refreshFromDb();
+  if (!opts?.alreadyRefreshed) {
+    host.refreshFromDb();
+  }
   const started: TaskState[] = [];
   const activeAttempts = host.countActivePersistedAttempts();
   let availableSlots = Math.max(0, host.maxConcurrency - activeAttempts);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Task-scoped lifecycle mutations (retryTask, recreateTask, recreateDownstream, recreateWorkflow) were calling refreshFromDb() which reloads ALL tasks from ALL active workflows.

With 687 workflows and 2702 tasks, each retryTask call took 15-45s. This fix scopes the refresh to only the target workflow.

The fix uses refreshWorkflowFromDb(workflowId) instead of refreshFromDb() for task-scoped operations. The scheduler's drainSchedulerImpl now accepts an alreadyRefreshed option to avoid redundant full reloads when the caller has already refreshed.

## Review Claim

The reviewer is asked to approve that task-scoped lifecycle mutations now refresh only the target workflow instead of the entire database, preserving correctness while improving performance.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change preserves data consistency: we still refresh from the database before operating, just scoped to the relevant workflow. The fallback to refreshFromDb() when workflowId is unknown ensures the mutation still works for edge cases. All 985 existing tests pass.

## Slice Rationale

This is a focused performance fix for the specific functions identified as having the full-reload regression. Other callers of refreshFromDb (like startExecution, handleWorkerResponse) are not changed because they legitimately need cross-workflow visibility.

## Non-goals

- Changing start-ready's syncAllFromDb call (it legitimately needs all workflows)
- Optimizing CLI retry-tasks per-item snapshot loading
- Modifying data-store loadWorkflowTaskSnapshot implementation
- UI read path optimizations (covered by prior PRs #11418, #11420-#11427)

## Architecture

### Before

```mermaid
graph TD
    A["retryTask(taskId)"] --> B["refreshFromDb()"]
    B --> C["loadTasksForWorkflows(ALL workflow IDs)"]
    C --> D["Process single task"]
```

### After

```mermaid
graph TD
    A["retryTask(taskId)"] --> B["Get existing task workflowId"]
    B --> C["refreshWorkflowFromDb(workflowId)"]
    C --> D["loadTasks(single workflow)"]
    D --> E["Process single task"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test -- --run lifecycle-full-reload-regression`
- [x] `cd packages/workflow-core && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3bd1a833e`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41947384-0bb7-4e63-90d6-141001dbc19e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41947384-0bb7-4e63-90d6-141001dbc19e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

