### PR TITLE
[Requeue cap escalation](1) Escalate to an agent when a PR's Mergify requeue hits its retry cap

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -47,6 +47,10 @@ def repair_bot_thread_plan_name(pr_number: int, start_head: str) -> str:
     return f"admin-bypass-repair-bot-thread-pr-{pr_number}-{start_head[:7]}"
 
 
+def requeue_stuck_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-requeue-stuck-pr-{pr_number}-{start_head[:7]}"
+
+
 def _yaml_str(value: str) -> str:
     # JSON string encoding is a valid YAML flow scalar and, unlike naive shell
     # quoting, correctly escapes quotes/colons/backslashes in PR titles/branch
@@ -323,6 +327,45 @@ def build_repair_bot_thread_plan(
         name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review"
     )
     yaml_text += _repair_task_yaml(description=f"Resolve bot review thread on PR #{pr.number}", prompt=prompt)
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move",
+        dependencies="repair",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        skip_if_prereq=False,
+        foreign=foreign,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def build_requeue_stuck_plan(
+    pr: PrSnapshot,
+    attempts: int,
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+    foreign: bool = False,
+) -> AsyncRepairPlan:
+    name = requeue_stuck_plan_name(pr.number, start_head)
+    prompt = (
+        f"PR #{pr.number} has been requeued {attempts} time(s) at head {start_head} without landing, "
+        "and the automated requeue attempts have stopped. Investigate why it is not merging and fix it.\n\n"
+        "Check the PR's real current state directly (checks, review status, mergeability) rather than "
+        "trusting any cached summary. If a required check's own status page is stuck reporting an old "
+        "result after a later run actually passed, or any other blocker has genuinely already cleared, "
+        "push a small real commit (e.g. an empty commit, or a real fix if you find one) so the next "
+        "automated requeue attempt gets a fresh check run against a new commit. If a real blocker remains "
+        "(a genuine failing check, a merge conflict, requested changes), fix it with a real code change "
+        "and commit locally. Do not push if you make no change. Do not merge or bypass CI yourself.\n\n"
+        f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\n"
+        f"Base branch: {pr.base_ref_name}\nRequeue attempts so far: {attempts}\n"
+    )
+    yaml_text = _write_plan_header(
+        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review"
+    )
+    yaml_text += _repair_task_yaml(description=f"Investigate why PR #{pr.number} is stuck in the merge queue", prompt=prompt)
     yaml_text += _safe_push_task_yaml(
         task_id="safe-push",
         description=f"Safely push PR #{pr.number} only if its head did not move",

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -90,6 +90,8 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{repair_prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
     elif action.kind == "comment_blocked":
         print(f"BLOCK PR #{action.pr_number} {action.detail}")
+    elif action.kind == "escalate_requeue_stuck":
+        print(f"{repair_prefix}escalate-requeue-stuck PR #{action.pr_number} {action.detail}")
     elif action.kind == "comment_admin_bypass_nudge":
         print(f"{prefix}comment-admin-bypass-nudge PR #{action.pr_number}")
     elif action.kind == "restore_admin_bypass_label":
@@ -119,6 +121,8 @@ def print_repair_acknowledged(action: Action, as_json: bool) -> None:
         print(f"ACKNOWLEDGED repair-check PR #{action.pr_number} check={json.dumps(key)}")
     elif action.kind == "rebase_onto_master":
         print(f"ACKNOWLEDGED rebase-onto-master PR #{action.pr_number} {action.detail}")
+    elif action.kind == "escalate_requeue_stuck":
+        print(f"ACKNOWLEDGED escalate-requeue-stuck PR #{action.pr_number} {action.detail}")
 
 
 def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClient, logger: AdminBypassLogger) -> dict[int, bool]:
@@ -399,6 +403,35 @@ def run_cycle(
                     )
                     if release_repair_filing is not None:
                         release_repair_filing(REBASE_ONTO_MASTER_FILING_KIND, str(action.pr_number), pr.head_ref_oid)
+                    report_repair_dispatch_failure(executor, logger, pr, action.kind, now)
+                    should_poll = True
+                    continue
+                if progressed:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_succeeded += 1
+                    any_progress = True
+                else:
+                    should_poll = True
+                continue
+            elif action.kind == "escalate_requeue_stuck":
+                try:
+                    attempts = ledger.count("requeue", action.pr_number, pr.head_ref_oid, action.key)
+                    outcome = repairer.escalate_stuck_requeue(pr, action.key, attempts, now)
+                    if outcome.status == "submitted":
+                        print_repair_acknowledged(action, args.json)
+                    progressed = outcome.status == "submitted"
+                except Exception as exc:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_failed += 1
+                    repair_dispatch_last_error = str(exc)
+                    logger.trace(
+                        "admin-bypass-repair-attempt-failed",
+                        repo=args.repo,
+                        pr_number=action.pr_number,
+                        action_kind=action.kind,
+                        key=action.key,
+                        error=str(exc),
+                    )
                     report_repair_dispatch_failure(executor, logger, pr, action.kind, now)
                     should_poll = True
                     continue

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1512,6 +1512,13 @@ def plan_bottom_progress(
         requeue_reason = "eligible-after-dequeued-label"
     attempts = ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key)
     if attempts >= max_requeue_attempts:
+        if ledger.count("requeue-escalation", bottom.number, bottom.head_ref_oid, requeue_key) == 0:
+            return Action(
+                "escalate_requeue_stuck",
+                bottom.number,
+                requeue_key,
+                f"requeue capped after {attempts} attempt(s) at head {bottom.head_ref_oid}; escalating to an agent",
+            )
         return cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue")
     return Action("requeue", bottom.number, requeue_key, requeue_reason)
 

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -257,6 +257,28 @@ class AdminBypassRepairer:
         self.submit_repair_plan(plan, "repair-check", pr.number, start_head, check_name, now)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
+    def escalate_stuck_requeue(self, pr: PrSnapshot, requeue_key: str, attempts: int, now: int | None = None) -> RepairOutcome:
+        start_head = pr.head_ref_oid
+        plan = async_repair.build_requeue_stuck_plan(
+            pr,
+            attempts,
+            repo=self.repo,
+            start_head=start_head,
+            state_file=self.ledger.path,
+            foreign=self.is_foreign,
+        )
+        self.logger.trace(
+            "admin-bypass-requeue-stuck-escalation-start",
+            repo=self.repo,
+            pr_number=pr.number,
+            requeue_key=requeue_key,
+            attempts=attempts,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
+        )
+        self.submit_repair_plan(plan, "requeue-escalation", pr.number, start_head, requeue_key, now)
+        return self.blocked_outcome("submitted", requeue_key, start_head, start_head)
+
     def rebase_onto_master(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
         check_name = "rebase-onto-master"
         start_head = pr.head_ref_oid

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -276,12 +276,21 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("requeue", 2605, "m1")])
 
-    def test_requeue_same_dequeue_event_hits_cap(self):
+    def test_requeue_same_dequeue_event_hits_cap_and_escalates_to_agent(self):
         ledger = self.ledger()
         ledger.record("requeue", 2605, HEAD, "m1", 1)
         ledger.record("requeue", 2605, HEAD, "m1", 2)
         stack = StackGroup("s", (pr(2605, latest=mergify(comment_id="m1")),))
         actions = plan_stack_actions(stack, REQUIRED, ledger, 3)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("escalate_requeue_stuck", 2605, "m1")])
+
+    def test_requeue_cap_falls_back_to_comment_once_already_escalated(self):
+        ledger = self.ledger()
+        ledger.record("requeue", 2605, HEAD, "m1", 1)
+        ledger.record("requeue", 2605, HEAD, "m1", 2)
+        ledger.record("requeue-escalation", 2605, HEAD, "m1", 3)
+        stack = StackGroup("s", (pr(2605, latest=mergify(comment_id="m1")),))
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2605, "capped")])
 
     def test_failed_check_repairs_before_requeue(self):

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -314,6 +314,47 @@ class AsyncRepairPlanTests(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 async_repair.submit_async_repair_plan(plan)
 
+    def test_requeue_stuck_plan_yaml_is_accepted_by_invokers_real_plan_validator(self):
+        plan = async_repair.build_requeue_stuck_plan(
+            pr(number=11441, head_ref_name="stack/requeue-stuck-example", merge_state_status="BLOCKED"),
+            attempts=2,
+            repo="owner/repo",
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+
+        repo_root = Path(__file__).resolve().parent.parent
+        validator = repo_root / "skills" / "plan-to-invoker" / "scripts" / "validate-plan.sh"
+        self.assertTrue(validator.exists(), f"real validator missing at {validator}")
+
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+            fh.write(plan.yaml_text)
+            plan_path = fh.name
+        try:
+            result = subprocess.run(
+                ["bash", str(validator), plan_path],
+                capture_output=True,
+                text=True,
+                cwd=repo_root,
+                timeout=30,
+            )
+        finally:
+            os.unlink(plan_path)
+
+        if result.returncode != 0:
+            import json
+
+            errors = json.loads(result.stdout or result.stderr)
+            # non_portable_pipefail on safe-push predates this feature (every plan
+            # _safe_push_task_yaml builds trips it, see the sibling plan asserted in
+            # test_non_foreign_repair_check_plan_still_includes_invoker_helpers) and
+            # is intentionally excluded here rather than silently un-asserted.
+            unexpected = [e for e in errors if e.get("errorType") != "non_portable_pipefail"]
+            self.assertEqual(
+                unexpected, [],
+                f"requeue-stuck plan failed real Invoker plan validation: {unexpected}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -1035,14 +1035,38 @@ class PlanStackActions(PlannerTestCase):
         execution = p.plan_stack_execution(stack, REQUIRED, ledger, NOW, (), {}, trunk="master")
         self.assertEqual(execution.wait_reason, "repair-in-flight")
 
-    def test_requeue_is_capped_after_repeated_attempts(self):
+    def test_requeue_capped_first_time_escalates_to_agent(self):
         ledger = self._ledger()
         # Two prior requeue attempts on this head+key -> the third is capped.
         ledger.record("requeue", 1, HEAD, "cm1")
         ledger.record("requeue", 1, HEAD, "cm1")
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
         actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("escalate_requeue_stuck", "cm1"))
+
+    def test_requeue_capped_after_escalation_falls_back_to_comment(self):
+        ledger = self._ledger()
+        ledger.record("requeue", 1, HEAD, "cm1")
+        ledger.record("requeue", 1, HEAD, "cm1")
+        # Escalation already recorded for this exact head+key -> no duplicate
+        # agent submission; falls back to the existing capped-comment behavior.
+        ledger.record("requeue-escalation", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        actions = self._plan(snapshot, ledger)
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
+    def test_requeue_escalation_only_fires_once_per_head(self):
+        ledger = self._ledger()
+        ledger.record("requeue", 1, HEAD, "cm1")
+        ledger.record("requeue", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        first = self._plan(snapshot, ledger)
+        self.assertEqual((first[0].kind, first[0].key), ("escalate_requeue_stuck", "cm1"))
+        # Simulate the executor recording the escalation after dispatch, then
+        # replanning on the same state -> must not escalate a second time.
+        ledger.record("requeue-escalation", 1, HEAD, "cm1")
+        second = self._plan(snapshot, ledger)
+        self.assertEqual((second[0].kind, second[0].key), ("comment_blocked", "capped"))
 
     def test_queue_only_missing_head_check_repairs_from_mergify_failure(self):
         snapshot = pr(


### PR DESCRIPTION
## Summary

`pr-admin-bypass-land`'s Mergify-requeue automation gives up forever once a PR hits its requeue attempt cap (default 2) at one commit — it posts a "requeue attempt cap was reached" comment and stops touching that PR.

Confirmed live on PR #11441 tonight: the cap was hit while the actual blocker (a stuck GitHub check-status summary) had already cleared over an hour earlier. Nothing was wrong with the PR, but nothing was watching it either — a human had to push an empty commit by hand to unstick it.

This adds an automatic fallback: the first time a PR's requeue count hits the cap, dispatch one real agent task to investigate and either nudge or fix it.

## Review Claim

On the first capped tick for a given (PR, head SHA, requeue key), dispatch an Invoker repair task asking an agent to investigate the PR's real current state and push a small fix or nudge commit if warranted — reusing the same async-repair-plan dispatch pattern already used for `repair_check`/`rebase_onto_master`. Later ticks on the same commit fall back to the existing capped-comment behavior, so this never dispatches more than one agent task per commit.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Fork-drafted; needs a careful human read given this triggers real agent-spawning automation. The agent's own task prompt explicitly forbids merging or bypassing CI itself — it may only push a real commit (fix or nudge) or make no change. A fresh commit naturally resets the existing per-commit requeue-cap counter (unchanged, pre-existing logic), so the normal pipeline resumes on its own; this adds no new direct path around CI or branch protection. Idempotency is enforced with the same ledger `count()`/`record()` mechanism every other repair kind in this file already relies on (verified: a second planning pass against the same escalated state falls back to the comment, not a second dispatch — see the new tests).

## Slice Rationale

Single, self-contained behavior slice: one new escalation branch in the existing requeue-cap check, one new plan-builder function following an existing sibling's shape, one new executor action-kind handler, plus the tests. All in one PR since the pieces are small and only make sense together.

## Non-goals

Does not change `max_requeue_attempts`'s default value (separate ask, not part of this change). Does not touch the other ~9 `cap_action()` call sites in this file (squash-merge cap, queue-event-staleness cap, etc.) — scoped to the exact "requeue" cap path that caused tonight's incident. Does not fix the underlying stuck-GitHub-check-summary bug itself; that's a GitHub-side issue this escalation works around by asking an agent to notice and nudge past it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan.PlanStackActions.test_requeue_capped_first_time_escalates_to_agent` — real fail-before/pass-after: fails against the pre-fix `plan_bottom_progress` (`comment_blocked` returned instead of `escalate_requeue_stuck`), passes after.
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan.PlanStackActions.test_requeue_capped_after_escalation_falls_back_to_comment` — proves the fallback path once already escalated.
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan.PlanStackActions.test_requeue_escalation_only_fires_once_per_head` — proves idempotency: replanning the same escalated state never dispatches a second agent task.
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue.MergifyAdminRequeueTests.test_requeue_same_dequeue_event_hits_cap_and_escalates_to_agent` and `.test_requeue_cap_falls_back_to_comment_once_already_escalated` — same coverage against the sibling top-level test file's own copy of this cap path.
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_async_repair.AsyncRepairPlanTests.test_requeue_stuck_plan_yaml_is_accepted_by_invokers_real_plan_validator` — stronger than the tests above: no `submit_async_repair_plan` mocking at all. Calls the real, unmocked `build_requeue_stuck_plan()`, writes its real YAML output to a temp file, then shells out to Invoker's actual standalone plan validator (`skills/plan-to-invoker/scripts/validate-plan.sh`, the same binary a human runs by hand) as a real subprocess. Real fail-before/pass-after: checked out against pre-PR master (`e7444cde6b`), `build_requeue_stuck_plan` doesn't exist yet and the test errors with `AttributeError: module 'scripts.mergify_admin_requeue_async_repair' has no attribute 'build_requeue_stuck_plan'`; on this PR's branch it passes. One pre-existing, unrelated `non_portable_pipefail` validator finding on the shared `safe-push` task helper (confirmed present on the already-shipped `build_repair_check_plan` too, not introduced by this PR) is explicitly excluded — anything else would fail the test.
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_async_repair` (full suite, run from repo root) — 221/221 pass, no regressions.
- [x] `node scripts/check-added-comments.mjs` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — new ledger rows (`requeue-escalation`, `requeue-escalation-pending`, etc.) are additive; reverting just stops writing/reading them.

</details>

