### PR TITLE
proof: planning session active-id lost on browser refresh

### DIFF
--- a/packages/ui/src/__tests__/planning-session-active-id-lost-on-refresh-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-session-active-id-lost-on-refresh-repro.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning session active-id survives a real browser refresh', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    cleanup();
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('re-selects the session the user was on after a full unmount+remount, not the first one', async () => {
+    const sessionA = makePlanningSessionSummary({ id: 'session-a', title: 'Session A' });
+    const sessionB = makePlanningSessionSummary({ id: 'session-b', title: 'Session B' });
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: [sessionA, sessionB] }));
+
+    render(<App />);
+    await screen.findByTitle('Session A');
+    await screen.findByTitle('Session B');
+
+    // Sanity: session A (sessions[0]) is active by default on first load.
+    expect(screen.getByTitle('Session A').closest('[data-testid="planning-session-row"]')?.className)
+      .toContain('bg-accent/40');
+
+    // The user explicitly switches to session B.
+    fireEvent.click(screen.getByTitle('Session B'));
+    expect(screen.getByTitle('Session B').closest('[data-testid="planning-session-row"]')?.className)
+      .toContain('bg-accent/40');
+    expect(screen.getByTitle('Session A').closest('[data-testid="planning-session-row"]')?.className)
+      .not.toContain('bg-accent/40');
+
+    // Simulate a real browser refresh: full unmount wipes all in-memory React
+    // state (nothing about "which session was active" is ever written to
+    // localStorage or the server), then a fresh mount re-hydrates from the
+    // same server-side session list.
+    cleanup();
+    render(<App />);
+    await screen.findByTitle('Session A');
+    await screen.findByTitle('Session B');
+
+    // BUG: session B was never persisted as the active session, so the
+    // fresh mount falls back to sessions[0] (session A) instead of
+    // restoring what the user was actually looking at.
+    expect(screen.getByTitle('Session B').closest('[data-testid="planning-session-row"]')?.className)
+      .not.toContain('bg-accent/40');
+    expect(screen.getByTitle('Session A').closest('[data-testid="planning-session-row"]')?.className)
+      .toContain('bg-accent/40');
+  });
+});


### PR DESCRIPTION
## Summary

The Invoker web UI forgets which planning session was active after a
browser refresh. It always falls back to the first session instead of
the one the user was on.

This PR adds a component-level test that proves this, using the real
`App` component (not a mock of the selection logic).

## Review Claim

Adds one regression-proof test demonstrating that the active planning
session is not restored across a refresh. It does not fix the bug.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

New, isolated test file only — no product code changes. It cannot affect
any running behavior; it only adds a test that currently passes against
the existing (buggy) code, documenting the gap for a future fix.

## Slice Rationale

Per stack-ordering convention, the repro lands before the fix. Filing it
separately means a follow-up fix PR's diff can be reviewed against an
already-agreed reproduction instead of bundling proof and fix together.

## Non-goals

- Does not fix the underlying gap: `activePlanningSessionId` is never
  written to `RendererRecoveryState`/localStorage
  (`packages/ui/src/lib/renderer-recovery-state.ts:5-11`), so a fresh
  mount always falls back to `nextSessions[0]`
  (`packages/ui/src/App.tsx:809-812`).
- Does not address the analogous terminal-tab selection, which has the
  same class of bug: it always falls back to `list[list.length - 1]`
  on refresh with no persisted "last active terminal"
  (`packages/ui/src/App.tsx:827-834`).

## Visual Proof

Captured live against `https://demo.invoker-control.dev/` (current master
build), driving a real headless Chromium session — not the local dev server.
This is a state-persists-across-a-refresh claim, so the walkthrough video is
the primary evidence; the stills are the same recording's two key frames.

[Walkthrough: session selected, page reloaded, wrong session ends up active](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-ca63d7/refresh-loses-active-session.webm)

**Before refresh** — "Change the UI from black to pink" is explicitly
selected (highlighted row + its conversation shown):

![Session explicitly selected before refresh](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-ca63d7/before-refresh-session-active.png)

**After a full page reload** — the same session is no longer selected;
the UI silently jumped to a different session ("Refresh-persistence repro:
this is session B") instead of restoring what was open:

![Wrong session selected after refresh](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-ca63d7/after-refresh-wrong-session-active.png)

Manually inspected: the video and both stills show the left "Planning" rail
and right conversation pane; the selected-row highlight and the conversation
title in the top bar confirm which session is active before and after the
reload event visible mid-recording.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- --run planning-session-active-id-lost-on-refresh-repro` — 1 passed (proves current buggy behavior)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6c72ddd948`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new test file only; no runtime or persistence behavior changes.
> 
> **Overview**
> Adds a **Vitest integration test** that mounts the real `App`, switches the active planning session, then simulates a browser refresh via `cleanup()` + a second `render(<App />)`.
> 
> The test asserts today’s behavior: after remount, the highlight falls back to **`sessions[0]`** instead of the session the user had selected, because the active planning session id is only in-memory and is not restored from persistence.
> 
> **No product code changes** — this is a repro-only slice meant to land before a follow-up fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a506a09d7cccc230bb631eb21654dc42f83f2a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->