### PR TITLE
[Trusted verification evidence](1) attested contracts

### DIFF
--- a/packages/contracts/src/__tests__/verification-contract.test.ts
+++ b/packages/contracts/src/__tests__/verification-contract.test.ts
@@ -1,11 +1,52 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
   advanceVerifierWorkflow,
   canonicalVerifierFindingKey,
   compileVerificationRequirements,
   createVerifierWorkflow,
+  isTrustedVerificationEvidenceRecord,
+  parseVerificationEvidenceRecord,
+  type LegacyUntrustedVerificationEvidenceRecord,
+  type TrustedVerificationEvidenceRecord,
+  type VerificationEvidenceRecord,
 } from '../verification-contract.js';
+
+const commandReceipt = {
+  id: 'command-1',
+  kind: 'deterministic_command' as const,
+  commitSha: 'abc123',
+  recordedAt: '2026-08-31T10:00:00.000Z',
+  actor: { id: 'builder-1', role: 'builder' as const },
+  status: 'passed' as const,
+  command: 'pnpm test',
+  exitCode: 0,
+  output: 'Tests passed',
+};
+
+function trustedCommandRecord(): unknown {
+  return {
+    version: 2,
+    trust: 'trusted',
+    receipt: commandReceipt,
+    attestation: {
+      repository: 'Neko-Catpital-Labs/Invoker',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      generation: 2,
+      attemptId: 'wf-1/task-1-a1',
+      commitSha: 'abc123',
+      canonicalPayloadDigest: 'sha256:receipt-digest',
+      signatureAlgorithm: 'Ed25519',
+      signature: 'base64-signature',
+      trustedKeyId: 'executor-key-1',
+      provider: { kind: 'executor', providerId: 'codex' },
+      actorId: 'builder-1',
+      issuedAt: '2026-08-31T09:59:59.000Z',
+      recordedAt: '2026-08-31T10:00:00.000Z',
+    },
+  };
+}
 
 describe('verifier workflow contract', () => {
   it('uses canonical lineage and finding identity as the idempotency key', () => {
@@ -147,5 +188,132 @@ describe('verification requirement compiler', () => {
       'bug_repro_fail_pass',
       'independent_judgment',
     ]);
+  });
+});
+
+describe('verification evidence record contract', () => {
+  it('keeps version-1 receipts readable but explicitly untrusted', () => {
+    const legacy: VerificationEvidenceRecord = {
+      version: 1,
+      trust: 'untrusted',
+      receipt: commandReceipt,
+    };
+
+    expect(parseVerificationEvidenceRecord(legacy)).toEqual(legacy);
+    expect(isTrustedVerificationEvidenceRecord(legacy)).toBe(false);
+    expectTypeOf<LegacyUntrustedVerificationEvidenceRecord>()
+      .not.toMatchTypeOf<TrustedVerificationEvidenceRecord>();
+  });
+
+  it('parses a complete version-2 attested receipt as trusted evidence', () => {
+    const parsed = parseVerificationEvidenceRecord(trustedCommandRecord());
+
+    expect(parsed).toMatchObject({
+      version: 2,
+      trust: 'trusted',
+      attestation: {
+        repository: 'Neko-Catpital-Labs/Invoker',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/task-1',
+        generation: 2,
+        attemptId: 'wf-1/task-1-a1',
+        commitSha: 'abc123',
+        canonicalPayloadDigest: 'sha256:receipt-digest',
+        signatureAlgorithm: 'Ed25519',
+        signature: 'base64-signature',
+        trustedKeyId: 'executor-key-1',
+        provider: { kind: 'executor', providerId: 'codex' },
+        actorId: 'builder-1',
+        issuedAt: '2026-08-31T09:59:59.000Z',
+        recordedAt: '2026-08-31T10:00:00.000Z',
+      },
+    });
+    expect(isTrustedVerificationEvidenceRecord(trustedCommandRecord())).toBe(true);
+  });
+
+  it('accepts an attestation without an attempt ID', () => {
+    const input = trustedCommandRecord() as {
+      attestation: Record<string, unknown>;
+    };
+    delete input.attestation.attemptId;
+
+    const parsed = parseVerificationEvidenceRecord(input);
+
+    expect(parsed.version).toBe(2);
+    if (parsed.version !== 2) return;
+    expect(parsed.attestation.attemptId).toBeUndefined();
+  });
+
+  it.each([
+    'repository',
+    'workflowId',
+    'taskId',
+    'generation',
+    'commitSha',
+    'canonicalPayloadDigest',
+    'signatureAlgorithm',
+    'signature',
+    'trustedKeyId',
+    'provider',
+    'actorId',
+    'issuedAt',
+    'recordedAt',
+  ])('rejects a version-2 record missing attestation.%s', (field) => {
+    const input = trustedCommandRecord() as {
+      attestation: Record<string, unknown>;
+    };
+    delete input.attestation[field];
+
+    expect(() => parseVerificationEvidenceRecord(input)).toThrow(field);
+    expect(isTrustedVerificationEvidenceRecord(input)).toBe(false);
+  });
+
+  it('rejects malformed records instead of allowing them to claim trust', () => {
+    expect(() => parseVerificationEvidenceRecord({
+      version: 2,
+      trust: 'trusted',
+      receipt: commandReceipt,
+      attestation: {
+        ...((trustedCommandRecord() as { attestation: object }).attestation),
+        signatureAlgorithm: 'self-asserted',
+      },
+    })).toThrow(/Ed25519/);
+    expect(isTrustedVerificationEvidenceRecord({
+      version: 1,
+      trust: 'trusted',
+      receipt: commandReceipt,
+    })).toBe(false);
+  });
+
+  it('carries distinct provider identities for independent judges', () => {
+    const judgmentReceipt = {
+      ...commandReceipt,
+      id: 'judgment-1',
+      kind: 'independent_judgment' as const,
+      actor: { id: 'judge-actor', role: 'judge' as const },
+      verdict: 'approve' as const,
+      rationale: 'The evidence satisfies the contract',
+    };
+    const codex = trustedCommandRecord() as {
+      receipt: unknown;
+      attestation: Record<string, unknown>;
+    };
+    codex.receipt = judgmentReceipt;
+    codex.attestation.provider = { kind: 'judge', providerId: 'codex' };
+    codex.attestation.actorId = 'judge-actor';
+    codex.attestation.trustedKeyId = 'codex-judge-key';
+    const claude = structuredClone(codex);
+    claude.attestation.provider = { kind: 'judge', providerId: 'claude' };
+    claude.attestation.trustedKeyId = 'claude-judge-key';
+
+    const codexParsed = parseVerificationEvidenceRecord(codex);
+    const claudeParsed = parseVerificationEvidenceRecord(claude);
+
+    expect(codexParsed.version).toBe(2);
+    expect(claudeParsed.version).toBe(2);
+    if (codexParsed.version !== 2 || claudeParsed.version !== 2) return;
+    expect(codexParsed.attestation.actorId).toBe(claudeParsed.attestation.actorId);
+    expect(codexParsed.attestation.provider.providerId).not.toBe(claudeParsed.attestation.provider.providerId);
+    expect(codexParsed.attestation.trustedKeyId).not.toBe(claudeParsed.attestation.trustedKeyId);
   });
 });

--- a/packages/contracts/src/verification-contract.ts
+++ b/packages/contracts/src/verification-contract.ts
@@ -137,6 +137,309 @@ export type VerificationReceipt =
   | DeployedVersionReceipt
   | IndependentJudgmentReceipt;
 
+export type VerificationAttestationProviderKind = 'executor' | 'judge';
+
+export interface VerificationAttestationProvider {
+  kind: VerificationAttestationProviderKind;
+  providerId: string;
+}
+
+export type VerificationSignatureAlgorithm = 'Ed25519';
+
+export interface VerificationAttestationV2 {
+  repository: string;
+  workflowId: string;
+  taskId: string;
+  generation: number;
+  attemptId?: string;
+  commitSha: string;
+  canonicalPayloadDigest: string;
+  signatureAlgorithm: VerificationSignatureAlgorithm;
+  signature: string;
+  trustedKeyId: string;
+  provider: VerificationAttestationProvider;
+  actorId: string;
+  issuedAt: string;
+  recordedAt: string;
+}
+
+export interface LegacyUntrustedVerificationEvidenceRecord {
+  version: 1;
+  trust: 'untrusted';
+  receipt: VerificationReceipt;
+}
+
+export interface TrustedVerificationEvidenceRecord {
+  version: 2;
+  trust: 'trusted';
+  receipt: VerificationReceipt;
+  attestation: VerificationAttestationV2;
+}
+
+export type VerificationEvidenceRecord =
+  | LegacyUntrustedVerificationEvidenceRecord
+  | TrustedVerificationEvidenceRecord;
+
+type UnknownRecord = Record<string, unknown>;
+
+function isUnknownRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function evidenceObject(value: unknown, field: string): UnknownRecord {
+  if (!isUnknownRecord(value)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return value;
+}
+
+function evidenceText(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function evidenceTimestamp(value: unknown, field: string): string {
+  const timestamp = evidenceText(value, field);
+  if (Number.isNaN(Date.parse(timestamp))) {
+    throw new Error(`${field} must be a valid timestamp`);
+  }
+  return timestamp;
+}
+
+function evidenceInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new Error(`${field} must be an integer`);
+  }
+  return value;
+}
+
+function evidenceNonNegativeInteger(value: unknown, field: string): number {
+  const integer = evidenceInteger(value, field);
+  if (integer < 0) throw new Error(`${field} must be non-negative`);
+  return integer;
+}
+
+function evidenceBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${field} must be a boolean`);
+  return value;
+}
+
+function parseVerificationActor(value: unknown, field: string): VerificationActor {
+  const actor = evidenceObject(value, field);
+  const role = actor.role;
+  if (role !== 'builder' && role !== 'verifier' && role !== 'judge') {
+    throw new Error(`${field}.role must be builder, verifier, or judge`);
+  }
+  return {
+    id: evidenceText(actor.id, `${field}.id`),
+    role,
+  };
+}
+
+interface ParsedReceiptBase {
+  id: string;
+  commitSha: string;
+  recordedAt: string;
+  actor: VerificationActor;
+  status: 'passed' | 'failed';
+}
+
+function parseReceiptBase(receipt: UnknownRecord): ParsedReceiptBase {
+  const status = receipt.status;
+  if (status !== 'passed' && status !== 'failed') {
+    throw new Error('receipt.status must be passed or failed');
+  }
+  return {
+    id: evidenceText(receipt.id, 'receipt.id'),
+    commitSha: evidenceText(receipt.commitSha, 'receipt.commitSha'),
+    recordedAt: evidenceTimestamp(receipt.recordedAt, 'receipt.recordedAt'),
+    actor: parseVerificationActor(receipt.actor, 'receipt.actor'),
+    status,
+  };
+}
+
+interface ParsedCommandResult {
+  command: string;
+  exitCode: number;
+  output: string;
+}
+
+function parseCommandResult(value: unknown, field: string): ParsedCommandResult {
+  const result = evidenceObject(value, field);
+  return {
+    command: evidenceText(result.command, `${field}.command`),
+    exitCode: evidenceInteger(result.exitCode, `${field}.exitCode`),
+    output: evidenceText(result.output, `${field}.output`),
+  };
+}
+
+export function parseVerificationReceipt(value: unknown): VerificationReceipt {
+  const receipt = evidenceObject(value, 'receipt');
+  const base = parseReceiptBase(receipt);
+
+  switch (receipt.kind) {
+    case 'deterministic_command':
+      return {
+        ...base,
+        kind: 'deterministic_command',
+        command: evidenceText(receipt.command, 'receipt.command'),
+        exitCode: evidenceInteger(receipt.exitCode, 'receipt.exitCode'),
+        output: evidenceText(receipt.output, 'receipt.output'),
+      };
+    case 'bug_repro_fail_pass':
+      return {
+        ...base,
+        kind: 'bug_repro_fail_pass',
+        before: parseCommandResult(receipt.before, 'receipt.before'),
+        after: parseCommandResult(receipt.after, 'receipt.after'),
+      };
+    case 'opened_visual_proof':
+      return {
+        ...base,
+        kind: 'opened_visual_proof',
+        mediaPath: evidenceText(receipt.mediaPath, 'receipt.mediaPath'),
+        openedAt: evidenceTimestamp(receipt.openedAt, 'receipt.openedAt'),
+        observation: evidenceText(receipt.observation, 'receipt.observation'),
+      };
+    case 'external_effect_reconciliation':
+      return {
+        ...base,
+        kind: 'external_effect_reconciliation',
+        system: evidenceText(receipt.system, 'receipt.system'),
+        expectedState: evidenceText(receipt.expectedState, 'receipt.expectedState'),
+        observedState: evidenceText(receipt.observedState, 'receipt.observedState'),
+        reconciled: evidenceBoolean(receipt.reconciled, 'receipt.reconciled'),
+      };
+    case 'deployed_version':
+      return {
+        ...base,
+        kind: 'deployed_version',
+        environment: evidenceText(receipt.environment, 'receipt.environment'),
+        deployedCommitSha: evidenceText(receipt.deployedCommitSha, 'receipt.deployedCommitSha'),
+        version: evidenceText(receipt.version, 'receipt.version'),
+      };
+    case 'independent_judgment': {
+      const verdict = receipt.verdict;
+      if (verdict !== 'approve' && verdict !== 'reject') {
+        throw new Error('receipt.verdict must be approve or reject');
+      }
+      return {
+        ...base,
+        kind: 'independent_judgment',
+        verdict,
+        rationale: evidenceText(receipt.rationale, 'receipt.rationale'),
+      };
+    }
+    default:
+      throw new Error('receipt.kind is not a supported verification receipt kind');
+  }
+}
+
+function parseVerificationAttestationV2(value: unknown): VerificationAttestationV2 {
+  const attestation = evidenceObject(value, 'attestation');
+  const provider = evidenceObject(attestation.provider, 'attestation.provider');
+  const providerKind = provider.kind;
+  if (providerKind !== 'executor' && providerKind !== 'judge') {
+    throw new Error('attestation.provider.kind must be executor or judge');
+  }
+  if (attestation.signatureAlgorithm !== 'Ed25519') {
+    throw new Error('attestation.signatureAlgorithm must be Ed25519');
+  }
+
+  const attemptId = attestation.attemptId === undefined
+    ? undefined
+    : evidenceText(attestation.attemptId, 'attestation.attemptId');
+
+  return {
+    repository: evidenceText(attestation.repository, 'attestation.repository'),
+    workflowId: evidenceText(attestation.workflowId, 'attestation.workflowId'),
+    taskId: evidenceText(attestation.taskId, 'attestation.taskId'),
+    generation: evidenceNonNegativeInteger(attestation.generation, 'attestation.generation'),
+    ...(attemptId === undefined ? {} : { attemptId }),
+    commitSha: evidenceText(attestation.commitSha, 'attestation.commitSha'),
+    canonicalPayloadDigest: evidenceText(
+      attestation.canonicalPayloadDigest,
+      'attestation.canonicalPayloadDigest',
+    ),
+    signatureAlgorithm: 'Ed25519',
+    signature: evidenceText(attestation.signature, 'attestation.signature'),
+    trustedKeyId: evidenceText(attestation.trustedKeyId, 'attestation.trustedKeyId'),
+    provider: {
+      kind: providerKind,
+      providerId: evidenceText(provider.providerId, 'attestation.provider.providerId'),
+    },
+    actorId: evidenceText(attestation.actorId, 'attestation.actorId'),
+    issuedAt: evidenceTimestamp(attestation.issuedAt, 'attestation.issuedAt'),
+    recordedAt: evidenceTimestamp(attestation.recordedAt, 'attestation.recordedAt'),
+  };
+}
+
+function assertAttestationMatchesReceipt(
+  receipt: VerificationReceipt,
+  attestation: VerificationAttestationV2,
+): void {
+  if (attestation.commitSha.trim().toLowerCase() !== receipt.commitSha.trim().toLowerCase()) {
+    throw new Error('attestation.commitSha must match receipt.commitSha');
+  }
+  if (attestation.actorId !== receipt.actor.id) {
+    throw new Error('attestation.actorId must match receipt.actor.id');
+  }
+  const isJudgment = receipt.kind === 'independent_judgment';
+  if (isJudgment && receipt.actor.role !== 'judge') {
+    throw new Error('trusted independent judgments require receipt.actor.role judge');
+  }
+  if (isJudgment && attestation.provider.kind !== 'judge') {
+    throw new Error('trusted independent judgments require a judge provider');
+  }
+  if (!isJudgment && attestation.provider.kind !== 'executor') {
+    throw new Error('trusted non-judgment receipts require an executor provider');
+  }
+}
+
+export function parseVerificationEvidenceRecord(value: unknown): VerificationEvidenceRecord {
+  const record = evidenceObject(value, 'verification evidence record');
+  const receipt = parseVerificationReceipt(record.receipt);
+
+  if (record.version === 1) {
+    if (record.trust !== 'untrusted') {
+      throw new Error('version-1 verification evidence must be untrusted');
+    }
+    return { version: 1, trust: 'untrusted', receipt };
+  }
+
+  if (record.version === 2) {
+    if (record.trust !== 'trusted') {
+      throw new Error('version-2 verification evidence must be trusted');
+    }
+    const attestation = parseVerificationAttestationV2(record.attestation);
+    assertAttestationMatchesReceipt(receipt, attestation);
+    return { version: 2, trust: 'trusted', receipt, attestation };
+  }
+
+  throw new Error('verification evidence record.version must be 1 or 2');
+}
+
+export function isVerificationEvidenceRecord(value: unknown): value is VerificationEvidenceRecord {
+  try {
+    parseVerificationEvidenceRecord(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isTrustedVerificationEvidenceRecord(
+  value: unknown,
+): value is TrustedVerificationEvidenceRecord {
+  try {
+    return parseVerificationEvidenceRecord(value).version === 2;
+  } catch {
+    return false;
+  }
+}
+
 const requirementOrder: VerificationRequirementKind[] = [
   'deterministic_command',
   'bug_repro_fail_pass',


### PR DESCRIPTION
## Summary

Define a versioned attestation envelope for commit-bound evidence and independent judge identity.

Legacy receipt records remain readable for audits but cannot represent trusted evidence.

## Review Claim

Approve the versioned contract that separates attested trusted evidence from legacy untrusted records.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Existing records remain readable for audit, but no legacy or malformed record is marked trusted by construction.

## Slice Rationale

This dormant contract foundation precedes persistence, signature checking, policy decisions, and automatic-action wiring.

## Non-goals

- No database migration.
- No signature verification or receipt production.
- No policy decision or automatic-action wiring.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/contracts exec vitest run src/__tests__/verification-contract.test.ts`
- [x] `pnpm --filter @invoker/contracts build`
- [x] `pnpm run check:comments`
- [x] `git diff --check origin/stack/EdbertChan/reflect/verification-contract-20260831/refuse-unverified-automatic-completion--23b16a10...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cf155590eda87b2190ecdfba13afe937f1f02752`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-only parsing and types in `packages/contracts` with no persistence, crypto verification, or runtime wiring yet.
> 
> **Overview**
> Introduces a **versioned verification evidence envelope** in `@invoker/contracts`: **v1** stays readable for audit but is always **`untrusted`**, while **v2** is **`trusted`** only when wrapped with a full **Ed25519 attestation** (workflow lineage, digest, signature metadata, and executor vs judge **provider** identity).
> 
> Adds **`parseVerificationReceipt`**, **`parseVerificationEvidenceRecord`**, and **`isTrustedVerificationEvidenceRecord`** with strict structural validation: missing attestation fields, wrong signature algorithm, or mismatched commit/actor/provider rules fail parsing instead of accepting self-asserted trust. Independent-judge receipts must pair **`judge`** actors with judge providers; other receipt kinds require executor providers.
> 
> Tests cover legacy compatibility, complete v2 parsing, optional `attemptId`, per-field rejection, and distinct judge provider keys across providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7272309cf28978eac4302437cc7725222668afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->