### PR TITLE
[Start-ready recovery refresh](1) Repro: one full reload per recoverable task

### DIFF
--- a/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
+++ b/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import { runStartReady } from '../start-ready.js';
+
+/**
+ * runStartReadyAsync's recoverable-tasks loop
+ * (packages/app/src/start-ready.ts:335-338) calls
+ * `orchestrator.prepareTaskForNewAttempt(task.id, ...)` once per recoverable
+ * task found system-wide, and `prepareTaskForNewAttempt` unconditionally
+ * calls the orchestrator's private `refreshFromDb()` at its own top
+ * (packages/workflow-core/src/orchestrator.ts:1307-1308) — a full reload of
+ * every task in every active workflow, not just the recoverable task's own
+ * workflow. On DO1's real backlog this measured 350-400s for a single
+ * `invoker:start-ready` dispatch.
+ *
+ * This seeds two runs against the same on-disk shape (many small active
+ * workflows) that differ only in how many recoverable tasks exist, and
+ * shows the batch-reload call count (and wall time) scales with the
+ * recoverable-task count instead of staying constant.
+ */
+
+const SMALL_WORKFLOW_COUNT = 300;
+const RECOVERABLE_TASK_COUNT = 8;
+
+async function seedAndRun(recoverableCount: number): Promise<{ batchLoadCalls: number; elapsedMs: number }> {
+  const dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-start-ready-refresh-'));
+  const dbPath = path.join(dbDir, 'invoker.db');
+  try {
+    const realisticDescription = 'x'.repeat(4800);
+    const realisticPrompt = 'y'.repeat(3000);
+
+    const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      for (let i = 0; i < SMALL_WORKFLOW_COUNT; i += 1) {
+        const wfId = `wf-small-${i}`;
+        const nowIso = new Date().toISOString();
+        seedAdapter.saveWorkflow({ id: wfId, name: wfId, createdAt: nowIso, updatedAt: nowIso } as any);
+        const createdAt = new Date();
+        const isRecoverable = i < recoverableCount;
+        // A stale startedAt (well past ATTEMPT_LEASE_MS) with no matching
+        // `attempts` row is what makes isTaskExecutionActive() report this
+        // 'running' task as not-active, so collectRecoverableTasks() picks
+        // it up as orphaned/recoverable instead of still-in-flight.
+        const staleStartedAt = new Date(createdAt.getTime() - 24 * 60 * 60 * 1000);
+        seedAdapter.saveTask(wfId, {
+          id: `${wfId}/t0`,
+          description: realisticDescription,
+          prompt: realisticPrompt,
+          status: isRecoverable ? 'running' : 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: isRecoverable
+            ? { startedAt: staleStartedAt }
+            : { exitCode: 0 },
+        } as TaskState);
+      }
+    } finally {
+      seedAdapter.close();
+    }
+
+    const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      let batchLoadCalls = 0;
+      const realLoadTasksForWorkflows = bootAdapter.loadTasksForWorkflows.bind(bootAdapter);
+      (bootAdapter as any).loadTasksForWorkflows = (workflowIds: string[]) => {
+        batchLoadCalls += 1;
+        return realLoadTasksForWorkflows(workflowIds);
+      };
+
+      const orchestrator = new Orchestrator({
+        persistence: bootAdapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      const start = performance.now();
+      await runStartReady(orchestrator as any, {});
+      const elapsedMs = performance.now() - start;
+
+      return { batchLoadCalls, elapsedMs };
+    } finally {
+      bootAdapter.close();
+    }
+  } finally {
+    rmSync(dbDir, { recursive: true, force: true });
+  }
+}
+
+describe('runStartReady pays one full refreshFromDb per recoverable task', () => {
+  afterEach(() => {
+    // seedAndRun cleans up its own temp dir.
+  });
+
+  it.fails(
+    'batch-reload call count scales with recoverable-task count instead of staying constant',
+    async () => {
+      const zero = await seedAndRun(0);
+      const withRecoverable = await seedAndRun(RECOVERABLE_TASK_COUNT);
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `runStartReady with 0 recoverable tasks: ${zero.batchLoadCalls} batch reloads, ${zero.elapsedMs.toFixed(1)}ms; `
+          + `with ${RECOVERABLE_TASK_COUNT} recoverable tasks: ${withRecoverable.batchLoadCalls} batch reloads, `
+          + `${withRecoverable.elapsedMs.toFixed(1)}ms`,
+      );
+
+      // Desired invariant: the recoverable-tasks loop must not pay one full
+      // cross-workflow reload per recoverable task found system-wide.
+      expect(withRecoverable.batchLoadCalls - zero.batchLoadCalls).toBe(0);
+    },
+    120_000,
+  );
+});

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -114,7 +114,7 @@ describe('start-ready', () => {
     expect(orchestrator.startExecution).not.toHaveBeenCalled();
   });
 
-  it('recovers interrupted claims and starts executable ready tasks', async () => {
+  it.fails('recovers interrupted claims and starts executable ready tasks', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
@@ -122,12 +122,16 @@ describe('start-ready', () => {
     const result = await runStartReady(orchestrator);
 
     expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
-    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith(
+      'wf-1/recoverable',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
   });
 
-  it('leaves actively executing tasks alone instead of superseding their attempts', async () => {
+  it.fails('leaves actively executing tasks alone instead of superseding their attempts', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const live = makeTask('wf-1/live', 'running', {
       execution: { selectedAttemptId: 'attempt-live' },
@@ -137,8 +141,16 @@ describe('start-ready', () => {
 
     const result = await runStartReady(orchestrator);
 
-    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith('wf-1/live', 'start_ready_recovery');
-    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/orphaned', 'start_ready_recovery');
+    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith(
+      'wf-1/live',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith(
+      'wf-1/orphaned',
+      'start_ready_recovery',
+      { alreadyRefreshed: true },
+    );
     expect(result.preview.recoverableTaskIds).toEqual(['wf-1/orphaned']);
   });
 


### PR DESCRIPTION
## Summary

`runStartReadyAsync`'s recovery loop calls `prepareTaskForNewAttempt()` once for every recoverable task found across the whole process.

That method always reloads every task in every active workflow from disk before doing its own work.

So one `start-ready` dispatch pays a full cross-workflow reload once per recoverable task, instead of once total.

On DO1's real production backlog this measured 350-400 seconds for a single `invoker:start-ready` call, confirmed via the app's own mutation-timing log.

This slice adds the real on-disk repro proving it. The fix lands in the next stacked slice.

## Review Claim

A new on-disk repro test proves the batch-reload call count scales with the recoverable-task count instead of staying constant, and two existing tests are updated to the call signature the next slice introduces. All three are marked `it.fails` here since the fix does not exist yet.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product file is touched in this slice, so there is nothing to review for runtime behavior here.

## Slice Rationale

Repro before fix, per this repo's stack-ordering convention: the bug is demonstrated and reviewable before the behavior change that resolves it.

## Non-goals

Does not change any product code. Does not flip the `it.fails` markers to `it` — that is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- start-ready-recoverable-tasks-refresh-cost` — real on-disk SQLite, 300 seeded workflows. Log shows 4 batch reloads with 0 recoverable tasks vs 12 with 8, proving the per-task multiplier. `it.fails` reports this as a pass since the underlying `expect` throws as expected against unfixed code.
- [x] `pnpm --filter @invoker/app test -- start-ready` — 30/30 pass (the two updated assertions are `it.fails` here too).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or production behavior impact.
> 
> **Overview**
> Adds an **on-disk SQLite repro** that seeds 300 small workflows and asserts `runStartReady` should not increase `loadTasksForWorkflows` batch-reload count when more recoverable tasks exist. The test is **`it.fails`** today because each recoverable task still triggers a full cross-workflow reload via `prepareTaskForNewAttempt` → `refreshFromDb()`.
> 
> Updates two **`start-ready`** unit tests to expect the upcoming third argument `{ alreadyRefreshed: true }` on `prepareTaskForNewAttempt` during recovery, and marks those cases **`it.fails`** until the stacked fix lands. **No production code changes** in this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4db729660c4c925d580682ca920215452b9e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for recovering tasks across multiple active workflows.
  * Expanded recovery scenarios to verify interrupted claims and active-task isolation.
  * Documented currently failing recovery checks to support future fixes and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->