### PR TITLE
proof(app): boot and first IPC do not read from events table

### DIFF
--- a/packages/app/src/__tests__/boot-events-on-demand.test.ts
+++ b/packages/app/src/__tests__/boot-events-on-demand.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import { getEventsPage } from '../get-events-page.js';
+
+const EVENT_COUNT_PER_TASK = 10_000;
+const TASK_COUNT = 50;
+const WORKFLOW_COUNT = 10;
+
+function seedFatEventWorkflows(
+  adapter: SQLiteAdapter,
+  opts: { workflowCount: number; tasksPerWorkflow: number; eventsPerTask: number },
+): { totalEvents: number; totalTasks: number } {
+  let totalEvents = 0;
+  let totalTasks = 0;
+
+  adapter.runInTransaction(() => {
+    for (let w = 0; w < opts.workflowCount; w += 1) {
+      const workflowId = `wf-${w}`;
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: `Workflow ${w}`,
+        status: w % 5 === 0 ? 'running' : 'completed',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      });
+
+      const tasksPerWf = Math.ceil(opts.tasksPerWorkflow / opts.workflowCount);
+      for (let t = 0; t < tasksPerWf; t += 1) {
+        const taskId = `${workflowId}/t${t}`;
+        adapter.saveTask(workflowId, {
+          id: taskId,
+          description: `Task ${t} of workflow ${w}`,
+          status: t === 0 && w % 5 === 0 ? 'running' : 'completed',
+          dependencies: [],
+          createdAt: new Date('2026-07-01T00:00:00.000Z'),
+          config: { workflowId },
+          execution: {},
+          taskStateVersion: 1,
+        });
+        totalTasks += 1;
+
+        for (let e = 0; e < opts.eventsPerTask; e += 1) {
+          adapter.logEvent(taskId, 'task.progress', { idx: e });
+          totalEvents += 1;
+        }
+      }
+    }
+  });
+
+  return { totalEvents, totalTasks };
+}
+
+describe('boot-events-on-demand', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('syncAllFromDb does NOT read from events table', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'boot-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    seedFatEventWorkflows(adapter, {
+      workflowCount: WORKFLOW_COUNT,
+      tasksPerWorkflow: TASK_COUNT,
+      eventsPerTask: EVENT_COUNT_PER_TASK,
+    });
+
+    const getEventsSpy = vi.spyOn(adapter, 'getEvents');
+    const getEventsSlimSpy = vi.spyOn(adapter, 'getEventsSlim');
+    const getEventsByTypesSpy = vi.spyOn(adapter, 'getEventsByTypes');
+    const listTaskEventsSpy = vi.spyOn(adapter, 'listTaskEvents');
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    expect(getEventsSpy).not.toHaveBeenCalled();
+    expect(getEventsSlimSpy).not.toHaveBeenCalled();
+    expect(getEventsByTypesSpy).not.toHaveBeenCalled();
+    expect(listTaskEventsSpy).not.toHaveBeenCalled();
+
+    const tasks = orchestrator.getAllTasks();
+    expect(tasks.length).toBe(TASK_COUNT);
+  });
+
+  it('loadWorkflowTaskSnapshot does NOT read from events table', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'snapshot-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    seedFatEventWorkflows(adapter, {
+      workflowCount: WORKFLOW_COUNT,
+      tasksPerWorkflow: TASK_COUNT,
+      eventsPerTask: EVENT_COUNT_PER_TASK,
+    });
+
+    const getEventsSpy = vi.spyOn(adapter, 'getEvents');
+    const getEventsSlimSpy = vi.spyOn(adapter, 'getEventsSlim');
+    const getEventsByTypesSpy = vi.spyOn(adapter, 'getEventsByTypes');
+    const listTaskEventsSpy = vi.spyOn(adapter, 'listTaskEvents');
+
+    const snapshot = adapter.loadWorkflowTaskSnapshot();
+
+    expect(getEventsSpy).not.toHaveBeenCalled();
+    expect(getEventsSlimSpy).not.toHaveBeenCalled();
+    expect(getEventsByTypesSpy).not.toHaveBeenCalled();
+    expect(listTaskEventsSpy).not.toHaveBeenCalled();
+
+    expect(snapshot.workflows).toHaveLength(WORKFLOW_COUNT);
+    expect(snapshot.tasks).toHaveLength(TASK_COUNT);
+  });
+
+  it('first cheap IPC (listWorkflows + getQueueStatus) does NOT read events', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ipc-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    seedFatEventWorkflows(adapter, {
+      workflowCount: WORKFLOW_COUNT,
+      tasksPerWorkflow: TASK_COUNT,
+      eventsPerTask: EVENT_COUNT_PER_TASK,
+    });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const getEventsSpy = vi.spyOn(adapter, 'getEvents');
+    const getEventsSlimSpy = vi.spyOn(adapter, 'getEventsSlim');
+    const getEventsByTypesSpy = vi.spyOn(adapter, 'getEventsByTypes');
+    const listTaskEventsSpy = vi.spyOn(adapter, 'listTaskEvents');
+
+    adapter.listWorkflows();
+    orchestrator.getQueueStatus();
+    orchestrator.startExecution();
+
+    expect(getEventsSpy).not.toHaveBeenCalled();
+    expect(getEventsSlimSpy).not.toHaveBeenCalled();
+    expect(getEventsByTypesSpy).not.toHaveBeenCalled();
+    expect(listTaskEventsSpy).not.toHaveBeenCalled();
+  });
+
+  it('getEventsPage loads only bounded events for a specific task', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'page-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    seedFatEventWorkflows(adapter, {
+      workflowCount: 1,
+      tasksPerWorkflow: 1,
+      eventsPerTask: EVENT_COUNT_PER_TASK,
+    });
+
+    const page = getEventsPage(adapter, 'wf-0/t0', { limit: 20, sortBy: 'desc' });
+
+    expect(page).toHaveLength(20);
+  });
+
+  it('boot+first-IPC p95 stays under 2s budget even with 500k events', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'boot-budget-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedFatEventWorkflows(adapter, {
+      workflowCount: WORKFLOW_COUNT,
+      tasksPerWorkflow: TASK_COUNT,
+      eventsPerTask: EVENT_COUNT_PER_TASK,
+    });
+    expect(seeded.totalEvents).toBeGreaterThanOrEqual(100_000);
+
+    const samples: number[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const orchestrator = new Orchestrator({
+        persistence: adapter as never,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 4,
+      });
+
+      const started = performance.now();
+      orchestrator.syncAllFromDb();
+      adapter.listWorkflows();
+      orchestrator.getQueueStatus();
+      samples.push(performance.now() - started);
+    }
+
+    const sorted = samples.sort((a, b) => a - b);
+    const p95 = sorted[Math.floor(sorted.length * 0.95)]!;
+    expect(
+      p95,
+      `boot+first-IPC p95=${p95.toFixed(1)}ms (events=${seeded.totalEvents})`,
+    ).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add benchmark tests verifying that boot and first IPC do not read from the events table.

With 500k events seeded across 50 tasks, boot+first-IPC stays under 2s. This proves events are already loaded on-demand in the current architecture.

syncAllFromDb loads only workflows and tasks tables. loadWorkflowTaskSnapshot does the same bulk load. Event reads happen only when explicitly requested via bounded paginated queries.

## Review Claim

The reviewer is asked to approve adding proof tests that confirm the events table is never read during boot, snapshot load, or first cheap IPC calls.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only new test files under `packages/app/src/__tests__/`. No production code changes. The tests use isolated temp SQLite databases and clean up after each test.

## Slice Rationale

Proof tests document and gate the expected behavior: events must remain on-demand during boot. This is standalone proof work, not bundled with any behavior fix.

## Non-goals

- Does not change production code.
- Does not add fixtures to git.
- Does not overlap with #11418 (added separate benchmark file).
- Does not touch #11420–#11427 (SQL variables, getEvents default limit, getEventsSlim).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments`
- [x] `cd packages/app && pnpm test -- --run boot-events-on-demand`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d322cdd2-93ed-4f95-ae8a-ce93f82832fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d322cdd2-93ed-4f95-ae8a-ce93f82832fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

