### PR TITLE
[Idle task cleanup](2) route live workflow retirement through owner

### DIFF
--- a/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
+++ b/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
@@ -38,7 +38,8 @@ const MAIN = path.resolve(__dirname, '..', 'main.ts');
 // direct user-button IPC actions (Approve, Retry, Fix with Agent), a
 // different code path that happens to share 3 of the 8 channel names because
 // those actions are dual-purpose. It has no entry for background-only
-// channels (requeue, requeue-escalate, infra-repair-*, start-ready) because
+// channels (requeue, requeue-escalate, infra-repair-*, delete-workflow,
+// start-ready) because
 // there is no button for them, and that's correct: a GUI process acting as
 // owner dispatches worker-submitted mutations through the same `if
 // (ownerMode)` block checked below (see the `mode: 'gui'` label on its

--- a/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
+++ b/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
@@ -74,6 +74,11 @@ describe('worker mutation channel completeness', () => {
       runHeadlessCommand: async () => ({ ok: true }),
       getTaskExecutor: () => ({}) as never,
       getMutationTiming: () => undefined,
+      idleTaskCleanup: {
+        store: { listWorkflows: () => [], loadTasks: () => [] },
+        now: () => Date.now(),
+        idleThresholdMs: 48 * 60 * 60_000,
+      },
       contextLabel: 'test',
     });
 

--- a/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
+++ b/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
@@ -307,6 +307,11 @@ describe('worker-submitted mutation channel repro', () => {
         runHeadlessCommand: async () => ({ ok: true }),
         getTaskExecutor: () => ({}) as never,
         getMutationTiming: () => undefined,
+        idleTaskCleanup: {
+          store: adapter,
+          now: () => Date.now(),
+          idleThresholdMs: 48 * 60 * 60_000,
+        },
         contextLabel: 'test.owner',
       });
       const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);

--- a/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
+++ b/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
@@ -3,6 +3,7 @@ import { SQLiteAdapter } from '@invoker/data-store';
 import {
   AUTO_APPROVE_COMMAND_CHANNEL,
   createAutoApproveTick,
+  createIdleTaskCleanupWorker,
   createRequeueAttemptLedger,
   createRequeueRecoveryTick,
   REQUEUE_ESCALATE_CHANNEL,
@@ -14,6 +15,7 @@ import { executeApproveTaskMutation } from '../standalone-approve-task-dispatche
 import { executeRequeueEscalateMutation } from '../standalone-requeue-escalate-dispatcher.js';
 import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
 import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation-submit.js';
+import { buildWorkerMutationHandlers } from '../workflow-mutation-handlers.js';
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
 
 // Incident 2026-08-06/07: three separate worker-submitted mutation channels
@@ -255,6 +257,87 @@ describe('worker-submitted mutation channel repro', () => {
       expect(intents[0]).toMatchObject({ channel: REQUEUE_ESCALATE_CHANNEL, status: 'completed' });
       expect(adapter.listWorkflowMutationIntents(workflowId, ['failed'])).toEqual([]);
       expect(orchestrator.getTask(taskId)?.status).toBe('needs_input');
+    });
+  });
+
+  describe('idle-task-cleanup workflow retirement', () => {
+    it('retires a qualifying workflow and all tasks through the real owner mutation path while retaining controls', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      const orchestrator = new Orchestrator({
+        persistence: adapter,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+      } as never);
+
+      const loadSingleTaskWorkflow = (name: string): { workflowId: string } => {
+        const existingIds = new Set(orchestrator.getWorkflowIds());
+        orchestrator.loadPlan({
+          name,
+          onFinish: 'none',
+          tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+        });
+        const workflowId = orchestrator.getWorkflowIds().find((id) => !existingIds.has(id))!;
+        return { workflowId };
+      };
+      const setPersistedTaskStatus = (workflowId: string, status: 'completed' | 'failed' | 'running'): void => {
+        for (const task of adapter.loadTasks(workflowId)) {
+          adapter.saveTask(workflowId, { ...task, status });
+        }
+      };
+
+      const eligible = loadSingleTaskWorkflow('idle cleanup eligible completed');
+      setPersistedTaskStatus(eligible.workflowId, 'completed');
+      const freshInactive = loadSingleTaskWorkflow('idle cleanup fresh inactive control');
+      setPersistedTaskStatus(freshInactive.workflowId, 'failed');
+      const active = loadSingleTaskWorkflow('idle cleanup active control');
+      setPersistedTaskStatus(active.workflowId, 'running');
+
+      expect(adapter.loadWorkflow(eligible.workflowId)).toBeDefined();
+      expect(adapter.loadTasks(eligible.workflowId)).toHaveLength(2);
+      expect(adapter.loadWorkflow(freshInactive.workflowId)).toBeDefined();
+      expect(adapter.loadWorkflow(active.workflowId)).toBeDefined();
+
+      const logger = makeLogger();
+      const commandService = new CommandService(orchestrator);
+      const dispatcher = buildWorkerMutationHandlers({
+        orchestrator,
+        commandService,
+        logger,
+        runHeadlessCommand: async () => ({ ok: true }),
+        getTaskExecutor: () => ({}) as never,
+        getMutationTiming: () => undefined,
+        contextLabel: 'test.owner',
+      });
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+      const github = {
+        listOpenPullRequests: vi.fn(async () => []),
+        viewPullRequest: vi.fn(async () => ({ state: 'OPEN' as const })),
+        fetchCoderabbitComments: vi.fn(async () => []),
+        postPullRequestComment: vi.fn(async () => true),
+        closePullRequest: vi.fn(async () => true),
+      };
+      const worker = createIdleTaskCleanupWorker({
+        logger,
+        store: adapter,
+        submitter: { submit },
+        github,
+        now: () => Date.now(),
+        tickOnStart: false,
+        intervalMs: 0,
+      });
+
+      await worker.tick('manual');
+      await waitFor(() => adapter.loadWorkflow(eligible.workflowId) === undefined);
+
+      expect(adapter.loadWorkflow(eligible.workflowId)).toBeUndefined();
+      expect(adapter.loadTasks(eligible.workflowId)).toEqual([]);
+      expect(adapter.loadWorkflow(active.workflowId)).toBeDefined();
+      expect(adapter.loadTasks(active.workflowId)).toHaveLength(2);
+      expect(adapter.loadWorkflow(freshInactive.workflowId)).toBeDefined();
+      expect(adapter.loadTasks(freshInactive.workflowId)).toHaveLength(2);
+      expect(github.viewPullRequest).not.toHaveBeenCalled();
+      expect(github.closePullRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
+  planIdleTaskCleanup,
   WORKER_SUBMITTED_MUTATION_CHANNELS,
   WORKFLOW_RESUME_COMMAND_CHANNEL,
 } from '@invoker/execution-engine';
@@ -15,6 +16,11 @@ function fakeDeps() {
     runHeadlessCommand: async () => ({ ok: true }),
     getTaskExecutor: () => ({}) as never,
     getMutationTiming: () => undefined,
+    idleTaskCleanup: {
+      store: { listWorkflows: () => [], loadTasks: () => [] },
+      now: () => Date.now(),
+      idleThresholdMs: 48 * 60 * 60_000,
+    },
     contextLabel: 'test',
   };
 }
@@ -34,6 +40,19 @@ describe('buildWorkerMutationHandlers', () => {
     const handlers = buildWorkerMutationHandlers({
       ...fakeDeps(),
       commandService: { deleteWorkflow } as never,
+      idleTaskCleanup: {
+        store: {
+          listWorkflows: () => [{
+            id: 'wf-retire',
+            name: 'retire',
+            status: 'completed',
+            updatedAt: '2026-08-30T00:00:00.000Z',
+          }],
+          loadTasks: () => [],
+        },
+        now: () => new Date('2026-08-31T00:00:00.000Z').getTime(),
+        idleThresholdMs: 48 * 60 * 60_000,
+      },
     });
     const retire = handlers.get(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL)!;
 
@@ -49,6 +68,35 @@ describe('buildWorkerMutationHandlers', () => {
 
     await expect(retire('  ')).rejects.toThrow(/requires a workflow ID/);
     expect(deleteWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('revalidates a queued cleanup retirement against current task state', async () => {
+    const workflow = {
+      id: 'wf-stale-retirement',
+      name: 'stale retirement',
+      status: 'completed',
+      updatedAt: '2026-08-30T00:00:00.000Z',
+    };
+    let tasks = [{ status: 'completed' }] as never[];
+    const store = {
+      listWorkflows: () => [workflow],
+      loadTasks: () => tasks,
+    };
+    const now = new Date('2026-08-31T00:00:00.000Z').getTime();
+    expect(planIdleTaskCleanup([workflow], store.loadTasks, { now })).toHaveLength(1);
+
+    const deleteWorkflow = vi.fn(async () => ({ ok: true, data: undefined }));
+    const handlers = buildWorkerMutationHandlers({
+      ...fakeDeps(),
+      commandService: { deleteWorkflow } as never,
+      idleTaskCleanup: { store, now: () => now, idleThresholdMs: 48 * 60 * 60_000 },
+    });
+    tasks = [{ status: 'running' }] as never[];
+
+    await expect(
+      handlers.get(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL)!('wf-stale-retirement'),
+    ).resolves.toEqual({ ok: true });
+    expect(deleteWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { WORKER_SUBMITTED_MUTATION_CHANNELS, WORKFLOW_RESUME_COMMAND_CHANNEL } from '@invoker/execution-engine';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
+  WORKER_SUBMITTED_MUTATION_CHANNELS,
+  WORKFLOW_RESUME_COMMAND_CHANNEL,
+} from '@invoker/execution-engine';
 
 import { assertAllWorkerMutationChannelsRegistered, buildWorkerMutationHandlers } from '../workflow-mutation-handlers.js';
 
@@ -23,6 +27,28 @@ describe('buildWorkerMutationHandlers', () => {
       expect(handlers.has(channel)).toBe(true);
     }
     expect(handlers.has(WORKFLOW_RESUME_COMMAND_CHANNEL)).toBe(false);
+  });
+
+  it('routes a checked cleanup workflow ID through CommandService workflow retirement', async () => {
+    const deleteWorkflow = vi.fn(async () => ({ ok: true, data: undefined }));
+    const handlers = buildWorkerMutationHandlers({
+      ...fakeDeps(),
+      commandService: { deleteWorkflow } as never,
+    });
+    const retire = handlers.get(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL)!;
+
+    await expect(retire('wf-retire')).resolves.toEqual({ ok: true });
+    expect(deleteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandId: 'idle-task-cleanup-retire-workflow',
+        source: 'surface',
+        scope: 'workflow',
+        payload: { workflowId: 'wf-retire' },
+      }),
+    );
+
+    await expect(retire('  ')).rejects.toThrow(/requires a workflow ID/);
+    expect(deleteWorkflow).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -108,6 +108,7 @@ import {
   submitRepairWorkflowFromCiFailure,
   createPrMaintenanceGitHub,
   spawnPrMaintenanceCommand,
+  WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS,
   type AgentRegistry,
   type WorkerRegistry,
   type WorkerRuntimeDependencies,
@@ -1887,6 +1888,11 @@ function startHeadlessMode(): void {
             }),
             getTaskExecutor: createStandaloneTaskExecutor,
             getMutationTiming: () => activeMutationContext?.mutationTiming,
+            idleTaskCleanup: {
+              store: persistence,
+              now: () => Date.now(),
+              idleThresholdMs: WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS,
+            },
             contextLabel: 'standalone',
           });
           for (const [channel, handler] of standaloneWorkerHandlers) {
@@ -3238,6 +3244,11 @@ startMainProcessBootstrap({
           runHeadlessCommand: (args) => mutationActions.executeHeadlessExec({ args, waitForApproval: false, noTrack: true }),
           getTaskExecutor: requireTaskExecutor,
           getMutationTiming: () => activeMutationContext?.mutationTiming,
+          idleTaskCleanup: {
+            store: persistence,
+            now: () => Date.now(),
+            idleThresholdMs: WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS,
+          },
           contextLabel: 'owner',
         });
         for (const [channel, handler] of ownerWorkerHandlers) {

--- a/packages/app/src/workflow-mutation-handlers.ts
+++ b/packages/app/src/workflow-mutation-handlers.ts
@@ -4,11 +4,13 @@ import {
   AUTO_FIX_COMMAND_CHANNEL,
   AUTO_FIX_RECREATE_CHANNEL,
   buildHeadlessFixArgs,
+  IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
   parseFixWithAgentMutationArgs,
   parseInfraRepairRecreateTaskMutationArgs,
   parseInfraRepairRetryTaskMutationArgs,
+  parseIdleTaskCleanupRetireWorkflowMutationArgs,
   parseRequeueMutationArgs,
   REQUEUE_COMMAND_CHANNEL,
   REQUEUE_ESCALATE_CHANNEL,
@@ -16,7 +18,7 @@ import {
   type TaskRunner,
 } from '@invoker/execution-engine';
 
-import type { Logger } from '@invoker/contracts';
+import { makeEnvelope, type Logger } from '@invoker/contracts';
 import type { CommandService, Orchestrator } from '@invoker/workflow-core';
 
 import { executeApproveTaskMutation } from './standalone-approve-task-dispatcher.js';
@@ -95,6 +97,15 @@ export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Ma
   handlers.set(INFRA_REPAIR_RECREATE_TASK_CHANNEL, async (...recreateArgs: unknown[]) => {
     const { taskId } = parseInfraRepairRecreateTaskMutationArgs(recreateArgs);
     return runHeadlessCommand(['recreate-task', taskId]);
+  });
+
+  handlers.set(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL, async (...retireArgs: unknown[]) => {
+    const { workflowId } = parseIdleTaskCleanupRetireWorkflowMutationArgs(retireArgs);
+    const result = await commandService.deleteWorkflow(
+      makeEnvelope('idle-task-cleanup-retire-workflow', 'surface', 'workflow', { workflowId }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return { ok: true };
   });
 
   handlers.set(AUTO_APPROVE_COMMAND_CHANNEL, async (...args: unknown[]) => {

--- a/packages/app/src/workflow-mutation-handlers.ts
+++ b/packages/app/src/workflow-mutation-handlers.ts
@@ -4,6 +4,7 @@ import {
   AUTO_FIX_COMMAND_CHANNEL,
   AUTO_FIX_RECREATE_CHANNEL,
   buildHeadlessFixArgs,
+  decideWorkflowRetirement,
   IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
@@ -15,6 +16,7 @@ import {
   REQUEUE_COMMAND_CHANNEL,
   REQUEUE_ESCALATE_CHANNEL,
   WORKER_SUBMITTED_MUTATION_CHANNELS,
+  type IdleTaskCleanupWorkerStore,
   type TaskRunner,
 } from '@invoker/execution-engine';
 
@@ -49,6 +51,11 @@ export interface WorkerMutationHandlerDeps {
   getTaskExecutor: () => TaskRunner;
   /** Read fresh per dispatch — both modes track this as a mutable local variable. */
   getMutationTiming: () => WorkflowMutationTiming | undefined;
+  idleTaskCleanup: {
+    store: IdleTaskCleanupWorkerStore;
+    now: () => number;
+    idleThresholdMs: number;
+  };
   /** `'standalone'` or `'owner'` — only used for log/context strings. */
   contextLabel: string;
 }
@@ -68,7 +75,16 @@ export interface WorkerMutationHandlerDeps {
  * so completeness checks still cover it.
  */
 export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Map<string, WorkflowMutationHandler> {
-  const { orchestrator, commandService, logger, runHeadlessCommand, getTaskExecutor, getMutationTiming, contextLabel } = deps;
+  const {
+    orchestrator,
+    commandService,
+    logger,
+    runHeadlessCommand,
+    getTaskExecutor,
+    getMutationTiming,
+    idleTaskCleanup,
+    contextLabel,
+  } = deps;
   const handlers = new Map<string, WorkflowMutationHandler>();
 
   handlers.set(AUTO_FIX_COMMAND_CHANNEL, async (...fixArgs: unknown[]) => {
@@ -101,6 +117,20 @@ export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Ma
 
   handlers.set(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL, async (...retireArgs: unknown[]) => {
     const { workflowId } = parseIdleTaskCleanupRetireWorkflowMutationArgs(retireArgs);
+    const workflow = idleTaskCleanup.store.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const decision = workflow
+      ? decideWorkflowRetirement(workflow, idleTaskCleanup.store.loadTasks(workflowId), {
+          now: idleTaskCleanup.now(),
+          idleThresholdMs: idleTaskCleanup.idleThresholdMs,
+        })
+      : { kind: 'retain' as const };
+    if (decision.kind === 'retain') {
+      logger.info(
+        `[idle-task-cleanup] skipped stale workflow retirement for ${workflowId}`,
+        { module: 'idle-task-cleanup', workflowId },
+      );
+      return { ok: true };
+    }
     const result = await commandService.deleteWorkflow(
       makeEnvelope('idle-task-cleanup-retire-workflow', 'surface', 'workflow', { workflowId }),
     );

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
@@ -127,7 +127,7 @@ describe('planIdleTaskCleanup', () => {
   });
 });
 
-describe('createIdleTaskCleanupWorker: hard-disabled deletion', () => {
+describe('createIdleTaskCleanupWorker: live workflow retirement', () => {
   function makeGithub(): PrMaintenanceGitHub {
     return {
       listOpenPullRequests: vi.fn(async () => []),
@@ -138,7 +138,7 @@ describe('createIdleTaskCleanupWorker: hard-disabled deletion', () => {
     };
   }
 
-  it('logs one workflow retirement without submitting or touching PRs and branches', async () => {
+  it('submits a workflow retirement without calling GitHub or submitting a task mutation', async () => {
     const github = makeGithub();
     const submit = vi.fn(() => 1);
     const logger = {
@@ -163,12 +163,17 @@ describe('createIdleTaskCleanupWorker: hard-disabled deletion', () => {
 
     await worker.tick('manual');
 
-    expect(submit).not.toHaveBeenCalled();
     expect(github.viewPullRequest).not.toHaveBeenCalled();
     expect(github.closePullRequest).not.toHaveBeenCalled();
-    expect(logger.info.mock.calls).toEqual([[
-      expect.stringContaining('(dry-run) would delete workflow wf-completed'),
-      { module: 'idle-task-cleanup', workflowId: 'wf-completed' },
-    ]]);
+    expect(submit).toHaveBeenCalledExactlyOnceWith(
+      'wf-completed',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-completed'],
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('submitted workflow retirement for wf-completed'),
+      expect.objectContaining({ workflowId: 'wf-completed', intentId: 1 }),
+    );
   });
 });

--- a/packages/execution-engine/src/worker-mutation-channels.ts
+++ b/packages/execution-engine/src/worker-mutation-channels.ts
@@ -1,6 +1,7 @@
 import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL, AUTO_FIX_RECREATE_CHANNEL } from './auto-fix-recovery.js';
 import { AUTO_APPROVE_COMMAND_CHANNEL } from './workers/auto-approve-worker.js';
 import { INFRA_REPAIR_RECREATE_TASK_CHANNEL, INFRA_REPAIR_RETRY_TASK_CHANNEL } from './workers/infra-repair-worker.js';
+import { IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL } from './workers/idle-task-cleanup-worker.js';
 import { REQUEUE_COMMAND_CHANNEL, REQUEUE_ESCALATE_CHANNEL } from './workers/requeue-worker.js';
 import { WORKFLOW_RESUME_COMMAND_CHANNEL } from './workers/workflow-resume-worker.js';
 
@@ -30,5 +31,6 @@ export const WORKER_SUBMITTED_MUTATION_CHANNELS: readonly string[] = [
   REQUEUE_ESCALATE_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+  IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
   WORKFLOW_RESUME_COMMAND_CHANNEL,
 ];

--- a/packages/execution-engine/src/workers/idle-task-cleanup-worker.ts
+++ b/packages/execution-engine/src/workers/idle-task-cleanup-worker.ts
@@ -12,15 +12,9 @@ import {
 } from './idle-task-cleanup-policy.js';
 
 export const IDLE_TASK_CLEANUP_WORKER_KIND = 'idle-task-cleanup';
-export const DELETE_IDLE_WORKFLOW_CHANNEL = 'invoker:delete-workflow';
+export const IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL = 'invoker:delete-workflow';
 
 const DEFAULT_IDLE_TASK_CLEANUP_INTERVAL_MS = 5 * 60_000;
-
-/**
- * Hardcoded, not env-gated: this slice only proves workflow-retirement
- * decisions. There is deliberately no live deletion branch to activate.
- */
-const FORCE_DRY_RUN = true;
 
 export interface IdleTaskCleanupWorkflowRow {
   readonly id: string;
@@ -40,10 +34,21 @@ export interface IdleTaskCleanupWorkerSubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof DELETE_IDLE_WORKFLOW_CHANNEL,
+    channel: typeof IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
+}
+export function buildIdleTaskCleanupRetireWorkflowMutationArgs(workflowId: string): unknown[] {
+  return [workflowId];
+}
+
+export function parseIdleTaskCleanupRetireWorkflowMutationArgs(args: unknown[]): { workflowId: string } {
+  const [workflowId] = args;
+  if (typeof workflowId !== 'string' || workflowId.trim().length === 0) {
+    throw new Error(`${IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL} mutation requires a workflow ID`);
+  }
+  return { workflowId };
 }
 
 export type CleanupAction = {
@@ -119,27 +124,27 @@ export function createIdleTaskCleanupWorker(options: IdleTaskCleanupWorkerOption
 
       for (const action of actions) {
         if (ctx.signal?.aborted) return;
-
-        if (!FORCE_DRY_RUN) {
-          throw new Error('idle-task-cleanup workflow deletion is hard-disabled');
-        }
-
+        const intentId = options.submitter.submit(
+          action.workflowId,
+          'high',
+          IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL,
+          buildIdleTaskCleanupRetireWorkflowMutationArgs(action.workflowId),
+        );
         options.logger.info(
-          `[idle-task-cleanup] (dry-run) would delete workflow ${action.workflowId} (${action.reason})`,
-          { module: 'idle-task-cleanup', workflowId: action.workflowId },
+          `[idle-task-cleanup] submitted workflow retirement for ${action.workflowId} (${action.reason})`,
+          { module: 'idle-task-cleanup', workflowId: action.workflowId, intentId },
         );
       }
     },
   });
 }
 
-/** Register the built-in idle-task-cleanup worker (dry-run only in this version). */
 export function registerIdleTaskCleanupWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: IDLE_TASK_CLEANUP_WORKER_KIND,
-    note: 'Dry-run: reports completed or inactive-over-48-hours workflows with no active tasks.',
+    note: 'Retires completed workflows immediately and inactive workflows older than 48 hours.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.idleTaskCleanup;
       if (!config) {


### PR DESCRIPTION
## Summary

Connect the idle worker's selected-workflow handoff to the serialized owner mutation dispatcher.

Both owner modes register the channel and forward its workflow request through `CommandService`.

## Review Claim

Owner modes dispatch the idle worker's selected-workflow handoff through canonical serialized mutation routing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only workflow IDs produced by the preceding selection slice enter this channel. Runtime states not selected remain untouched, and GitHub pull-request and branch APIs are never called.

Assumptions: This is the safety invariant approved with the submitted two-slice cleanup plan.

## Slice Rationale

This owner-channel connection lands separately from selection rules, keeping each boundary independently reviewable while ensuring the live channel is registered.

## Non-goals

- No direct SQLite access.
- No task-level mutation path.
- No GitHub API mutation.
- No settings UI.

## Architecture

### Before

```mermaid
graph LR
    A["Idle worker selected workflow"] --> B["Log only"]
```

### After

```mermaid
graph LR
    A["Idle worker selected workflow"] --> B["Persisted mutation coordinator"]
    B --> C["Owner mutation dispatcher"]
    C --> D["CommandService workflow operation"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts src/__tests__/worker-mutation-channel-repro.test.ts src/__tests__/workflow-mutation-handlers.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/idle-task-cleanup-policy.test.ts src/__tests__/idle-task-cleanup-worker.test.ts`
- [x] `pnpm run check:comments`
- [x] `pnpm --filter @invoker/app... build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. The preceding policy slice remains dormant without this owner handoff.
- Revert command: `git revert bf74ec5911a965a2afbc7e4cbab1f76149be1620 721ddd6bc4a142b3eab9fc0c48e89375066bcf2b`
- Post-revert steps: Restart the owner worker process.
- Data migration? No.

</details>
