### PR TITLE
[E2e Needs-Human Babysit](2) Claim a repair-filing when e2e-regression-watch marks needsHuman

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2153,6 +2153,7 @@ function startHeadlessMode(): void {
                 deleteRepairFiling: (kind, subject, stateSha) => (
                   persistence.deleteRepairFiling(kind, subject, stateSha)
                 ),
+                insertRepairFiling: (input) => persistence.insertRepairFiling(input),
               },
               investigativePlanSubmitter: {
                 submitPlan: (planText) => {
@@ -3433,6 +3434,7 @@ startMainProcessBootstrap({
               deleteRepairFiling: (kind, subject, stateSha) => (
                 persistence.deleteRepairFiling(kind, subject, stateSha)
               ),
+              insertRepairFiling: (input) => persistence.insertRepairFiling(input),
             },
             investigativePlanSubmitter: {
               submitPlan: (planText) => {

--- a/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   DEFAULT_WATCHED_WORKER_KINDS,
+  E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX,
+  E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX,
   REPAIR_FILING_STALE_TTL_MS,
   runAdminBypassE2eBabysitTick,
   type AdminBypassE2eBabysitWorkerOptions,
   type InvestigativePlanSubmitter,
+  type RepairFilingInsertResult,
   type RepairFilingRow,
   type RepairFilingStore,
   type WorkerLifecycleReader,
@@ -30,11 +33,18 @@ class FakeWorkerLifecycle implements WorkerLifecycleReader, WorkerLifecycleStart
 
 class FakeRepairFilingStore implements RepairFilingStore {
   readonly deleteCalls: Array<[kind: string, subject: string, stateSha: string]> = [];
+  readonly insertCalls: Array<{ kind: string; subject: string; stateSha: string }> = [];
+  private readonly claimedKeys = new Set<string>();
+  private rows: RepairFilingRow[];
 
   constructor(
-    private readonly rows: readonly RepairFilingRow[],
+    rows: readonly RepairFilingRow[],
     private readonly deleteError?: Error,
-  ) {}
+    private readonly insertError?: Error,
+  ) {
+    this.rows = [...rows];
+    for (const row of rows) this.claimedKeys.add(`${row.kind}:${row.subject}:${row.stateSha}`);
+  }
 
   listRepairFilings(): readonly RepairFilingRow[] {
     return this.rows;
@@ -43,6 +53,16 @@ class FakeRepairFilingStore implements RepairFilingStore {
   deleteRepairFiling(kind: string, subject: string, stateSha: string): void {
     this.deleteCalls.push([kind, subject, stateSha]);
     if (this.deleteError) throw this.deleteError;
+  }
+
+  insertRepairFiling(input: { kind: string; subject: string; stateSha: string }): RepairFilingInsertResult {
+    this.insertCalls.push(input);
+    if (this.insertError) throw this.insertError;
+    const key = `${input.kind}:${input.subject}:${input.stateSha}`;
+    if (this.claimedKeys.has(key)) return { inserted: false };
+    this.claimedKeys.add(key);
+    this.rows = [...this.rows, { ...input, createdAt: new Date().toISOString() }];
+    return { inserted: true };
   }
 }
 
@@ -182,5 +202,92 @@ describe('runAdminBypassE2eBabysitTick', () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(rows).toContainEqual({ subjectId: 'admin-requeue:rebase-conflict:11219:sha-stale', status: 'failed' });
+  });
+
+  it('files one investigation for a fresh e2e-regression needs-human finding and claims the investigated marker', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped',
+      createdAt: new Date().toISOString(),
+    };
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(repairFilings.insertCalls).toEqual([{
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: needsHumanRow.subject,
+      stateSha: needsHumanRow.stateSha,
+    }]);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(planSubmitter.submittedPlans[0]).toContain(needsHumanRow.kind);
+    expect(planSubmitter.submittedPlans[0]).toContain(needsHumanRow.stateSha);
+    expect(planSubmitter.submittedPlans[0]).toContain('needsHuman');
+  });
+
+  it('does not re-file an investigation for a needs-human finding already marked investigated', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped',
+      createdAt: new Date().toISOString(),
+    };
+    const investigatedRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX}playwright-5-of-9:job-level`,
+      subject: needsHumanRow.subject,
+      stateSha: needsHumanRow.stateSha,
+      createdAt: new Date().toISOString(),
+    };
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow, investigatedRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+
+    await runAdminBypassE2eBabysitTick({
+      logger: makeLogger(),
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    });
+
+    expect(repairFilings.insertCalls).toEqual([]);
+    expect(planSubmitter.submittedPlans).toHaveLength(0);
+  });
+
+  it('logs and records a failed needs-human claim without throwing or filing a duplicate later', async () => {
+    const needsHumanRow: RepairFilingRow = {
+      kind: `${E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX}flaky-job:job-level`,
+      subject: 'Neko-Catpital-Labs/Invoker',
+      stateSha: 'sha-capped-2',
+      createdAt: new Date().toISOString(),
+    };
+    const logger = makeLogger();
+    const repairFilings = new FakeRepairFilingStore([needsHumanRow], undefined, new Error('insert failed'));
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store, rows } = makeDecisionStore();
+
+    await expect(runAdminBypassE2eBabysitTick({
+      logger,
+      workerLifecycle: new FakeWorkerLifecycle([]),
+      repairFilings,
+      planSubmitter,
+      store,
+    })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(planSubmitter.submittedPlans).toHaveLength(0);
+    expect(rows).toContainEqual({
+      subjectId: `${needsHumanRow.kind}:${needsHumanRow.subject}:${needsHumanRow.stateSha}`,
+      status: 'failed',
+    });
   });
 });

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -15,6 +15,20 @@ export const DEFAULT_WATCHED_WORKER_KINDS = [
   'claude-oauth-refresh',
 ] as const;
 
+/**
+ * Prefix for repair_filings rows scripts/e2e-regression-watch.mjs inserts
+ * (via claimNeedsHumanRepairFiling) when a failure exhausts its automated
+ * fix-attempt retry budget. Matches needsHumanRepairFilingKind() there.
+ */
+export const E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX = 'ci-regression-needs-human:';
+
+/**
+ * Prefix for the companion claim this worker inserts once it has filed an
+ * investigation for a given needs-human row, so a later tick does not
+ * re-file for the same (subject, stateSha) every cycle.
+ */
+export const E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX = 'ci-regression-needs-human-investigated:';
+
 const DEFAULT_INTERVAL_MS = 10 * 60_000;
 
 export interface WorkerLifecycleSnapshot {
@@ -38,9 +52,18 @@ export interface RepairFilingRow {
   readonly createdAt: string;
 }
 
+export interface RepairFilingInsertResult {
+  readonly inserted: boolean;
+}
+
 export interface RepairFilingStore {
   listRepairFilings(): readonly RepairFilingRow[] | Promise<readonly RepairFilingRow[]>;
   deleteRepairFiling(kind: string, subject: string, stateSha: string): unknown;
+  insertRepairFiling(input: {
+    kind: string;
+    subject: string;
+    stateSha: string;
+  }): RepairFilingInsertResult | Promise<RepairFilingInsertResult>;
 }
 
 export interface InvestigativePlanSubmitter {
@@ -81,6 +104,12 @@ export type AdminBypassE2eBabysitAction =
       readonly subject: string;
       readonly stateSha: string;
       readonly createdAt: string;
+    }
+  | {
+      readonly type: 'e2e-regression-needs-human';
+      readonly kind: string;
+      readonly subject: string;
+      readonly stateSha: string;
     };
 
 function yamlString(value: string): string {
@@ -96,13 +125,24 @@ function investigativePrompt(action: AdminBypassE2eBabysitAction): string {
       + 'and what would durably prevent recurrence. Support conclusions with evidence and propose a concrete prevention.'
     );
   }
+  if (action.type === 'repair-filing-delete') {
+    return (
+      'Assume zero prior context. Investigate a production repair-filings finding: '
+      + `the admin-bypass-e2e-babysit worker attempted to delete a stale repair_filings row with kind `
+      + `${JSON.stringify(action.kind)}, subject ${JSON.stringify(action.subject)}, stateSha `
+      + `${JSON.stringify(action.stateSha)}, and createdAt ${JSON.stringify(action.createdAt)}. `
+      + 'Determine what caused the claim to remain stale and what would durably prevent recurrence. '
+      + 'Support conclusions with evidence and propose a concrete prevention.'
+    );
+  }
   return (
-    'Assume zero prior context. Investigate a production repair-filings finding: '
-    + `the admin-bypass-e2e-babysit worker attempted to delete a stale repair_filings row with kind `
-    + `${JSON.stringify(action.kind)}, subject ${JSON.stringify(action.subject)}, stateSha `
-    + `${JSON.stringify(action.stateSha)}, and createdAt ${JSON.stringify(action.createdAt)}. `
-    + 'Determine what caused the claim to remain stale and what would durably prevent recurrence. '
-    + 'Support conclusions with evidence and propose a concrete prevention.'
+    'Assume zero prior context. Investigate a production e2e-regression-watch finding: '
+    + `scripts/e2e-regression-watch.mjs exhausted its automated fix-attempt retry budget and marked a `
+    + `failure needsHuman -- repair_filings kind ${JSON.stringify(action.kind)}, subject `
+    + `${JSON.stringify(action.subject)}, first-bad stateSha ${JSON.stringify(action.stateSha)}. `
+    + 'Determine why the automated fix attempts did not land (read the actual CI job log and any repair '
+    + 'PR history for this failure) and propose a concrete fix or escalation. '
+    + 'Support conclusions with evidence.'
   );
 }
 
@@ -245,6 +285,69 @@ export async function runAdminBypassE2eBabysitTick(
         payload: { ...row, staleTtlMs, error: detail },
       });
     }
+  }
+
+  const needsHumanRows = repairFilings.filter((row) => row.kind.startsWith(E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX));
+  const alreadyInvestigatedKeys = new Set(
+    repairFilings
+      .filter((row) => row.kind.startsWith(E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX))
+      .map((row) => `${row.subject}:${row.stateSha}`),
+  );
+  for (const row of needsHumanRows) {
+    const dedupeKey = `${row.subject}:${row.stateSha}`;
+    if (alreadyInvestigatedKeys.has(dedupeKey)) continue;
+
+    const investigatedKind = E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX
+      + row.kind.slice(E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX.length);
+    const subjectId = `${row.kind}:${row.subject}:${row.stateSha}`;
+    let claim: RepairFilingInsertResult;
+    try {
+      claim = await options.repairFilings.insertRepairFiling({
+        kind: investigatedKind,
+        subject: row.subject,
+        stateSha: row.stateSha,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(
+        `[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] failed to claim e2e-regression needs-human finding ${subjectId}: ${detail}`,
+        { module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND, kind: row.kind, subject: row.subject, stateSha: row.stateSha },
+      );
+      recordDecision(options.store, {
+        actionType: 'e2e-regression-needs-human',
+        externalKey: `repair-filing:${subjectId}`,
+        subjectType: 'repair-filing',
+        subjectId,
+        status: 'failed',
+        summary: `Failed to claim e2e-regression needs-human finding ${subjectId}: ${detail}`,
+        payload: { ...row, error: detail },
+      });
+      continue;
+    }
+    // Another concurrent tick already claimed and is filing this one.
+    if (!claim.inserted) continue;
+
+    actions.push({
+      type: 'e2e-regression-needs-human',
+      kind: row.kind,
+      subject: row.subject,
+      stateSha: row.stateSha,
+    });
+    options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] filing investigation for e2e-regression needs-human finding`, {
+      module: ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND,
+      kind: row.kind,
+      subject: row.subject,
+      stateSha: row.stateSha,
+    });
+    recordDecision(options.store, {
+      actionType: 'e2e-regression-needs-human',
+      externalKey: `repair-filing:${subjectId}`,
+      subjectType: 'repair-filing',
+      subjectId,
+      status: 'completed',
+      summary: `Filed investigation for e2e-regression needs-human finding ${subjectId}`,
+      payload: { ...row },
+    });
   }
 
   if (actions.length === 0) return;

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -1341,6 +1341,45 @@ export function shouldSkipFilingAlreadyAddressed(failure, {
  * must not crash the sweep; it just means this key stays claimed until a
  * human clears it or the sha changes.
  */
+/**
+ * Kind for the needs-human signal claimed once a failure exhausts
+ * shouldFileFailure's retry budget. Unlike repairFilingKind, this is NOT
+ * attempt-scoped: needs-human is a terminal state for a given firstBadSha,
+ * so ON CONFLICT DO NOTHING naturally suppresses duplicate claims across
+ * every sweep until the sha changes (the test is actually fixed). This is
+ * the row admin-bypass-e2e-babysit-worker.ts watches for and files a
+ * production investigation against (see E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX
+ * there).
+ */
+export function needsHumanRepairFilingKind(failure) {
+  const job = failure.markerJobName ?? failure.jobName;
+  const test = failure.failureId && failure.failureId !== JOB_LEVEL_FAILURE_ID
+    ? failure.failureId
+    : JOB_LEVEL_FAILURE_ID;
+  return `ci-regression-needs-human:${slugify(job)}:${slugify(test)}`;
+}
+
+/**
+ * Claims the needs-human signal for admin-bypass-e2e-babysit-worker.ts to
+ * pick up. Never throws -- a failed claim just means the worker's next
+ * periodic sweep of desired-enabled/stopped workers still runs; it only
+ * costs one missed cap-notification, not a crashed sweep.
+ */
+export function claimNeedsHumanRepairFiling(failure, insert = insertRepairFiling) {
+  try {
+    const result = insert({
+      kind: needsHumanRepairFilingKind(failure),
+      subject: resolveRepairFilingSubject(TARGET_REPO),
+      stateSha: failure.firstBadSha,
+      metadata: buildRepairFilingMetadata(failure),
+    });
+    return result.inserted;
+  } catch (err) {
+    console.error(`ci-regression-watch: claimNeedsHumanRepairFiling failed for kind="${needsHumanRepairFilingKind(failure)}" sha="${failure.firstBadSha}": ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 export function releaseRepairFilingClaim(failure, release = releaseRepairFiling) {
   try {
     release({ kind: repairFilingKind(failure), subject: resolveRepairFilingSubject(TARGET_REPO), stateSha: failure.firstBadSha });
@@ -1690,6 +1729,7 @@ export async function main() {
     save: saveState,
     onNeedsHuman: (failure, attemptGate) => {
       console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName, failure.failureId)}" reached attempt cap (${attemptGate.attempts}); needs human review`);
+      if (!dryRun) claimNeedsHumanRepairFiling(failure);
     },
     onRetired: (failure, reason) => {
       const detail = reason === 'stale-observation'

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -8,6 +8,7 @@ import {
   buildFailureKey,
   buildMarker,
   buildRepairFilingMetadata,
+  claimNeedsHumanRepairFiling,
   claimRepairFiling,
   CATSTACK_REPO_URL,
   DEFAULT_TARGET_REPO,
@@ -24,6 +25,7 @@ import {
   loadEmptyState,
   liveQueryHasNonTerminalWork,
   loadWatchConfigFile,
+  needsHumanRepairFilingKind,
   normalizeState,
   parseTargetRepoFlag,
   parseWatchConfigFlag,
@@ -143,23 +145,24 @@ describe('liveQueryHasNonTerminalWork', () => {
   });
 });
 
+function makeFakeLedger() {
+  const rows = new Map();
+  return {
+    rows,
+    insert: ({ kind, subject, stateSha, metadata }) => {
+      const key = `${kind} ${subject} ${stateSha}`;
+      if (rows.has(key)) return { inserted: false, row: rows.get(key) };
+      const row = { kind, subject, stateSha, metadata };
+      rows.set(key, row);
+      return { inserted: true, row };
+    },
+    release: ({ kind, subject, stateSha }) => {
+      rows.delete(`${kind} ${subject} ${stateSha}`);
+    },
+  };
+}
+
 describe('repair_filings ledger gate (claimRepairFiling / releaseRepairFilingClaim)', () => {
-  function makeFakeLedger() {
-    const rows = new Map();
-    return {
-      rows,
-      insert: ({ kind, subject, stateSha, metadata }) => {
-        const key = `${kind} ${subject} ${stateSha}`;
-        if (rows.has(key)) return { inserted: false, row: rows.get(key) };
-        const row = { kind, subject, stateSha, metadata };
-        rows.set(key, row);
-        return { inserted: true, row };
-      },
-      release: ({ kind, subject, stateSha }) => {
-        rows.delete(`${kind} ${subject} ${stateSha}`);
-      },
-    };
-  }
 
   it('kind is namespaced per CI job, failure identity, and attempt ordinal', () => {
     assert.equal(
@@ -304,6 +307,67 @@ describe('repair_filings ledger gate (claimRepairFiling / releaseRepairFilingCla
     });
 
     assert.equal(filedCount, 1, 'the second sweep must not file a duplicate for the identical key');
+    assert.equal(ledger.rows.size, 1);
+  });
+});
+
+describe('needs-human repair-filings claim (claimNeedsHumanRepairFiling)', () => {
+  it('kind is namespaced per CI job and failure identity, with no attempt ordinal (needs-human is terminal per sha)', () => {
+    assert.equal(
+      needsHumanRepairFilingKind(makeFailure({ jobName: 'required-fast / Guardrails' })),
+      'ci-regression-needs-human:required-fast-guardrails:job',
+    );
+    assert.equal(
+      needsHumanRepairFilingKind(makeFailure({
+        jobName: 'fleet / abc123d',
+        markerJobName: 'fleet',
+        failureId: 'job',
+        attempts: 5,
+      })),
+      'ci-regression-needs-human:fleet:job',
+    );
+  });
+
+  it('claims the key once; a second claim for the identical (kind, subject, stateSha) is rejected', () => {
+    const ledger = makeFakeLedger();
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+
+    assert.equal(claimNeedsHumanRepairFiling(failure, ledger.insert), true, 'first claim must succeed');
+    assert.equal(ledger.rows.size, 1);
+
+    assert.equal(claimNeedsHumanRepairFiling(failure, ledger.insert), false, 'second claim for the identical key must be rejected');
+    assert.equal(ledger.rows.size, 1, 'exactly one row must exist for this key, not two');
+  });
+
+  it('fails closed to false (no crash) when the ledger call throws', () => {
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+    const throwingInsert = () => { throw new Error('headless_mutation timed out'); };
+    assert.equal(claimNeedsHumanRepairFiling(failure, throwingInsert), false);
+  });
+
+  it('processFailureFilingSweep end-to-end: reaching the attempt cap claims the needs-human key exactly once across repeated sweeps', () => {
+    const ledger = makeFakeLedger();
+    const state = stateWithFailure(makeFailure({ attempts: 3, firstBadSha: 'shaA' }));
+    let claims = 0;
+
+    const sweepOnce = (sweepState) => processFailureFilingSweep(sweepState, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      maxAttempts: 3,
+      liveQuery: () => false,
+      fileFailure: () => {},
+      onNeedsHuman: (failure) => {
+        if (claimNeedsHumanRepairFiling(failure, ledger.insert)) claims += 1;
+      },
+    });
+
+    sweepOnce(state);
+    assert.equal(claims, 1);
+    assert.equal(ledger.rows.size, 1);
+
+    // A second sweep still under the same cap (same firstBadSha, still
+    // needsHuman) must not claim a duplicate key.
+    sweepOnce(state);
+    assert.equal(claims, 1, 'a repeat sweep for the identical (kind, subject, stateSha) must not re-claim');
     assert.equal(ledger.rows.size, 1);
   });
 });


### PR DESCRIPTION
## Summary

scripts/e2e-regression-watch.mjs's onNeedsHuman callback only logs when an e2e test has run out of automated fix attempts. Nothing else in the fleet acts on that moment.

This slice makes that callback claim a `ci-regression-needs-human:*` repair_filings row. PR #11449 already taught admin-bypass-e2e-babysit to pick that row up and open a production investigation.

## Review Claim

Approve wiring the real onNeedsHuman call site to claimNeedsHumanRepairFiling, a new function namespaced separately from the existing per-attempt repair-filing claim so it fires once per (job, test, firstBadSha) no matter how many sweeps run afterward.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

claimNeedsHumanRepairFiling reuses the same insertRepairFiling ON CONFLICT DO NOTHING primitive the file's existing per-attempt claim already relies on, so two overlapping sweeps for the same finding can't both succeed. The claim never blocks the sweep on error (catches, logs, returns false) and only fires inside the existing dryRun guard, so a dry-run invocation writes nothing.

## Slice Rationale

This is a separate PR from #11449 because scripts/e2e-regression-watch.mjs and packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts land under different review units per scripts/review-unit-rules.mjs, and the validator forbids mixing them in one PR. It builds on top of #11449 so the finding has somewhere to go before this PR starts producing it.

## Non-goals

Does not change the existing per-attempt repair-filing claim/release path (claimRepairFiling / releaseRepairFilingClaim) that gates whether fileFailure runs — this is a separate, additively-namespaced claim fired only on the needs-human transition. Does not change admin-bypass-e2e-babysit itself (that's PR #11449).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs` — 73/73 tests pass, 0 fail, exit 0. Includes 4 new tests: needsHumanRepairFilingKind's per-job/test namespacing (no attempt ordinal), a single claim succeeding then a second identical claim being turned away, a thrown ledger call failing closed to false, and an end-to-end processFailureFilingSweep run proving a repeat sweep for the same finding claims the key exactly once.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — onNeedsHuman goes back to only logging.
- Data migration? No
</details>
