### PR TITLE
[Scratch Branch Guard](1) Exempt scratch-mode dependencies from the branch-metadata guard

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1892,6 +1892,20 @@ describe('TaskRunner', () => {
       ).toThrow('completed without branch metadata');
     });
 
+    it('assertCompletedDependencyHasBranch does not throw when the dep is a scratch-mode task with no branch', () => {
+      // ScratchExecutor never sets a branch by design (no git worktree at
+      // all in scratch mode), so the guard must not apply to scratch deps.
+      const dep = makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        config: { runnerKind: 'scratch' },
+      });
+
+      expect(() =>
+        assertCompletedDependencyHasBranch('child-task', 'dependency "dep-a"', dep),
+      ).not.toThrow();
+    });
+
     it('assertCompletedDependencyHasBranch does not throw when the dep has a branch', () => {
       const dep = makeTask({
         id: 'dep-a',

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -27,6 +27,7 @@ export function assertCompletedDependencyHasBranch(
   depLabel: string,
   dep: TaskState | undefined,
 ): void {
+  if (dep?.config.runnerKind === 'scratch') return;
   if (dep && dep.status === 'completed' && !dep.execution.branch) {
     throw new Error(
       `Task "${taskId}": ${depLabel} completed without branch metadata` +


### PR DESCRIPTION
## Summary

Any `scratch: true` plan with a dependency chain longer than one task always failed before starting its second task.

The dependency-branch guard requires every completed dependency to carry git branch metadata. Scratch-mode tasks never set one — scratch mode does zero git operations by design.

This exempts scratch-mode dependencies from that guard, matching the executor's own documented behavior.

## Review Claim

Approve exempting scratch-mode task dependencies from `assertCompletedDependencyHasBranch`'s branch-metadata requirement.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The guard exists to stop a downstream worktree from silently running against the bare base branch when an upstream branch was lost. That risk is specific to git-backed executors (worktree, docker, ssh); `ScratchExecutor` has no worktree and no branch at all, so there is nothing for it to silently drop. The exemption only fires when the dependency's `config.runnerKind === 'scratch'`, so worktree/docker/ssh dependencies keep the exact same guard behavior as before.

## Slice Rationale

Single guard function, single exemption condition, one review claim. No other file needed changing.

## Non-goals

- Does not change the guard's behavior for any non-scratch executor.
- Does not add workspace-sharing between scratch tasks in a dependency chain — that's a separate, larger design question (each scratch task still gets its own isolated temp directory; a multi-task scratch pipeline needs to be self-contained per task, or pass data another way).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/task-runner.test.ts` (154/154 passed, including the new regression test)
- [x] Repro proof: reverted the fix locally and reran only the new test — it failed with `Task "child-task": dependency "dep-a" completed without branch metadata`, confirming the guard is what blocked scratch dependents before this fix.
- [x] Live repro: submitted a real 6-task `scratch: true` Invoker plan with a dependency chain end to end via `invoker-cli run --standalone` — failed at the second task before this fix, completed cleanly after rebuilding with the fix applied.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2b0ed5952a`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scratch-mode tasks can now complete successfully without branch metadata.
  * Prevented erroneous failures when validating completed scratch-mode dependencies.

* **Tests**
  * Added coverage confirming that scratch-mode dependencies without branch metadata are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->