### PR TITLE
[Idle task cleanup](1) fail-closed workflow deletion policy

### DIFF
--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
@@ -1,67 +1,117 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { TASK_STATUSES, type TaskStatus, type WorkflowDerivedStatus } from '@invoker/workflow-core';
+
 import {
-  isAdminBypassRepairTask,
-  isE2eRepairWorkflow,
-  isCleanupEligibleWorkflow,
+  decideWorkflowRetirement,
+  hasActiveOrUnknownTask,
+  WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS,
 } from '../workers/idle-task-cleanup-policy.js';
 
-describe('isAdminBypassRepairTask', () => {
-  it('matches a repair-pr plan name with a numeric PR and a fingerprint suffix', () => {
-    expect(isAdminBypassRepairTask('repair-pr-801-ab12cd34ef56ab12')).toBe(true);
+const NOW = new Date('2026-08-15T12:00:00.000Z').getTime();
+const JUST_OVER_48_HOURS_AGO = new Date(NOW - WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS - 1).toISOString();
+
+function decide(
+  status: string,
+  updatedAt: string | Date,
+  taskStatuses: string[],
+) {
+  return decideWorkflowRetirement(
+    { status, updatedAt },
+    taskStatuses.map((taskStatus) => ({ status: taskStatus })),
+    { now: NOW },
+  );
+}
+
+describe('decideWorkflowRetirement', () => {
+  it.each<TaskStatus>(['completed', 'failed', 'closed', 'stale'])(
+    'retires a completed workflow immediately when its task is %s',
+    (taskStatus) => {
+      expect(decide('completed', new Date(NOW), [taskStatus])).toEqual({
+        kind: 'retire',
+        reason: 'completed',
+      });
+    },
+  );
+
+  it.each<WorkflowDerivedStatus>([
+    'pending',
+    'running',
+    'fixing_with_ai',
+    'failed',
+    'closed',
+    'blocked',
+    'review_ready',
+    'awaiting_approval',
+    'stale',
+  ])('retires a %s workflow only after more than 48 inactive hours', (status) => {
+    expect(decide(status, JUST_OVER_48_HOURS_AGO, ['failed'])).toEqual({
+      kind: 'retire',
+      reason: 'inactive-over-threshold',
+    });
+    expect(decide(
+      status,
+      new Date(NOW - WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS),
+      ['failed'],
+    )).toEqual({ kind: 'retain' });
   });
 
-  it('rejects a near-miss with no fingerprint suffix', () => {
-    expect(isAdminBypassRepairTask('repair-pr-801')).toBe(false);
-    expect(isAdminBypassRepairTask('repair-pr-801-')).toBe(false);
+  it.each<TaskStatus>([
+    'pending',
+    'queued',
+    'running',
+    'fixing_with_ai',
+    'needs_input',
+    'blocked',
+    'review_ready',
+    'awaiting_approval',
+  ])('retains workflows with %s work regardless of completion or age', (taskStatus) => {
+    expect(decide('completed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({ kind: 'retain' });
+    expect(decide('failed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({ kind: 'retain' });
   });
 
-  it('rejects an unrelated workflow name', () => {
-    expect(isAdminBypassRepairTask('my-feature-workflow')).toBe(false);
-    expect(isAdminBypassRepairTask('close-pr-801-ab12cd34')).toBe(false);
+  it('retains unknown workflow and task statuses', () => {
+    expect(decide('future_workflow_state', JUST_OVER_48_HOURS_AGO, ['failed']))
+      .toEqual({ kind: 'retain' });
+    expect(decide('completed', JUST_OVER_48_HOURS_AGO, ['future_task_state']))
+      .toEqual({ kind: 'retain' });
   });
 
-  it('rejects undefined', () => {
-    expect(isAdminBypassRepairTask(undefined)).toBe(false);
+  it('retains missing, malformed, and future activity timestamps', () => {
+    expect(decideWorkflowRetirement(
+      { status: 'failed' },
+      [{ status: 'failed' }],
+      { now: NOW },
+    )).toEqual({ kind: 'retain' });
+    expect(decide('failed', 'not-a-date', ['failed'])).toEqual({ kind: 'retain' });
+    expect(decide('failed', new Date(NOW + 1), ['failed'])).toEqual({ kind: 'retain' });
+  });
+
+  it('uses a caller-supplied inactivity threshold without changing strict-boundary behavior', () => {
+    const threshold = 1_000;
+    expect(decideWorkflowRetirement(
+      { status: 'failed', updatedAt: new Date(NOW - threshold) },
+      [{ status: 'failed' }],
+      { now: NOW, idleThresholdMs: threshold },
+    )).toEqual({ kind: 'retain' });
+    expect(decideWorkflowRetirement(
+      { status: 'failed', updatedAt: new Date(NOW - threshold - 1) },
+      [{ status: 'failed' }],
+      { now: NOW, idleThresholdMs: threshold },
+    )).toEqual({ kind: 'retire', reason: 'inactive-over-threshold' });
   });
 });
 
-describe('isE2eRepairWorkflow', () => {
-  it('matches a workflow description carrying the ci-regression-watch marker', () => {
-    expect(
-      isE2eRepairWorkflow('invoker-ci-regression-watch: first-bad-sha=abc123; job=playwright-6-of-9'),
-    ).toBe(true);
+describe('hasActiveOrUnknownTask', () => {
+  it('classifies every current task status into the retention matrix', () => {
+    const inactiveStatuses = new Set<TaskStatus>(['completed', 'failed', 'closed', 'stale']);
+
+    for (const status of TASK_STATUSES) {
+      expect(hasActiveOrUnknownTask([{ status }])).toBe(!inactiveStatuses.has(status));
+    }
   });
 
-  it('matches when the marker appears mid-description', () => {
-    expect(
-      isE2eRepairWorkflow('Fix CI regression. invoker-ci-regression-watch: first-bad-sha=abc123; job=unit'),
-    ).toBe(true);
-  });
-
-  it('rejects an unrelated description that merely mentions ci-regression-watch by name', () => {
-    expect(isE2eRepairWorkflow('See invoker-ci-regression-watch docs for context')).toBe(false);
-  });
-
-  it('rejects undefined', () => {
-    expect(isE2eRepairWorkflow(undefined)).toBe(false);
-  });
-});
-
-describe('isCleanupEligibleWorkflow', () => {
-  it('is eligible via the admin-bypass-repair workflow name alone', () => {
-    expect(isCleanupEligibleWorkflow({ name: 'repair-pr-42-deadbeef00000000', description: 'unrelated' })).toBe(true);
-  });
-
-  it('is eligible via the e2e-repair workflow description marker alone', () => {
-    expect(
-      isCleanupEligibleWorkflow({
-        name: 'CI regression: abc123-unit',
-        description: 'invoker-ci-regression-watch: first-bad-sha=abc; job=unit',
-      }),
-    ).toBe(true);
-  });
-
-  it('is not eligible when neither signal matches', () => {
-    expect(isCleanupEligibleWorkflow({ name: 'my-other-workflow', description: 'plain workflow' })).toBe(false);
+  it('treats a missing or unknown task status as active', () => {
+    expect(hasActiveOrUnknownTask([{}])).toBe(true);
+    expect(hasActiveOrUnknownTask([{ status: 'future_task_state' }])).toBe(true);
   });
 });

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
@@ -1,159 +1,133 @@
-import { describe, it, expect, vi } from 'vitest';
-import type { TaskState } from '@invoker/workflow-core';
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState, TaskStatus } from '@invoker/workflow-core';
+
 import {
-  planIdleTaskCleanup,
   createIdleTaskCleanupWorker,
+  planIdleTaskCleanup,
   type IdleTaskCleanupWorkflowRow,
 } from '../workers/idle-task-cleanup-worker.js';
+import { WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS } from '../workers/idle-task-cleanup-policy.js';
 import type { PrMaintenanceGitHub } from '../workers/pr-maintenance-github.js';
 
 const NOW = new Date('2026-08-15T12:00:00.000Z').getTime();
-const IDLE_15M = 15 * 60_000;
+const OVER_48_HOURS_AGO = new Date(NOW - WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS - 1).toISOString();
 
-function makeTask(overrides: Partial<TaskState> & { id: string }): TaskState {
+function makeWorkflow(
+  id: string,
+  status: string,
+  updatedAt: string = new Date(NOW).toISOString(),
+): IdleTaskCleanupWorkflowRow {
+  return { id, name: id, status, updatedAt };
+}
+
+function makeTask(id: string, status: TaskStatus): TaskState {
   return {
-    id: overrides.id,
-    description: overrides.description ?? 'task',
-    status: overrides.status ?? 'pending',
-    dependencies: overrides.dependencies ?? [],
-    createdAt: overrides.createdAt ?? new Date(NOW - 60 * 60_000),
-    config: { workflowId: 'wf-1', ...overrides.config },
-    execution: { generation: 0, ...overrides.execution },
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(NOW - 60 * 60_000),
+    config: { workflowId: id.split('/')[0] },
+    execution: { generation: 0 },
     taskStateVersion: 1,
   } as TaskState;
 }
 
-const adminBypassWorkflow: IdleTaskCleanupWorkflowRow = {
-  id: 'wf-admin',
-  name: 'repair-pr-801-ab12cd34ef56ab12',
-  description: 'repair admin-bypass PR #801',
-};
-
-const e2eWorkflow: IdleTaskCleanupWorkflowRow = {
-  id: 'wf-e2e',
-  name: 'CI regression: abc123-unit',
-  description: 'invoker-ci-regression-watch: first-bad-sha=abc123; job=unit',
-};
-
-const unrelatedWorkflow: IdleTaskCleanupWorkflowRow = {
-  id: 'wf-other',
-  name: 'my-feature-workflow',
-  description: 'just a normal feature',
-};
-
-async function plan(
+function plan(
   workflows: IdleTaskCleanupWorkflowRow[],
   tasksByWorkflow: Record<string, TaskState[]>,
-  overrides: { isPullRequestMerged?: (prNumber: number) => Promise<boolean>; idleThresholdMs?: number } = {},
 ) {
-  return planIdleTaskCleanup(workflows, (id) => tasksByWorkflow[id] ?? [], {
-    now: NOW,
-    idleThresholdMs: overrides.idleThresholdMs ?? IDLE_15M,
-    isPullRequestMerged: overrides.isPullRequestMerged ?? (async () => false),
-  });
+  return planIdleTaskCleanup(workflows, (id) => tasksByWorkflow[id] ?? [], { now: NOW });
 }
 
-describe('planIdleTaskCleanup: scope', () => {
-  it('ignores workflows that match neither the admin-bypass-repair nor e2e-repair family', async () => {
-    const task = makeTask({ id: 'wf-other/task', status: 'failed', execution: { completedAt: new Date(NOW - IDLE_15M) } });
-    const actions = await plan([unrelatedWorkflow], { 'wf-other': [task] });
-    expect(actions).toEqual([]);
+describe('planIdleTaskCleanup', () => {
+  it('plans one workflow retirement for a completed workflow with no active tasks', () => {
+    const workflow = makeWorkflow('wf-completed', 'completed');
+    const tasks = [
+      makeTask('wf-completed/task-1', 'completed'),
+      makeTask('wf-completed/task-2', 'closed'),
+      makeTask('wf-completed/task-3', 'stale'),
+    ];
+
+    expect(plan([workflow], { 'wf-completed': tasks })).toEqual([
+      { kind: 'delete-workflow', workflowId: 'wf-completed', reason: 'workflow completed' },
+    ]);
   });
 
-  it('ignores non-closable statuses even in an eligible workflow', async () => {
-    const task = makeTask({ id: 'wf-admin/task', status: 'running', execution: { completedAt: new Date(NOW - IDLE_15M) } });
-    const actions = await plan([adminBypassWorkflow], { 'wf-admin': [task] });
-    expect(actions).toEqual([]);
+  it('plans one workflow retirement, not one action per task, when inactive beyond 48 hours', () => {
+    const workflow = makeWorkflow('wf-old', 'failed', OVER_48_HOURS_AGO);
+    const tasks = [
+      makeTask('wf-old/task-1', 'failed'),
+      makeTask('wf-old/task-2', 'closed'),
+      makeTask('wf-old/task-3', 'completed'),
+    ];
+
+    expect(plan([workflow], { 'wf-old': tasks })).toEqual([
+      {
+        kind: 'delete-workflow',
+        workflowId: 'wf-old',
+        reason: 'workflow inactive beyond retirement threshold',
+      },
+    ]);
+  });
+
+  it('retains a non-completed workflow at exactly 48 hours', () => {
+    const workflow = makeWorkflow(
+      'wf-boundary',
+      'failed',
+      new Date(NOW - WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS).toISOString(),
+    );
+
+    expect(plan([workflow], { 'wf-boundary': [makeTask('wf-boundary/task', 'failed')] })).toEqual([]);
+  });
+
+  it('retains a fresh non-completed workflow', () => {
+    const workflow = makeWorkflow('wf-fresh', 'failed');
+
+    expect(plan([workflow], { 'wf-fresh': [makeTask('wf-fresh/task', 'failed')] })).toEqual([]);
+  });
+
+  it.each<TaskStatus>([
+    'pending',
+    'queued',
+    'running',
+    'fixing_with_ai',
+    'needs_input',
+    'blocked',
+    'review_ready',
+    'awaiting_approval',
+  ])('retains an old workflow while a task is %s', (status) => {
+    const workflow = makeWorkflow(`wf-active-${status}`, 'failed', OVER_48_HOURS_AGO);
+
+    expect(plan([workflow], {
+      [workflow.id]: [makeTask(`${workflow.id}/task`, status)],
+    })).toEqual([]);
+  });
+
+  it('retains a completed workflow when its task state is active', () => {
+    const workflow = makeWorkflow('wf-completed-active', 'completed', OVER_48_HOURS_AGO);
+
+    expect(plan([workflow], {
+      [workflow.id]: [makeTask(`${workflow.id}/task`, 'running')],
+    })).toEqual([]);
+  });
+
+  it('retains unknown workflow and task states', () => {
+    const unknownWorkflow = makeWorkflow('wf-unknown-workflow', 'future_workflow_state', OVER_48_HOURS_AGO);
+    const unknownTaskWorkflow = makeWorkflow('wf-unknown-task', 'failed', OVER_48_HOURS_AGO);
+    const unknownTask = {
+      ...makeTask('wf-unknown-task/task', 'failed'),
+      status: 'future_task_state',
+    } as unknown as TaskState;
+
+    expect(plan([unknownWorkflow, unknownTaskWorkflow], {
+      'wf-unknown-workflow': [makeTask('wf-unknown-workflow/task', 'failed')],
+      'wf-unknown-task': [unknownTask],
+    })).toEqual([]);
   });
 });
 
-describe('planIdleTaskCleanup: idle threshold', () => {
-  it('does not act just under 15 minutes idle', async () => {
-    const task = makeTask({
-      id: 'wf-admin/task',
-      status: 'failed',
-      execution: { completedAt: new Date(NOW - (IDLE_15M - 1000)) },
-    });
-    const actions = await plan([adminBypassWorkflow], { 'wf-admin': [task] });
-    expect(actions).toEqual([]);
-  });
-
-  it('acts once idle reaches exactly 15 minutes', async () => {
-    const task = makeTask({
-      id: 'wf-admin/task',
-      status: 'failed',
-      execution: { completedAt: new Date(NOW - IDLE_15M) },
-    });
-    const actions = await plan([adminBypassWorkflow], { 'wf-admin': [task] });
-    expect(actions).toHaveLength(1);
-  });
-
-  it('skips a task with no completedAt (never actually terminal)', async () => {
-    const task = makeTask({ id: 'wf-admin/task', status: 'failed' });
-    const actions = await plan([adminBypassWorkflow], { 'wf-admin': [task] });
-    expect(actions).toEqual([]);
-  });
-});
-
-describe('planIdleTaskCleanup: status branching', () => {
-  it('failed in an admin-bypass-repair workflow: unconditional close-task-and-pr, PR from workflow name', async () => {
-    const task = makeTask({ id: 'wf-admin/task', status: 'failed', execution: { completedAt: new Date(NOW - IDLE_15M) } });
-    const actions = await plan([adminBypassWorkflow], { 'wf-admin': [task] });
-    expect(actions).toEqual([
-      expect.objectContaining({ kind: 'close-task-and-pr', taskId: 'wf-admin/task', prNumber: 801, deleteBranch: true }),
-    ]);
-  });
-
-  it('review_ready in an e2e-repair workflow: unconditional close-task-and-pr, PR from execution.reviewId', async () => {
-    const mergeTask = makeTask({
-      id: '__merge__wf-e2e',
-      status: 'review_ready',
-      execution: { completedAt: new Date(NOW - IDLE_15M), reviewId: '4242' },
-    });
-    const actions = await plan([e2eWorkflow], { 'wf-e2e': [mergeTask] });
-    expect(actions).toEqual([
-      expect.objectContaining({ kind: 'close-task-and-pr', taskId: '__merge__wf-e2e', prNumber: 4242, deleteBranch: true }),
-    ]);
-  });
-
-  it('failed/review_ready with no resolvable PR: close-task-only', async () => {
-    const task = makeTask({
-      id: 'wf-e2e/fix-ci-abc',
-      status: 'failed',
-      execution: { completedAt: new Date(NOW - IDLE_15M) }, // no reviewId: not the merge node
-    });
-    const actions = await plan([e2eWorkflow], { 'wf-e2e': [task] });
-    expect(actions).toEqual([
-      expect.objectContaining({ kind: 'close-task-only', taskId: 'wf-e2e/fix-ci-abc' }),
-    ]);
-  });
-
-  it('completed with an already-merged PR: close-task-and-pr', async () => {
-    const mergeTask = makeTask({
-      id: '__merge__wf-e2e',
-      status: 'completed',
-      execution: { completedAt: new Date(NOW - IDLE_15M), reviewId: '4242' },
-    });
-    const actions = await plan([e2eWorkflow], { 'wf-e2e': [mergeTask] }, { isPullRequestMerged: async () => true });
-    expect(actions).toEqual([
-      expect.objectContaining({ kind: 'close-task-and-pr', taskId: '__merge__wf-e2e', prNumber: 4242, deleteBranch: true }),
-    ]);
-  });
-
-  it('completed with a not-yet-merged PR: close-task-only, PR/branch untouched', async () => {
-    const mergeTask = makeTask({
-      id: '__merge__wf-e2e',
-      status: 'completed',
-      execution: { completedAt: new Date(NOW - IDLE_15M), reviewId: '4242' },
-    });
-    const actions = await plan([e2eWorkflow], { 'wf-e2e': [mergeTask] }, { isPullRequestMerged: async () => false });
-    expect(actions).toEqual([
-      expect.objectContaining({ kind: 'close-task-only', taskId: '__merge__wf-e2e' }),
-    ]);
-  });
-});
-
-describe('createIdleTaskCleanupWorker: dry-run', () => {
+describe('createIdleTaskCleanupWorker: hard-disabled deletion', () => {
   function makeGithub(): PrMaintenanceGitHub {
     return {
       listOpenPullRequests: vi.fn(async () => []),
@@ -164,20 +138,20 @@ describe('createIdleTaskCleanupWorker: dry-run', () => {
     };
   }
 
-  it('never calls closePullRequest or submit — dry-run only logs', async () => {
+  it('logs one workflow retirement without submitting or touching PRs and branches', async () => {
     const github = makeGithub();
     const submit = vi.fn(() => 1);
     const logger = {
       debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
       child: vi.fn(function (this: unknown) { return this; }),
     } as any;
-    const task = makeTask({ id: 'wf-admin/task', status: 'failed', execution: { completedAt: new Date(NOW - IDLE_15M) } });
+    const workflow = makeWorkflow('wf-completed', 'completed');
 
     const worker = createIdleTaskCleanupWorker({
       logger,
       store: {
-        listWorkflows: () => [adminBypassWorkflow],
-        loadTasks: (id) => (id === 'wf-admin' ? [task] : []),
+        listWorkflows: () => [workflow],
+        loadTasks: () => [makeTask('wf-completed/task', 'completed')],
         logEvent: vi.fn(),
       },
       submitter: { submit },
@@ -189,11 +163,12 @@ describe('createIdleTaskCleanupWorker: dry-run', () => {
 
     await worker.tick('manual');
 
-    expect(github.closePullRequest).not.toHaveBeenCalled();
     expect(submit).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.stringContaining('(dry-run) would close task + PR #801'),
-      expect.objectContaining({ taskId: 'wf-admin/task' }),
-    );
+    expect(github.viewPullRequest).not.toHaveBeenCalled();
+    expect(github.closePullRequest).not.toHaveBeenCalled();
+    expect(logger.info.mock.calls).toEqual([[
+      expect.stringContaining('(dry-run) would delete workflow wf-completed'),
+      { module: 'idle-task-cleanup', workflowId: 'wf-completed' },
+    ]]);
   });
 });

--- a/packages/execution-engine/src/workers/idle-task-cleanup-policy.ts
+++ b/packages/execution-engine/src/workers/idle-task-cleanup-policy.ts
@@ -1,34 +1,97 @@
-/**
- * Duplicated from `scripts/e2e-regression-watch.mjs`'s `MARKER_PREFIX` — that
- * file is not importable from this TS package (plain .mjs script, no build
- * step shared with @invoker/execution-engine). Keep the two in sync by hand;
- * `idle-task-cleanup-policy.test.ts` pins the literal value.
- *
- * The marker lives on the *workflow's* description (the plan's top-level
- * `description:`, set from `ci-regression-watch.workflow.yaml`), not on any
- * individual task — confirmed against `liveQueryHasNonTerminalWork`
- * (`scripts/e2e-regression-watch.mjs:885-889`), which checks `w.description`
- * on `query workflows` rows.
- */
-const E2E_REPAIR_MARKER = 'invoker-ci-regression-watch: first-bad-sha=';
+import {
+  TASK_STATUSES,
+  type TaskStatus,
+  type WorkflowDerivedStatus,
+} from '@invoker/workflow-core';
 
-const ADMIN_BYPASS_REPAIR_NAME_PATTERN = /^repair-pr-\d+-.+$/;
+export const WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS = 48 * 60 * 60_000;
 
-/** Matches the `repair-pr-<num>-<fingerprint>` plans filed by `scripts/cron-pr-orphan-repair.sh`. */
-export function isAdminBypassRepairTask(workflowName: string | undefined): boolean {
-  return typeof workflowName === 'string' && ADMIN_BYPASS_REPAIR_NAME_PATTERN.test(workflowName);
-}
-
-/** Matches workflows filed by `scripts/e2e-regression-watch.mjs`, tagged via their description marker. */
-export function isE2eRepairWorkflow(workflowDescription: string | undefined): boolean {
-  return typeof workflowDescription === 'string' && workflowDescription.includes(E2E_REPAIR_MARKER);
-}
+const KNOWN_TASK_STATUS_SET: ReadonlySet<string> = new Set(TASK_STATUSES);
 
 /**
- * Whether a workflow belongs to one of the two automated repair families this
- * cleanup worker is scoped to. Every task in a non-matching workflow is left
- * alone, no matter its status or idle time.
+ * These outcomes contain no work that can still advance. Every other known
+ * task status remains active for retirement purposes. Keeping the inactive
+ * allowlist narrow makes a newly-added task status fail closed automatically.
  */
-export function isCleanupEligibleWorkflow(workflow: { name?: string; description?: string }): boolean {
-  return isAdminBypassRepairTask(workflow.name) || isE2eRepairWorkflow(workflow.description);
+const INACTIVE_TASK_STATUS_SET: ReadonlySet<TaskStatus> = new Set([
+  'completed',
+  'failed',
+  'closed',
+  'stale',
+]);
+
+const KNOWN_WORKFLOW_STATUSES = [
+  'pending',
+  'running',
+  'fixing_with_ai',
+  'completed',
+  'failed',
+  'closed',
+  'blocked',
+  'review_ready',
+  'awaiting_approval',
+  'stale',
+] as const satisfies readonly WorkflowDerivedStatus[];
+
+const KNOWN_WORKFLOW_STATUS_SET: ReadonlySet<string> = new Set(KNOWN_WORKFLOW_STATUSES);
+
+export interface WorkflowRetirementCandidate {
+  readonly status?: string;
+  readonly updatedAt?: string | Date;
+}
+
+export interface WorkflowRetirementTask {
+  readonly status?: string;
+}
+
+export type WorkflowRetirementDecision =
+  | { readonly kind: 'retain' }
+  | {
+      readonly kind: 'retire';
+      readonly reason: 'completed' | 'inactive-over-threshold';
+    };
+
+function isKnownTaskStatus(status: string | undefined): status is TaskStatus {
+  return status !== undefined && KNOWN_TASK_STATUS_SET.has(status);
+}
+
+function isKnownWorkflowStatus(status: string | undefined): status is WorkflowDerivedStatus {
+  return status !== undefined && KNOWN_WORKFLOW_STATUS_SET.has(status);
+}
+
+export function hasActiveOrUnknownTask(tasks: readonly WorkflowRetirementTask[]): boolean {
+  return tasks.some((task) =>
+    !isKnownTaskStatus(task.status) || !INACTIVE_TASK_STATUS_SET.has(task.status),
+  );
+}
+
+/**
+ * Completed workflows retire immediately once all tasks are inactive. Other
+ * known workflow states retire only when their last update is strictly older
+ * than the threshold. Unknown states and malformed timestamps are retained.
+ */
+export function decideWorkflowRetirement(
+  workflow: WorkflowRetirementCandidate,
+  tasks: readonly WorkflowRetirementTask[],
+  options: {
+    readonly now: number;
+    readonly idleThresholdMs?: number;
+  },
+): WorkflowRetirementDecision {
+  if (!isKnownWorkflowStatus(workflow.status)) return { kind: 'retain' };
+  if (hasActiveOrUnknownTask(tasks)) return { kind: 'retain' };
+
+  if (workflow.status === 'completed') {
+    return { kind: 'retire', reason: 'completed' };
+  }
+
+  const updatedAtMs = workflow.updatedAt instanceof Date
+    ? workflow.updatedAt.getTime()
+    : Date.parse(workflow.updatedAt ?? '');
+  if (!Number.isFinite(updatedAtMs)) return { kind: 'retain' };
+
+  const idleThresholdMs = options.idleThresholdMs ?? WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS;
+  if (options.now - updatedAtMs <= idleThresholdMs) return { kind: 'retain' };
+
+  return { kind: 'retire', reason: 'inactive-over-threshold' };
 }

--- a/packages/execution-engine/src/workers/idle-task-cleanup-worker.ts
+++ b/packages/execution-engine/src/workers/idle-task-cleanup-worker.ts
@@ -6,20 +6,19 @@ import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.j
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 import type { PrMaintenanceGitHub } from './pr-maintenance-github.js';
-import { isCleanupEligibleWorkflow } from './idle-task-cleanup-policy.js';
+import {
+  decideWorkflowRetirement,
+  WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS,
+} from './idle-task-cleanup-policy.js';
 
 export const IDLE_TASK_CLEANUP_WORKER_KIND = 'idle-task-cleanup';
-export const CLOSE_IDLE_TASK_CHANNEL = 'invoker:close-idle-task';
+export const DELETE_IDLE_WORKFLOW_CHANNEL = 'invoker:delete-workflow';
 
 const DEFAULT_IDLE_TASK_CLEANUP_INTERVAL_MS = 5 * 60_000;
-const DEFAULT_IDLE_THRESHOLD_MS = 15 * 60_000;
-const CLOSABLE_STATUSES = new Set(['failed', 'completed', 'review_ready']);
-const ADMIN_BYPASS_REPAIR_PR_NUMBER = /^repair-pr-(\d+)-.+$/;
 
 /**
- * Hardcoded, not env-gated: this ships dry-run only. Flipping to live is a
- * separate, explicitly-reviewed follow-up that removes this constant — no
- * config toggle can accidentally turn on real PR/branch/task mutation.
+ * Hardcoded, not env-gated: this slice only proves workflow-retirement
+ * decisions. There is deliberately no live deletion branch to activate.
  */
 const FORCE_DRY_RUN = true;
 
@@ -27,6 +26,8 @@ export interface IdleTaskCleanupWorkflowRow {
   readonly id: string;
   readonly name: string;
   readonly description?: string;
+  readonly status?: string;
+  readonly updatedAt?: string | Date;
 }
 
 export interface IdleTaskCleanupWorkerStore {
@@ -39,145 +40,43 @@ export interface IdleTaskCleanupWorkerSubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof CLOSE_IDLE_TASK_CHANNEL,
+    channel: typeof DELETE_IDLE_WORKFLOW_CHANNEL,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
 }
 
-export interface CloseIdleTaskMutationArgs {
-  readonly taskId: string;
-}
-
-export function buildCloseIdleTaskMutationArgs(taskId: string): unknown[] {
-  return [{ taskId } satisfies CloseIdleTaskMutationArgs];
-}
-
-export function parseCloseIdleTaskMutationArgs(args: unknown[]): CloseIdleTaskMutationArgs {
-  const [raw] = args;
-  if (!raw || typeof raw !== 'object' || typeof (raw as { taskId?: unknown }).taskId !== 'string') {
-    throw new Error('invoker:close-idle-task mutation requires { taskId: string }');
-  }
-  return { taskId: (raw as CloseIdleTaskMutationArgs).taskId };
-}
-
-export type CleanupAction =
-  | { kind: 'close-task-only'; taskId: string; workflowId: string; reason: string }
-  | {
-      kind: 'close-task-and-pr';
-      taskId: string;
-      workflowId: string;
-      prNumber: number;
-      deleteBranch: boolean;
-      reason: string;
-    };
+export type CleanupAction = {
+  readonly kind: 'delete-workflow';
+  readonly workflowId: string;
+  readonly reason: string;
+};
 
 /**
- * Resolve the PR this task's family owns, if any:
- *   - admin-bypass-repair: the PR number is embedded directly in the
- *     `repair-pr-<num>-<fingerprint>` workflow name (the PR being repaired).
- *   - e2e-repair: only the workflow's merge-node task carries a PR — its
- *     `execution.reviewId` is the provider identifier set by
- *     `GitHubMergeGateProvider.createReview` (`merge-runner.ts`). A non-merge
- *     task in the same workflow has no PR of its own.
+ * Pure workflow-level decision planner. It emits at most one retirement action
+ * per workflow and cannot represent task, PR, or branch mutations.
  */
-function resolvePrNumber(workflow: IdleTaskCleanupWorkflowRow, task: TaskState): number | undefined {
-  const adminBypassMatch = workflow.name.match(ADMIN_BYPASS_REPAIR_PR_NUMBER);
-  if (adminBypassMatch) return Number(adminBypassMatch[1]);
-  const reviewId = task.execution.reviewId;
-  if (reviewId) {
-    const n = Number(reviewId);
-    if (Number.isFinite(n)) return n;
-  }
-  return undefined;
-}
-
-function idleMinutes(idleMs: number): number {
-  return Math.round(idleMs / 60_000);
-}
-
-/**
- * Pure decision function: given the candidate workflows/tasks and a
- * merged-PR checker, decide what cleanup (if anything) each idle task needs.
- * No side effects — the worker tick executes (or, in dry-run, only logs)
- * whatever this returns. Kept separate from the tick so the decision logic
- * (scope, idle threshold, unconditional vs merged-only PR teardown) is
- * testable without a real WorkerRuntime.
- */
-export async function planIdleTaskCleanup(
+export function planIdleTaskCleanup(
   workflows: ReadonlyArray<IdleTaskCleanupWorkflowRow>,
   loadTasks: (workflowId: string) => TaskState[],
-  opts: {
-    now: number;
-    idleThresholdMs: number;
-    isPullRequestMerged: (prNumber: number) => Promise<boolean>;
+  options: {
+    readonly now: number;
+    readonly idleThresholdMs?: number;
   },
-): Promise<CleanupAction[]> {
+): CleanupAction[] {
   const actions: CleanupAction[] = [];
 
   for (const workflow of workflows) {
-    if (!isCleanupEligibleWorkflow(workflow)) continue;
+    const decision = decideWorkflowRetirement(workflow, loadTasks(workflow.id), options);
+    if (decision.kind === 'retain') continue;
 
-    for (const task of loadTasks(workflow.id)) {
-      if (!CLOSABLE_STATUSES.has(task.status)) continue;
-      const completedAt = task.execution.completedAt;
-      if (!completedAt) continue;
-      const idleMs = opts.now - new Date(completedAt).getTime();
-      if (idleMs < opts.idleThresholdMs) continue;
-
-      const prNumber = resolvePrNumber(workflow, task);
-
-      if (task.status === 'failed' || task.status === 'review_ready') {
-        actions.push(
-          prNumber === undefined
-            ? {
-                kind: 'close-task-only',
-                taskId: task.id,
-                workflowId: workflow.id,
-                reason: `${task.status}, idle ${idleMinutes(idleMs)}m, no associated PR`,
-              }
-            : {
-                kind: 'close-task-and-pr',
-                taskId: task.id,
-                workflowId: workflow.id,
-                prNumber,
-                deleteBranch: true,
-                reason: `${task.status}, idle ${idleMinutes(idleMs)}m`,
-              },
-        );
-        continue;
-      }
-
-      // completed: only close the PR/branch once it's already merged;
-      // otherwise task-only bookkeeping, leaving an in-flight PR untouched.
-      if (prNumber === undefined) {
-        actions.push({
-          kind: 'close-task-only',
-          taskId: task.id,
-          workflowId: workflow.id,
-          reason: `completed, idle ${idleMinutes(idleMs)}m, no associated PR`,
-        });
-        continue;
-      }
-      const merged = await opts.isPullRequestMerged(prNumber);
-      actions.push(
-        merged
-          ? {
-              kind: 'close-task-and-pr',
-              taskId: task.id,
-              workflowId: workflow.id,
-              prNumber,
-              deleteBranch: true,
-              reason: `completed, idle ${idleMinutes(idleMs)}m, PR already merged`,
-            }
-          : {
-              kind: 'close-task-only',
-              taskId: task.id,
-              workflowId: workflow.id,
-              reason: `completed, idle ${idleMinutes(idleMs)}m, PR not yet merged`,
-            },
-      );
-    }
+    actions.push({
+      kind: 'delete-workflow',
+      workflowId: workflow.id,
+      reason: decision.reason === 'completed'
+        ? 'workflow completed'
+        : 'workflow inactive beyond retirement threshold',
+    });
   }
 
   return actions;
@@ -198,14 +97,8 @@ export interface IdleTaskCleanupWorkerOptions extends IdleTaskCleanupWorkerConfi
   submitter: IdleTaskCleanupWorkerSubmitter;
 }
 
-function describeAction(action: CleanupAction): string {
-  return action.kind === 'close-task-and-pr'
-    ? `close task + PR #${action.prNumber}${action.deleteBranch ? ' + delete branch' : ''}`
-    : 'close task only';
-}
-
 export function createIdleTaskCleanupWorker(options: IdleTaskCleanupWorkerOptions): WorkerRuntime {
-  const idleThresholdMs = options.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+  const idleThresholdMs = options.idleThresholdMs ?? WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS;
   const now = options.now ?? (() => Date.now());
 
   return createWorkerRuntime({
@@ -218,58 +111,23 @@ export function createIdleTaskCleanupWorker(options: IdleTaskCleanupWorkerOption
       await options.onTick?.(ctx);
       ctx.signal?.throwIfAborted();
 
-      const workflows = options.store.listWorkflows();
-      const actions = await planIdleTaskCleanup(
-        workflows,
+      const actions = planIdleTaskCleanup(
+        options.store.listWorkflows(),
         (workflowId) => options.store.loadTasks(workflowId),
-        {
-          now: now(),
-          idleThresholdMs,
-          isPullRequestMerged: async (prNumber) => {
-            const pr = await options.github.viewPullRequest(prNumber, ['state', 'mergedAt']);
-            return pr.state === 'MERGED' || Boolean(pr.mergedAt);
-          },
-        },
+        { now: now(), idleThresholdMs },
       );
 
       for (const action of actions) {
         if (ctx.signal?.aborted) return;
 
-        if (FORCE_DRY_RUN) {
-          options.logger.info(
-            `[idle-task-cleanup] (dry-run) would ${describeAction(action)}: ${action.taskId} (${action.reason})`,
-            { module: 'idle-task-cleanup', taskId: action.taskId, workflowId: action.workflowId },
-          );
-          continue;
+        if (!FORCE_DRY_RUN) {
+          throw new Error('idle-task-cleanup workflow deletion is hard-disabled');
         }
 
-        if (action.kind === 'close-task-and-pr') {
-          const closed = await options.github.closePullRequest(action.prNumber, {
-            deleteBranch: action.deleteBranch,
-          });
-          options.logger.info(
-            `[idle-task-cleanup] ${closed ? 'closed' : 'failed to close'} PR #${action.prNumber} for task ${action.taskId}`,
-            {
-              module: 'idle-task-cleanup',
-              taskId: action.taskId,
-              workflowId: action.workflowId,
-              prNumber: action.prNumber,
-            },
-          );
-        }
-
-        const intentId = options.submitter.submit(
-          action.workflowId,
-          'normal',
-          CLOSE_IDLE_TASK_CHANNEL,
-          buildCloseIdleTaskMutationArgs(action.taskId),
+        options.logger.info(
+          `[idle-task-cleanup] (dry-run) would delete workflow ${action.workflowId} (${action.reason})`,
+          { module: 'idle-task-cleanup', workflowId: action.workflowId },
         );
-        options.store.logEvent?.(action.taskId, 'idle-task-cleanup.submit', {
-          worker: IDLE_TASK_CLEANUP_WORKER_KIND,
-          intentId,
-          channel: CLOSE_IDLE_TASK_CHANNEL,
-          reason: action.reason,
-        });
       }
     },
   });
@@ -281,11 +139,11 @@ export function registerIdleTaskCleanupWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: IDLE_TASK_CLEANUP_WORKER_KIND,
-    note: 'Dry-run: reports failed/completed/review_ready admin-bypass-repair and e2e-repair tasks idle 15+ minutes.',
+    note: 'Dry-run: reports completed or inactive-over-48-hours workflows with no active tasks.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.idleTaskCleanup;
       if (!config) {
-        throw new Error('idle-task-cleanup worker requires deps.idleTaskCleanup (github client) to be configured');
+        throw new Error('idle-task-cleanup worker requires deps.idleTaskCleanup to be configured');
       }
       return createIdleTaskCleanupWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

The idle-task worker now plans one workflow retirement instead of per-task and GitHub actions.

Completed workflows qualify immediately. Other inactive workflows qualify only after more than 48 hours.

Active tasks and unknown statuses are retained, and the worker remains hard-wired to dry-run.

## Review Claim

Approve one fail-closed workflow-retirement decision for completed workflows and workflows inactive beyond 48 hours when every task is inactive.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice cannot delete anything. Every workflow with an active or unknown-status task is retained, and no pull request or branch action is planned.

## Slice Rationale

Eligibility is isolated from the future live executor so destructive execution receives a separate review.

## Non-goals

No live deletion, owner wiring, deployment, UI changes, pull request changes, branch changes, or unrelated refactors.

## Architecture

### Before

```mermaid
graph TD
    A["Repair-family task passes the 15-minute threshold"] --> B["Plan task and GitHub cleanup actions"]
```

### After

```mermaid
graph TD
    A["Workflow has no active or unknown task"] --> B["Completed now or inactive beyond 48 hours"]
    B --> C["Plan one dry-run workflow retirement"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/idle-task-cleanup-worker.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 16ac104ed6368ddc30dcdceb79e31ab7816e1600`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow-level retirement for completed workflows without active tasks.
  - Added automatic cleanup of inactive workflows after 48 hours.
  - Added handling for status and timestamp boundaries, including invalid or future timestamps.
  - Added dry-run logging for workflows eligible for deletion.

- **Bug Fixes**
  - Prevented cleanup of workflows with active or unknown statuses.
  - Ensured cleanup decisions use the workflow’s canonical update time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle policy for all workflows (not just repair families) and defines future deletion intent, though execution remains hard-disabled dry-run in this slice.
> 
> **Overview**
> Replaces repair-family, per-task idle cleanup (15-minute task `completedAt`, PR close/branch logic) with **workflow-level retirement** driven by `decideWorkflowRetirement` and `hasActiveOrUnknownTask`.
> 
> **Completed** workflows retire as soon as every task is in an inactive status (`completed`, `failed`, `closed`, `stale`). Other known workflow states retire only when `updatedAt` is **strictly older than 48 hours** and all tasks are inactive. Unknown workflow/task statuses, bad timestamps, and any active task **retain** the workflow (fail-closed).
> 
> `planIdleTaskCleanup` is now synchronous and emits at most one `delete-workflow` action per workflow; task/PR mutation helpers and `invoker:close-idle-task` are removed in favor of `invoker:delete-workflow`. The worker still **dry-runs only** (logs would-delete, no submit/GitHub calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83e9d68827e94dad99da38449129b2289fb5c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->