### PR TITLE
[Idle task cleanup: make the 48-hour cutoff authoritative](2) Enforce age retirement

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -70,7 +70,7 @@ describe('buildWorkerMutationHandlers', () => {
     expect(deleteWorkflow).toHaveBeenCalledTimes(1);
   });
 
-  it.fails.each(['running', 'fixing_with_ai', 'future_task_state'])(
+  it.each(['running', 'fixing_with_ai', 'future_task_state'])(
     'revalidates a queued age-based retirement against current %s task state',
     async (currentStatus) => {
       const workflow = {

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-policy.test.ts
@@ -80,7 +80,7 @@ describe('decideWorkflowRetirement', () => {
     });
   });
 
-  it.fails.each<TaskStatus>([
+  it.each<TaskStatus>([
     'pending',
     'queued',
     'needs_input',

--- a/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/idle-task-cleanup-worker.test.ts
@@ -71,7 +71,7 @@ describe('planIdleTaskCleanup', () => {
     ]);
   });
 
-  it.fails('retires an old failed workflow with an inert pending merge task', () => {
+  it('retires an old failed workflow with an inert pending merge task', () => {
     const workflow = makeWorkflow('wf-old-pending-merge', 'failed', OVER_48_HOURS_AGO);
     const pendingMergeTask = {
       ...makeTask('wf-old-pending-merge/__merge__', 'pending'),
@@ -123,7 +123,7 @@ describe('planIdleTaskCleanup', () => {
     }]);
   });
 
-  it.fails.each<TaskStatus>([
+  it.each<TaskStatus>([
     'pending',
     'queued',
     'needs_input',

--- a/packages/execution-engine/src/workers/idle-task-cleanup-policy.ts
+++ b/packages/execution-engine/src/workers/idle-task-cleanup-policy.ts
@@ -9,15 +9,20 @@ export const WORKFLOW_RETIREMENT_IDLE_THRESHOLD_MS = 48 * 60 * 60_000;
 const KNOWN_TASK_STATUS_SET: ReadonlySet<string> = new Set(TASK_STATUSES);
 
 /**
- * These outcomes contain no work that can still advance. Every other known
- * task status remains active for retirement purposes. Keeping the inactive
- * allowlist narrow makes a newly-added task status fail closed automatically.
+ * These outcomes contain no work that can still advance, so they permit
+ * immediate retirement of a completed workflow. Every other known task status
+ * blocks that path. Unknown statuses fail closed automatically.
  */
 const INACTIVE_TASK_STATUS_SET: ReadonlySet<TaskStatus> = new Set([
   'completed',
   'failed',
   'closed',
   'stale',
+]);
+
+const EXECUTING_TASK_STATUS_SET: ReadonlySet<TaskStatus> = new Set([
+  'running',
+  'fixing_with_ai',
 ]);
 
 const KNOWN_WORKFLOW_STATUSES = [
@@ -65,10 +70,17 @@ export function hasActiveOrUnknownTask(tasks: readonly WorkflowRetirementTask[])
   );
 }
 
+function hasExecutingOrUnknownTask(tasks: readonly WorkflowRetirementTask[]): boolean {
+  return tasks.some((task) =>
+    !isKnownTaskStatus(task.status) || EXECUTING_TASK_STATUS_SET.has(task.status),
+  );
+}
+
 /**
  * Completed workflows retire immediately once all tasks are inactive. Other
  * known workflow states retire only when their last update is strictly older
- * than the threshold. Unknown states and malformed timestamps are retained.
+ * than the threshold and no task is executing. Unknown states and malformed
+ * timestamps are retained.
  */
 export function decideWorkflowRetirement(
   workflow: WorkflowRetirementCandidate,
@@ -79,11 +91,13 @@ export function decideWorkflowRetirement(
   },
 ): WorkflowRetirementDecision {
   if (!isKnownWorkflowStatus(workflow.status)) return { kind: 'retain' };
-  if (hasActiveOrUnknownTask(tasks)) return { kind: 'retain' };
 
   if (workflow.status === 'completed') {
+    if (hasActiveOrUnknownTask(tasks)) return { kind: 'retain' };
     return { kind: 'retire', reason: 'completed' };
   }
+
+  if (hasExecutingOrUnknownTask(tasks)) return { kind: 'retain' };
 
   const updatedAtMs = workflow.updatedAt instanceof Date
     ? workflow.updatedAt.getTime()


### PR DESCRIPTION
## Summary

The worker now retires workflows strictly older than 48 hours when their task graphs contain only inert, known states.

Completed workflows still retire immediately only when every task is inactive.

Running, `fixing_with_ai`, unknown task states, unknown workflow states, fresh workflows, and the exact 48-hour boundary remain protected.

## Review Claim

Approve the retirement decision: completion requires every task inactive, while age retirement is blocked only by active execution or unknown future states.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

At planning and owner-side revalidation, unknown states and actually executing tasks remain protected. The change cannot call PR, branch, SQL, or owner-dispatch APIs.

## Slice Rationale

This slice converts the preceding expected failures into passing checks. The existing mutation channel and persistence path remain unchanged.

## Non-goals

The interval, owner handoff, storage implementation, GitHub operations, deployment, and unrelated behavior remain unchanged.

## Architecture

### Before

```mermaid
graph TD
    A["Workflow is completed or older than 48 hours"] --> B{"Every task is inactive?"}
    B -->|Yes| C["Retire workflow"]
    B -->|No| D["Retain workflow"]
```

### After

```mermaid
graph TD
    A["Evaluate workflow"] --> B{"Completed?"}
    B -->|Yes| C{"Every task is inactive?"}
    C -->|Yes| D["Retire workflow"]
    C -->|No| E{"Strictly older than 48 hours?"}
    B -->|No| E
    E -->|No| F["Retain workflow"]
    E -->|Yes| G{"Executing or unknown task state?"}
    G -->|Yes| F
    G -->|No| D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/idle-task-cleanup-policy.test.ts src/__tests__/idle-task-cleanup-worker.test.ts`
- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/workflow-mutation-handlers.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8672428b0c5cf887e085f70092a10bea6cd98856`
- Post-revert steps: Run the focused execution-engine and app tests above.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow deletion eligibility for long-idle graphs with inert pending work; executing and unknown states remain fail-closed at plan and handler revalidation.
> 
> **Overview**
> **Idle workflow retirement** now treats the 48-hour cutoff as authoritative for non-completed workflows: stale workflows can be retired when every task is *inert* (e.g. `pending`, `queued`, merge nodes), not only when all tasks are terminal inactive outcomes.
> 
> `decideWorkflowRetirement` splits the rules: **completed** workflows still retire immediately only if every task is inactive/unknown-safe via `hasActiveOrUnknownTask`; **other** known states retire after strictly more than 48 hours unless a task is **executing** (`running`, `fixing_with_ai`) or has an **unknown** status. Previously, any non-inactive known task blocked age retirement the same way it blocked completion retirement.
> 
> Tests that were marked `it.fails` now pass across policy, worker planning, and app mutation-handler revalidation (queued retirements are still suppressed when live task state is executing or unknown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487483753a10291651890a66c1ff47c0340b4b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->