### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](1) Fall back to os.homedir() when userInfo().homedir is empty

### DIFF
--- a/scripts/repro/repro-stale-late-completion-after-reset.sh
+++ b/scripts/repro/repro-stale-late-completion-after-reset.sh
@@ -114,7 +114,7 @@ submit_workflow_with_retry() {
       continue
     fi
 
-    if rg -q 'requires an owner process|No request handler registered' "$SUBMIT_STDERR"; then
+    if grep -Eq 'requires an owner process|No request handler registered' "$SUBMIT_STDERR"; then
       sleep 0.2
       continue
     fi

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -53,8 +53,7 @@ function resolveValue(name, value) {
 function realHomeDir() {
   // Unlike os.homedir(), userInfo().homedir ignores an overridden $HOME —
   // needed so a caller's own sandboxed $HOME/.invoker isn't mistaken for
-  // the real production namespace this guard protects. It can also return an
-  // empty string instead of throwing on some sandboxes, so fall back to homedir().
+  // the real production namespace this guard protects.
   try {
     return userInfo().homedir || homedir();
   } catch {

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -53,9 +53,10 @@ function resolveValue(name, value) {
 function realHomeDir() {
   // Unlike os.homedir(), userInfo().homedir ignores an overridden $HOME —
   // needed so a caller's own sandboxed $HOME/.invoker isn't mistaken for
-  // the real production namespace this guard protects.
+  // the real production namespace this guard protects. It can also return an
+  // empty string instead of throwing on some sandboxes, so fall back to homedir().
   try {
-    return userInfo().homedir;
+    return userInfo().homedir || homedir();
   } catch {
     return homedir();
   }


### PR DESCRIPTION
## Summary

Some sandboxed CI runners return an empty string from `userInfo().homedir()` instead of throwing.

The dev-profile guard used that value unchecked, so it silently resolved a relative path and stopped catching collisions with the real `$HOME/.invoker` production namespace.

This fixes CI job `fleet / 195e2a4`, which first failed on default-branch commit `195e2a45d70f8d9c81069cb8731fe34781e06093`.

## Review Claim

Approve falling back to `os.homedir()` in `realHomeDir()` when `userInfo().homedir()` is empty, so the production-collision guard keeps resolving a real home directory on affected runners.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`realHomeDir()` only changes behavior when `userInfo().homedir()` is falsy; when it already returns a real path, the resolved value and every downstream collision check are byte-for-byte unchanged from before this PR.

## Slice Rationale

This file lives under `scripts/`, which the repo's scope classifier (`scripts/review-unit-rules.mjs`) always treats as `tooling-policy`. The companion `rg`/`grep` portability fix touches a script under `scripts/repro/`, which the same classifier always treats as `proof`; that half ships as stack PR (2) instead of here.

## Non-goals

No change to the platform branching, port derivation, or any other path in `productionUserDataDir` / `developmentEnvironment`. No change to the repro script's retry logic (see slice (2)).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --check scripts/with-invoker-development-profile.mjs`
- [ ] `node -e "console.log('' || require('node:os').homedir())"` — confirms the fallback resolves a real path instead of the empty string the broken guard used to accept
- [ ] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='3' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh` — the shared effectiveness command for CI job `fleet / 195e2a4`, recorded passing (exit 0) on this branch by the source Invoker plan's verify task

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
