### PR TITLE
[Verification Contract](2) Route automatic decisions through receipts

### DIFF
--- a/packages/contracts/src/__tests__/verification-contract.test.ts
+++ b/packages/contracts/src/__tests__/verification-contract.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  advanceVerifierWorkflow,
+  canonicalVerifierFindingKey,
+  compileVerificationRequirements,
+  createVerifierWorkflow,
+} from '../verification-contract.js';
+
+describe('verifier workflow contract', () => {
+  it('uses canonical lineage and finding identity as the idempotency key', () => {
+    const left = canonicalVerifierFindingKey({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'ABC123',
+      sourceSessionId: 'codex/session-1',
+      findingHash: 'FINDING-A',
+    });
+    const right = canonicalVerifierFindingKey({
+      repository: ' neko-catpital-labs/invoker ',
+      baseCommitSha: 'abc123',
+      sourceSessionId: ' codex/session-1 ',
+      findingHash: 'finding-a',
+    });
+
+    expect(left).toBe(right);
+  });
+
+  it('advances each workflow phase exactly once through the PR branch', () => {
+    const discovered = createVerifierWorkflow({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'abc123',
+      sourceSessionId: 'claude/session-2',
+      findingHash: 'finding-b',
+      discoveredAt: '2026-08-31T10:00:00.000Z',
+    });
+    const validated = advanceVerifierWorkflow(discovered, {
+      phase: 'validated',
+      at: '2026-08-31T10:01:00.000Z',
+    });
+    const dispatched = advanceVerifierWorkflow(validated, {
+      phase: 'dispatched',
+      workflowId: 'wf-1',
+      at: '2026-08-31T10:02:00.000Z',
+    });
+    const prOpened = advanceVerifierWorkflow(dispatched, {
+      phase: 'pr_opened',
+      pullRequestUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+      at: '2026-08-31T10:03:00.000Z',
+    });
+    const graded = advanceVerifierWorkflow(prOpened, {
+      phase: 'independently_graded',
+      grade: 'accepted',
+      graderId: 'codex-judge',
+      at: '2026-08-31T10:04:00.000Z',
+    });
+    const terminal = advanceVerifierWorkflow(graded, {
+      phase: 'terminal',
+      outcome: 'pr_opened',
+      at: '2026-08-31T10:05:00.000Z',
+    });
+
+    expect(terminal.phase).toBe('terminal');
+    expect(terminal.history.map((entry) => entry.phase)).toEqual([
+      'discovered',
+      'validated',
+      'dispatched',
+      'pr_opened',
+      'independently_graded',
+      'terminal',
+    ]);
+    expect(advanceVerifierWorkflow(terminal, {
+      phase: 'terminal',
+      outcome: 'pr_opened',
+      at: '2026-08-31T10:05:00.000Z',
+    })).toBe(terminal);
+  });
+
+  it('supports no-finding terminalization and refuses skipped or repeated phases', () => {
+    const discovered = createVerifierWorkflow({
+      repository: 'Neko-Catpital-Labs/Invoker',
+      baseCommitSha: 'abc123',
+      sourceSessionId: 'cursor/session-3',
+      findingHash: 'finding-c',
+      discoveredAt: '2026-08-31T10:00:00.000Z',
+    });
+
+    expect(() => advanceVerifierWorkflow(discovered, {
+      phase: 'dispatched',
+      workflowId: 'wf-skipped-validation',
+      at: '2026-08-31T10:01:00.000Z',
+    })).toThrow(/cannot transition from discovered to dispatched/);
+
+    const validated = advanceVerifierWorkflow(discovered, {
+      phase: 'validated',
+      at: '2026-08-31T10:01:00.000Z',
+    });
+    expect(() => advanceVerifierWorkflow(validated, {
+      phase: 'validated',
+      at: '2026-08-31T10:02:00.000Z',
+    })).toThrow(/phase validated was already persisted/);
+
+    const dispatched = advanceVerifierWorkflow(validated, {
+      phase: 'dispatched',
+      workflowId: 'wf-2',
+      at: '2026-08-31T10:02:00.000Z',
+    });
+    const noFinding = advanceVerifierWorkflow(dispatched, {
+      phase: 'no_finding',
+      reason: 'No durable finding survived validation',
+      at: '2026-08-31T10:03:00.000Z',
+    });
+    const graded = advanceVerifierWorkflow(noFinding, {
+      phase: 'independently_graded',
+      grade: 'accepted',
+      graderId: 'claude-judge',
+      at: '2026-08-31T10:04:00.000Z',
+    });
+
+    expect(advanceVerifierWorkflow(graded, {
+      phase: 'terminal',
+      outcome: 'no_finding',
+      at: '2026-08-31T10:05:00.000Z',
+    }).phase).toBe('terminal');
+  });
+});
+
+describe('verification requirement compiler', () => {
+  it('orders deterministic execution first and independent judgment last', () => {
+    expect(compileVerificationRequirements([
+      'bug_fix',
+      'visual_ui',
+      'external_effect',
+      'deployment',
+    ])).toEqual([
+      'deterministic_command',
+      'bug_repro_fail_pass',
+      'opened_visual_proof',
+      'external_effect_reconciliation',
+      'deployed_version',
+      'independent_judgment',
+    ]);
+  });
+
+  it('deduplicates repeated change classes', () => {
+    expect(compileVerificationRequirements(['bug_fix', 'bug_fix'])).toEqual([
+      'deterministic_command',
+      'bug_repro_fail_pass',
+      'independent_judgment',
+    ]);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -18,4 +18,5 @@ export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export * from './planning-surface.ts';
+export * from './verification-contract.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/verification-contract.ts
+++ b/packages/contracts/src/verification-contract.ts
@@ -1,0 +1,258 @@
+export type VerificationChangeClass =
+  | 'code'
+  | 'bug_fix'
+  | 'visual_ui'
+  | 'external_effect'
+  | 'deployment'
+  | 'documentation';
+
+export type VerificationRequirementKind =
+  | 'deterministic_command'
+  | 'bug_repro_fail_pass'
+  | 'opened_visual_proof'
+  | 'external_effect_reconciliation'
+  | 'deployed_version'
+  | 'independent_judgment';
+
+export type VerifierWorkflowPhase =
+  | 'discovered'
+  | 'validated'
+  | 'dispatched'
+  | 'pr_opened'
+  | 'no_finding'
+  | 'independently_graded'
+  | 'terminal';
+
+export interface VerifierFindingIdentity {
+  repository: string;
+  baseCommitSha: string;
+  sourceSessionId: string;
+  findingHash: string;
+}
+
+export interface CanonicalVerifierFindingIdentity extends VerifierFindingIdentity {
+  key: string;
+}
+
+export type VerifierWorkflowEvent =
+  | { phase: 'discovered'; at: string }
+  | { phase: 'validated'; at: string }
+  | { phase: 'dispatched'; workflowId: string; at: string }
+  | { phase: 'pr_opened'; pullRequestUrl: string; at: string }
+  | { phase: 'no_finding'; reason: string; at: string }
+  | {
+    phase: 'independently_graded';
+    grade: 'accepted' | 'rejected';
+    graderId: string;
+    at: string;
+  }
+  | {
+    phase: 'terminal';
+    outcome: 'pr_opened' | 'no_finding' | 'rejected';
+    at: string;
+  };
+
+export interface VerifierWorkflowRecord {
+  version: 1;
+  identity: CanonicalVerifierFindingIdentity;
+  phase: VerifierWorkflowPhase;
+  history: VerifierWorkflowEvent[];
+}
+
+export interface CreateVerifierWorkflowInput extends VerifierFindingIdentity {
+  discoveredAt: string;
+}
+
+export type AdvanceVerifierWorkflowEvent = Exclude<VerifierWorkflowEvent, { phase: 'discovered' }>;
+
+export type VerificationActorRole = 'builder' | 'verifier' | 'judge';
+
+export interface VerificationActor {
+  id: string;
+  role: VerificationActorRole;
+}
+
+interface VerificationReceiptBase {
+  id: string;
+  commitSha: string;
+  recordedAt: string;
+  actor: VerificationActor;
+  status: 'passed' | 'failed';
+}
+
+export interface DeterministicCommandReceipt extends VerificationReceiptBase {
+  kind: 'deterministic_command';
+  command: string;
+  exitCode: number;
+  output: string;
+}
+
+export interface BugReproFailPassReceipt extends VerificationReceiptBase {
+  kind: 'bug_repro_fail_pass';
+  before: {
+    command: string;
+    exitCode: number;
+    output: string;
+  };
+  after: {
+    command: string;
+    exitCode: number;
+    output: string;
+  };
+}
+
+export interface OpenedVisualProofReceipt extends VerificationReceiptBase {
+  kind: 'opened_visual_proof';
+  mediaPath: string;
+  openedAt: string;
+  observation: string;
+}
+
+export interface ExternalEffectReconciliationReceipt extends VerificationReceiptBase {
+  kind: 'external_effect_reconciliation';
+  system: string;
+  expectedState: string;
+  observedState: string;
+  reconciled: boolean;
+}
+
+export interface DeployedVersionReceipt extends VerificationReceiptBase {
+  kind: 'deployed_version';
+  environment: string;
+  deployedCommitSha: string;
+  version: string;
+}
+
+export interface IndependentJudgmentReceipt extends VerificationReceiptBase {
+  kind: 'independent_judgment';
+  verdict: 'approve' | 'reject';
+  rationale: string;
+}
+
+export type VerificationReceipt =
+  | DeterministicCommandReceipt
+  | BugReproFailPassReceipt
+  | OpenedVisualProofReceipt
+  | ExternalEffectReconciliationReceipt
+  | DeployedVersionReceipt
+  | IndependentJudgmentReceipt;
+
+const requirementOrder: VerificationRequirementKind[] = [
+  'deterministic_command',
+  'bug_repro_fail_pass',
+  'opened_visual_proof',
+  'external_effect_reconciliation',
+  'deployed_version',
+  'independent_judgment',
+];
+
+const requirementsByChangeClass: Record<VerificationChangeClass, VerificationRequirementKind[]> = {
+  code: [],
+  bug_fix: ['bug_repro_fail_pass'],
+  visual_ui: ['opened_visual_proof'],
+  external_effect: ['external_effect_reconciliation'],
+  deployment: ['deployed_version'],
+  documentation: [],
+};
+
+const nextPhases: Record<VerifierWorkflowPhase, VerifierWorkflowPhase[]> = {
+  discovered: ['validated'],
+  validated: ['dispatched'],
+  dispatched: ['pr_opened', 'no_finding'],
+  pr_opened: ['independently_graded'],
+  no_finding: ['independently_graded'],
+  independently_graded: ['terminal'],
+  terminal: [],
+};
+
+function requiredText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${field} must be a non-empty string`);
+  return normalized;
+}
+
+function encoded(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function canonicalVerifierFindingIdentity(
+  input: VerifierFindingIdentity,
+): CanonicalVerifierFindingIdentity {
+  const repository = requiredText(input.repository, 'repository').toLowerCase();
+  const baseCommitSha = requiredText(input.baseCommitSha, 'baseCommitSha').toLowerCase();
+  const sourceSessionId = requiredText(input.sourceSessionId, 'sourceSessionId');
+  const findingHash = requiredText(input.findingHash, 'findingHash').toLowerCase();
+  return {
+    repository,
+    baseCommitSha,
+    sourceSessionId,
+    findingHash,
+    key: `v1:${encoded(repository)}:${encoded(baseCommitSha)}:${encoded(sourceSessionId)}:${encoded(findingHash)}`,
+  };
+}
+
+export function canonicalVerifierFindingKey(input: VerifierFindingIdentity): string {
+  return canonicalVerifierFindingIdentity(input).key;
+}
+
+export function createVerifierWorkflow(input: CreateVerifierWorkflowInput): VerifierWorkflowRecord {
+  const discoveredAt = requiredText(input.discoveredAt, 'discoveredAt');
+  return {
+    version: 1,
+    identity: canonicalVerifierFindingIdentity(input),
+    phase: 'discovered',
+    history: [{ phase: 'discovered', at: discoveredAt }],
+  };
+}
+
+function sameEvent(left: VerifierWorkflowEvent, right: VerifierWorkflowEvent): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function assertTerminalOutcome(record: VerifierWorkflowRecord, event: AdvanceVerifierWorkflowEvent): void {
+  if (event.phase !== 'terminal') return;
+  const grade = record.history.findLast((entry) => entry.phase === 'independently_graded');
+  const result = record.history.findLast((entry) => entry.phase === 'pr_opened' || entry.phase === 'no_finding');
+  const expectedOutcome = grade?.phase === 'independently_graded' && grade.grade === 'rejected'
+    ? 'rejected'
+    : result?.phase;
+  if (event.outcome !== expectedOutcome) {
+    throw new Error(`terminal outcome ${event.outcome} does not match independently graded result ${expectedOutcome ?? 'missing'}`);
+  }
+}
+
+export function advanceVerifierWorkflow(
+  record: VerifierWorkflowRecord,
+  event: AdvanceVerifierWorkflowEvent,
+): VerifierWorkflowRecord {
+  const last = record.history.at(-1);
+  if (last && last.phase === event.phase) {
+    if (sameEvent(last, event)) return record;
+    throw new Error(`phase ${event.phase} was already persisted for ${record.identity.key}`);
+  }
+  if (record.history.some((entry) => entry.phase === event.phase)) {
+    throw new Error(`phase ${event.phase} was already persisted for ${record.identity.key}`);
+  }
+  if (!nextPhases[record.phase].includes(event.phase)) {
+    throw new Error(`cannot transition from ${record.phase} to ${event.phase}`);
+  }
+  assertTerminalOutcome(record, event);
+  return {
+    ...record,
+    phase: event.phase,
+    history: [...record.history, event],
+  };
+}
+
+export function compileVerificationRequirements(
+  changeClasses: readonly VerificationChangeClass[],
+): VerificationRequirementKind[] {
+  const required = new Set<VerificationRequirementKind>([
+    'deterministic_command',
+    'independent_judgment',
+  ]);
+  for (const changeClass of changeClasses) {
+    for (const requirement of requirementsByChangeClass[changeClass]) required.add(requirement);
+  }
+  return requirementOrder.filter((requirement) => required.has(requirement));
+}

--- a/packages/workflow-core/src/__tests__/verification-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/verification-policy.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  IndependentJudgmentReceipt,
+  VerificationReceipt,
+} from '@invoker/contracts';
+
+import { evaluateAutomaticVerificationReadiness } from '../verification-policy.js';
+
+const commitSha = 'abc123';
+
+function deterministicReceipt(overrides: Partial<VerificationReceipt> = {}): VerificationReceipt {
+  return {
+    id: 'command-1',
+    kind: 'deterministic_command',
+    commitSha,
+    recordedAt: '2026-08-31T10:00:00.000Z',
+    actor: { id: 'builder-1', role: 'builder' },
+    status: 'passed',
+    command: 'pnpm test',
+    exitCode: 0,
+    output: 'Tests passed',
+    ...overrides,
+  } as VerificationReceipt;
+}
+
+function judgmentReceipt(
+  overrides: Partial<IndependentJudgmentReceipt> = {},
+): IndependentJudgmentReceipt {
+  return {
+    id: 'judgment-1',
+    kind: 'independent_judgment',
+    commitSha,
+    recordedAt: '2026-08-31T10:05:00.000Z',
+    actor: { id: 'judge-1', role: 'judge' },
+    status: 'passed',
+    verdict: 'approve',
+    rationale: 'Evidence matches the change class',
+    ...overrides,
+  };
+}
+
+function bugReproReceipt(overrides: Partial<VerificationReceipt> = {}): VerificationReceipt {
+  return {
+    id: 'repro-1',
+    kind: 'bug_repro_fail_pass',
+    commitSha,
+    recordedAt: '2026-08-31T10:02:00.000Z',
+    actor: { id: 'builder-1', role: 'builder' },
+    status: 'passed',
+    before: { command: 'pnpm test -- bug', exitCode: 1, output: '1 failed' },
+    after: { command: 'pnpm test -- bug', exitCode: 0, output: '1 passed' },
+    ...overrides,
+  } as VerificationReceipt;
+}
+
+function decision(receipts: VerificationReceipt[]) {
+  return evaluateAutomaticVerificationReadiness({
+    target: 'review_ready',
+    targetCommitSha: commitSha,
+    builderActorId: 'builder-1',
+    changeClasses: ['bug_fix'],
+    receipts,
+  });
+}
+
+describe('evaluateAutomaticVerificationReadiness', () => {
+  it('accepts commit-bound evidence with an independent approving judge', () => {
+    expect(decision([
+      deterministicReceipt(),
+      bugReproReceipt(),
+      judgmentReceipt(),
+    ])).toEqual({
+      ready: true,
+      target: 'review_ready',
+      targetCommitSha: commitSha,
+      requirements: [
+        'deterministic_command',
+        'bug_repro_fail_pass',
+        'independent_judgment',
+      ],
+      refusals: [],
+    });
+  });
+
+  it('refuses missing required evidence', () => {
+    expect(decision([deterministicReceipt(), judgmentReceipt()])).toMatchObject({
+      ready: false,
+      refusals: [{
+        code: 'missing_receipt',
+        requirement: 'bug_repro_fail_pass',
+      }],
+    });
+  });
+
+  it('refuses receipts whose recorded result or payload failed', () => {
+    const result = decision([
+      deterministicReceipt({ exitCode: 1 }),
+      bugReproReceipt({ status: 'failed' }),
+      judgmentReceipt(),
+    ]);
+
+    expect(result.ready).toBe(false);
+    expect(result.refusals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'failed_receipt', receiptId: 'command-1' }),
+      expect.objectContaining({ code: 'failed_receipt', receiptId: 'repro-1' }),
+    ]));
+  });
+
+  it('refuses receipts bound to another commit', () => {
+    const result = decision([
+      deterministicReceipt({ commitSha: 'old123' }),
+      bugReproReceipt(),
+      judgmentReceipt(),
+    ]);
+
+    expect(result).toMatchObject({
+      ready: false,
+      refusals: [expect.objectContaining({
+        code: 'stale_receipt',
+        receiptId: 'command-1',
+        requirement: 'deterministic_command',
+      })],
+    });
+  });
+
+  it('refuses disagreeing independent judgments', () => {
+    const result = decision([
+      deterministicReceipt(),
+      bugReproReceipt(),
+      judgmentReceipt(),
+      judgmentReceipt({
+        id: 'judgment-2',
+        actor: { id: 'judge-2', role: 'judge' },
+        status: 'failed',
+        verdict: 'reject',
+      }),
+    ]);
+
+    expect(result.ready).toBe(false);
+    expect(result.refusals).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'disagreeing_receipts',
+        requirement: 'independent_judgment',
+      }),
+    ]));
+  });
+
+  it('refuses when the builder is the sole judge', () => {
+    const result = decision([
+      deterministicReceipt(),
+      bugReproReceipt(),
+      judgmentReceipt({ actor: { id: 'builder-1', role: 'judge' } }),
+    ]);
+
+    expect(result).toMatchObject({
+      ready: false,
+      refusals: [{
+        code: 'builder_is_sole_judge',
+        requirement: 'independent_judgment',
+      }],
+    });
+  });
+
+  it('applies the same refusal policy to automatic completion', () => {
+    const result = evaluateAutomaticVerificationReadiness({
+      target: 'completion',
+      targetCommitSha: commitSha,
+      builderActorId: 'builder-1',
+      changeClasses: ['code'],
+      receipts: [deterministicReceipt()],
+    });
+
+    expect(result).toMatchObject({
+      ready: false,
+      target: 'completion',
+      refusals: [{
+        code: 'missing_receipt',
+        requirement: 'independent_judgment',
+      }],
+    });
+  });
+
+  it('enforces opened visual, external reconciliation, and deployed version payloads', () => {
+    const receipts: VerificationReceipt[] = [
+      deterministicReceipt(),
+      {
+        id: 'visual-1',
+        kind: 'opened_visual_proof',
+        commitSha,
+        recordedAt: '2026-08-31T10:01:00.000Z',
+        actor: { id: 'verifier-1', role: 'verifier' },
+        status: 'passed',
+        mediaPath: '/tmp/proof.png',
+        openedAt: '2026-08-31T10:01:00.000Z',
+        observation: 'The changed state is visible',
+      },
+      {
+        id: 'external-1',
+        kind: 'external_effect_reconciliation',
+        commitSha,
+        recordedAt: '2026-08-31T10:02:00.000Z',
+        actor: { id: 'verifier-1', role: 'verifier' },
+        status: 'passed',
+        system: 'GitHub',
+        expectedState: 'PR open',
+        observedState: 'PR open',
+        reconciled: true,
+      },
+      {
+        id: 'deployment-1',
+        kind: 'deployed_version',
+        commitSha,
+        recordedAt: '2026-08-31T10:03:00.000Z',
+        actor: { id: 'verifier-1', role: 'verifier' },
+        status: 'passed',
+        environment: 'production',
+        deployedCommitSha: commitSha,
+        version: 'v1.2.3',
+      },
+      judgmentReceipt(),
+    ];
+    const input = {
+      target: 'completion' as const,
+      targetCommitSha: commitSha,
+      builderActorId: 'builder-1',
+      changeClasses: ['visual_ui', 'external_effect', 'deployment'] as const,
+    };
+
+    expect(evaluateAutomaticVerificationReadiness({ ...input, receipts }).ready).toBe(true);
+    expect(evaluateAutomaticVerificationReadiness({
+      ...input,
+      receipts: receipts.map((receipt) => receipt.kind === 'external_effect_reconciliation'
+        ? { ...receipt, reconciled: false }
+        : receipt),
+    }).refusals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'failed_receipt', receiptId: 'external-1' }),
+    ]));
+    expect(evaluateAutomaticVerificationReadiness({
+      ...input,
+      receipts: receipts.map((receipt) => receipt.kind === 'deployed_version'
+        ? { ...receipt, deployedCommitSha: 'old123' }
+        : receipt),
+    }).refusals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'failed_receipt', receiptId: 'deployment-1' }),
+    ]));
+  });
+});

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -17,3 +17,4 @@ export * from './attempt-policy.js';
 export * from './task-reset-policy.js';
 export * from './state-invariants.js';
 export * from './repo-default-branch.js';
+export * from './verification-policy.js';

--- a/packages/workflow-core/src/verification-policy.ts
+++ b/packages/workflow-core/src/verification-policy.ts
@@ -1,0 +1,165 @@
+import {
+  compileVerificationRequirements,
+  type VerificationChangeClass,
+  type VerificationReceipt,
+  type VerificationRequirementKind,
+} from '@invoker/contracts';
+
+export type AutomaticVerificationTarget = 'completion' | 'review_ready';
+
+export type VerificationRefusal =
+  | {
+    code: 'missing_receipt';
+    requirement: VerificationRequirementKind;
+  }
+  | {
+    code: 'failed_receipt' | 'stale_receipt';
+    requirement: VerificationRequirementKind;
+    receiptId: string;
+  }
+  | {
+    code: 'disagreeing_receipts';
+    requirement: VerificationRequirementKind;
+    receiptIds: string[];
+  }
+  | {
+    code: 'builder_is_sole_judge';
+    requirement: 'independent_judgment';
+  };
+
+export interface AutomaticVerificationReadinessInput {
+  target: AutomaticVerificationTarget;
+  targetCommitSha: string;
+  builderActorId: string;
+  changeClasses: readonly VerificationChangeClass[];
+  receipts: readonly VerificationReceipt[];
+}
+
+export interface AutomaticVerificationReadinessDecision {
+  ready: boolean;
+  target: AutomaticVerificationTarget;
+  targetCommitSha: string;
+  requirements: VerificationRequirementKind[];
+  refusals: VerificationRefusal[];
+}
+
+function normalizedSha(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function hasText(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function receiptPassed(receipt: VerificationReceipt, targetCommitSha: string): boolean {
+  if (receipt.status !== 'passed') return false;
+  switch (receipt.kind) {
+    case 'deterministic_command':
+      return receipt.exitCode === 0
+        && hasText(receipt.command)
+        && hasText(receipt.output);
+    case 'bug_repro_fail_pass':
+      return receipt.before.exitCode !== 0
+        && receipt.after.exitCode === 0
+        && hasText(receipt.before.command)
+        && receipt.before.command.trim() === receipt.after.command.trim()
+        && hasText(receipt.before.output)
+        && hasText(receipt.after.output);
+    case 'opened_visual_proof':
+      return hasText(receipt.mediaPath)
+        && hasText(receipt.openedAt)
+        && hasText(receipt.observation);
+    case 'external_effect_reconciliation':
+      return receipt.reconciled
+        && hasText(receipt.system)
+        && hasText(receipt.expectedState)
+        && hasText(receipt.observedState);
+    case 'deployed_version':
+      return normalizedSha(receipt.deployedCommitSha) === targetCommitSha
+        && hasText(receipt.environment)
+        && hasText(receipt.version);
+    case 'independent_judgment':
+      return receipt.verdict === 'approve'
+        && receipt.actor.role === 'judge'
+        && hasText(receipt.rationale);
+  }
+}
+
+function receiptOutcome(receipt: VerificationReceipt, targetCommitSha: string): 'passed' | 'failed' {
+  return receiptPassed(receipt, targetCommitSha) ? 'passed' : 'failed';
+}
+
+function receiptsForRequirement(
+  receipts: readonly VerificationReceipt[],
+  requirement: VerificationRequirementKind,
+): VerificationReceipt[] {
+  return receipts.filter((receipt) => receipt.kind === requirement);
+}
+
+export function evaluateAutomaticVerificationReadiness(
+  input: AutomaticVerificationReadinessInput,
+): AutomaticVerificationReadinessDecision {
+  const targetCommitSha = normalizedSha(input.targetCommitSha);
+  const requirements = compileVerificationRequirements(input.changeClasses);
+  const refusals: VerificationRefusal[] = [];
+
+  for (const requirement of requirements) {
+    const receipts = receiptsForRequirement(input.receipts, requirement);
+    if (receipts.length === 0) {
+      refusals.push({ code: 'missing_receipt', requirement });
+      continue;
+    }
+
+    const currentReceipts = receipts.filter((receipt) => {
+      if (normalizedSha(receipt.commitSha) === targetCommitSha) return true;
+      refusals.push({
+        code: 'stale_receipt',
+        requirement,
+        receiptId: receipt.id,
+      });
+      return false;
+    });
+
+    const outcomes = new Set<'passed' | 'failed'>();
+    for (const receipt of currentReceipts) {
+      const outcome = receiptOutcome(receipt, targetCommitSha);
+      outcomes.add(outcome);
+      if (outcome === 'failed') {
+        refusals.push({
+          code: 'failed_receipt',
+          requirement,
+          receiptId: receipt.id,
+        });
+      }
+    }
+    if (outcomes.size > 1) {
+      refusals.push({
+        code: 'disagreeing_receipts',
+        requirement,
+        receiptIds: currentReceipts.map((receipt) => receipt.id),
+      });
+    }
+
+    if (requirement === 'independent_judgment') {
+      const independentJudge = currentReceipts.some((receipt) =>
+        receipt.kind === 'independent_judgment'
+          && receipt.actor.role === 'judge'
+          && receipt.actor.id !== input.builderActorId,
+      );
+      if (!independentJudge) {
+        refusals.push({
+          code: 'builder_is_sole_judge',
+          requirement: 'independent_judgment',
+        });
+      }
+    }
+  }
+
+  return {
+    ready: refusals.length === 0,
+    target: input.target,
+    targetCommitSha,
+    requirements,
+    refusals,
+  };
+}


### PR DESCRIPTION
## Summary

Routes automatic completion and review preparation through one shared evidence gate.

The gate returns a refusal for incomplete, failing, wrong-commit, conflicting, or builder-only evidence.

## Review Claim

Approve routing automatic decisions through workflow-core's commit-bound receipt gate.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

UNCONFIRMED headless assumption: the exported pure policy changes no current runtime path until an existing automatic decision point calls it.

## Slice Rationale

This slice consumes the preceding contract without mixing future persistence or worker integration into the evidence decision.

## Non-goals

- No session-miner or persistence bridge.
- No automatic-decision call-site activation.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- verification-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core build`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 65ac746a54`
- Post-revert steps: None
- Data migration? No

</details>
