### PR TITLE
[Demo Default Codex](1) Default the planning harness preset to Codex

### DIFF
--- a/packages/surfaces/src/__tests__/slack-approve-button-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-approve-button-repros.e2e.test.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path';
 import { ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, SQLiteAdapter } from '@invoker/data-store';
 import { SlackSurface } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 type MockHandlerFn = (args: Record<string, unknown>) => Promise<void> | void;
 
@@ -188,6 +189,7 @@ describe('Slack approve-button repro contracts', () => {
       planningHeartbeatIntervalSeconds: 0,
       workingDir,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     surfaces.push(created);
     return created;
@@ -223,6 +225,10 @@ describe('Slack approve-button repro contracts', () => {
     const draft = slackPlanDrafts.getReady('C_LOBBY', 'thread-a1');
     expect(draft?.planText).toContain('name: Good');
     expect(actionValueFromUpdatedCard(planSay, 'plan_draft_approve')).toBe(`${draft?.draftId}:${draft?.version}`);
+    // Proves the default harness preset really spawned codex sessions.
+    for (const call of mockSpawn.mock.calls) {
+      expect(call[0]).toBe('codex');
+    }
   });
 
   it('carries the Approve/Cancel actions on the same message as the drafted plan brief', async () => {

--- a/packages/surfaces/src/__tests__/slack-confirm-expiry-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-confirm-expiry-repros.e2e.test.ts
@@ -19,6 +19,7 @@ import type { ChildProcess } from 'node:child_process';
 import { ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, SQLiteAdapter } from '@invoker/data-store';
 import { SlackSurface } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 type MockHandlerFn = (args: Record<string, unknown>) => Promise<void> | void;
 
@@ -235,6 +236,7 @@ describe('Slack confirmation expiry repro contracts', () => {
       planningHeartbeatIntervalSeconds: 0,
       workingDir: process.cwd(),
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     surfaces.push(created);
     return created;
@@ -268,6 +270,10 @@ describe('Slack confirmation expiry repro contracts', () => {
       type: 'start_plan',
       planText: expect.stringContaining('name: First'),
     }));
+    // Proves the default harness preset really spawned codex sessions.
+    for (const call of mockSpawn.mock.calls) {
+      expect(call[0]).toBe('codex');
+    }
   });
 
   it('reports a superseded sibling draft honestly after the current draft is approved', async () => {

--- a/packages/surfaces/src/__tests__/slack-multi-thread-channel-isolation.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-multi-thread-channel-isolation.e2e.test.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path';
 import { SlackSurface } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 interface MockHandler {
   pattern: string | RegExp;
@@ -112,6 +113,7 @@ describe('E2E: real SlackSurface + real persistence — multi-channel isolation'
       channelId: 'C-BOT-DEFAULT-HOME',
       cursorCommand: 'cursor',
       conversationRepo: repo,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (cmd) => { receivedCommands.push(cmd); });
   });
@@ -196,6 +198,7 @@ describe('E2E: real SlackSurface + real persistence — multi-channel isolation'
       channelId: 'C-BOT-DEFAULT-HOME',
       cursorCommand: 'cursor',
       conversationRepo: repo,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await restarted.start(async (cmd) => { receivedCommands.push(cmd); });
     await flushAsync(); // let background recoverActiveConversations() settle
@@ -216,6 +219,8 @@ describe('E2E: real SlackSurface + real persistence — multi-channel isolation'
     // channel's turn — i.e. it must never be spawned as part of the CLI
     // invocation's args (which embed the full prompt, history included).
     expect(mockSpawn).toHaveBeenCalledTimes(1);
+    // Proves the default harness preset really spawned a codex session.
+    expect(mockSpawn.mock.calls[0][0]).toBe('codex');
     const spawnedArgs = mockSpawn.mock.calls[0][1] as string[];
     const spawnedCommandText = spawnedArgs.join(' ');
     expect(spawnedCommandText).not.toContain('unrelated pre-fix conversation content');

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
 import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 // A plain-English request ("submit it") should never draft or submit a plan
 // on its own. If the agent judges the request is itself a plan ask, it can
@@ -173,6 +174,7 @@ describe('Slack plan-intent auto-detect repro', () => {
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (command) => { commands.push(command); });
   });
@@ -194,6 +196,8 @@ describe('Slack plan-intent auto-detect repro', () => {
     });
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
+    // Proves the default harness preset really spawned a codex session.
+    expect(mockSpawn.mock.calls[0][0]).toBe('codex');
     expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
     expect(tryButtonValue(say, 'lobby_continue_conversation')).toBeUndefined();
   });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
 import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 // A bounded, seeded random ("monkey") pass over the Slack plan-intent flow —
 // not to prove any one specific behavior (the targeted repro suites already
@@ -167,6 +168,7 @@ describe('Slack plan-intent monkey pass', () => {
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (command) => { commands.push(command); });
   });
@@ -329,5 +331,11 @@ describe('Slack plan-intent monkey pass', () => {
     // step spawns at most once (mention/plan/approve/no), so the ceiling is
     // generous on purpose — this is a smoke check, not a tight budget.
     expect(mockSpawn.mock.calls.length).toBeLessThan(RUN_COUNT * STEPS_PER_RUN * 2);
+    // Every spawn actually went through the codex-shaped command, proving
+    // the default harness preset is really backed by a codex session here.
+    expect(mockSpawn.mock.calls.length).toBeGreaterThan(0);
+    for (const call of mockSpawn.mock.calls) {
+      expect(call[0]).toBe('codex');
+    }
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
 import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 // Replays the real Slack thread that motivated this feature: a long
 // multi-turn investigation ("why did so many fail" -> repro scripts -> a
@@ -148,6 +149,7 @@ describe('Slack real-thread replay: the original "submit it" incident', () => {
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (command) => { commands.push(command); });
   });
@@ -197,6 +199,10 @@ describe('Slack real-thread replay: the original "submit it" incident', () => {
 
     // None of the investigative/design turns should have staged anything.
     expect(mockSpawn).toHaveBeenCalledTimes(3);
+    // Proves the default harness preset really spawned codex sessions.
+    for (const call of mockSpawn.mock.calls) {
+      expect(call[0]).toBe('codex');
+    }
     expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
     expect(slackSessionRepo.getPendingConfirmation(threadTs)).toBeNull();
 

--- a/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
@@ -159,6 +159,10 @@ describe('Slack and planning-terminal parity for the same request (real surface,
       signingSecret: 'test-secret',
       channelId: 'C-test',
       cursorCommand: 'cursor',
+      // Pinned explicitly: this test exercises the cursor-fallback prompt
+      // path specifically (see cursorCommand above), independent of
+      // whatever the app-wide default harness preset is.
+      defaultHarnessPreset: 'cursor+claude',
       workingDir: slackDir,
       defaultRepoUrl: 'https://github.com/example/repo.git',
       conversationalPlanning: true,

--- a/packages/surfaces/src/__tests__/test-support/fake-codex-planning-command-builder.ts
+++ b/packages/surfaces/src/__tests__/test-support/fake-codex-planning-command-builder.ts
@@ -1,0 +1,12 @@
+import type { PlanningCommandBuilder } from '../../slack/plan-conversation.js';
+
+// Mirrors CodexPlanningAgent.buildPlanningCommand
+// (packages/execution-engine/src/agents/codex-planning-agent.ts) so tests
+// exercising the default harness preset are backed by the same
+// command/args shape a real codex session actually spawns.
+export const fakeCodexPlanningCommandBuilder: PlanningCommandBuilder = ({ tool, prompt }) => {
+  if (tool !== 'codex') {
+    throw new Error(`fakeCodexPlanningCommandBuilder does not support tool "${tool}"`);
+  }
+  return { command: 'codex', args: ['exec', '--json', '--sandbox', 'workspace-write', prompt] };
+};

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -183,7 +183,7 @@ export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   claude: { tool: 'claude' },
 };
 
-export const DEFAULT_HARNESS_PRESET = 'cursor+claude';
+export const DEFAULT_HARNESS_PRESET = 'codex';
 
 interface PlanningContext {
   repoUrl?: string;


### PR DESCRIPTION
## Summary

The demo's composer Options panel showed Claude selected by default, not Codex.

`DEFAULT_HARNESS_PRESET` in the Slack surface module still pointed at `cursor+claude`. That constant is shared by the Slack bot and the web/desktop planning UI, so it drove the Options panel too.

This flips it to plain `codex`.

## Review Claim

Approve flipping the shared default harness preset constant from `cursor+claude` to `codex`, plus the test-fixture fix needed to keep 7 Slack e2e tests passing under the new default.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The only production-code change is a one-line literal swap (`packages/surfaces/src/slack/slack-surface.ts:186`). It is read through `resolveDefaultPresetKey` and only takes effect when no `defaultSlackHarnessPreset` is set in config, so any operator who has already configured an explicit default is unaffected.

Verified end-to-end against a live rebuilt server: called the exact `invoker:get-planning-presets` channel the Options panel calls and confirmed `codex` now carries `isDefault: true` where `cursor+claude` did before.

## Slice Rationale

Kept to exactly one review unit. Two secondary "diagnostics panel" fallback literals (`packages/app/src/main.ts`, `packages/app/src/ipc/gui-mutation-handlers.ts`) also said `cursor+claude` and would now drift, but they classify into a different Review Unit (`activation-surface`) than this file's `routing`, so they're left for a separate follow-up rather than mixed into this diff.

## Non-goals

- Does not update the `defaultPreset` fallback text shown in the System Diagnostics panel (`main.ts`, `gui-mutation-handlers.ts`) — cosmetic drift only, unrelated Review Unit, follow-up PR.
- Does not touch `packages/app/src/planning-presets.ts`'s `DEFAULT_PLANNING_PRESET` — confirmed dead code, zero callers repo-wide.
- Does not change which Codex-flavored preset is default: plain `codex`, not `cursor+codex`, per explicit choice (plain `codex` requires a registered `planningCommandBuilder`; `cursor+codex` would not have, but wasn't picked).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test` (targeted: the 7 fixed e2e files + `slack-surface-workflows.test.ts`) — 8 files / 117 tests passed, run against a clean worktree rebased on `origin/master`
- [x] Live rebuild + `owner-serve` + `POST /invoke {"channel":"invoker:get-planning-presets"}` — confirmed `codex` is `isDefault: true`

</details>

## Visual Proof

Before — Options panel defaulted to Harness: Cursor, Model: Claude:

![Options panel before, Cursor/Claude selected](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-7ac364/options-panel-before.png)

After — Options panel defaults to Harness: Codex:

![Options panel after, Codex selected](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-7ac364/options-panel-after.png)

Manually inspected: opened both PNGs myself. The before image shows a "Harness" dropdown reading "Cursor" and a separate "Model" dropdown reading "Claude". The after image shows the same panel with a single "Harness" dropdown reading "Codex" (the plain-codex preset has no separate Model dropdown). Both were captured from the same live app build via Playwright against the real running web surface, toggling only the `DEFAULT_HARNESS_PRESET` source line between captures.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 52e2b5f158`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests without an explicit harness selection now use Codex by default.
  * Added coverage to verify Codex sessions and command execution across Slack planning workflows.

* **Bug Fixes**
  * Improved Slack test coverage for confirmation expiry, thread isolation, plan intent detection, and approval scenarios.
  * Preserved cursor fallback behavior for scenarios that explicitly require it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->