### PR TITLE
[E2e Needs-Human Babysit](1) Consume a needs-human finding in admin-bypass-e2e-babysit

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -18,6 +18,17 @@ test('workers surface shows db-reaper registered', async ({ page }) => {
   await captureScreenshot(page, 'workers-db-reaper-registered');
 });
 
+test('workers surface shows admin-bypass-e2e-babysit registered', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+  await expect(page.getByTestId('worker-process-list')).toBeVisible();
+  await expect(page.getByTestId('worker-row-admin-bypass-e2e-babysit')).toBeVisible();
+
+  await page.getByTestId('worker-row-admin-bypass-e2e-babysit').click();
+  await expect(page.getByTestId('worker-detail-start-stop')).toBeVisible();
+
+  await captureScreenshot(page, 'workers-admin-bypass-e2e-babysit-registered');
+});
+
 test('workers surface shows the worker control in the details panel', async ({ page }) => {
   await page.getByTestId('sidebar-workers').click();
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2153,6 +2153,7 @@ function startHeadlessMode(): void {
                 deleteRepairFiling: (kind, subject, stateSha) => (
                   persistence.deleteRepairFiling(kind, subject, stateSha)
                 ),
+                insertRepairFiling: (input) => persistence.insertRepairFiling(input),
               },
               investigativePlanSubmitter: {
                 submitPlan: (planText) => {
@@ -3433,6 +3434,7 @@ startMainProcessBootstrap({
               deleteRepairFiling: (kind, subject, stateSha) => (
                 persistence.deleteRepairFiling(kind, subject, stateSha)
               ),
+              insertRepairFiling: (input) => persistence.insertRepairFiling(input),
             },
             investigativePlanSubmitter: {
               submitPlan: (planText) => {

--- a/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   DEFAULT_WATCHED_WORKER_KINDS,
+  E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX,
+  E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX,
   REPAIR_FILING_STALE_TTL_MS,
   runAdminBypassE2eBabysitTick,
   type AdminBypassE2eBabysitWorkerOptions,
   type InvestigativePlanSubmitter,
+  type RepairFilingInsertResult,
   type RepairFilingRow,
   type RepairFilingStore,
   type WorkerLifecycleReader,
@@ -30,11 +33,18 @@ class FakeWorkerLifecycle implements WorkerLifecycleReader, WorkerLifecycleStart
 
 class FakeRepairFilingStore implements RepairFilingStore {
   readonly deleteCalls: Array<[kind: string, subject: string, stateSha: string]> = [];
+  readonly insertCalls: Array<{ kind: string; subject: string; stateSha: string }> = [];
+  private readonly claimedKeys = new Set<string>();
+  private rows: RepairFilingRow[];
 
   constructor(
-    private readonly rows: readonly RepairFilingRow[],
+    rows: readonly RepairFilingRow[],
     private readonly deleteError?: Error,
-  ) {}
+    private readonly insertError?: Error,
+  ) {
+    this.rows = [...rows];
+    for (const row of rows) this.claimedKeys.add(`${row.kind}:${row.subject}:${row.stateSha}`);
+  }
 
   listRepairFilings(): readonly RepairFilingRow[] {
     return this.rows;
@@ -43,6 +53,16 @@ class FakeRepairFilingStore implements RepairFilingStore {
   deleteRepairFiling(kind: string, subject: string, stateSha: string): void {
     this.deleteCalls.push([kind, subject, stateSha]);
     if (this.deleteError) throw this.deleteError;
+  }
+
+  insertRepairFiling(input: { kind: string; subject: string; stateSha: string }): RepairFilingInsertResult {
+    this.insertCalls.push(input);
+    if (this.insertError) throw this.insertError;
+    const key = `${input.kind}:${input.subject}:${input.stateSha}`;
+    if (this.claimedKeys.has(key)) return { inserted: false };
+    this.claimedKeys.add(key);
+    this.rows = [...this.rows, { ...input, createdAt: new Date().toISOString() }];
+    return { inserted: true };
   }
 }
 
@@ -182,5 +202,92 @@ describe('runAdminBypassE2eBabysitTick', () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(rows).toContainEqual({ subjectId: 'admin-requeue:rebase-conflict:11219:sha-stale', status: 'failed' });
+  });
+
+  it('files one investigation for a fresh e2e-regression needs-human finding and claims the investigated marker', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped',
+      createdAt: new Date().toISOString(),
+    };
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(repairFilings.insertCalls).toEqual([{
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: needsHumanRow.subject,
+      stateSha: needsHumanRow.stateSha,
+    }]);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(planSubmitter.submittedPlans[0]).toContain(needsHumanRow.kind);
+    expect(planSubmitter.submittedPlans[0]).toContain(needsHumanRow.stateSha);
+    expect(planSubmitter.submittedPlans[0]).toContain('needsHuman');
+  });
+
+  it('does not re-file an investigation for a needs-human finding already marked investigated', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped',
+      createdAt: new Date().toISOString(),
+    };
+    const investigatedRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: needsHumanRow.subject,
+      stateSha: needsHumanRow.stateSha,
+      createdAt: new Date().toISOString(),
+    };
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow, investigatedRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(repairFilings.insertCalls).toEqual([]);
+    expect(planSubmitter.submittedPlans).toHaveLength(0);
+  });
+
+  it('logs and records a failed needs-human claim without throwing or filing a duplicate later', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}flaky-job:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped-2',
+      createdAt: new Date().toISOString(),
+    };
+    const logger = makeLogger();
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow], undefined, new Error('insert failed'));
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store, rows } = makeDecisionStore();
+
+    await expect(runAdminBypassE2eBabysitTick({
+      logger,
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(planSubmitter.submittedPlans).toHaveLength(0);
+    expect(rows).toContainEqual({
+      subjectId: `${needsHumanRow.kind}:${needsHumanRow.subject}:${needsHumanRow.stateSha}`,
+      status: 'failed',
+    });
   });
 });

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -15,6 +15,20 @@ export const DEFAULT_WATCHED_WORKER_KINDS = [
   'claude-oauth-refresh',
 ] as const;
 
+/**
+ * Prefix for repair_filings rows scripts/e2e-regression-watch.mjs inserts
+ * (via claimNeedsHumanRepairFiling) when a failure exhausts its automated
+ * fix-attempt retry budget. Matches needsHumanRepairFilingKind() there.
+ */
+export const E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX = 'ci-regression-needs-human:';
+
+/**
+ * Prefix for the companion claim this worker inserts once it has filed an
+ * investigation for a given needs-human row, so a later tick does not
+ * re-file for the same (subject, stateSha) every cycle.
+ */
+export const E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX = 'ci-regression-needs-human-investigated:';
+
 const DEFAULT_INTERVAL_MS = 10 * 60_000;
 
 export interface WorkerLifecycleSnapshot {
@@ -38,9 +52,18 @@ export interface RepairFilingRow {
   readonly createdAt: string;
 }
 
+export interface RepairFilingInsertResult {
+  readonly inserted: boolean;
+}
+
 export interface RepairFilingStore {
   listRepairFilings(): readonly RepairFilingRow[] | Promise<readonly RepairFilingRow[]>;
   deleteRepairFiling(kind: string, subject: string, stateSha: string): unknown;
+  insertRepairFiling(input: {
+    kind: string;
+    subject: string;
+    stateSha: string;
+  }): RepairFilingInsertResult | Promise<RepairFilingInsertResult>;
 }
 
 export interface InvestigativePlanSubmitter {
@@ -81,6 +104,12 @@ export type AdminBypassE2eBabysitAction =
       readonly subject: string;
       readonly stateSha: string;
       readonly createdAt: string;
+    }
+  | {
+      readonly type: 'e2e-regression-needs-human';
+      readonly kind: string;
+      readonly subject: string;
+      readonly stateSha: string;
     };
 
 function yamlString(value: string): string {
@@ -96,13 +125,24 @@ function investigativePrompt(action: AdminBypassE2eBabysitAction): string {
       + 'and what would durably prevent recurrence. Support conclusions with evidence and propose a concrete prevention.'
     );
   }
+  if (action.type === 'repair-filing-delete') {
+    return (
+      'Assume zero prior context. Investigate a production repair-filings finding: '
+      + `the admin-bypass-e2e-babysit worker attempted to delete a stale repair_filings row with kind `
+      + `${JSON.stringify(action.kind)}, subject ${JSON.stringify(action.subject)}, stateSha `
+      + `${JSON.stringify(action.stateSha)}, and createdAt ${JSON.stringify(action.createdAt)}. `
+      + 'Determine what caused the claim to remain stale and what would durably prevent recurrence. '
+      + 'Support conclusions with evidence and propose a concrete prevention.'
+    );
+  }
   return (
-    'Assume zero prior context. Investigate a production repair-filings finding: '
-    + `the admin-bypass-e2e-babysit worker attempted to delete a stale repair_filings row with kind `
-    + `${JSON.stringify(action.kind)}, subject ${JSON.stringify(action.subject)}, stateSha `
-    + `${JSON.stringify(action.stateSha)}, and createdAt ${JSON.stringify(action.createdAt)}. `
-    + 'Determine what caused the claim to remain stale and what would durably prevent recurrence. '
-    + 'Support conclusions with evidence and propose a concrete prevention.'
+    'Assume zero prior context. Investigate a production e2e-regression-watch finding: '
+    + `scripts/e2e-regression-watch.mjs exhausted its automated fix-attempt retry budget and marked a `
+    + `failure needsHuman -- repair_filings kind ${JSON.stringify(action.kind)}, subject `
+    + `${JSON.stringify(action.subject)}, first-bad stateSha ${JSON.stringify(action.stateSha)}. `
+    + 'Determine why the automated fix attempts did not land (read the actual CI job log and any repair '
+    + 'PR history for this failure) and propose a concrete fix or escalation. '
+    + 'Support conclusions with evidence.'
   );
 }
 
@@ -245,6 +285,69 @@ export async function runAdminBypassE2eBabysitTick(
         payload: { ...row, staleTtlMs, error: detail },
       });
     }
+  }
+
+  const needsHumanRows = repairFilings.filter((row) => row.kind.startsWith(E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX));
+  const alreadyInvestigatedKeys = new Set(
+    repairFilings
+      .filter((row) => row.kind.startsWith(E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX))
+      .map((row) => `${row.subject}:${row.stateSha}`),
+  );
+  for (const row of needsHumanRows) {
+    const dedupeKey = `${row.subject}:${row.stateSha}`;
+    if (alreadyInvestigatedKeys.has(dedupeKey)) continue;
+
+    const investigatedKind = E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX
+      + row.kind.slice(E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX.length);
+    const subjectId = `${row.kind}:${row.subject}:${row.stateSha}`;
+    let claim: RepairFilingInsertResult;
+    try {
+      claim = await options.repairFilings.insertRepairFiling({
+        kind: investigatedKind,
+        subject: row.subject,
+        stateSha: row.stateSha,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(
+        `[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] failed to claim e2e-regression needs-human finding ${subjectId}: ${detail}`,
+        { module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND, kind: row.kind, subject: row.subject, stateSha: row.stateSha },
+      );
+      recordDecision(options.store, {
+        actionType: 'e2e-regression-needs-human',
+        externalKey: `repair-filing:${subjectId}`,
+        subjectType: 'repair-filing',
+        subjectId,
+        status: 'failed',
+        summary: `Failed to claim e2e-regression needs-human finding ${subjectId}: ${detail}`,
+        payload: { ...row, error: detail },
+      });
+      continue;
+    }
+    // Another concurrent tick already claimed and is filing this one.
+    if (!claim.inserted) continue;
+
+    actions.push({
+      type: 'e2e-regression-needs-human',
+      kind: row.kind,
+      subject: row.subject,
+      stateSha: row.stateSha,
+    });
+    options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] filing investigation for e2e-regression needs-human finding`, {
+      module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+      kind: row.kind,
+      subject: row.subject,
+      stateSha: row.stateSha,
+    });
+    recordDecision(options.store, {
+      actionType: 'e2e-regression-needs-human',
+      externalKey: `repair-filing:${subjectId}`,
+      subjectType: 'repair-filing',
+      subjectId,
+      status: 'completed',
+      summary: `Filed investigation for e2e-regression needs-human finding ${subjectId}`,
+      payload: { ...row },
+    });
   }
 
   if (actions.length === 0) return;


### PR DESCRIPTION
## Summary

Today, when scripts/e2e-regression-watch.mjs marks a broken e2e test needsHuman (it has run out of automated fix attempts), that finding just gets logged and nothing else happens.

This slice teaches admin-bypass-e2e-babysit to react to that finding once one exists. It is dormant alone: nothing writes the marker row it reads until PR #11450 ships.

## Review Claim

Approve extending admin-bypass-e2e-babysit-worker.ts's repair_filings sweep with a new branch that files exactly one investigation per fresh `ci-regression-needs-human:*` row, claiming a companion `ci-regression-needs-human-investigated:*` marker so a later tick never re-files for the same (subject, stateSha).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new branch only reads/writes repair_filings rows under the two new kind prefixes (E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX / _INVESTIGATED_KIND_PREFIX); it never touches the existing worker-lifecycle or stale-deletion branches, and claims the investigated marker via the same ON CONFLICT DO NOTHING insertRepairFiling primitive already used elsewhere in this file, so a claim race between two ticks can't double-file. With no producer wired up yet (that's PR #11450), listRepairFilings() never returns a row matching the new prefix in production, so this PR ships no observable behavior change on its own.

## Slice Rationale

scripts/e2e-regression-watch.mjs (the producer) and packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts (the consumer) fall under different review units per scripts/review-unit-rules.mjs (tooling-policy vs routing) — the repo's validator forbids a PR whose changed files span both. This PR ships the consumer half first because it is safe to merge standalone (dormant without a producer); PR #11450 activates the behavior end-to-end.

## Non-goals

Does not change scripts/e2e-regression-watch.mjs or wire up the actual producer of `ci-regression-needs-human:*` rows — that is PR #11450, stacked on top of this one. Does not change the existing worker-start or stale-repair-filing-delete branches of the tick.

## Visual Proof

![Admin-bypass/e2e babysit worker card in the Workers panel, detail view open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-a478ad/admin-bypass-e2e-babysit-worker-card-after.png)

Manually inspected: opened the captured screenshot myself. It shows the Workers panel with the "Admin-bypass/e2e babysit" card selected and its detail panel open on the right — Kind `admin-bypass-e2e-babysit`, Note "Restarts desired-enabled watched workers and expires stale repair-filing claims, then files investigations.", State `Stopped`. This PR's own change (the new needs-human branch inside the tick, plus the `insertRepairFiling` wiring in main.ts) has no separate visible surface of its own — it doesn't touch this worker's registration or note text. This screenshot proves the app still builds and boots with the new dependency wired, and the existing worker card renders unchanged, the same pattern PR #11394 used for an equivalent main.ts dependency-wiring change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/admin-bypass-e2e-babysit-worker.test.ts` — 7/7 pass, including the 3 new tests: files one investigation for a fresh needs-human finding, does not re-file once already investigated, and logs+records (without throwing) a failed claim.
- [x] `pnpm --filter @invoker/execution-engine test` (full package) — 146 test files / 1817 tests passed, 1 skipped, exit 0.
- [x] `pnpm --filter @invoker/execution-engine build` — exit 0.
- [x] `pnpm --filter @invoker/app build` — exit 0 (verifies the new `insertRepairFiling` wiring in both main.ts owner-worker-deps call sites typechecks).
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/workers-surface.spec.ts -g "admin-bypass-e2e-babysit registered"` — 1/1 passed (24.1s), real Electron app boot capturing the screenshot above.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the new repair_filings kind prefixes are additive; reverting just stops the worker from reading rows under them.
- Data migration? No

</details>
