### PR TITLE
(3) fix(INV-XXX): make syncFromDb workflow-scoped to avoid reload loop

### DIFF
--- a/packages/app/src/__tests__/scheduler-domain-double-refresh-cost.test.ts
+++ b/packages/app/src/__tests__/scheduler-domain-double-refresh-cost.test.ts
@@ -18,19 +18,17 @@ import type { TaskState } from '@invoker/workflow-core';
  * already keeps the in-memory graph current). retryTask() and
  * startExecution() both go through this path on every dispatch.
  *
- * On this baseline (plain master; PR #11431's workflow-scoped
- * refreshWorkflowFromDb for retryTaskImpl's own initial refresh is not yet
- * merged), retryTaskImpl still makes one additional full refreshFromDb
- * call of its own before reaching autoStartReadyTasks, so the expected
- * count here is 2 (down from 3), not 1 (down from 2). Once #11431 lands,
- * that first call becomes workflow-scoped and stops going through
- * loadTasksForWorkflows, and this count should drop to 1.
+ * With syncFromDb(workflowId) now scoped to a single workflow (instead of
+ * clearing and reloading ALL active workflows), retryTaskImpl's initial
+ * refresh uses the per-workflow loadTasks path instead of the batched
+ * loadTasksForWorkflows, so the batchLoadCalls count is now 1 (the single
+ * call inside autoStartReadyTasks).
  */
 
 const SMALL_WORKFLOW_COUNT = 686;
 const BIG_WORKFLOW_TASK_COUNT = 828;
 
-describe('autoStartReadyTasks pays a full refreshFromDb twice per dispatch', () => {
+describe('autoStartReadyTasks pays one full refreshFromDb per dispatch', () => {
   let dbDir: string | undefined;
 
   afterEach(() => {
@@ -39,7 +37,7 @@ describe('autoStartReadyTasks pays a full refreshFromDb twice per dispatch', () 
   });
 
   it(
-    'refreshFromDb is called twice (not three times) per retryTask dispatch',
+    'refreshFromDb is called once per retryTask dispatch (syncFromDb is now workflow-scoped)',
     async () => {
       dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-double-refresh-'));
       const dbPath = path.join(dbDir, 'invoker.db');
@@ -132,7 +130,7 @@ describe('autoStartReadyTasks pays a full refreshFromDb twice per dispatch', () 
             + `full-batch refreshFromDb calls during dispatch: ${batchLoadCalls}`,
         );
 
-        expect(batchLoadCalls).toBe(2);
+        expect(batchLoadCalls).toBe(1);
       } finally {
         bootAdapter.close();
       }

--- a/packages/app/src/__tests__/task-reload-loop-proof.test.ts
+++ b/packages/app/src/__tests__/task-reload-loop-proof.test.ts
@@ -1,0 +1,387 @@
+/**
+ * INV-XXX: Proof that LaunchDispatcher.poll triggers O(workflows) full task
+ * reloads during dispatch, not O(1) per-workflow loads.
+ *
+ * The bug: `syncFromDb(workflowId)` in `resolveTaskForDispatch` clears the
+ * entire state machine and reloads ALL active workflows, not just the target
+ * workflow. Combined with `refreshFromDb()` in `startExecution()`, this causes
+ * 743× full-table task loads (2702 rows each) on a 900-workflow DB — the
+ * same SQL pattern that blocked HTTP bind in the DO1 incident.
+ *
+ * This test proves the loop exists by counting `loadTasksForWorkflows` calls
+ * (the batched full-reload) and `loadTasks` calls (per-workflow fallback)
+ * during a single dispatcher poll cycle with running tasks that need dispatch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+const WORKFLOW_COUNT = 50;
+const TASKS_PER_WORKFLOW = 3;
+
+describe('task reload loop during LaunchDispatcher poll', () => {
+  let dbDir: string | undefined;
+
+  beforeEach(() => {
+    dbDir = undefined;
+  });
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('syncFromDb(workflowId) reloads only that workflow, not all workflows', async () => {
+    dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-syncfromdb-reload-'));
+    const dbPath = path.join(dbDir, 'invoker.db');
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+
+    try {
+      for (let i = 0; i < WORKFLOW_COUNT; i++) {
+        const wfId = `wf-${i}`;
+        const nowIso = new Date().toISOString();
+        adapter.saveWorkflow({
+          id: wfId,
+          name: wfId,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any);
+
+        const createdAt = new Date();
+        for (let j = 0; j < TASKS_PER_WORKFLOW; j++) {
+          adapter.saveTask(wfId, {
+            id: `${wfId}/task-${j}`,
+            description: `task ${j}`,
+            status: j === 0 ? 'completed' : 'pending',
+            dependencies: j === 0 ? [] : [`${wfId}/task-${j - 1}`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: j === 0 ? { exitCode: 0 } : {},
+          } as TaskState);
+        }
+      }
+
+      const orchestrator = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      orchestrator.syncAllFromDb();
+
+      let loadTasksCalls = 0;
+      let totalTasksLoaded = 0;
+      const realLoadTasks = adapter.loadTasks.bind(adapter);
+      (adapter as any).loadTasks = (workflowId: string) => {
+        loadTasksCalls += 1;
+        const tasks = realLoadTasks(workflowId);
+        totalTasksLoaded += tasks.length;
+        return tasks;
+      };
+
+      orchestrator.syncFromDb('wf-0');
+
+      expect(
+        loadTasksCalls,
+        `syncFromDb('wf-0') should reload only 1 workflow, not all ${WORKFLOW_COUNT}`,
+      ).toBe(1);
+      expect(
+        totalTasksLoaded,
+        `Should load only wf-0's ${TASKS_PER_WORKFLOW} tasks`,
+      ).toBe(TASKS_PER_WORKFLOW);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('PROOF: refreshFromDb reloads ALL workflows on every startExecution call', async () => {
+    dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-refreshfromdb-loop-'));
+    const dbPath = path.join(dbDir, 'invoker.db');
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+
+    try {
+      for (let i = 0; i < WORKFLOW_COUNT; i++) {
+        const wfId = `wf-${i}`;
+        const nowIso = new Date().toISOString();
+        adapter.saveWorkflow({
+          id: wfId,
+          name: wfId,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any);
+
+        const createdAt = new Date();
+        adapter.saveTask(wfId, {
+          id: `${wfId}/root`,
+          description: 'root',
+          status: 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: { exitCode: 0 },
+        } as TaskState);
+
+        adapter.saveTask(wfId, {
+          id: `${wfId}/pending`,
+          description: 'pending work',
+          status: 'pending',
+          dependencies: [`${wfId}/root`],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: {},
+        } as TaskState);
+      }
+
+      const orchestrator = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      orchestrator.syncAllFromDb();
+
+      let loadTasksForWorkflowsCalls = 0;
+      let totalTasksLoaded = 0;
+      const realLoadTasksForWorkflows = adapter.loadTasksForWorkflows.bind(adapter);
+      (adapter as any).loadTasksForWorkflows = (workflowIds: string[]) => {
+        loadTasksForWorkflowsCalls += 1;
+        const tasks = realLoadTasksForWorkflows(workflowIds);
+        totalTasksLoaded += tasks.length;
+        return tasks;
+      };
+
+      const START_EXECUTION_CALLS = 5;
+      for (let i = 0; i < START_EXECUTION_CALLS; i++) {
+        orchestrator.startExecution({ limit: 32 });
+      }
+
+      expect(
+        loadTasksForWorkflowsCalls,
+        `PROOF: ${START_EXECUTION_CALLS} startExecution calls triggered ${loadTasksForWorkflowsCalls} full-table reloads (should be at most ${START_EXECUTION_CALLS}, but refreshFromDb is called multiple times per startExecution)`,
+      ).toBeGreaterThanOrEqual(START_EXECUTION_CALLS);
+
+      expect(
+        totalTasksLoaded,
+        `Total tasks loaded across all refreshFromDb calls: ${totalTasksLoaded} (${WORKFLOW_COUNT * 2} tasks × ${loadTasksForWorkflowsCalls} reloads)`,
+      ).toBe(loadTasksForWorkflowsCalls * WORKFLOW_COUNT * 2);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('PROOF: dispatcher poll triggers multiple full reloads via refreshFromDb', async () => {
+    dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-dispatch-reload-'));
+    const dbPath = path.join(dbDir, 'invoker.db');
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+
+    try {
+      for (let i = 0; i < WORKFLOW_COUNT; i++) {
+        const wfId = `wf-${i}`;
+        const nowIso = new Date().toISOString();
+        adapter.saveWorkflow({
+          id: wfId,
+          name: wfId,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any);
+
+        const createdAt = new Date();
+        adapter.saveTask(wfId, {
+          id: `${wfId}/root`,
+          description: 'root',
+          status: 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: { exitCode: 0 },
+        } as TaskState);
+
+        adapter.saveTask(wfId, {
+          id: `${wfId}/work`,
+          description: 'work',
+          status: 'pending',
+          dependencies: [`${wfId}/root`],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: {},
+        } as TaskState);
+      }
+
+      const orchestrator = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      orchestrator.syncAllFromDb();
+
+      let loadTasksForWorkflowsCalls = 0;
+      let totalWorkflowsLoaded = 0;
+      const realLoadTasksForWorkflows = adapter.loadTasksForWorkflows.bind(adapter);
+      (adapter as any).loadTasksForWorkflows = (workflowIds: string[]) => {
+        loadTasksForWorkflowsCalls += 1;
+        totalWorkflowsLoaded += workflowIds.length;
+        return realLoadTasksForWorkflows(workflowIds);
+      };
+
+      const launchDispatcher = new LaunchDispatcher({
+        persistence: adapter as any,
+        orchestrator: orchestrator as any,
+        ownerId: 'test-owner',
+        taskRunnerProvider: () => ({
+          executeTask: async () => {},
+        }),
+        maxLeasesPerPoll: 10,
+      });
+
+      launchDispatcher.poll();
+
+      expect(
+        loadTasksForWorkflowsCalls,
+        `PROOF: single dispatcher poll triggered ${loadTasksForWorkflowsCalls} loadTasksForWorkflows calls (full-table reloads via refreshFromDb)`,
+      ).toBeGreaterThan(1);
+
+      expect(
+        totalWorkflowsLoaded,
+        `PROOF: total workflows loaded: ${totalWorkflowsLoaded} = ${loadTasksForWorkflowsCalls} calls × ${WORKFLOW_COUNT} workflows each`,
+      ).toBe(loadTasksForWorkflowsCalls * WORKFLOW_COUNT);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('PROOF: combined loop count during boot + first poll matches observed pattern', async () => {
+    dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-combined-loop-'));
+    const dbPath = path.join(dbDir, 'invoker.db');
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+
+    try {
+      const runningTasks: string[] = [];
+
+      for (let i = 0; i < WORKFLOW_COUNT; i++) {
+        const wfId = `wf-${i}`;
+        const nowIso = new Date().toISOString();
+        adapter.saveWorkflow({
+          id: wfId,
+          name: wfId,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any);
+
+        const createdAt = new Date();
+        adapter.saveTask(wfId, {
+          id: `${wfId}/root`,
+          description: 'root',
+          status: 'completed',
+          dependencies: [],
+          createdAt,
+          config: { workflowId: wfId },
+          execution: { exitCode: 0 },
+        } as TaskState);
+
+        if (i < WORKFLOW_COUNT / 2) {
+          const taskId = `${wfId}/running`;
+          adapter.saveTask(wfId, {
+            id: taskId,
+            description: 'running work',
+            status: 'running',
+            dependencies: [`${wfId}/root`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: { startedAt: createdAt },
+          } as TaskState);
+          runningTasks.push(taskId);
+        } else {
+          adapter.saveTask(wfId, {
+            id: `${wfId}/pending`,
+            description: 'pending work',
+            status: 'pending',
+            dependencies: [`${wfId}/root`],
+            createdAt,
+            config: { workflowId: wfId },
+            execution: {},
+          } as TaskState);
+        }
+      }
+
+      let totalLoadTasksCalls = 0;
+      let totalLoadTasksForWorkflowsCalls = 0;
+
+      const realLoadTasks = adapter.loadTasks.bind(adapter);
+      (adapter as any).loadTasks = (workflowId: string) => {
+        totalLoadTasksCalls += 1;
+        return realLoadTasks(workflowId);
+      };
+
+      const realLoadTasksForWorkflows = adapter.loadTasksForWorkflows.bind(adapter);
+      (adapter as any).loadTasksForWorkflows = (workflowIds: string[]) => {
+        totalLoadTasksForWorkflowsCalls += 1;
+        return realLoadTasksForWorkflows(workflowIds);
+      };
+
+      const orchestrator = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 200,
+      });
+
+      orchestrator.syncAllFromDb();
+
+      const launchDispatcher = new LaunchDispatcher({
+        persistence: adapter as any,
+        orchestrator: orchestrator as any,
+        ownerId: 'test-owner',
+        taskRunnerProvider: () => ({
+          executeTask: async () => {},
+        }),
+        maxLeasesPerPoll: 32,
+      });
+
+      const POLL_TICKS = 10;
+      for (let tick = 0; tick < POLL_TICKS; tick++) {
+        launchDispatcher.poll();
+      }
+
+      const totalFullReloads = totalLoadTasksForWorkflowsCalls + Math.floor(totalLoadTasksCalls / WORKFLOW_COUNT);
+
+      expect(
+        totalFullReloads,
+        `PROOF: ${POLL_TICKS} dispatcher polls triggered ${totalFullReloads} full-table reloads (via refreshFromDb/syncFromDb). ` +
+        `loadTasksForWorkflows: ${totalLoadTasksForWorkflowsCalls}, loadTasks: ${totalLoadTasksCalls}`,
+      ).toBeGreaterThan(POLL_TICKS);
+
+      console.log(`
+================================================================================
+TASK RELOAD LOOP PROOF SUMMARY
+================================================================================
+Workflows: ${WORKFLOW_COUNT}
+Tasks per workflow: 2 (1 completed root + 1 running/pending)
+Running tasks (keep dispatcher polling): ${runningTasks.length}
+Dispatcher poll ticks: ${POLL_TICKS}
+
+OBSERVED:
+- loadTasksForWorkflows (batched full reload): ${totalLoadTasksForWorkflowsCalls} calls
+- loadTasks (per-workflow): ${totalLoadTasksCalls} calls
+- Estimated full-table reloads: ${totalFullReloads}
+
+EXPECTED AFTER FIX:
+- Full reloads during boot: 1 (syncAllFromDb)
+- Full reloads during dispatch: 0 (syncFromDb should be workflow-scoped)
+- Per-dispatch workflow loads: proportional to dispatched tasks, not all workflows
+================================================================================
+`);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3051,18 +3051,14 @@ export class Orchestrator {
   }
 
   /**
-   * Load tasks from a single workflow. Kept for backward compatibility
-   * (e.g. resuming a specific workflow).
+   * Load tasks from a single workflow incrementally. Does NOT clear the
+   * entire state machine - only reloads the target workflow's tasks into
+   * the existing graph. This avoids the O(workflows) full reload that
+   * caused the DO1 incident (743× full-table task loads during dispatcher
+   * poll with 900 active workflows).
    */
   syncFromDb(workflowId: string): void {
-    this.activeWorkflowIds.add(workflowId);
-    this.stateMachine.clear();
-    for (const wfId of this.activeWorkflowIds) {
-      const tasks = this.persistence.loadTasks(wfId);
-      for (const task of tasks) {
-        this.stateMachine.restoreTask(task);
-      }
-    }
+    this.refreshWorkflowFromDb(workflowId);
     this.assertMergeLeavesInvariant(workflowId);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`syncFromDb(workflowId)` was clearing the entire state machine and reloading ALL active workflows instead of just the target workflow. This caused O(workflows) full-table task loads during LaunchDispatcher dispatch.

The DO1 incident showed 743× full-table task loads (2702 rows each) on a 900-workflow DB. The root cause: `syncFromDb(workflowId)` called `this.stateMachine.clear()` then iterated over ALL active workflows, not just the target.

The fix delegates to `refreshWorkflowFromDb`, which incrementally hydrates just the target workflow into the existing graph. Before this fix, `syncFromDb('wf-0')` with 50 active workflows triggered 50 loadTasks calls. After, it triggers 1.

## Review Claim

Reviewer is asked to approve that `syncFromDb(workflowId)` now loads only the specified workflow, not all active workflows.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The fix uses `refreshWorkflowFromDb`, which is already used by `hydrateWorkflowFromDb` and `forkWorkflow`. The change is additive to the in-memory graph (adds/updates workflow's tasks) rather than full-clear-and-reload, preserving existing behavior while avoiding the N+1 reload.

## Slice Rationale

This is a targeted fix for the task reload loop. The proof test (first commit) demonstrates the bug exists. The fix (second commit) addresses just `syncFromDb` without touching `refreshFromDb` which has broader usage patterns.

## Non-goals

- Does not change `refreshFromDb()` which is called on every mutation. That is a separate fix.
- Does not add async/yielding to allow HTTP bind during startup. PR #11443/#11444 address that.
- behavior unchanged: `syncFromDb(workflowId)` still adds the workflow to `activeWorkflowIds`, still hydrates its tasks, still asserts merge-leaves invariant.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- task-reload-loop-proof.test.ts` - proves syncFromDb now loads only 1 workflow
- [x] `cd packages/app && pnpm test -- scheduler-domain-double-refresh-cost.test.ts` - confirms batchLoadCalls reduced from 2 to 1
- [x] `cd packages/workflow-core && pnpm test -- orchestrator` - all 979 orchestrator tests pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3129ceb7-2adc-4eac-960d-abf7f826c6ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3129ceb7-2adc-4eac-960d-abf7f826c6ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

