### PR TITLE
[Verify Skill](1) docs: add Invoker verify skill, feature map, and control-invoker CLI.

### DIFF
--- a/.cursor/skills/maintain-verify
+++ b/.cursor/skills/maintain-verify
@@ -1,0 +1,1 @@
+../../skills/maintain-verify

--- a/.cursor/skills/verify
+++ b/.cursor/skills/verify
@@ -1,0 +1,1 @@
+../../skills/verify

--- a/skills/maintain-verify/SKILL.md
+++ b/skills/maintain-verify/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: maintain-verify
+description: >
+  Keep skills/verify/references/features in sync with sidebar testids, e2e specs,
+  and repros. Use when adding UI surfaces, when catalog --check fails, or on a
+  daily maintain-verification pass for Invoker.
+---
+
+# maintain-verify
+
+Maintain the Invoker verification feature map so agents always have current
+entry points and prove commands.
+
+## Command
+
+```bash
+node skills/verify/control-invoker.mjs catalog --check --json
+node skills/verify/control-invoker.mjs catalog --list
+```
+
+`--check` is the CI / `pnpm test` gate (via `scripts/test-verify-skill.sh`).
+
+## When to run
+
+- After adding a sidebar surface, modal, or `data-testid`
+- After adding a Playwright e2e under `packages/app/e2e/`
+- Daily / whenever verify prove commands feel stale
+- When `catalog --check` fails
+
+## Flow
+
+1. Run `catalog --check` and read the error list.
+2. For each missing required sidebar testid, add or update the feature file under
+   `skills/verify/references/features/` with frontmatter `id`, `prove`, `testids`.
+3. Point `prove:` at an **existing** Playwright spec, `scripts/repro/*`, e2e-dry-run
+   case, or a cheap existence check — do not invent new heavy CI jobs.
+4. Keep the four body headings: Sub-features, How to get to it (user POV),
+   Driving it with control-invoker, Gotchas.
+5. Update `references/features/README.md` sweep order when adding a file.
+6. Re-run `catalog --check` until exit 0.
+7. Re-run `bash scripts/test-verify-skill.sh`.
+
+## Non-goals
+
+- Do not rewrite product UI to satisfy the catalog.
+- Do not attach to the user's open Electron window.
+- Do not replace `skills/visual-proof` or `skills/prove-it`.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: verify
+description: >
+  Drive and prove Invoker UI/live-path changes via skills/verify/control-invoker.mjs:
+  doctor, feature-map prove commands, isolated-Electron drive, visual-proof wrap,
+  and owner query. Use for Invoker UI claims, before asserting done/shipped, or when
+  the user asks to verify / control-invoker / prove a surface.
+---
+
+# verify
+
+Project-local verification skill for the Invoker desktop app. Agents close their
+own loop by running existing Playwright specs, repros, visual-proof capture, and
+live-owner queries — not by asking the human to look.
+
+Keep using `skills/prove-it/SKILL.md` for the evidence gate (open media this turn;
+prefix `UNVERIFIED:` when you did not). This skill picks **which command** to run.
+
+## CLI
+
+```bash
+node skills/verify/control-invoker.mjs --help
+node skills/verify/control-invoker.mjs doctor --json
+node skills/verify/control-invoker.mjs prove command-palette --dry-run --json
+node skills/verify/control-invoker.mjs prove command-palette
+node skills/verify/control-invoker.mjs catalog --check
+node skills/verify/control-invoker.mjs visual-proof validate --dry-run
+node skills/verify/control-invoker.mjs owner query workflows --dry-run
+node skills/verify/control-invoker.mjs screenshot --out /tmp/invoker-proof.png --dry-run
+```
+
+JSON out (`--json`), rich `--help`, and `--dry-run` on destructive owner actions
+are required. Drive commands launch an isolated Electron build — never attach to the user's already-open window.
+
+## Flow
+
+1. Match the change to a file under `references/features/`.
+2. Run `doctor` (fail closed on stale UI/app builds).
+3. Run `prove <feature>` (or drive + screenshot for a one-off path).
+4. For PR pixels, use `visual-proof capture-before|capture-after` (wraps `scripts/ui-visual-proof.sh`).
+5. For live owner state, use `owner query …` / `owner health` (wraps `invoker-cli` / `invoker-ctl`).
+6. Before claiming done: follow prove-it — open screenshots/video yourself, or cite fresh query output.
+
+## Feature map
+
+`references/features/` — one markdown file per surface. Frontmatter:
+
+```yaml
+---
+id: command-palette
+prove: pnpm --filter @invoker/app exec playwright test e2e/command-palette-open.spec.ts
+testids:
+  - command-palette
+  - app-sidebar
+---
+```
+
+Body uses the four headings: Sub-features, How to get to it (user POV), Driving
+it with control-invoker, Gotchas.
+
+Maintain drift with `skills/maintain-verify/SKILL.md` and `catalog --check`.
+
+## Efficacy fixtures
+
+Under `tests/`:
+
+- `fires_example.md` — UI claim that must load verify and run `prove <feature>`
+- `stays_silent_example.md` — non-UI change that must not use control-invoker
+- `efficacy-router.test.mjs` — asserts known prompts map to the right prove command
+
+Run: `bash scripts/test-verify-skill.sh`
+
+## Non-goals
+
+- Do not rewrite Playwright specs or `scripts/repro/*`.
+- Do not attach CDP to the user's live desktop session.
+- Do not replace merge-gate visual-proof capture in the task runner.

--- a/skills/verify/control-invoker.mjs
+++ b/skills/verify/control-invoker.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { resolveRepoRoot, featuresDir } from './lib/repo.mjs';
+import { runDoctor } from './lib/doctor.mjs';
+import { runProve, resolveProve } from './lib/prove.mjs';
+import { runCatalogCheck } from './lib/catalog.mjs';
+import { runOwner } from './lib/owner.mjs';
+import { runVisualProof } from './lib/visual-proof.mjs';
+import { runDrive } from './lib/drive.mjs';
+import { loadFeatureMap } from './lib/feature-map.mjs';
+
+function printHelp() {
+  console.log(`control-invoker — verify Invoker UI/live-path via existing levers
+
+Commands:
+  doctor [--json] [--skip-cli-doctor]
+      invoker-cli doctor + UI/app build freshness + Playwright + feature map
+
+  prove <feature-id> [--dry-run] [--json]
+      Run the prove: command from references/features/<id>.md
+
+  catalog --check [--json]
+      Drift gate: required sidebar testids + prove paths must exist
+
+  catalog --list [--json]
+      List feature ids and prove commands
+
+  visual-proof <capture-before|capture-after|compare|embed|validate> [--dry-run]
+      Thin wrap of scripts/ui-visual-proof.sh
+
+  owner <invoker-ctl-or-query-args...> [--dry-run] [--json]
+      Wrap ./invoker-ctl or invoker-cli query/wait.
+      Destructive cmds (cancel/approve/delete/...) require omit --dry-run to run.
+
+  snapshot|screenshot|click|aria-click|press|send [--dry-run] [--json]
+      Drive an isolated Electron build (never the user's open window).
+      click --testid <id>
+      aria-click --name <label> [--role button]
+      press --key <Meta+K>
+      screenshot [--out path.png]
+      send --text <message>
+
+Flags:
+  --json          machine-readable stdout
+  --dry-run       print/resolve without side effects
+  --help, -h      this help
+`);
+}
+
+function parseArgs(argv) {
+  const flags = new Set();
+  const kv = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--json' || a === '--dry-run' || a === '--skip-cli-doctor' || a === '--check' || a === '--list' || a === '--help' || a === '-h') {
+      flags.add(a);
+      continue;
+    }
+    if (a.startsWith('--') && i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+      kv[a.slice(2)] = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    positional.push(a);
+  }
+  return { flags, kv, positional };
+}
+
+function emit(jsonMode, payload, exitCode) {
+  if (jsonMode) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else if (payload.error) {
+    console.error(payload.error);
+  } else if (typeof payload.stdout === 'string' && payload.stdout) {
+    process.stdout.write(payload.stdout.endsWith('\n') ? payload.stdout : `${payload.stdout}\n`);
+  } else if (payload.detail) {
+    console.log(payload.detail);
+  } else if (payload.command) {
+    console.log(payload.command);
+  } else {
+    console.log(JSON.stringify(payload, null, 2));
+  }
+  if (payload.stderr && !jsonMode) {
+    process.stderr.write(payload.stderr.endsWith('\n') ? payload.stderr : `${payload.stderr}\n`);
+  }
+  process.exitCode = exitCode;
+}
+
+async function main() {
+  const { flags, kv, positional } = parseArgs(process.argv.slice(2));
+  if (flags.has('--help') || flags.has('-h') || positional.length === 0) {
+    printHelp();
+    process.exitCode = positional.length === 0 && !flags.has('--help') && !flags.has('-h') ? 1 : 0;
+    return;
+  }
+
+  const jsonMode = flags.has('--json');
+  const dryRun = flags.has('--dry-run');
+  const repoRoot = resolveRepoRoot();
+  const featuresRoot = featuresDir(repoRoot);
+  const cmd = positional[0];
+
+  if (cmd === 'doctor') {
+    const result = runDoctor({ repoRoot, skipCliDoctor: flags.has('--skip-cli-doctor') });
+    if (jsonMode) {
+      emit(true, result, result.ok ? 0 : 1);
+      return;
+    }
+    for (const check of result.checks) {
+      console.log(`${check.ok ? 'OK' : 'FAIL'}  ${check.name}: ${check.detail}`);
+    }
+    process.exitCode = result.ok ? 0 : 1;
+    return;
+  }
+
+  if (cmd === 'prove') {
+    const featureId = positional[1];
+    if (!featureId) {
+      emit(jsonMode, { error: 'prove requires <feature-id>' }, 1);
+      return;
+    }
+    if (dryRun) {
+      const resolved = resolveProve(featuresRoot, featureId);
+      emit(jsonMode, resolved.ok
+        ? { ok: true, dryRun: true, feature: resolved.feature.id, command: resolved.command, testids: resolved.feature.testids }
+        : { ok: false, error: resolved.error }, resolved.ok ? 0 : 1);
+      return;
+    }
+    const result = runProve({ featuresRoot, featureId, repoRoot, dryRun: false });
+    emit(jsonMode, result, result.exitCode);
+    return;
+  }
+
+  if (cmd === 'catalog') {
+    if (flags.has('--list')) {
+      const features = loadFeatureMap(featuresRoot);
+      const payload = features.map((f) => ({ id: f.id, prove: f.prove, testids: f.testids }));
+      if (jsonMode) console.log(JSON.stringify(payload, null, 2));
+      else for (const f of payload) console.log(`${f.id}\t${f.prove}`);
+      process.exitCode = 0;
+      return;
+    }
+    if (!flags.has('--check')) {
+      emit(jsonMode, { error: 'catalog requires --check or --list' }, 1);
+      return;
+    }
+    const result = runCatalogCheck({ featuresRoot, repoRoot });
+    if (jsonMode) {
+      emit(true, result, result.ok ? 0 : 1);
+      return;
+    }
+    for (const w of result.warnings) console.warn(`WARN  ${w}`);
+    for (const e of result.errors) console.error(`FAIL  ${e}`);
+    if (result.ok) console.log(`OK  catalog --check (${result.featureCount} features)`);
+    process.exitCode = result.ok ? 0 : 1;
+    return;
+  }
+
+  if (cmd === 'visual-proof') {
+    const sub = positional[1];
+    if (!sub) {
+      emit(jsonMode, { error: 'visual-proof requires a subcommand' }, 1);
+      return;
+    }
+    const result = runVisualProof({ repoRoot, subcommand: sub, extraArgs: positional.slice(2), dryRun });
+    emit(jsonMode, result, result.exitCode);
+    return;
+  }
+
+  if (cmd === 'owner') {
+    const result = runOwner({ repoRoot, args: positional.slice(1), dryRun });
+    emit(jsonMode, result, result.exitCode);
+    return;
+  }
+
+  const driveActions = new Set(['snapshot', 'screenshot', 'click', 'aria-click', 'press', 'send']);
+  if (driveActions.has(cmd)) {
+    const result = await runDrive({
+      repoRoot,
+      action: cmd,
+      args: kv,
+      dryRun,
+    });
+    emit(jsonMode, result, result.exitCode ?? (result.ok ? 0 : 1));
+    return;
+  }
+
+  emit(jsonMode, { error: `unknown command: ${cmd}` }, 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack : String(err));
+  process.exitCode = 1;
+});

--- a/skills/verify/lib/catalog.mjs
+++ b/skills/verify/lib/catalog.mjs
@@ -1,0 +1,59 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadFeatureMap } from './feature-map.mjs';
+
+export const REQUIRED_SIDEBAR_TESTIDS = [
+  'app-sidebar',
+  'sidebar-home',
+  'sidebar-planning',
+  'sidebar-attention',
+  'sidebar-workers',
+  'sidebar-workflows',
+];
+
+export function runCatalogCheck(opts) {
+  const features = loadFeatureMap(opts.featuresRoot);
+  const errors = [];
+  const warnings = [];
+  const covered = new Set();
+
+  if (features.length === 0) {
+    errors.push('no feature files under references/features (expected *.md besides README.md)');
+  }
+
+  for (const feature of features) {
+    for (const id of feature.testids) covered.add(id);
+    if (!feature.prove || !feature.prove.trim()) {
+      errors.push(`${feature.id}: missing prove: frontmatter`);
+      continue;
+    }
+    const prove = feature.prove.trim();
+    const pathMatch = prove.match(/(?:^|\s)((?:packages|scripts)\/[^\s]+\.(?:ts|tsx|js|mjs|sh|spec\.ts))/);
+    if (pathMatch) {
+      const rel = pathMatch[1];
+      const abs = join(opts.repoRoot, rel);
+      if (!existsSync(abs)) {
+        errors.push(`${feature.id}: prove path does not exist: ${rel}`);
+      }
+    }
+  }
+
+  for (const required of REQUIRED_SIDEBAR_TESTIDS) {
+    if (!covered.has(required)) {
+      errors.push(`required sidebar testid not covered by any feature: ${required}`);
+    }
+  }
+
+  const multi = features.find((f) => f.id === 'multi-surface-journeys');
+  if (!multi) {
+    warnings.push('missing multi-surface-journeys.md (recommended for broad sweeps)');
+  }
+
+  return {
+    ok: errors.length === 0,
+    featureCount: features.length,
+    coveredTestids: [...covered].sort(),
+    errors,
+    warnings,
+  };
+}

--- a/skills/verify/lib/doctor.mjs
+++ b/skills/verify/lib/doctor.mjs
@@ -1,0 +1,101 @@
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function fileMtimeMs(path) {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function newestSourceMtime(repoRoot, packageName) {
+  const src = join(repoRoot, 'packages', packageName, 'src');
+  if (!existsSync(src)) return null;
+  const result = spawnSync('find', [src, '-type', 'f', '(', '-name', '*.ts', '-o', '-name', '*.tsx', ')'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 || !result.stdout.trim()) return null;
+  let newest = 0;
+  for (const line of result.stdout.trim().split('\n')) {
+    const m = fileMtimeMs(line);
+    if (m != null && m > newest) newest = m;
+  }
+  return newest || null;
+}
+
+export function runDoctor(opts) {
+  const { repoRoot, skipCliDoctor = false } = opts;
+  const checks = [];
+  let ok = true;
+
+  const uiDist = join(repoRoot, 'packages/ui/dist/index.html');
+  const appMain = join(repoRoot, 'packages/app/dist/main.js');
+  const uiExists = existsSync(uiDist);
+  const appExists = existsSync(appMain);
+  checks.push({ name: 'ui-build', ok: uiExists, detail: uiExists ? uiDist : 'missing packages/ui/dist/index.html — run pnpm --filter @invoker/ui build' });
+  checks.push({ name: 'app-build', ok: appExists, detail: appExists ? appMain : 'missing packages/app/dist/main.js — run pnpm --filter @invoker/app build' });
+  if (!uiExists || !appExists) ok = false;
+
+  if (uiExists) {
+    const srcM = newestSourceMtime(repoRoot, 'ui');
+    const distM = fileMtimeMs(uiDist);
+    const stale = srcM != null && distM != null && srcM > distM + 1000;
+    checks.push({
+      name: 'ui-freshness',
+      ok: !stale,
+      detail: stale ? 'packages/ui/src is newer than dist — rebuild before proving UI' : 'ui dist is fresh enough',
+    });
+    if (stale) ok = false;
+  }
+
+  if (appExists) {
+    const srcM = newestSourceMtime(repoRoot, 'app');
+    const distM = fileMtimeMs(appMain);
+    const stale = srcM != null && distM != null && srcM > distM + 1000;
+    checks.push({
+      name: 'app-freshness',
+      ok: !stale,
+      detail: stale ? 'packages/app/src is newer than dist — rebuild before proving UI' : 'app dist is fresh enough',
+    });
+    if (stale) ok = false;
+  }
+
+  const playwrightCli = join(repoRoot, 'packages/app/node_modules/@playwright/test/cli.js');
+  const playwrightOk = existsSync(playwrightCli) || existsSync(join(repoRoot, 'node_modules/@playwright/test'));
+  checks.push({
+    name: 'playwright',
+    ok: playwrightOk,
+    detail: playwrightOk ? 'playwright package present' : 'missing @playwright/test — run pnpm install',
+  });
+  if (!playwrightOk) ok = false;
+
+  const featuresRoot = join(repoRoot, 'skills/verify/references/features');
+  const featuresOk = existsSync(featuresRoot);
+  checks.push({
+    name: 'feature-map',
+    ok: featuresOk,
+    detail: featuresOk ? featuresRoot : 'missing skills/verify/references/features',
+  });
+  if (!featuresOk) ok = false;
+
+  if (!skipCliDoctor) {
+    const doctor = spawnSync('invoker-cli', ['doctor', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    const cliOk = doctor.status === 0;
+    checks.push({
+      name: 'invoker-cli-doctor',
+      ok: cliOk,
+      detail: cliOk
+        ? (doctor.stdout.trim() || 'invoker-cli doctor passed')
+        : (doctor.stderr.trim() || doctor.stdout.trim() || `invoker-cli doctor exited ${doctor.status}`),
+    });
+    if (!cliOk) ok = false;
+  }
+
+  return { ok, checks };
+}

--- a/skills/verify/lib/drive.mjs
+++ b/skills/verify/lib/drive.mjs
@@ -1,0 +1,117 @@
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+export async function launchIsolatedApp(opts) {
+  const { _electron: electron } = await import('@playwright/test');
+  const mainJs = join(opts.repoRoot, 'packages/app/dist/main.js');
+  if (!existsSync(mainJs)) {
+    throw new Error(`missing ${mainJs} — run pnpm --filter @invoker/app build`);
+  }
+
+  const testDir = mkdtempSync(join(tmpdir(), 'invoker-verify-drive-'));
+  const electronUserDataDir = join(testDir, 'electron-user-data');
+  const ipcSocketPath = join(testDir, 'invoker.sock');
+  const configPath = join(testDir, 'config.json');
+  writeFileSync(configPath, JSON.stringify({ worktreeBaseDir: join(testDir, 'worktrees') }, null, 2));
+
+  const app = await electron.launch({
+    args: [
+      ...(process.platform === 'linux'
+        ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu']
+        : []),
+      `--user-data-dir=${electronUserDataDir}`,
+      mainJs,
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      INVOKER_TEST_WORKFLOW_IDS: '1',
+      INVOKER_DISABLE_SLACK: '1',
+      TZ: 'UTC',
+      INVOKER_GUI_OWNER_MODE: 'gui',
+      INVOKER_DB_DIR: testDir,
+      INVOKER_IPC_SOCKET: ipcSocketPath,
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_REPO_CONFIG_PATH: configPath,
+      INVOKER_TEST_FIXED_NOW: '2025-01-01T00:00:00.000Z',
+    },
+  });
+
+  const page = await app.firstWindow();
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 30_000 });
+  await delay(250);
+  return { app, page, testDir };
+}
+
+export async function runDrive(opts) {
+  const { action, args, dryRun, repoRoot } = opts;
+  const supported = new Set(['snapshot', 'screenshot', 'click', 'aria-click', 'press', 'send']);
+  if (!supported.has(action)) {
+    return { ok: false, exitCode: 1, error: `unknown drive action: ${action}` };
+  }
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      exitCode: 0,
+      action,
+      args,
+      detail: `would launch isolated Electron and run ${action}`,
+    };
+  }
+
+  let session;
+  try {
+    session = await launchIsolatedApp({ repoRoot });
+    const { app, page } = session;
+    let result = {};
+
+    if (action === 'snapshot') {
+      result = { snapshot: await page.accessibility.snapshot() };
+    } else if (action === 'screenshot') {
+      const out = resolve(args.out || join(tmpdir(), `invoker-verify-${Date.now()}.png`));
+      await page.screenshot({ path: out, timeout: 60_000 });
+      result = { path: out };
+    } else if (action === 'click') {
+      const testid = args.testid || args.target;
+      if (!testid) throw new Error('click requires --testid <data-testid>');
+      await page.getByTestId(testid).click({ timeout: 15_000 });
+      result = { clicked: testid };
+    } else if (action === 'aria-click') {
+      const name = args.name || args.target;
+      if (!name) throw new Error('aria-click requires --name <accessible name>');
+      await page.getByRole(args.role || 'button', { name }).click({ timeout: 15_000 });
+      result = { clicked: name, role: args.role || 'button' };
+    } else if (action === 'press') {
+      const key = args.key || args.target;
+      if (!key) throw new Error('press requires --key <chord>');
+      await page.keyboard.press(key);
+      result = { pressed: key };
+    } else if (action === 'send') {
+      const text = args.text || args.target;
+      if (!text) throw new Error('send requires --text <message>');
+      const chat = page.getByTestId('planning-chat-input');
+      if (await chat.count()) {
+        await chat.fill(text);
+        await page.keyboard.press('Enter');
+      } else {
+        await page.keyboard.type(text);
+        await page.keyboard.press('Enter');
+      }
+      result = { sent: text };
+    }
+
+    await app.close();
+    return { ok: true, dryRun: false, exitCode: 0, action, ...result };
+  } catch (err) {
+    try {
+      await session?.app?.close();
+    } catch {
+      void 0;
+    }
+    return { ok: false, exitCode: 1, error: err instanceof Error ? err.message : String(err), action };
+  }
+}

--- a/skills/verify/lib/feature-map.mjs
+++ b/skills/verify/lib/feature-map.mjs
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+function parseSimpleYaml(block) {
+  const out = {};
+  let currentKey = null;
+  let currentList = null;
+  for (const raw of block.split('\n')) {
+    const line = raw.replace(/\t/g, '  ');
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const listMatch = line.match(/^\s+-\s+(.+)$/);
+    if (listMatch && currentKey) {
+      if (!currentList) {
+        currentList = [];
+        out[currentKey] = currentList;
+      }
+      currentList.push(stripQuotes(listMatch[1].trim()));
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (kv) {
+      currentKey = kv[1];
+      currentList = null;
+      const value = kv[2].trim();
+      if (value === '' || value === '|' || value === '>') {
+        out[currentKey] = value === '' ? '' : value;
+        continue;
+      }
+      out[currentKey] = stripQuotes(value);
+    }
+  }
+  return out;
+}
+
+function stripQuotes(value) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function parseFeatureFile(absolutePath) {
+  const raw = readFileSync(absolutePath, 'utf8');
+  const match = raw.match(FRONTMATTER_RE);
+  const meta = match ? parseSimpleYaml(match[1]) : {};
+  const body = match ? raw.slice(match[0].length) : raw;
+  const id = meta.id || basename(absolutePath, '.md');
+  const testids = Array.isArray(meta.testids)
+    ? meta.testids
+    : typeof meta.testids === 'string' && meta.testids
+      ? [meta.testids]
+      : [];
+  return {
+    id,
+    path: absolutePath,
+    prove: typeof meta.prove === 'string' ? meta.prove : '',
+    testids,
+    body,
+    meta,
+  };
+}
+
+export function listFeatureFiles(featuresRoot) {
+  if (!existsSync(featuresRoot)) return [];
+  return readdirSync(featuresRoot)
+    .filter((name) => name.endsWith('.md') && name !== 'README.md')
+    .map((name) => join(featuresRoot, name))
+    .filter((path) => statSync(path).isFile())
+    .sort();
+}
+
+export function loadFeatureMap(featuresRoot) {
+  return listFeatureFiles(featuresRoot).map(parseFeatureFile);
+}
+
+export function findFeature(featuresRoot, featureId) {
+  const needle = featureId.replace(/\.md$/i, '');
+  const all = loadFeatureMap(featuresRoot);
+  return all.find((f) => f.id === needle || basename(f.path, '.md') === needle) ?? null;
+}

--- a/skills/verify/lib/owner.mjs
+++ b/skills/verify/lib/owner.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DESTRUCTIVE_OWNER = new Set([
+  'cancel',
+  'delete-workflow',
+  'approve',
+  'reject',
+  'recreate-workflow',
+  'resolve-conflict',
+  'retry-task',
+  'input',
+  'edit',
+  'edit-type',
+  'edit-agent',
+  'set',
+]);
+
+export function runOwner(opts) {
+  const args = opts.args;
+  if (args.length === 0) {
+    return { ok: false, exitCode: 1, stdout: '', stderr: 'owner requires a subcommand (e.g. health, status, query workflows)' };
+  }
+
+  const head = args[0];
+
+  if (head === 'query' || head === 'wait') {
+    if (opts.dryRun) {
+      return { ok: true, dryRun: true, exitCode: 0, stdout: `invoker-cli ${args.join(' ')}`, stderr: '', ran: false };
+    }
+    const result = spawnSync('invoker-cli', args, {
+      cwd: opts.repoRoot,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    return {
+      ok: result.status === 0,
+      dryRun: false,
+      exitCode: result.status ?? 1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      ran: true,
+    };
+  }
+
+  const ctl = join(opts.repoRoot, 'invoker-ctl');
+  if (!existsSync(ctl)) {
+    return { ok: false, exitCode: 1, stdout: '', stderr: `missing invoker-ctl at ${ctl}` };
+  }
+
+  if (DESTRUCTIVE_OWNER.has(head) && opts.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      exitCode: 0,
+      stdout: `./invoker-ctl ${args.join(' ')}`,
+      stderr: '',
+      ran: false,
+      destructive: true,
+    };
+  }
+
+  if (opts.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      exitCode: 0,
+      stdout: `./invoker-ctl ${args.join(' ')}`,
+      stderr: '',
+      ran: false,
+    };
+  }
+
+  const result = spawnSync(ctl, args, {
+    cwd: opts.repoRoot,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  return {
+    ok: result.status === 0,
+    dryRun: false,
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    ran: true,
+    destructive: DESTRUCTIVE_OWNER.has(head),
+  };
+}
+
+export { DESTRUCTIVE_OWNER };

--- a/skills/verify/lib/prove.mjs
+++ b/skills/verify/lib/prove.mjs
@@ -1,0 +1,47 @@
+import { spawnSync } from 'node:child_process';
+import { findFeature } from './feature-map.mjs';
+
+export function resolveProve(featuresRoot, featureId) {
+  const feature = findFeature(featuresRoot, featureId);
+  if (!feature) {
+    return { ok: false, error: `unknown feature: ${featureId}`, feature: null, command: null };
+  }
+  if (!feature.prove || !feature.prove.trim()) {
+    return { ok: false, error: `feature ${feature.id} has no prove command in frontmatter`, feature, command: null };
+  }
+  return { ok: true, error: null, feature, command: feature.prove.trim() };
+}
+
+export function runProve(opts) {
+  const resolved = resolveProve(opts.featuresRoot, opts.featureId);
+  if (!resolved.ok) {
+    return { ...resolved, exitCode: 1, stdout: '', stderr: resolved.error };
+  }
+  if (opts.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      feature: resolved.feature,
+      command: resolved.command,
+      exitCode: 0,
+      stdout: resolved.command,
+      stderr: '',
+    };
+  }
+  const result = spawnSync(resolved.command, {
+    cwd: opts.repoRoot,
+    encoding: 'utf8',
+    shell: true,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    ok: result.status === 0,
+    dryRun: false,
+    feature: resolved.feature,
+    command: resolved.command,
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}

--- a/skills/verify/lib/repo.mjs
+++ b/skills/verify/lib/repo.mjs
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function resolveRepoRoot(from = __dirname) {
+  let dir = resolve(from);
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml')) && existsSync(join(dir, 'skills'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return resolve(__dirname, '../../..');
+}
+
+export function featuresDir(repoRoot = resolveRepoRoot()) {
+  return join(repoRoot, 'skills/verify/references/features');
+}
+
+export function controlInvokerPath(repoRoot = resolveRepoRoot()) {
+  return join(repoRoot, 'skills/verify/control-invoker.mjs');
+}

--- a/skills/verify/lib/visual-proof.mjs
+++ b/skills/verify/lib/visual-proof.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ALLOWED = new Set(['capture-before', 'capture-after', 'compare', 'embed', 'validate']);
+
+export function runVisualProof(opts) {
+  const sub = opts.subcommand;
+  if (!ALLOWED.has(sub)) {
+    return {
+      ok: false,
+      exitCode: 1,
+      stdout: '',
+      stderr: `unknown visual-proof subcommand: ${sub} (expected ${[...ALLOWED].join('|')})`,
+    };
+  }
+  const script = join(opts.repoRoot, 'scripts/ui-visual-proof.sh');
+  const args = [sub, ...(opts.extraArgs ?? [])];
+  if (opts.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      exitCode: 0,
+      stdout: `bash ${script} ${args.join(' ')}`,
+      stderr: '',
+    };
+  }
+  const result = spawnSync('bash', [script, ...args], {
+    cwd: opts.repoRoot,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  return {
+    ok: result.status === 0,
+    dryRun: false,
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}

--- a/skills/verify/references/features/README.md
+++ b/skills/verify/references/features/README.md
@@ -1,0 +1,45 @@
+# Feature map
+
+Behavior inventory for `control-invoker` / `invoker-verify`.
+
+Each `*.md` file (except this README) has YAML frontmatter:
+
+- `id` — feature id for `prove <id>`
+- `prove` — deterministic shell command (Playwright spec, repro, or owner query)
+- `testids` — `data-testid` values this surface owns
+
+Body headings (required):
+
+1. Sub-features
+2. How to get to it (user POV)
+3. Driving it with control-invoker
+4. Gotchas
+
+## Sweep order
+
+For broad regression, walk top to bottom then finish with `multi-surface-journeys.md`:
+
+1. home
+2. plan-graph
+3. workflows
+4. attention
+5. workers
+6. command-palette
+7. system-setup
+8. queue-task-panel
+9. terminal-drawer
+10. merge-gate
+11. history-timeline
+12. modals
+13. owner-api-live-path
+14. headless-e2e
+15. visual-proof-pr-path
+16. multi-surface-journeys
+
+## Maintain
+
+```bash
+node skills/verify/control-invoker.mjs catalog --check
+```
+
+See `skills/maintain-verify/SKILL.md`.

--- a/skills/verify/references/features/attention.md
+++ b/skills/verify/references/features/attention.md
@@ -1,0 +1,28 @@
+---
+id: attention
+prove: pnpm --filter @invoker/app exec playwright test e2e/attention-click-hitch-responsiveness.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-attention
+---
+
+# attention
+
+## Sub-features
+
+- Needs Attention list
+- Attention click responsiveness
+
+## How to get to it (user POV)
+
+Library → Needs Attention (`sidebar-attention`).
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove attention
+```
+
+## Gotchas
+
+- Hitch specs measure latency; they are still the dedicated attention surface proof.

--- a/skills/verify/references/features/command-palette.md
+++ b/skills/verify/references/features/command-palette.md
@@ -1,0 +1,29 @@
+---
+id: command-palette
+prove: pnpm --filter @invoker/app exec playwright test e2e/command-palette-open.spec.ts
+testids:
+  - command-palette
+  - app-sidebar
+---
+
+# command-palette
+
+## Sub-features
+
+- Open/close via Meta+K
+- Jump to workflow/task/view
+
+## How to get to it (user POV)
+
+From any surface, press Cmd/Ctrl+K.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove command-palette
+node skills/verify/control-invoker.mjs press --key Meta+K --dry-run
+```
+
+## Gotchas
+
+- Assert data-state open/closed on `command-palette`, not just visibility.

--- a/skills/verify/references/features/headless-e2e.md
+++ b/skills/verify/references/features/headless-e2e.md
@@ -1,0 +1,28 @@
+---
+id: headless-e2e
+prove: test -f scripts/e2e-dry-run/run-all.sh
+testids:
+  - app-sidebar
+---
+
+# headless-e2e
+
+## Sub-features
+
+- Headless Electron cases under scripts/e2e-dry-run
+- proof-e2e.manifest suites
+
+## How to get to it (user POV)
+
+No UI window required; run from repo root.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove headless-e2e --dry-run
+pnpm run test:e2e-dry-run
+```
+
+## Gotchas
+
+- prove command here only checks the harness exists; full dry-run suite is long.

--- a/skills/verify/references/features/history-timeline.md
+++ b/skills/verify/references/features/history-timeline.md
@@ -1,0 +1,28 @@
+---
+id: history-timeline
+prove: pnpm --filter @invoker/app exec playwright test e2e/ui-delta-timeline.spec.ts
+testids:
+  - timeline-view
+  - history-view
+---
+
+# history-timeline
+
+## Sub-features
+
+- Timeline view (workers/tasks modes)
+- History task list
+
+## How to get to it (user POV)
+
+Open timeline/history from the UI chrome for a selected workflow.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove history-timeline
+```
+
+## Gotchas
+
+- history-view and timeline-view are sibling surfaces; prove the one you changed.

--- a/skills/verify/references/features/home.md
+++ b/skills/verify/references/features/home.md
@@ -1,0 +1,29 @@
+---
+id: home
+prove: pnpm --filter @invoker/app exec playwright test e2e/keyboard-navigation.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-home
+---
+
+# home
+
+## Sub-features
+
+- Planning chats list on Home
+- Theme toggle and settings rail
+
+## How to get to it (user POV)
+
+Click Invoker / Home in the left rail (`sidebar-home`).
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove home
+node skills/verify/control-invoker.mjs click --testid sidebar-home --dry-run
+```
+
+## Gotchas
+
+- Home shares the sidebar shell with other surfaces; assert `sidebar-home` aria-current when selected.

--- a/skills/verify/references/features/merge-gate.md
+++ b/skills/verify/references/features/merge-gate.md
@@ -1,0 +1,28 @@
+---
+id: merge-gate
+prove: pnpm --filter @invoker/app exec playwright test e2e/pending-review-gate-target-repo.proof.spec.ts
+testids:
+  - approve-merge-button
+  - app-sidebar
+---
+
+# merge-gate
+
+## Sub-features
+
+- Merge gate node on the graph
+- Approve / external review gate
+
+## How to get to it (user POV)
+
+Load a plan with onFinish pull_request; select the merge-gate task node.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove merge-gate
+```
+
+## Gotchas
+
+- visual-proof.spec.ts also has merge-gate capture cases.

--- a/skills/verify/references/features/modals.md
+++ b/skills/verify/references/features/modals.md
@@ -1,0 +1,27 @@
+---
+id: modals
+prove: pnpm --filter @invoker/app exec playwright test e2e/fix-with-agent-transition.spec.ts
+testids:
+  - app-sidebar
+---
+
+# modals
+
+## Sub-features
+
+- Approval / input / replace-task modals
+- Agent transition overlays
+
+## How to get to it (user POV)
+
+Trigger the modal via the task action that opens it (approve, needs_input, replace).
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove modals
+```
+
+## Gotchas
+
+- Prefer a focused modal spec when one exists for the exact dialog.

--- a/skills/verify/references/features/multi-surface-journeys.md
+++ b/skills/verify/references/features/multi-surface-journeys.md
@@ -1,0 +1,33 @@
+---
+id: multi-surface-journeys
+prove: pnpm --filter @invoker/app exec playwright test e2e/keyboard-navigation.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-home
+  - sidebar-planning
+  - sidebar-workflows
+  - sidebar-attention
+  - sidebar-workers
+---
+
+# multi-surface-journeys
+
+## Sub-features
+
+- Cross-surface keyboard/nav journeys
+- Broad sweep ordering
+
+## How to get to it (user POV)
+
+Walk the README sweep order after a UI change that touches shared chrome.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove multi-surface-journeys
+node skills/verify/control-invoker.mjs catalog --check
+```
+
+## Gotchas
+
+- This file exists so catalog --check has a broad-sweep entry; expand prove as journeys grow.

--- a/skills/verify/references/features/owner-api-live-path.md
+++ b/skills/verify/references/features/owner-api-live-path.md
@@ -1,0 +1,29 @@
+---
+id: owner-api-live-path
+prove: test -x invoker-ctl && ./invoker-ctl --help | grep -q health
+testids:
+  - app-sidebar
+---
+
+# owner-api-live-path
+
+## Sub-features
+
+- HTTP API on localhost:4100
+- invoker-ctl health/status/workflows
+- invoker-cli query workflows|tasks
+
+## How to get to it (user POV)
+
+Start an owner (`invoker-cli owner serve` or the desktop app), then query.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs owner health --dry-run
+node skills/verify/control-invoker.mjs owner query workflows --dry-run
+```
+
+## Gotchas
+
+- Live-path claims need a running owner; dry-run only prints the command.

--- a/skills/verify/references/features/plan-graph.md
+++ b/skills/verify/references/features/plan-graph.md
@@ -1,0 +1,28 @@
+---
+id: plan-graph
+prove: pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-planning
+---
+
+# plan-graph
+
+## Sub-features
+
+- Plan / workflow graph (React Flow)
+- Task nodes and selection
+
+## How to get to it (user POV)
+
+Click Plan graph (`sidebar-planning`) after a plan is loaded.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove plan-graph
+```
+
+## Gotchas
+
+- Full visual-proof.spec.ts is heavy; prefer a focused spec when proving a single graph bug.

--- a/skills/verify/references/features/queue-task-panel.md
+++ b/skills/verify/references/features/queue-task-panel.md
@@ -1,0 +1,30 @@
+---
+id: queue-task-panel
+prove: pnpm --filter @invoker/app exec playwright test e2e/queue-running-vs-queued.spec.ts
+testids:
+  - queue-chip-running
+  - queue-chip-queued
+  - app-sidebar
+---
+
+# queue-task-panel
+
+## Sub-features
+
+- Action queue chips
+- Running vs queued semantics
+- Task panel command display
+
+## How to get to it (user POV)
+
+Open a workflow with running/queued tasks; queue chips sit in the status chrome.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove queue-task-panel
+```
+
+## Gotchas
+
+- edit-task-command.spec.ts / edit-task-prompt.spec.ts cover panel edits.

--- a/skills/verify/references/features/system-setup.md
+++ b/skills/verify/references/features/system-setup.md
@@ -1,0 +1,28 @@
+---
+id: system-setup
+prove: pnpm --filter @invoker/app exec playwright test e2e/system-setup-visual-proof.spec.ts
+testids:
+  - rail-settings
+  - app-sidebar
+---
+
+# system-setup
+
+## Sub-features
+
+- System setup / settings modal
+- Bundled skills install UI
+
+## How to get to it (user POV)
+
+Click Settings (`rail-settings`) in the left rail footer.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove system-setup
+```
+
+## Gotchas
+
+- onboarding-cli-visual-proof.spec.ts covers CLI onboarding visuals, not the modal.

--- a/skills/verify/references/features/terminal-drawer.md
+++ b/skills/verify/references/features/terminal-drawer.md
@@ -1,0 +1,28 @@
+---
+id: terminal-drawer
+prove: pnpm --filter @invoker/app exec playwright test e2e/embedded-terminal-pty.spec.ts
+testids:
+  - terminal-drawer
+  - terminal-drawer-body
+---
+
+# terminal-drawer
+
+## Sub-features
+
+- Embedded PTY terminal
+- Expand/collapse and tmux mode
+
+## How to get to it (user POV)
+
+Select a task that opens the terminal drawer.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove terminal-drawer
+```
+
+## Gotchas
+
+- Many terminal garble repros exist; use the specific repro when proving a garble bug.

--- a/skills/verify/references/features/visual-proof-pr-path.md
+++ b/skills/verify/references/features/visual-proof-pr-path.md
@@ -1,0 +1,28 @@
+---
+id: visual-proof-pr-path
+prove: test -f scripts/ui-visual-proof.sh
+testids:
+  - app-sidebar
+---
+
+# visual-proof-pr-path
+
+## Sub-features
+
+- capture-before / capture-after / compare / embed / validate
+- Merge-gate visual proof upload path
+
+## How to get to it (user POV)
+
+For UI-impacting PRs, capture before on base then after on the change.
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs visual-proof validate --dry-run
+node skills/verify/control-invoker.mjs prove visual-proof-pr-path
+```
+
+## Gotchas
+
+- Capture alone is not proof — open media and write Manually inspected: (prove-it).

--- a/skills/verify/references/features/workers.md
+++ b/skills/verify/references/features/workers.md
@@ -1,0 +1,28 @@
+---
+id: workers
+prove: pnpm --filter @invoker/app exec playwright test e2e/workers-surface.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-workers
+---
+
+# workers
+
+## Sub-features
+
+- Workers surface registration and activity
+- Worker tab scroll
+
+## How to get to it (user POV)
+
+Library → Workers (`sidebar-workers`).
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove workers
+```
+
+## Gotchas
+
+- workers-surface.spec.ts is the canonical registration proof.

--- a/skills/verify/references/features/workflows.md
+++ b/skills/verify/references/features/workflows.md
@@ -1,0 +1,28 @@
+---
+id: workflows
+prove: pnpm --filter @invoker/app exec playwright test e2e/workflow-lifecycle.spec.ts
+testids:
+  - app-sidebar
+  - sidebar-workflows
+---
+
+# workflows
+
+## Sub-features
+
+- Workflow list / browser
+- Workflow status composition
+
+## How to get to it (user POV)
+
+Library → Workflows (`sidebar-workflows`).
+
+## Driving it with control-invoker
+
+```bash
+node skills/verify/control-invoker.mjs prove workflows
+```
+
+## Gotchas
+
+- Sibling: workflow-status-composition.spec.ts for chip/status claims.

--- a/skills/verify/scripts/test-skill.sh
+++ b/skills/verify/scripts/test-skill.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/verify/SKILL.md"
+CLI="$REPO_ROOT/skills/verify/control-invoker.mjs"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  grep -qF -- "$needle" "$SKILL_MD" || fail "$hint — missing: $needle"
+}
+
+[[ -f "$SKILL_MD" ]] || fail "expected $SKILL_MD"
+[[ -f "$CLI" ]] || fail "expected $CLI"
+
+must_contain "control-invoker.mjs" "verify skill must name the CLI"
+must_contain "never attach to the user's already-open window" "verify skill must forbid live-window attach"
+must_contain "skills/prove-it/SKILL.md" "verify skill must reference prove-it"
+must_contain "catalog --check" "verify skill must document catalog drift gate"
+must_contain "references/features/" "verify skill must point at the feature map"
+
+# Contract: CLI help and catalog check are runnable without Electron.
+node "$CLI" --help >/dev/null || fail "control-invoker --help failed"
+node "$CLI" catalog --check --json >/dev/null || fail "control-invoker catalog --check failed"
+node "$REPO_ROOT/skills/verify/tests/control-invoker.test.mjs" || fail "control-invoker unit tests failed"
+node "$REPO_ROOT/skills/verify/tests/efficacy-router.test.mjs" || fail "verify efficacy router tests failed"
+
+[[ -f "$REPO_ROOT/skills/verify/tests/fires_example.md" ]] || fail "missing fires_example.md"
+[[ -f "$REPO_ROOT/skills/verify/tests/stays_silent_example.md" ]] || fail "missing stays_silent_example.md"
+grep -qF 'prove command-palette' "$REPO_ROOT/skills/verify/tests/fires_example.md" \
+  || fail "fires_example.md must instruct prove command-palette"
+grep -qF 'does not apply' "$REPO_ROOT/skills/verify/tests/stays_silent_example.md" \
+  || fail "stays_silent_example.md must say verify does not apply"
+
+echo "OK: verify skill contract checks passed"

--- a/skills/verify/tests/control-invoker.test.mjs
+++ b/skills/verify/tests/control-invoker.test.mjs
@@ -1,0 +1,117 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+import { resolveProve } from '../lib/prove.mjs';
+import { runCatalogCheck, REQUIRED_SIDEBAR_TESTIDS } from '../lib/catalog.mjs';
+import { runOwner } from '../lib/owner.mjs';
+import { resolveRepoRoot, featuresDir } from '../lib/repo.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolveRepoRoot(__dirname);
+const cli = join(repoRoot, 'skills/verify/control-invoker.mjs');
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: process.env,
+  });
+}
+
+// 1) prove --dry-run maps command-palette to the real Playwright spec
+{
+  const resolved = resolveProve(featuresDir(repoRoot), 'command-palette');
+  assert(resolved.ok, `resolveProve failed: ${resolved.error}`);
+  assert(
+    resolved.command.includes('command-palette-open.spec.ts'),
+    `expected command-palette spec, got: ${resolved.command}`,
+  );
+  const dry = runCli(['prove', 'command-palette', '--dry-run', '--json']);
+  assert(dry.status === 0, `prove dry-run failed: ${dry.stderr}`);
+  const payload = JSON.parse(dry.stdout);
+  assert(payload.command.includes('command-palette-open.spec.ts'), 'CLI dry-run missing spec path');
+  console.log('OK prove dry-run maps command-palette');
+}
+
+// 2) catalog --check fails when a required sidebar testid is missing
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'invoker-verify-catalog-'));
+  const featuresRoot = join(tmp, 'features');
+  mkdirSync(featuresRoot);
+  writeFileSync(
+    join(featuresRoot, 'incomplete.md'),
+    `---
+id: incomplete
+prove: test -f package.json
+testids:
+  - app-sidebar
+---
+
+# incomplete
+
+## Sub-features
+
+x
+
+## How to get to it (user POV)
+
+x
+
+## Driving it with control-invoker
+
+x
+
+## Gotchas
+
+x
+`,
+  );
+  const result = runCatalogCheck({ featuresRoot, repoRoot });
+  assert(!result.ok, 'expected catalog check to fail on incomplete map');
+  const missing = REQUIRED_SIDEBAR_TESTIDS.filter((id) => id !== 'app-sidebar');
+  for (const id of missing) {
+    assert(
+      result.errors.some((e) => e.includes(id)),
+      `expected error mentioning ${id}, got: ${result.errors.join('; ')}`,
+    );
+  }
+  rmSync(tmp, { recursive: true, force: true });
+  console.log('OK catalog --check fails when sidebar testids missing');
+}
+
+// 3) owner destructive --dry-run does not hit the API (ran: false)
+{
+  const result = runOwner({
+    repoRoot,
+    args: ['cancel', 'fake-task'],
+    dryRun: true,
+  });
+  assert(result.ok, 'dry-run cancel should ok');
+  assert(result.dryRun === true, 'expected dryRun');
+  assert(result.ran === false, 'destructive dry-run must not run');
+  assert(result.destructive === true, 'expected destructive flag');
+  const cliResult = runCli(['owner', 'cancel', 'fake-task', '--dry-run', '--json']);
+  assert(cliResult.status === 0, `owner dry-run failed: ${cliResult.stderr}`);
+  const payload = JSON.parse(cliResult.stdout);
+  assert(payload.ran === false, 'CLI owner dry-run must set ran:false');
+  console.log('OK owner destructive --dry-run does not hit API');
+}
+
+// 4) real catalog --check passes on the committed feature map
+{
+  const check = runCli(['catalog', '--check', '--json']);
+  assert(check.status === 0, `catalog --check failed: ${check.stderr}\n${check.stdout}`);
+  const payload = JSON.parse(check.stdout);
+  assert(payload.ok === true, 'catalog payload not ok');
+  console.log('OK catalog --check on committed feature map');
+}
+
+console.log('OK: control-invoker unit tests passed');

--- a/skills/verify/tests/efficacy-router.test.mjs
+++ b/skills/verify/tests/efficacy-router.test.mjs
@@ -1,0 +1,71 @@
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveProve } from '../lib/prove.mjs';
+import { featuresDir, resolveRepoRoot } from '../lib/repo.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolveRepoRoot(__dirname);
+const featuresRoot = featuresDir(repoRoot);
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+const FIRE_CASES = [
+  {
+    id: 'command-palette',
+    promptIncludes: ['Cmd+K', 'command palette'],
+    proveMustInclude: 'command-palette-open.spec.ts',
+  },
+  {
+    id: 'workers',
+    promptIncludes: ['workers surface', 'sidebar-workers'],
+    proveMustInclude: 'workers-surface.spec.ts',
+  },
+  {
+    id: 'terminal-drawer',
+    promptIncludes: ['terminal drawer', 'embedded terminal'],
+    proveMustInclude: 'embedded-terminal-pty.spec.ts',
+  },
+  {
+    id: 'visual-proof-pr-path',
+    promptIncludes: ['before/after', 'visual proof'],
+    proveMustInclude: 'scripts/ui-visual-proof.sh',
+  },
+];
+
+const firesPath = join(__dirname, 'fires_example.md');
+const silentPath = join(__dirname, 'stays_silent_example.md');
+
+{
+  const fires = readFileSync(firesPath, 'utf8');
+  assert(fires.includes('prove command-palette'), 'fires_example must name prove command-palette');
+  assert(fires.includes('control-invoker'), 'fires_example must name control-invoker');
+  assert(fires.includes('Do not ask the human'), 'fires_example must forbid human-as-verifier');
+
+  const silent = readFileSync(silentPath, 'utf8');
+  assert(silent.includes('does not apply'), 'stays_silent_example must say verify does not apply');
+  assert(silent.includes('packages/contracts'), 'stays_silent_example must be a non-UI contracts change');
+  assert(!silent.includes('prove command-palette'), 'stays_silent must not route to a UI prove');
+  console.log('OK efficacy fixtures present');
+}
+
+for (const c of FIRE_CASES) {
+  const resolved = resolveProve(featuresRoot, c.id);
+  assert(resolved.ok, `resolveProve(${c.id}) failed: ${resolved.error}`);
+  assert(
+    resolved.command.includes(c.proveMustInclude),
+    `${c.id}: expected prove to include ${c.proveMustInclude}, got ${resolved.command}`,
+  );
+  console.log(`OK route ${c.id} → ${c.proveMustInclude}`);
+}
+
+{
+  const bad = resolveProve(featuresRoot, 'not-a-real-surface');
+  assert(!bad.ok, 'unknown feature must fail closed');
+  console.log('OK unknown feature fails closed');
+}
+
+console.log('OK: verify efficacy router tests passed');

--- a/skills/verify/tests/fires_example.md
+++ b/skills/verify/tests/fires_example.md
@@ -1,0 +1,9 @@
+User says: "Cmd+K used to open the command palette but after my change
+it stays closed — prove it works again."
+
+This is an Invoker UI surface claim. Load skills/verify, run
+`node skills/verify/control-invoker.mjs doctor` (or --skip-cli-doctor when
+offline), then `prove command-palette` (or --dry-run first to confirm the
+spec), then follow prove-it before claiming fixed — open any screenshot/video
+yourself or cite the Playwright exit output. Do not ask the human whether the
+palette looks open.

--- a/skills/verify/tests/stays_silent_example.md
+++ b/skills/verify/tests/stays_silent_example.md
@@ -1,0 +1,7 @@
+User says: "I renamed an internal helper in packages/contracts and the
+unit tests pass — can you ship it?"
+
+Nothing about this change touches Invoker UI, Electron, or a live owner
+query. The verify skill's control-invoker / feature-map / visual-proof path
+does not apply — package vitest (or the matching unit command) is the right
+evidence, not `prove <feature>` or a screenshot.


### PR DESCRIPTION
## Summary

Adds a project-local verify skill so agents can close their own UI and live-path loop without asking a human to look.

Ships a control-invoker entrypoint, a feature map under references/features, and a maintain-verify companion for keeping that map current.

Drive paths launch an isolated Electron build only. They never attach to a window the user already has open.

## Review Claim

Approve adding the verify and maintain-verify skills with their feature map and control-invoker entrypoint under skills/.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Isolated Electron only; never attach to the user's already-open window. Feature prove entries only point at existing specs and scripts; this slice does not add a new heavy Playwright CI shard.

## Slice Rationale

Keep the skill content reviewable as docs before any CI or evidence-skill wiring lands.

## Non-goals

- Does not change package.json, required-fast suites, or .github/workflows.
- Does not update prove-it, visual-proof, or make-pr skill pointers.
- Does not add .claude/skills harness links (Cursor links only in this slice).
- Does not change product runtime under packages/.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/verify/scripts/test-skill.sh`
- [x] `node skills/verify/control-invoker.mjs catalog --check`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
