### PR TITLE
(2) fix(INV-XXX): defer LaunchDispatcher poll until HTTP server binds

### DIFF
--- a/packages/app/src/__tests__/owner-serve-http-bind-blocked.test.ts
+++ b/packages/app/src/__tests__/owner-serve-http-bind-blocked.test.ts
@@ -25,6 +25,8 @@ import { SQLiteAdapter } from '@invoker/data-store';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
 import type { TaskState } from '@invoker/workflow-core';
+import { startStandaloneLaunchDispatcher } from '../headless-standalone-launch-dispatcher.js';
+import type { HeadlessDeps } from '../headless.js';
 
 const TEST_PORT = 0;
 const WORKFLOW_COUNT = 100;
@@ -219,6 +221,98 @@ describe('owner-serve HTTP bind blocked by LaunchDispatcher poll', () => {
         listenCallbackFired,
         'listen callback fires after yielding to event loop',
       ).toBe(true);
+    } finally {
+      bootAdapter.close();
+    }
+  });
+
+  it('deferFirstPollUntil option allows HTTP to bind before dispatcher starts polling', async () => {
+    dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-defer-poll-'));
+    const dbPath = path.join(dbDir, 'invoker.db');
+
+    const seedAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+        const wfId = `wf-seed-${i}`;
+        const nowIso = new Date().toISOString();
+        seedAdapter.saveWorkflow({
+          id: wfId,
+          name: wfId,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any);
+
+        const createdAt = new Date();
+        seedAdapter.saveTask(wfId, {
+          id: `${wfId}/root`,
+          description: 'root',
+          status: 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: { exitCode: 0 },
+        } as TaskState);
+
+        const hasPendingTask = i % 2 === 0;
+        seedAdapter.saveTask(wfId, {
+          id: `${wfId}/work`,
+          description: 'work',
+          status: hasPendingTask ? 'pending' : 'completed',
+          dependencies: [`${wfId}/root`],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: hasPendingTask ? {} : { exitCode: 0 },
+        } as TaskState);
+      }
+    } finally {
+      seedAdapter.close();
+    }
+
+    const bootAdapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    let listenCallbackFired = false;
+    server = createServer();
+    const { promise: whenReady, resolve: resolveReady } = Promise.withResolvers<void>();
+
+    try {
+      const orchestrator = new Orchestrator({
+        persistence: bootAdapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+      orchestrator.syncAllFromDb();
+
+      server.listen(TEST_PORT, '127.0.0.1', () => {
+        listenCallbackFired = true;
+        resolveReady();
+      });
+
+      const mockHeadlessDeps = {
+        persistence: bootAdapter,
+        orchestrator,
+        logger: { warn: () => {}, info: () => {}, error: () => {} },
+      } as unknown as HeadlessDeps;
+
+      const dispatcher = startStandaloneLaunchDispatcher({
+        headlessDeps: mockHeadlessDeps,
+        ownerId: 'test-owner',
+        createTaskExecutor: () => ({ executeTask: async () => {} }) as any,
+        setLatestTaskExecutor: () => {},
+        topUpReadyLaunchesEnabled: () => false,
+        deferFirstPollUntil: whenReady,
+      });
+
+      expect(
+        listenCallbackFired,
+        'FIX VERIFIED: listen callback can fire because dispatcher deferred first poll',
+      ).toBe(false);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(
+        listenCallbackFired,
+        'listen callback fires after yielding to event loop',
+      ).toBe(true);
+
+      dispatcher.stop();
     } finally {
       bootAdapter.close();
     }

--- a/packages/app/src/__tests__/standalone-owner-web-surface.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-web-surface.test.ts
@@ -50,11 +50,17 @@ describe('standalone owner web surface wiring', () => {
     expect(autoStartedWorkersIdx, 'owner-serve must auto-start workers before exposing the web surface').toBeLessThan(
       startWebSurfaceIdx,
     );
-    expect(launchDispatcherIdx, 'owner-serve must start the launch dispatcher before exposing the web surface').toBeLessThan(
-      startWebSurfaceIdx,
+    expect(startWebSurfaceIdx, 'owner-serve must start the web surface before the launch dispatcher starts polling').toBeLessThan(
+      launchDispatcherIdx,
     );
     expect(startWebSurfaceIdx, 'owner-serve must start the web surface before the idle loop begins').toBeLessThan(
       runHeadlessIdx,
     );
+  });
+
+  it('passes deferFirstPollUntil to the launch dispatcher for owner-serve', () => {
+    const source = readFileSync(MAIN, 'utf8');
+    const deferOptionIdx = source.indexOf('deferFirstPollUntil: headlessWebBridge?.whenReady');
+    expect(deferOptionIdx, 'launch dispatcher must receive deferFirstPollUntil option').toBeGreaterThan(-1);
   });
 });

--- a/packages/app/src/headless-standalone-launch-dispatcher.ts
+++ b/packages/app/src/headless-standalone-launch-dispatcher.ts
@@ -12,6 +12,7 @@ interface StandaloneLaunchDispatcherOptions {
   createTaskExecutor: () => TaskRunner;
   setLatestTaskExecutor: (executor: TaskRunner) => void;
   topUpReadyLaunchesEnabled?: () => boolean;
+  deferFirstPollUntil?: Promise<unknown>;
 }
 
 export function startStandaloneLaunchDispatcher(
@@ -51,13 +52,22 @@ export function startStandaloneLaunchDispatcher(
     }
   };
 
-  poll();
-  const pollInterval = setInterval(poll, 2_000);
-  pollInterval.unref?.();
+  let pollInterval: ReturnType<typeof setInterval> | undefined;
+  const startPolling = (): void => {
+    poll();
+    pollInterval = setInterval(poll, 2_000);
+    pollInterval.unref?.();
+  };
+
+  if (options.deferFirstPollUntil) {
+    void options.deferFirstPollUntil.then(startPolling).catch(() => startPolling());
+  } else {
+    startPolling();
+  }
 
   return {
     stop(): void {
-      clearInterval(pollInterval);
+      if (pollInterval) clearInterval(pollInterval);
       headlessDeps.ownerTaskRunnerProvider = originalProvider;
     },
   };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2182,15 +2182,6 @@ function startHeadlessMode(): void {
         }
         if (!sourceDevelopmentProfile) workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.
-        if (!readOnlyMode) {
-          standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
-            headlessDeps,
-            ownerId: workflowMutationOwnerId,
-            createTaskExecutor: createStandaloneTaskExecutor,
-            setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
-            topUpReadyLaunchesEnabled: () => !sourceDevelopmentProfile && !invokerConfig.disableAutoRunOnStartup,
-          });
-        }
         if (command === 'owner-serve') {
           const ownerServeTaskExecutor = createStandaloneTaskExecutor();
           const apiServerDeps = buildHeadlessApiServerDeps(headlessDeps, ownerServeTaskExecutor);
@@ -2215,6 +2206,16 @@ function startHeadlessMode(): void {
             headlessWebBridge?.broadcast('invoker:planning-chat-stream', event);
           };
           startOwnerSocketSentinelForBus(messageBus);
+        }
+        if (!readOnlyMode) {
+          standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
+            headlessDeps,
+            ownerId: workflowMutationOwnerId,
+            createTaskExecutor: createStandaloneTaskExecutor,
+            setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
+            topUpReadyLaunchesEnabled: () => !sourceDevelopmentProfile && !invokerConfig.disableAutoRunOnStartup,
+            deferFirstPollUntil: headlessWebBridge?.whenReady,
+          });
         }
 
         void recoverWorkflowMutationsOnStartup({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Defers the LaunchDispatcher's first poll until after the HTTP server binds for owner-serve.

Without this fix, the dispatcher's synchronous startExecution path blocks the event loop, preventing server.listen() callback from firing. HTTP never binds.

## Review Claim

The deferFirstPollUntil option allows HTTP to bind before the dispatcher starts heavy DB work.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Deferral only happens when deferFirstPollUntil is passed. Non-owner-serve commands use immediate polling unchanged.

## Slice Rationale

Stacked on the proof PR. Fix applies the solution demonstrated by the proof tests.

## Non-goals

Does not optimize the underlying DB query performance. Does not change recovery semantics.

## Architecture

### Before

```mermaid
graph TD
    A["startStandaloneLaunchDispatcher"] --> B["poll() immediately"]
    B --> C["blocks event loop"]
    D["startWebSurfaceForHeadless"] --> E["server.listen()"]
    E --> F["callback never fires"]
```

### After

```mermaid
graph TD
    A["startWebSurfaceForHeadless"] --> B["server.listen()"]
    C["startStandaloneLaunchDispatcher"] --> D["waits for whenReady"]
    B --> E["callback fires"]
    E --> D
    D --> F["poll() starts"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && node_modules/.bin/vitest run src/__tests__/owner-serve-http-bind-blocked.test.ts`
- [x] `cd packages/app && node_modules/.bin/vitest run src/__tests__/standalone-owner-web-surface.test.ts`
- [x] `cd packages/app && node_modules/.bin/vitest run src/__tests__/standalone-owner-handler-ordering.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcd282c3-19c3-40a5-b714-0725ff92ffb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcd282c3-19c3-40a5-b714-0725ff92ffb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

