### PR TITLE
[Verification Contract](1) Define verifier lifecycle and receipts

### DIFF
--- a/packages/contracts/src/__tests__/verification-contract.test.ts
+++ b/packages/contracts/src/__tests__/verification-contract.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  advanceVerifierWorkflow,
+  canonicalVerifierFindingKey,
+  compileVerificationRequirements,
+  createVerifierWorkflow,
+} from '../verification-contract.js';
+
+describe('verifier workflow contract', () => {
+  it('uses canonical lineage and finding identity as the idempotency key', () => {
+    const left = canonicalVerifierFindingKey({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'ABC123',
+      sourceSessionId: 'codex/session-1',
+      findingHash: 'FINDING-A',
+    });
+    const right = canonicalVerifierFindingKey({
+      repository: ' neko-catpital-labs/invoker ',
+      baseCommitSha: 'abc123',
+      sourceSessionId: ' codex/session-1 ',
+      findingHash: 'finding-a',
+    });
+
+    expect(left).toBe(right);
+  });
+
+  it('advances each workflow phase exactly once through the PR branch', () => {
+    const discovered = createVerifierWorkflow({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'abc123',
+      sourceSessionId: 'claude/session-2',
+      findingHash: 'finding-b',
+      discoveredAt: '2026-08-31T10:00:00.000Z',
+    });
+    const validated = advanceVerifierWorkflow(discovered, {
+      phase: 'validated',
+      at: '2026-08-31T10:01:00.000Z',
+    });
+    const dispatched = advanceVerifierWorkflow(validated, {
+      phase: 'dispatched',
+      workflowId: 'wf-1',
+      at: '2026-08-31T10:02:00.000Z',
+    });
+    const prOpened = advanceVerifierWorkflow(dispatched, {
+      phase: 'pr_opened',
+      pullRequestUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+      at: '2026-08-31T10:03:00.000Z',
+    });
+    const graded = advanceVerifierWorkflow(prOpened, {
+      phase: 'independently_graded',
+      grade: 'accepted',
+      graderId: 'codex-judge',
+      at: '2026-08-31T10:04:00.000Z',
+    });
+    const terminal = advanceVerifierWorkflow(graded, {
+      phase: 'terminal',
+      outcome: 'pr_opened',
+      at: '2026-08-31T10:05:00.000Z',
+    });
+
+    expect(terminal.phase).toBe('terminal');
+    expect(terminal.history.map((entry) => entry.phase)).toEqual([
+      'discovered',
+      'validated',
+      'dispatched',
+      'pr_opened',
+      'independently_graded',
+      'terminal',
+    ]);
+    expect(advanceVerifierWorkflow(terminal, {
+      phase: 'terminal',
+      outcome: 'pr_opened',
+      at: '2026-08-31T10:05:00.000Z',
+    })).toBe(terminal);
+  });
+
+  it('supports no-finding terminalization and refuses skipped or repeated phases', () => {
+    const discovered = createVerifierWorkflow({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'abc123',
+      sourceSessionId: 'cursor/session-3',
+      findingHash: 'finding-c',
+      discoveredAt: '2026-08-31T10:00:00.000Z',
+    });
+
+    expect(() => advanceVerifierWorkflow(discovered, {
+      phase: 'dispatched',
+      workflowId: 'wf-skipped-validation',
+      at: '2026-08-31T10:01:00.000Z',
+    })).toThrow(/cannot transition from discovered to dispatched/);
+
+    const validated = advanceVerifierWorkflow(discovered, {
+      phase: 'validated',
+      at: '2026-08-31T10:01:00.000Z',
+    });
+    expect(() => advanceVerifierWorkflow(validated, {
+      phase: 'validated',
+      at: '2026-08-31T10:02:00.000Z',
+    })).toThrow(/phase validated was already persisted/);
+
+    const dispatched = advanceVerifierWorkflow(validated, {
+      phase: 'dispatched',
+      workflowId: 'wf-2',
+      at: '2026-08-31T10:02:00.000Z',
+    });
+    const noFinding = advanceVerifierWorkflow(dispatched, {
+      phase: 'no_finding',
+      reason: 'No durable finding survived validation',
+      at: '2026-08-31T10:03:00.000Z',
+    });
+    const graded = advanceVerifierWorkflow(noFinding, {
+      phase: 'independently_graded',
+      grade: 'accepted',
+      graderId: 'claude-judge',
+      at: '2026-08-31T10:04:00.000Z',
+    });
+
+    expect(advanceVerifierWorkflow(graded, {
+      phase: 'terminal',
+      outcome: 'no_finding',
+      at: '2026-08-31T10:05:00.000Z',
+    }).phase).toBe('terminal');
+  });
+});
+
+describe('verification requirement compiler', () => {
+  it('orders deterministic execution first and independent judgment last', () => {
+    expect(compileVerificationRequirements([
+      'bug_fix',
+      'visual_ui',
+      'external_effect',
+      'deployment',
+    ])).toEqual([
+      'deterministic_command',
+      'bug_repro_fail_pass',
+      'opened_visual_proof',
+      'external_effect_reconciliation',
+      'deployed_version',
+      'independent_judgment',
+    ]);
+  });
+
+  it('deduplicates repeated change classes', () => {
+    expect(compileVerificationRequirements(['bug_fix', 'bug_fix'])).toEqual([
+      'deterministic_command',
+      'bug_repro_fail_pass',
+      'independent_judgment',
+    ]);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -18,4 +18,5 @@ export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export * from './planning-surface.ts';
+export * from './verification-contract.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/verification-contract.ts
+++ b/packages/contracts/src/verification-contract.ts
@@ -1,0 +1,258 @@
+export type VerificationChangeClass =
+  | 'code'
+  | 'bug_fix'
+  | 'visual_ui'
+  | 'external_effect'
+  | 'deployment'
+  | 'documentation';
+
+export type VerificationRequirementKind =
+  | 'deterministic_command'
+  | 'bug_repro_fail_pass'
+  | 'opened_visual_proof'
+  | 'external_effect_reconciliation'
+  | 'deployed_version'
+  | 'independent_judgment';
+
+export type VerifierWorkflowPhase =
+  | 'discovered'
+  | 'validated'
+  | 'dispatched'
+  | 'pr_opened'
+  | 'no_finding'
+  | 'independently_graded'
+  | 'terminal';
+
+export interface VerifierFindingIdentity {
+  repository: string;
+  baseCommitSha: string;
+  sourceSessionId: string;
+  findingHash: string;
+}
+
+export interface CanonicalVerifierFindingIdentity extends VerifierFindingIdentity {
+  key: string;
+}
+
+export type VerifierWorkflowEvent =
+  | { phase: 'discovered'; at: string }
+  | { phase: 'validated'; at: string }
+  | { phase: 'dispatched'; workflowId: string; at: string }
+  | { phase: 'pr_opened'; pullRequestUrl: string; at: string }
+  | { phase: 'no_finding'; reason: string; at: string }
+  | {
+    phase: 'independently_graded';
+    grade: 'accepted' | 'rejected';
+    graderId: string;
+    at: string;
+  }
+  | {
+    phase: 'terminal';
+    outcome: 'pr_opened' | 'no_finding' | 'rejected';
+    at: string;
+  };
+
+export interface VerifierWorkflowRecord {
+  version: 1;
+  identity: CanonicalVerifierFindingIdentity;
+  phase: VerifierWorkflowPhase;
+  history: VerifierWorkflowEvent[];
+}
+
+export interface CreateVerifierWorkflowInput extends VerifierFindingIdentity {
+  discoveredAt: string;
+}
+
+export type AdvanceVerifierWorkflowEvent = Exclude<VerifierWorkflowEvent, { phase: 'discovered' }>;
+
+export type VerificationActorRole = 'builder' | 'verifier' | 'judge';
+
+export interface VerificationActor {
+  id: string;
+  role: VerificationActorRole;
+}
+
+interface VerificationReceiptBase {
+  id: string;
+  commitSha: string;
+  recordedAt: string;
+  actor: VerificationActor;
+  status: 'passed' | 'failed';
+}
+
+export interface DeterministicCommandReceipt extends VerificationReceiptBase {
+  kind: 'deterministic_command';
+  command: string;
+  exitCode: number;
+  output: string;
+}
+
+export interface BugReproFailPassReceipt extends VerificationReceiptBase {
+  kind: 'bug_repro_fail_pass';
+  before: {
+    command: string;
+    exitCode: number;
+    output: string;
+  };
+  after: {
+    command: string;
+    exitCode: number;
+    output: string;
+  };
+}
+
+export interface OpenedVisualProofReceipt extends VerificationReceiptBase {
+  kind: 'opened_visual_proof';
+  mediaPath: string;
+  openedAt: string;
+  observation: string;
+}
+
+export interface ExternalEffectReconciliationReceipt extends VerificationReceiptBase {
+  kind: 'external_effect_reconciliation';
+  system: string;
+  expectedState: string;
+  observedState: string;
+  reconciled: boolean;
+}
+
+export interface DeployedVersionReceipt extends VerificationReceiptBase {
+  kind: 'deployed_version';
+  environment: string;
+  deployedCommitSha: string;
+  version: string;
+}
+
+export interface IndependentJudgmentReceipt extends VerificationReceiptBase {
+  kind: 'independent_judgment';
+  verdict: 'approve' | 'reject';
+  rationale: string;
+}
+
+export type VerificationReceipt =
+  | DeterministicCommandReceipt
+  | BugReproFailPassReceipt
+  | OpenedVisualProofReceipt
+  | ExternalEffectReconciliationReceipt
+  | DeployedVersionReceipt
+  | IndependentJudgmentReceipt;
+
+const requirementOrder: VerificationRequirementKind[] = [
+  'deterministic_command',
+  'bug_repro_fail_pass',
+  'opened_visual_proof',
+  'external_effect_reconciliation',
+  'deployed_version',
+  'independent_judgment',
+];
+
+const requirementsByChangeClass: Record<VerificationChangeClass, VerificationRequirementKind[]> = {
+  code: [],
+  bug_fix: ['bug_repro_fail_pass'],
+  visual_ui: ['opened_visual_proof'],
+  external_effect: ['external_effect_reconciliation'],
+  deployment: ['deployed_version'],
+  documentation: [],
+};
+
+const nextPhases: Record<VerifierWorkflowPhase, VerifierWorkflowPhase[]> = {
+  discovered: ['validated'],
+  validated: ['dispatched'],
+  dispatched: ['pr_opened', 'no_finding'],
+  pr_opened: ['independently_graded'],
+  no_finding: ['independently_graded'],
+  independently_graded: ['terminal'],
+  terminal: [],
+};
+
+function requiredText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${field} must be a non-empty string`);
+  return normalized;
+}
+
+function encoded(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function canonicalVerifierFindingIdentity(
+  input: VerifierFindingIdentity,
+): CanonicalVerifierFindingIdentity {
+  const repository = requiredText(input.repository, 'repository').toLowerCase();
+  const baseCommitSha = requiredText(input.baseCommitSha, 'baseCommitSha').toLowerCase();
+  const sourceSessionId = requiredText(input.sourceSessionId, 'sourceSessionId');
+  const findingHash = requiredText(input.findingHash, 'findingHash').toLowerCase();
+  return {
+    repository,
+    baseCommitSha,
+    sourceSessionId,
+    findingHash,
+    key: `v1:${encoded(repository)}:${encoded(baseCommitSha)}:${encoded(sourceSessionId)}:${encoded(findingHash)}`,
+  };
+}
+
+export function canonicalVerifierFindingKey(input: VerifierFindingIdentity): string {
+  return canonicalVerifierFindingIdentity(input).key;
+}
+
+export function createVerifierWorkflow(input: CreateVerifierWorkflowInput): VerifierWorkflowRecord {
+  const discoveredAt = requiredText(input.discoveredAt, 'discoveredAt');
+  return {
+    version: 1,
+    identity: canonicalVerifierFindingIdentity(input),
+    phase: 'discovered',
+    history: [{ phase: 'discovered', at: discoveredAt }],
+  };
+}
+
+function sameEvent(left: VerifierWorkflowEvent, right: VerifierWorkflowEvent): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function assertTerminalOutcome(record: VerifierWorkflowRecord, event: AdvanceVerifierWorkflowEvent): void {
+  if (event.phase !== 'terminal') return;
+  const grade = record.history.findLast((entry) => entry.phase === 'independently_graded');
+  const result = record.history.findLast((entry) => entry.phase === 'pr_opened' || entry.phase === 'no_finding');
+  const expectedOutcome = grade?.phase === 'independently_graded' && grade.grade === 'rejected'
+    ? 'rejected'
+    : result?.phase;
+  if (event.outcome !== expectedOutcome) {
+    throw new Error(`terminal outcome ${event.outcome} does not match independently graded result ${expectedOutcome ?? 'missing'}`);
+  }
+}
+
+export function advanceVerifierWorkflow(
+  record: VerifierWorkflowRecord,
+  event: AdvanceVerifierWorkflowEvent,
+): VerifierWorkflowRecord {
+  const last = record.history.at(-1);
+  if (last && last.phase === event.phase) {
+    if (sameEvent(last, event)) return record;
+    throw new Error(`phase ${event.phase} was already persisted for ${record.identity.key}`);
+  }
+  if (record.history.some((entry) => entry.phase === event.phase)) {
+    throw new Error(`phase ${event.phase} was already persisted for ${record.identity.key}`);
+  }
+  if (!nextPhases[record.phase].includes(event.phase)) {
+    throw new Error(`cannot transition from ${record.phase} to ${event.phase}`);
+  }
+  assertTerminalOutcome(record, event);
+  return {
+    ...record,
+    phase: event.phase,
+    history: [...record.history, event],
+  };
+}
+
+export function compileVerificationRequirements(
+  changeClasses: readonly VerificationChangeClass[],
+): VerificationRequirementKind[] {
+  const required = new Set<VerificationRequirementKind>([
+    'deterministic_command',
+    'independent_judgment',
+  ]);
+  for (const changeClass of changeClasses) {
+    for (const requirement of requirementsByChangeClass[changeClass]) required.add(requirement);
+  }
+  return requirementOrder.filter((requirement) => required.has(requirement));
+}


### PR DESCRIPTION
## Summary

Defines canonical finding identity and a monotonic verifier lifecycle for future durable storage.

Defines change-class evidence requirements and commit-bound receipt unions shared across Invoker packages.

## Review Claim

Approve the verifier workflow and evidence contract as Invoker's typed foundation for production verification.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

UNCONFIRMED headless assumption: exported pure contracts do not alter existing execution because no runtime caller is activated in this slice.

## Slice Rationale

The shared identity, lifecycle, and receipt vocabulary must exist before workflow-core can enforce readiness decisions.

## Non-goals

- No session-miner, ledger, persistence adapter, or dispatch integration.
- No existing task completion or review behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts test -- verification-contract.test.ts`
- [x] `pnpm --filter @invoker/contracts build`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1c668fae1d`
- Post-revert steps: None
- Data migration? No

</details>
