### PR TITLE
[Autofix no-repo skip](1) Stop retrying an unfixable git-publish step

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-recovery.test.ts
@@ -71,7 +71,7 @@ function makeHarness(task = makeFailedTask()) {
   const actions = new Map<string, WorkerActionRecord>();
   const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 99);
   const store = {
-    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    listWorkflows: vi.fn(() => [{ id: 'wf-1', repoUrl: 'https://example.com/repo.git' }]),
     loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
     loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
     listWorkflowMutationIntents: vi.fn(() => []),
@@ -181,6 +181,41 @@ describe('collectValidatedAutoFixRecoveryCandidates', () => {
       task.id,
       'debug.auto-fix',
       expect.objectContaining({ phase: 'worker-autofix-skip', reason: 'admin-bypass-excluded' }),
+    );
+  });
+
+  it('skips a failed task in a repo-less workflow, since a fix can never be published as a branch', () => {
+    const task = makeFailedTask({
+      id: 'wf-scratch/investigate',
+      config: { workflowId: 'wf-scratch', prompt: 'Investigate a production finding.' },
+      execution: {
+        generation: 1,
+        selectedAttemptId: 'attempt-1',
+        branch: undefined,
+        error: 'Task wf-scratch/investigate has no branch for approved-fix publish',
+        failureClass: undefined,
+      },
+    });
+    const store = {
+      listWorkflows: vi.fn(() => [{ id: 'wf-scratch', name: 'Investigate a production finding', repoUrl: undefined }]),
+      loadTasks: vi.fn((workflowId: string) => (workflowId === 'wf-scratch' ? [task] : [])),
+      loadTask: vi.fn((taskId: string) => (taskId === task.id ? task : undefined)),
+      listWorkflowMutationIntents: vi.fn(() => []),
+      logEvent: vi.fn(),
+    };
+    const options = {
+      store,
+      submitter: { submit: vi.fn(() => 1) },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+    };
+
+    expect(collectValidatedAutoFixRecoveryCandidates(options)).toEqual([]);
+    expect(store.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'debug.auto-fix',
+      expect.objectContaining({ phase: 'worker-autofix-skip', reason: 'no-repo-workflow' }),
     );
   });
 });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -92,8 +92,8 @@ const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 
 };
 
 export interface AutoFixRecoveryStore {
-  listWorkflows(): ReadonlyArray<{ id: string; name?: string }>;
-  loadWorkflow?(workflowId: string): { name?: string | null } | undefined;
+  listWorkflows(): ReadonlyArray<{ id: string; name?: string; repoUrl?: string | null }>;
+  loadWorkflow?(workflowId: string): { name?: string | null; repoUrl?: string | null } | undefined;
   loadTasks(workflowId: string): TaskState[];
   loadTasksForWorkflows?(workflowIds: string[]): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
@@ -213,6 +213,17 @@ function workflowNameForId(
   if (typeof listed?.name === 'string' && listed.name.length > 0) return listed.name;
   const loaded = options.store.loadWorkflow?.(workflowId);
   if (typeof loaded?.name === 'string' && loaded.name.length > 0) return loaded.name;
+  return undefined;
+}
+
+function workflowRepoUrlForId(
+  options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
+  workflowId: string,
+): string | undefined {
+  const listed = options.store.listWorkflows().find((workflow) => workflow.id === workflowId);
+  if (typeof listed?.repoUrl === 'string' && listed.repoUrl.length > 0) return listed.repoUrl;
+  const loaded = options.store.loadWorkflow?.(workflowId);
+  if (typeof loaded?.repoUrl === 'string' && loaded.repoUrl.length > 0) return loaded.repoUrl;
   return undefined;
 }
 
@@ -527,6 +538,13 @@ function validateAutoFixCandidate(
   const workflowName = workflowNameForId(options, latestRef.workflowId);
   if (isAdminBypassNamedWorkflow(workflowName)) {
     skipAutoFixCandidate(options, candidate, 'admin-bypass-excluded', {
+      workflowName: workflowName ?? null,
+    });
+    return undefined;
+  }
+
+  if (!workflowRepoUrlForId(options, latestRef.workflowId)) {
+    skipAutoFixCandidate(options, candidate, 'no-repo-workflow', {
       workflowName: workflowName ?? null,
     });
     return undefined;


### PR DESCRIPTION
## Summary

The autofix-recovery worker treats every failed task as a fix candidate, including tasks that belong to a repo-less (scratch) workflow.

Its approve-and-publish step always requires a git branch on the task, but a repo-less workflow can never produce one.

So the cycle repeats forever: spawn a fix agent, fail to publish, wait, then dispatch again.

Confirmed live on a production host: one such task had gone through 26 state-version transitions and kept spawning Claude agent subprocesses into an empty scratch directory with nothing to fix.

## Review Claim

The autofix candidate check now excludes a failed task when its workflow has no `repoUrl`, since that task's fix can never be committed as a branch.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new check runs after the existing admin-bypass exclusion and before the attempt-budget check, using the same `listWorkflows()`/`loadWorkflow` lookup pattern the file already uses for the admin-bypass check. A task in any workflow that has a real `repoUrl` is completely unaffected, confirmed by the existing suite's 13 tests (all repo-backed fixtures) still passing unchanged.

## Slice Rationale

One review claim: one new candidate check plus its regression test.

## Non-goals

Does not change `publishApprovedFix`'s own branch requirement, which stays correct for repo-backed workflows. Does not add a different recovery path for repo-less tasks; they simply stop being auto-fixed and stay failed for a human or the workflow's own recovery logic to handle.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- auto-fix-recovery` — 13/13 pass. Fail-before: reverting the new candidate check made the new test's `expect(...).toEqual([])` assertion fail (the repo-less task was returned as a live candidate). Pass-after: the task is excluded with reason `no-repo-workflow`.
- [x] `pnpm --filter @invoker/execution-engine test` — full package suite passes, no regressions.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
