### PR TITLE
[Owner web readiness](1) guard optional bridge wait

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2216,8 +2216,10 @@ function startHeadlessMode(): void {
             headlessWebBridge?.broadcast('invoker:planning-chat-stream', event);
           };
           startOwnerSocketSentinelForBus(messageBus);
-          await headlessWebBridge.whenReady;
-          logger.info('Web surface ready, proceeding with workers/dispatcher/recovery', { module: 'headless' });
+          if (headlessWebBridge) {
+            await headlessWebBridge.whenReady;
+            logger.info('Web surface ready, proceeding with workers/dispatcher/recovery', { module: 'headless' });
+          }
         }
         if (!sourceDevelopmentProfile) workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.


### PR DESCRIPTION
## Summary

Guard the owner readiness wait when the optional web bridge is absent.

Owners with a bridge still wait at the same point before background work begins.

## Review Claim

Owner startup preserves bridge-before-workers ordering while allowing the optional bridge to be absent.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

When the bridge exists, readiness is awaited at the same point before workers, dispatcher, and recovery. When absent, no bridge property is accessed.

Assumptions: This prerequisite invariant is unconfirmed because the operator requested automatic continuation through reversible blockers.

## Slice Rationale

This one-line guard restores the master type gate without mixing the unrelated idle-worker stack into the prerequisite.

## Non-goals

- No bridge configuration change.
- No startup ordering change when a bridge exists.
- No worker behavior change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/standalone-owner-web-surface.test.ts`
- [x] `pnpm run check:comments`

</details>

## Visual Proof

![Terminal verification for the optional web bridge branch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260831-5b2ae9/webbridge-null-proof.png)

Manually inspected: I opened this exact PNG. It shows commit `7496eb2b10`, `tsc -p tsconfig.typecheck.json` exiting 0, and all three owner web-ordering tests passing.

The token-absent branch intentionally exposes no browser surface, so the terminal verification is the visible signal for this change.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? No. Reverting restores the master TypeScript failure and null dereference risk.
- Revert command: `git revert 7496eb2b10`
- Post-revert steps: None.
- Data migration? No.

</details>
