### PR TITLE
[Idle task cleanup: make the 48-hour cutoff authoritative](1) Prove inert graph retention

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -70,34 +70,37 @@ describe('buildWorkerMutationHandlers', () => {
     expect(deleteWorkflow).toHaveBeenCalledTimes(1);
   });
 
-  it('revalidates a queued cleanup retirement against current task state', async () => {
-    const workflow = {
-      id: 'wf-stale-retirement',
-      name: 'stale retirement',
-      status: 'completed',
-      updatedAt: '2026-08-30T00:00:00.000Z',
-    };
-    let tasks = [{ status: 'completed' }] as never[];
-    const store = {
-      listWorkflows: () => [workflow],
-      loadTasks: () => tasks,
-    };
-    const now = new Date('2026-08-31T00:00:00.000Z').getTime();
-    expect(planIdleTaskCleanup([workflow], store.loadTasks, { now })).toHaveLength(1);
+  it.fails.each(['running', 'fixing_with_ai', 'future_task_state'])(
+    'revalidates a queued age-based retirement against current %s task state',
+    async (currentStatus) => {
+      const workflow = {
+        id: 'wf-stale-retirement',
+        name: 'stale retirement',
+        status: 'failed',
+        updatedAt: '2026-08-28T00:00:00.000Z',
+      };
+      let tasks = [{ status: 'pending' }] as never[];
+      const store = {
+        listWorkflows: () => [workflow],
+        loadTasks: () => tasks,
+      };
+      const now = new Date('2026-08-31T00:00:00.000Z').getTime();
+      expect(planIdleTaskCleanup([workflow], store.loadTasks, { now })).toHaveLength(1);
 
-    const deleteWorkflow = vi.fn(async () => ({ ok: true, data: undefined }));
-    const handlers = buildWorkerMutationHandlers({
-      ...fakeDeps(),
-      commandService: { deleteWorkflow } as never,
-      idleTaskCleanup: { store, now: () => now, idleThresholdMs: 48 * 60 * 60_000 },
-    });
-    tasks = [{ status: 'running' }] as never[];
+      const deleteWorkflow = vi.fn(async () => ({ ok: true, data: undefined }));
+      const handlers = buildWorkerMutationHandlers({
+        ...fakeDeps(),
+        commandService: { deleteWorkflow } as never,
+        idleTaskCleanup: { store, now: () => now, idleThresholdMs: 48 * 60 * 60_000 },
+      });
+      tasks = [{ status: currentStatus }] as never[];
 
-    await expect(
-      handlers.get(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL)!('wf-stale-retirement'),
-    ).resolves.toEqual({ ok: true });
-    expect(deleteWorkflow).not.toHaveBeenCalled();
-  });
+      await expect(
+        handlers.get(IDLE_TASK_CLEANUP_RETIRE_WORKFLOW_CHANNEL)!('wf-stale-retirement'),
+      ).resolves.toEqual({ ok: true });
+      expect(deleteWorkflow).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('assertAllWorkerMutationChannelsRegistered', () => {

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
@@ -64,15 +64,55 @@ describe('decideWorkflowRetirement', () => {
     'blocked',
     'review_ready',
     'awaiting_approval',
-  ])('retains workflows with %s work regardless of completion or age', (taskStatus) => {
+  ])('retains a completed workflow with active %s work', (taskStatus) => {
     expect(decide('completed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({ kind: 'retain' });
-    expect(decide('failed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({ kind: 'retain' });
+  });
+
+  it.each<TaskStatus>([
+    'completed',
+    'failed',
+    'closed',
+    'stale',
+  ])('retires an old known workflow with inactive %s work', (taskStatus) => {
+    expect(decide('failed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({
+      kind: 'retire',
+      reason: 'inactive-over-threshold',
+    });
+  });
+
+  it.fails.each<TaskStatus>([
+    'pending',
+    'queued',
+    'needs_input',
+    'blocked',
+    'review_ready',
+    'awaiting_approval',
+  ])('retires an old known workflow with inert %s work', (taskStatus) => {
+    expect(decide('failed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({
+      kind: 'retire',
+      reason: 'inactive-over-threshold',
+    });
+  });
+
+  it.each<TaskStatus>(['running', 'fixing_with_ai'])(
+    'retains an old workflow with executing %s work',
+    (taskStatus) => {
+      expect(decide('failed', JUST_OVER_48_HOURS_AGO, [taskStatus])).toEqual({ kind: 'retain' });
+    },
+  );
+
+  it('retains an old workflow when any task is executing', () => {
+    expect(decide('failed', JUST_OVER_48_HOURS_AGO, ['failed', 'running'])).toEqual({
+      kind: 'retain',
+    });
   });
 
   it('retains unknown workflow and task statuses', () => {
     expect(decide('future_workflow_state', JUST_OVER_48_HOURS_AGO, ['failed']))
       .toEqual({ kind: 'retain' });
     expect(decide('completed', JUST_OVER_48_HOURS_AGO, ['future_task_state']))
+      .toEqual({ kind: 'retain' });
+    expect(decide('failed', JUST_OVER_48_HOURS_AGO, ['future_task_state']))
       .toEqual({ kind: 'retain' });
   });
 

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
@@ -71,6 +71,25 @@ describe('planIdleTaskCleanup', () => {
     ]);
   });
 
+  it.fails('retires an old failed workflow with an inert pending merge task', () => {
+    const workflow = makeWorkflow('wf-old-pending-merge', 'failed', OVER_48_HOURS_AGO);
+    const pendingMergeTask = {
+      ...makeTask('wf-old-pending-merge/__merge__', 'pending'),
+      config: { workflowId: 'wf-old-pending-merge', isMergeNode: true },
+    };
+
+    expect(plan([workflow], { 'wf-old-pending-merge': [
+      makeTask('wf-old-pending-merge/task-1', 'failed'),
+      pendingMergeTask,
+    ] })).toEqual([
+      {
+        kind: 'delete-workflow',
+        workflowId: 'wf-old-pending-merge',
+        reason: 'workflow inactive beyond retirement threshold',
+      },
+    ]);
+  });
+
   it('retains a non-completed workflow at exactly 48 hours', () => {
     const workflow = makeWorkflow(
       'wf-boundary',
@@ -88,21 +107,51 @@ describe('planIdleTaskCleanup', () => {
   });
 
   it.each<TaskStatus>([
+    'completed',
+    'failed',
+    'closed',
+    'stale',
+  ])('retires an old workflow while a task is inactive %s', (status) => {
+    const workflow = makeWorkflow(`wf-inactive-${status}`, 'failed', OVER_48_HOURS_AGO);
+
+    expect(plan([workflow], {
+      [workflow.id]: [makeTask(`${workflow.id}/task`, status)],
+    })).toEqual([{
+      kind: 'delete-workflow',
+      workflowId: workflow.id,
+      reason: 'workflow inactive beyond retirement threshold',
+    }]);
+  });
+
+  it.fails.each<TaskStatus>([
     'pending',
     'queued',
-    'running',
-    'fixing_with_ai',
     'needs_input',
     'blocked',
     'review_ready',
     'awaiting_approval',
-  ])('retains an old workflow while a task is %s', (status) => {
-    const workflow = makeWorkflow(`wf-active-${status}`, 'failed', OVER_48_HOURS_AGO);
+  ])('retires an old workflow while a task is inert %s', (status) => {
+    const workflow = makeWorkflow(`wf-inert-${status}`, 'failed', OVER_48_HOURS_AGO);
 
     expect(plan([workflow], {
       [workflow.id]: [makeTask(`${workflow.id}/task`, status)],
-    })).toEqual([]);
+    })).toEqual([{
+      kind: 'delete-workflow',
+      workflowId: workflow.id,
+      reason: 'workflow inactive beyond retirement threshold',
+    }]);
   });
+
+  it.each<TaskStatus>(['running', 'fixing_with_ai'])(
+    'retains an old workflow while a task is executing %s',
+    (status) => {
+      const workflow = makeWorkflow(`wf-executing-${status}`, 'failed', OVER_48_HOURS_AGO);
+
+      expect(plan([workflow], {
+        [workflow.id]: [makeTask(`${workflow.id}/task`, status)],
+      })).toEqual([]);
+    },
+  );
 
   it('retains a completed workflow when its task state is active', () => {
     const workflow = makeWorkflow('wf-completed-active', 'completed', OVER_48_HOURS_AGO);


### PR DESCRIPTION
## Summary

Regression coverage records that workflows older than 48 hours should retire when their task graphs contain only inert, known states.

Expected-failure cases expose the current gap while completion, execution, unknown-state, and boundary controls stay green.

## Review Claim

Approve the regression matrix as proof that inert known nodes alone must not defeat workflow age retirement.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only fixture-based tests change. Product code and live owner data remain untouched.

## Slice Rationale

The expected failures land before the behavior change so reviewers can see the requested property fail independently.

## Non-goals

This slice does not change retirement decisions or mutate live workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/idle-task-cleanup-policy.test.ts src/__tests__/idle-task-cleanup-worker.test.ts`
- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/workflow-mutation-handlers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 103c595f32e679031edba9efac62827223e6dbe4`
- Post-revert steps: None.
- Data migration? No

</details>
