### PR TITLE
[CI regression: 195e2a4-fleet-195e2a4](2) Use grep instead of rg in submit-retry detection

### DIFF
--- a/scripts/repro/repro-stale-late-completion-after-reset.sh
+++ b/scripts/repro/repro-stale-late-completion-after-reset.sh
@@ -114,7 +114,7 @@ submit_workflow_with_retry() {
       continue
     fi
 
-    if rg -q 'requires an owner process|No request handler registered' "$SUBMIT_STDERR"; then
+    if grep -Eq 'requires an owner process|No request handler registered' "$SUBMIT_STDERR"; then
       sleep 0.2
       continue
     fi

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -53,8 +53,7 @@ function resolveValue(name, value) {
 function realHomeDir() {
   // Unlike os.homedir(), userInfo().homedir ignores an overridden $HOME —
   // needed so a caller's own sandboxed $HOME/.invoker isn't mistaken for
-  // the real production namespace this guard protects. It can also return an
-  // empty string instead of throwing on some sandboxes, so fall back to homedir().
+  // the real production namespace this guard protects.
   try {
     return userInfo().homedir || homedir();
   } catch {

--- a/scripts/with-invoker-development-profile.mjs
+++ b/scripts/with-invoker-development-profile.mjs
@@ -53,9 +53,10 @@ function resolveValue(name, value) {
 function realHomeDir() {
   // Unlike os.homedir(), userInfo().homedir ignores an overridden $HOME —
   // needed so a caller's own sandboxed $HOME/.invoker isn't mistaken for
-  // the real production namespace this guard protects.
+  // the real production namespace this guard protects. It can also return an
+  // empty string instead of throwing on some sandboxes, so fall back to homedir().
   try {
-    return userInfo().homedir;
+    return userInfo().homedir || homedir();
   } catch {
     return homedir();
   }


### PR DESCRIPTION
## Summary

This repro script's stderr pattern check matched a known transient owner-process failure with `rg -q`, assuming ripgrep was on `PATH`.

Self-hosted runners without ripgrep crashed the whole script outright instead of looping past that transient failure.

This fixes CI job `fleet / 195e2a4`, which first failed on default-branch commit `195e2a45d70f8d9c81069cb8731fe34781e06093`.

## Review Claim

Approve replacing `rg -q` with `grep -Eq` in this repro script's stderr pattern check, so the transient-failure match works on runners without ripgrep.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The two patterns matched (`requires an owner process`, `No request handler registered`) and the retry/return control flow around them are unchanged; only the matching binary changes, so a runner that already had `rg` behaves identically.

## Slice Rationale

This file is under `scripts/repro/`, which the repo's scope classifier (`scripts/review-unit-rules.mjs`) always treats as `proof`. The companion `with-invoker-development-profile.mjs` home-directory fallback lands in a different unit, `tooling-policy`; it ships as stack PR (1) instead of here.

## Non-goals

No change to the timeout, deadline, or workflow-ID detection logic elsewhere in this script. No change to any other repro script.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/repro/repro-stale-late-completion-after-reset.sh`
- [ ] `printf 'requires an owner process\n' | grep -Eq 'requires an owner process|No request handler registered'; echo $?` — prints `0`, matching the old `rg -q` behavior
- [ ] `printf 'unrelated failure\n' | grep -Eq 'requires an owner process|No request handler registered'; echo $?` — prints `1`, confirming the pattern still only matches the intended transient errors
- [ ] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='3' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh` — the shared effectiveness command for CI job `fleet / 195e2a4`, recorded passing (exit 0) on this branch by the source Invoker plan's verify task

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
