### PR TITLE
[Start-ready recovery refresh](1) Skip one full reload per recoverable task

### DIFF
--- a/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
+++ b/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import { runStartReady } from '../start-ready.js';
+
+/**
+ * runStartReadyAsync's recoverable-tasks loop
+ * (packages/app/src/start-ready.ts:335-338) calls
+ * `orchestrator.prepareTaskForNewAttempt(task.id, ...)` once per recoverable
+ * task found system-wide, and `prepareTaskForNewAttempt` unconditionally
+ * calls the orchestrator's private `refreshFromDb()` at its own top
+ * (packages/workflow-core/src/orchestrator.ts:1307-1308) — a full reload of
+ * every task in every active workflow, not just the recoverable task's own
+ * workflow. On DO1's real backlog this measured 350-400s for a single
+ * `invoker:start-ready` dispatch.
+ *
+ * This seeds two runs against the same on-disk shape (many small active
+ * workflows) that differ only in how many recoverable tasks exist, and
+ * shows the batch-reload call count (and wall time) scales with the
+ * recoverable-task count instead of staying constant.
+ */
+
+const SMALL_WORKFLOW_COUNT = 300;
+const RECOVERABLE_TASK_COUNT = 8;
+
+async function seedAndRun(recoverableCount: number): Promise<{ batchLoadCalls: number; elapsedMs: number }> {
+  const dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-start-ready-refresh-'));
+  const dbPath = path.join(dbDir, 'invoker.db');
+  try {
+    const realisticDescription = 'x'.repeat(4800);
+    const realisticPrompt = 'y'.repeat(3000);
+
+    const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      for (let i = 0; i < SMALL_WORKFLOW_COUNT; i += 1) {
+        const wfId = `wf-small-${i}`;
+        const nowIso = new Date().toISOString();
+        seedAdapter.saveWorkflow({ id: wfId, name: wfId, createdAt: nowIso, updatedAt: nowIso } as any);
+        const createdAt = new Date();
+        const isRecoverable = i < recoverableCount;
+        // A stale startedAt (well past ATTEMPT_LEASE_MS) with no matching
+        // `attempts` row is what makes isTaskExecutionActive() report this
+        // 'running' task as not-active, so collectRecoverableTasks() picks
+        // it up as orphaned/recoverable instead of still-in-flight.
+        const staleStartedAt = new Date(createdAt.getTime() - 24 * 60 * 60 * 1000);
+        seedAdapter.saveTask(wfId, {
+          id: `${wfId}/t0`,
+          description: realisticDescription,
+          prompt: realisticPrompt,
+          status: isRecoverable ? 'running' : 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: isRecoverable
+            ? { startedAt: staleStartedAt }
+            : { exitCode: 0 },
+        } as TaskState);
+      }
+    } finally {
+      seedAdapter.close();
+    }
+
+    const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      let batchLoadCalls = 0;
+      const realLoadTasksForWorkflows = bootAdapter.loadTasksForWorkflows.bind(bootAdapter);
+      (bootAdapter as any).loadTasksForWorkflows = (workflowIds: string[]) => {
+        batchLoadCalls += 1;
+        return realLoadTasksForWorkflows(workflowIds);
+      };
+
+      const orchestrator = new Orchestrator({
+        persistence: bootAdapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      const start = performance.now();
+      await runStartReady(orchestrator as any, {});
+      const elapsedMs = performance.now() - start;
+
+      return { batchLoadCalls, elapsedMs };
+    } finally {
+      bootAdapter.close();
+    }
+  } finally {
+    rmSync(dbDir, { recursive: true, force: true });
+  }
+}
+
+describe('runStartReady pays one full refreshFromDb per recoverable task', () => {
+  afterEach(() => {
+    // seedAndRun cleans up its own temp dir.
+  });
+
+  it(
+    'batch-reload call count scales with recoverable-task count instead of staying constant',
+    async () => {
+      const zero = await seedAndRun(0);
+      const withRecoverable = await seedAndRun(RECOVERABLE_TASK_COUNT);
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `runStartReady with 0 recoverable tasks: ${zero.batchLoadCalls} batch reloads, ${zero.elapsedMs.toFixed(1)}ms; `
+          + `with ${RECOVERABLE_TASK_COUNT} recoverable tasks: ${withRecoverable.batchLoadCalls} batch reloads, `
+          + `${withRecoverable.elapsedMs.toFixed(1)}ms`,
+      );
+
+      // Desired invariant: the recoverable-tasks loop must not pay one full
+      // cross-workflow reload per recoverable task found system-wide.
+      expect(withRecoverable.batchLoadCalls - zero.batchLoadCalls).toBe(0);
+    },
+    120_000,
+  );
+});

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -122,7 +122,11 @@ describe('start-ready', () => {
     const result = await runStartReady(orchestrator);
 
     expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
-    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith(
+      'wf-1/recoverable',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
   });
@@ -137,8 +141,16 @@ describe('start-ready', () => {
 
     const result = await runStartReady(orchestrator);
 
-    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith('wf-1/live', 'start_ready_recovery');
-    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/orphaned', 'start_ready_recovery');
+    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith(
+      'wf-1/live',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith(
+      'wf-1/orphaned',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
     expect(result.preview.recoverableTaskIds).toEqual(['wf-1/orphaned']);
   });
 

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -334,7 +334,7 @@ async function runStartReadyAsync(
 
   const recoverableTasks = collectRecoverableTasks(orchestrator);
   for (const task of recoverableTasks) {
-    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery');
+    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery', { alreadyRefreshed: true });
   }
 
   started.push(...orchestrator.startExecution());

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1354,8 +1354,14 @@ export class Orchestrator {
     return freshAttempt.id;
   }
 
-  prepareTaskForNewAttempt(taskId: string, reason: string): TaskState {
-    this.refreshFromDb();
+  prepareTaskForNewAttempt(
+    taskId: string,
+    reason: string,
+    options?: { alreadyRefreshed?: boolean },
+  ): TaskState {
+    if (!options?.alreadyRefreshed) {
+      this.refreshFromDb();
+    }
     const task = this.stateGetTask(taskId);
     if (!task) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);


### PR DESCRIPTION
runStartReadyAsync's recoverable-tasks loop calls
prepareTaskForNewAttempt() once per recoverable task found system-wide,
and that method unconditionally called the orchestrator's full
cross-workflow refreshFromDb() at its own top -- multiplying a single
start-ready dispatch's cost by the number of recoverable tasks, not the
number of workflows actually being mutated. Measured on DO1's real
backlog: 350-400s for one invoker:start-ready dispatch.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator mutation entry (`prepareTaskForNewAttempt`); callers that pass `alreadyRefreshed` incorrectly could operate on stale in-memory state during recovery.
> 
> **Overview**
> **Fixes multi-minute `invoker:start-ready` runs** when many orphaned/recoverable tasks exist. Each recoverable task was triggering a full cross-workflow `refreshFromDb()` inside `prepareTaskForNewAttempt`, even though `runStartReady` already called `syncAllFromDb()` once up front.
> 
> `prepareTaskForNewAttempt` now accepts an optional `{ alreadyRefreshed: true }` flag to skip that reload. The start-ready recoverable-task loop passes it so batch DB reload cost stays flat as recoverable count grows. Unit expectations in `start-ready.test.ts` were updated accordingly.
> 
> A new SQLite integration test (`start-ready-recoverable-tasks-refresh-cost.test.ts`) seeds ~300 small workflows and asserts extra recoverable tasks do not add extra `loadTasksForWorkflows` batch reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01085d7323cdf808443062f23065ed02493e7b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup recovery performance by avoiding redundant task-data reloads when recovering multiple tasks.
  - Preserved existing behavior for standard task preparation and actively running tasks.

- **Tests**
  - Added coverage for large sets of active workflows to verify recovery performance remains efficient.
  - Updated recovery checks to confirm tasks are prepared correctly without unnecessary refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->