### PR TITLE
[Start-ready recovery refresh](2) Skip the redundant per-task reload

### DIFF
--- a/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
+++ b/packages/app/src/__tests__/start-ready-recoverable-tasks-refresh-cost.test.ts
@@ -98,7 +98,7 @@ describe('runStartReady pays one full refreshFromDb per recoverable task', () =>
     // seedAndRun cleans up its own temp dir.
   });
 
-  it.fails(
+  it(
     'batch-reload call count scales with recoverable-task count instead of staying constant',
     async () => {
       const zero = await seedAndRun(0);

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -114,7 +114,7 @@ describe('start-ready', () => {
     expect(orchestrator.startExecution).not.toHaveBeenCalled();
   });
 
-  it.fails('recovers interrupted claims and starts executable ready tasks', async () => {
+  it('recovers interrupted claims and starts executable ready tasks', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
@@ -131,7 +131,7 @@ describe('start-ready', () => {
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
   });
 
-  it.fails('leaves actively executing tasks alone instead of superseding their attempts', async () => {
+  it('leaves actively executing tasks alone instead of superseding their attempts', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const live = makeTask('wf-1/live', 'running', {
       execution: { selectedAttemptId: 'attempt-live' },

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -334,7 +334,7 @@ async function runStartReadyAsync(
 
   const recoverableTasks = collectRecoverableTasks(orchestrator);
   for (const task of recoverableTasks) {
-    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery');
+    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery', { alreadyRefreshed: true });
   }
 
   started.push(...orchestrator.startExecution());

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1354,8 +1354,14 @@ export class Orchestrator {
     return freshAttempt.id;
   }
 
-  prepareTaskForNewAttempt(taskId: string, reason: string): TaskState {
-    this.refreshFromDb();
+  prepareTaskForNewAttempt(
+    taskId: string,
+    reason: string,
+    options?: { alreadyRefreshed?: boolean },
+  ): TaskState {
+    if (!options?.alreadyRefreshed) {
+      this.refreshFromDb();
+    }
     const task = this.stateGetTask(taskId);
     if (!task) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);


### PR DESCRIPTION
## Summary

The previous stacked slice proved that `runStartReadyAsync`'s recovery loop pays one full cross-workflow reload per recoverable task, instead of once total.

This slice makes `prepareTaskForNewAttempt` omit that reload when the caller already knows the graph is current.

`runStartReadyAsync` already calls `syncAllFromDb()` moments earlier in the same function, so it can safely say so.

## Review Claim

`prepareTaskForNewAttempt` now accepts an `alreadyRefreshed` option, matching the pattern `drainSchedulerImpl` already uses, and the recovery loop passes it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The recovery loop runs after `syncAllFromDb()` already loaded the whole graph, and the only write between that call and the loop (`recreateWorkflow`) goes through `writeAndSync`, which keeps the in-memory graph current. So omitting the loop's own reload picks up nothing new, proven by the previous slice's repro flipping from failing to passing here. The one other caller of `prepareTaskForNewAttempt` (`resume_workflow_recovery`, not preceded by a fresh sync in the same call) is untouched and still refreshes normally every time.

## Slice Rationale

One behavior claim: thread one option through one method and its one affected call site. The repro landed as its own prior slice per this repo's proof-before-fix convention.

## Non-goals

Does not touch the other `prepareTaskForNewAttempt` caller (`resume_workflow_recovery`). Does not change `refreshFromDb`'s own cross-workflow scope, which is a larger, separate follow-up. Does not touch `recreate-task`'s own reload cost.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- start-ready-recoverable-tasks-refresh-cost` — the previous slice's `it.fails` repro now passes for real: batch-reload count stays at 4 regardless of recoverable-task count (was 4 -> 12 for 8 recoverable tasks before this fix).
- [x] `pnpm --filter @invoker/app test -- start-ready` — 30/30 pass, including the two previously-`it.fails` assertions now passing as ordinary tests.
- [x] `pnpm --filter @invoker/workflow-core test` — 979/979 pass, no regressions.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator mutation semantics on a hot start-ready path; correctness depends on the graph staying current between `syncAllFromDb()` and the recovery loop, though other callers are unchanged.
> 
> **Overview**
> **Start-ready** no longer triggers a full cross-workflow `refreshFromDb()` on every recoverable task during recovery. `prepareTaskForNewAttempt` now accepts an optional `{ alreadyRefreshed: true }` flag (same idea as scheduler paths that already skip reload). The start-ready recovery loop passes that flag because it runs right after `syncAllFromDb()`, so extra reloads were redundant and scaled with recoverable-task count.
> 
> Previously failing cost and behavior tests are promoted to normal passing tests, including the assertion that batch-reload count stays flat as recoverable tasks increase. **`resume_workflow_recovery`** and other callers still refresh on each call because they do not pass the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b23616cfa76b951e20593cee72d7ba1167e824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->