### PR TITLE
Resolve e2e-autofix ticks via exit when close never fires

### DIFF
--- a/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
@@ -18,6 +18,7 @@ import {
   createE2eAutoFixTick,
   createE2eAutoFixWorker,
 } from '../workers/e2e-autofix-worker.js';
+import { createWorkerRuntime } from '../worker-runtime.js';
 
 type SpawnCall = {
   command: string;
@@ -69,6 +70,43 @@ function makeSpawnHarness(options: {
       stdout.end(options.stdout ?? '');
       stderr.end(options.stderr ?? '');
       child.emit('close', options.exitCode ?? 0, null);
+    });
+
+    return child;
+  });
+
+  return { calls, spawnProcess: spawnProcess as unknown as typeof spawn };
+}
+
+/**
+ * Simulates a spawned child whose own process exits cleanly, but whose
+ * piped stdout/stderr never close — the real, proven failure mode when the
+ * shell entrypoint backgrounds a grandchild that inherits those fds (e.g.
+ * `something &`). `close` never fires in this scenario; only `exit` does.
+ */
+function makeExitWithoutCloseHarness(options: { exitCode?: number } = {}): {
+  calls: SpawnCall[];
+  spawnProcess: typeof spawn;
+} {
+  const calls: SpawnCall[] = [];
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      killed: false,
+      pid: 4242,
+      kill: vi.fn(),
+    }) as unknown as ChildProcess;
+
+    queueMicrotask(() => {
+      stdout.end('');
+      stderr.end('');
+      child.emit('exit', options.exitCode ?? 0, null);
+      // Deliberately never emits 'close' — the grandchild still holds the fds.
     });
 
     return child;
@@ -195,6 +233,65 @@ describe('e2e auto-fix worker', () => {
     });
 
     await expect(tick(makeCtx())).rejects.toThrow('exited with code 1');
+  });
+
+  it('resolves via exit when close never fires within the grace window, instead of hanging forever', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const harness = makeExitWithoutCloseHarness({ exitCode: 0 });
+    const logger = makeLogger();
+    const tick = createE2eAutoFixTick({
+      logger,
+      repoRoot,
+      closeGraceMs: 500,
+      spawnProcess: harness.spawnProcess,
+    });
+
+    const tickPromise = tick(makeCtx());
+    let settled = false;
+    void tickPromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(499);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(tickPromise).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('shell entrypoint exited but stdio did not close within 500ms'),
+      expect.objectContaining({ code: 0, source: 'exit' }),
+    );
+  });
+
+  it('does not permanently block future ticks when close never fires (the real production symptom)', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const harness = makeExitWithoutCloseHarness({ exitCode: 0 });
+    const worker = createE2eAutoFixWorker({
+      logger: makeLogger(),
+      repoRoot,
+      intervalMs: 1000,
+      closeGraceMs: 100,
+      spawnProcess: harness.spawnProcess,
+      installSignalHandlers: false,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(harness.calls).toHaveLength(1);
+
+    // Let the first tick's exit-grace fallback settle it.
+    await vi.advanceTimersByTimeAsync(100);
+
+    // A worker stuck on the old close-only behavior would never reach this
+    // second poll tick — inFlight stays set forever and every subsequent
+    // setInterval firing silently no-ops.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(harness.calls).toHaveLength(2);
+
+    await worker.stop();
   });
 
   it('ticks on start and arms the default fifteen-minute interval', async () => {

--- a/packages/execution-engine/src/workers/e2e-autofix-worker.ts
+++ b/packages/execution-engine/src/workers/e2e-autofix-worker.ts
@@ -12,6 +12,22 @@ export const E2E_AUTOFIX_WORKER_KIND = 'e2e-autofix';
 export const E2E_AUTOFIX_SCRIPT_RELATIVE_PATH = 'scripts/cron-e2e-regression-watch.sh';
 /** Default cadence: sweep default-branch push CI every fifteen minutes. */
 export const DEFAULT_E2E_AUTOFIX_INTERVAL_MS = 15 * 60_000;
+/**
+ * If the spawned child's own process exits but Node's `close` event does not
+ * follow within this window, resolve the tick using the `exit` result anyway
+ * instead of waiting on `close` forever. `close` only fires once every stdio
+ * pipe (not just the direct child's) has ended; a grandchild that inherits
+ * the piped stdout/stderr fds and outlives its parent (e.g. `something &`
+ * inside the shell entrypoint) can hold that pipe open indefinitely even
+ * though the direct child has fully exited, permanently blocking every
+ * future tick — worker-runtime.ts's scheduler coalesces ticks, so a tick
+ * that never settles blocks the worker forever, silently (2026-08-31: e2e-
+ * autofix ticked once after an owner restart, then never again for 40+
+ * minutes, with no error logged — proven root cause via a controlled repro:
+ * `exit` fires immediately while `close` never fires when the child
+ * backgrounds a long-lived grandchild sharing its stdio fds).
+ */
+export const DEFAULT_E2E_AUTOFIX_CLOSE_GRACE_MS = 2_000;
 
 type EnvOverrides = Record<string, string | undefined>;
 
@@ -24,6 +40,8 @@ export interface E2eAutoFixWorkerConfig {
   intervalMs?: number;
   /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
   shell?: string;
+  /** See DEFAULT_E2E_AUTOFIX_CLOSE_GRACE_MS. */
+  closeGraceMs?: number;
 }
 
 export interface E2eAutoFixWorkerOptions extends E2eAutoFixWorkerConfig {
@@ -70,6 +88,7 @@ export function createE2eAutoFixWorker(options: E2eAutoFixWorkerOptions): Worker
       env: options.env,
       intervalMs: options.intervalMs,
       shell: options.shell,
+      closeGraceMs: options.closeGraceMs,
       spawnProcess: options.spawnProcess,
     }),
   });
@@ -116,12 +135,47 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
   attachChildStreamLogger(options, child.stdout, 'stdout');
   attachChildStreamLogger(options, child.stderr, 'stderr');
 
+  const closeGraceMs = options.closeGraceMs ?? DEFAULT_E2E_AUTOFIX_CLOSE_GRACE_MS;
+
   await new Promise<void>((resolvePromise, rejectPromise) => {
     let settled = false;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
     const settle = (fn: () => void): void => {
       if (settled) return;
       settled = true;
+      if (graceTimer) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
       fn();
+    };
+
+    const finish = (code: number | null, signal: NodeJS.Signals | null, source: 'close' | 'exit'): void => {
+      settle(() => {
+        const fields = {
+          module: 'e2e-autofix-worker',
+          worker: E2E_AUTOFIX_WORKER_KIND,
+          code,
+          signal,
+          source,
+        };
+        if (code === 0) {
+          if (source === 'exit') {
+            options.logger.warn(
+              `[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint exited but stdio did not close within ${closeGraceMs}ms; resolving via exit so future ticks are not blocked`,
+              fields,
+            );
+          } else {
+            options.logger.info(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint completed`, fields);
+          }
+          resolvePromise();
+          return;
+        }
+        const message = `e2e auto-fix worker exited with code ${code ?? 'null'}`
+          + (signal ? ` signal ${signal}` : '');
+        options.logger.error(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint failed`, fields);
+        rejectPromise(new Error(message));
+      });
     };
 
     child.once('error', (err) => {
@@ -135,24 +189,12 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
       });
     });
 
-    child.once('close', (code, signal) => {
-      settle(() => {
-        const fields = {
-          module: 'e2e-autofix-worker',
-          worker: E2E_AUTOFIX_WORKER_KIND,
-          code,
-          signal,
-        };
-        if (code === 0) {
-          options.logger.info(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint completed`, fields);
-          resolvePromise();
-          return;
-        }
-        const message = `e2e auto-fix worker exited with code ${code ?? 'null'}`
-          + (signal ? ` signal ${signal}` : '');
-        options.logger.error(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint failed`, fields);
-        rejectPromise(new Error(message));
-      });
+    child.once('close', (code, signal) => finish(code, signal, 'close'));
+
+    child.once('exit', (code, signal) => {
+      if (settled) return;
+      graceTimer = setTimeout(() => finish(code, signal, 'exit'), closeGraceMs);
+      graceTimer.unref?.();
     });
   });
 }


### PR DESCRIPTION
## Summary

`e2e-autofix` spawns `scripts/cron-e2e-regression-watch.sh` and awaits the
child's `close` event before it considers the tick finished.

If that script backgrounds any subprocess that inherits the piped
stdout/stderr file descriptors, `close` never fires even though the child's
own process has exited cleanly.

Since the worker's scheduler runs one tick at a time, that permanently
blocks every future tick with no error logged.

## Review Claim

Add a bounded grace window after `exit` fires: if `close` hasn't followed
within it, resolve the tick using the `exit` result instead of waiting on
`close` forever.

## Review Lane

behavior

## Review Unit

worker-runtime

## Safety Invariant

The change only affects what event settles the tick promise. The common
case (child and all its stdio fully close promptly) is unchanged — `close`
still resolves the tick immediately when it fires, using the existing
success/failure logic. Only the pathological case (exit without a
following close) now resolves after a short configurable grace period
(`closeGraceMs`, default 2000ms) instead of hanging indefinitely.

## Slice Rationale

Single-file fix (plus its test) scoped to the one worker with live
production evidence of this hang. `packages/execution-engine/src/workers/pr-maintenance-workers.ts`
shares the exact same `child.once('close', ...)`-only pattern and the
same `child.once('close', ...)`-only pattern inside `terminateChildProcessGroup`
(`packages/execution-engine/src/process-utils.ts`) — both are a real,
provable instance of the same bug class, but pr-maintenance-workers.ts
already has a partial mitigation (`DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS`,
4 minutes) that e2e-autofix had none of, making e2e-autofix's case the
more severe, currently-live incident. Porting the same `closeGraceMs`
fallback to those siblings is a natural, low-risk follow-up but is left
out of this slice to keep the reviewable diff to the one file with direct
evidence.

## Non-goals

Does not touch `pr-maintenance-workers.ts` or `process-utils.ts`'s
`terminateChildProcessGroup` — see Slice Rationale. Does not change what
`scripts/cron-e2e-regression-watch.sh` itself does (the actual grandchild
process that inherits the fds was not identified from the production log
alone; the fix targets the general mechanism, not one specific offending
subprocess).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- e2e-autofix-worker.test.ts` — fail-before/pass-after, both real:
  - Before the fix (worker source reverted via `git stash`, new tests kept): `resolves via exit when close never fires within the grace window, instead of hanging forever` — genuinely times out at 20000ms (real hang, not a mock). `does not permanently block future ticks when close never fires` — fails: `expected [ 1 call ] to have a length of 2 but got 1` (the second tick never fires — the exact production symptom).
  - After the fix: `7 passed (7)`, `Duration 433ms` — no hang, second tick fires.
- [x] Full `pnpm --filter @invoker/execution-engine test` (whole package, not just this file) — `146 passed (146)` test files, `1816 passed | 1 skipped (1817)` tests. No regressions.
- [x] `pnpm run check:types` — clean, no errors.
- [x] Root-cause mechanism independently reproduced with a standalone script (not part of this diff): spawning a child with `stdio: ['ignore','pipe','pipe']` whose shell backgrounds a `sleep 30 &` grandchild — `exit` fires immediately (`code: 0`), `close` never fires within 5s. Confirms the exact fd-inheritance mechanism this fix targets.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how spawned shell completion is detected for one background worker; mis-tuned grace could mask lingering stdio or settle slightly early, but the happy path still resolves on `close` immediately.
> 
> **Overview**
> Fixes **e2e-autofix** ticks that could hang forever when the spawned shell exits but Node never emits **`close`** (e.g. a background grandchild still holds piped stdout/stderr). Because **worker-runtime** runs one tick at a time, an unsettled tick blocked all later polls with no error.
> 
> The worker now waits for **`close`** as before, but after **`exit`** starts a configurable **`closeGraceMs`** timer (default **2s**). If **`close`** does not arrive in time, the tick settles from the **`exit`** code/signal and logs a **warn** so scheduling can continue. **`closeGraceMs`** is wired through worker and tick options.
> 
> Tests add a spawn harness that emits **`exit`** without **`close`**, assert grace-window resolution and logging, and assert a second interval tick runs after the first tick would previously have stalled forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a456e015362fe5a0984f2ffdf25be88508d4ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated fix tasks from hanging when a child process exits but its output streams remain open.
  * Ensured subsequent scheduled fix tasks continue running instead of being blocked indefinitely.
  * Added a brief fallback window to safely complete tasks when the normal stream-close event does not occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->