### PR TITLE
[Freshness path intent](1) Bind anchors to existing paths only

### DIFF
--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -124,6 +124,18 @@ Files:
     ]);
   });
 
+  it('splits sentences that end with a closing quote or parenthesis', () => {
+    const specification = parseTaskFreshnessSpecification(
+      '"packages/ui/src/App.tsx already exists; do not create it." Create packages/ui/src/NewPanel.tsx. '
+      + '(packages/ui/src/Toolbar.tsx already exists.) Create packages/ui/src/NewToolbar.tsx.',
+    );
+
+    expect(specification.anchors.map(anchor => anchor.value)).toEqual([
+      'packages/ui/src/App.tsx',
+      'packages/ui/src/Toolbar.tsx',
+    ]);
+  });
+
   it('keeps an explicit do not create path as an anchor', () => {
     const specification = parseTaskFreshnessSpecification(
       'Do not create packages/ui/src/App.tsx; modify the existing file.',

--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -91,6 +91,51 @@ describe('stale task specification preflight', () => {
     }]);
   });
 
+  it('does not bind an existing marker across but create in the same sentence', () => {
+    const specification = parseTaskFreshnessSpecification(
+      'packages/ui/src/App.tsx already exists, but create packages/ui/src/NewPanel.tsx.',
+    );
+
+    expect(specification.anchors.map(anchor => anchor.value)).toEqual([
+      'packages/ui/src/App.tsx',
+    ]);
+  });
+
+  it('does not bind an existing marker across and create in the same sentence', () => {
+    const specification = parseTaskFreshnessSpecification(
+      'Use the existing packages/ui/src/App.tsx and create packages/ui/src/NewPanel.tsx.',
+    );
+
+    expect(specification.anchors.map(anchor => anchor.value)).toEqual([
+      'packages/ui/src/App.tsx',
+    ]);
+  });
+
+  it('keeps path intents separate in semicolon-delimited list items', () => {
+    const specification = parseTaskFreshnessSpecification(`
+Files:
+- packages/ui/src/App.tsx already exists; create packages/ui/src/NewPanel.tsx
+- do not create packages/ui/src/Toolbar.tsx; create packages/ui/src/NewToolbar.tsx
+`);
+
+    expect(specification.anchors.map(anchor => anchor.value)).toEqual([
+      'packages/ui/src/App.tsx',
+      'packages/ui/src/Toolbar.tsx',
+    ]);
+  });
+
+  it('keeps an explicit do not create path as an anchor', () => {
+    const specification = parseTaskFreshnessSpecification(
+      'Do not create packages/ui/src/App.tsx; modify the existing file.',
+    );
+
+    expect(specification.anchors).toEqual([{
+      kind: 'path',
+      value: 'packages/ui/src/App.tsx',
+      clause: 'Do not create packages/ui/src/App.tsx; modify the existing file.',
+    }]);
+  });
+
   it('allows unrelated base changes and current-base attempts', () => {
     const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
 

--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -81,6 +81,16 @@ describe('stale task specification preflight', () => {
     });
   });
 
+  it('does not inherit an earlier anchor marker in a later create sentence', () => {
+    const specification = parseTaskFreshnessSpecification('packages/ui/src/App.tsx already exists; do not create it. Create packages/ui/src/NewPanel.tsx.');
+
+    expect(specification.anchors).toEqual([{
+      kind: 'path',
+      value: 'packages/ui/src/App.tsx',
+      clause: 'packages/ui/src/App.tsx already exists; do not create it.',
+    }]);
+  });
+
   it('allows unrelated base changes and current-base attempts', () => {
     const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
 

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -30,9 +30,13 @@ export type TaskFreshnessDecision =
 const REPO_PATH_PATTERN = /(?:^|[\s`'"(])((?:\.github|corpus|docs|engine|packages|scripts|tests)\/[A-Za-z0-9_@./-]+)/g;
 const BACKTICK_TOKEN_PATTERN = /`([^`]+)`/g;
 const ANCHOR_CLAUSE_PATTERN = /\b(?:already exists?|existing|do not create|must not create|without creating)\b/i;
+const CREATE_PATH_PATTERN = /\b(?:create|creating)\b/i;
+const PATH_INTENT_BOUNDARY_PATTERN = /\s*;\s*|(?:,\s*|\s+)\b(?:but|and)\s+(?=(?:do not create|must not create|without creating|create|creating|existing)\b)|,\s*(?=(?:do not create|must not create|without creating|create|creating|existing)\b)/i;
 const GUARDED_MARKER_PATTERN = /guarded-behavior:\s*([A-Za-z0-9][\w-]*)/gi;
 const GUARDED_PROSE_PATTERN = /guarded behavior(?:\s+(?:id|marker))?\s*(?:`|"|')?([A-Za-z0-9][\w-]*)/gi;
 const REMOTE_REPORT_MARKER = '__INVOKER_TASK_FRESHNESS_STALE__';
+
+type PathIntent = 'existing' | 'create' | 'reference';
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
@@ -51,6 +55,20 @@ function normalizedRepoPaths(text: string): string[] {
   return uniqueSorted(paths);
 }
 
+function pathIntent(text: string): PathIntent {
+  if (ANCHOR_CLAUSE_PATTERN.test(text)) return 'existing';
+  if (CREATE_PATH_PATTERN.test(text)) return 'create';
+  return 'reference';
+}
+
+function pathIntentRegions(clause: string): Array<{ text: string; intent: PathIntent }> {
+  return clause
+    .split(PATH_INTENT_BOUNDARY_PATTERN)
+    .map(text => text.trim())
+    .filter(Boolean)
+    .map(text => ({ text, intent: pathIntent(text) }));
+}
+
 export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpecification {
   const referencedPaths = normalizedRepoPaths(text);
   const guardedBehaviorIds = uniqueSorted([
@@ -61,9 +79,15 @@ export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpec
 
   for (const rawClause of text.split(/\r?\n|(?<=[.!?])\s+/)) {
     const clause = rawClause.trim();
-    if (!clause || !ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
+    if (!clause) continue;
     const paths = normalizedRepoPaths(clause);
-    for (const value of paths) anchors.push({ kind: 'path', value, clause });
+    for (const region of pathIntentRegions(clause)) {
+      if (region.intent !== 'existing') continue;
+      for (const value of normalizedRepoPaths(region.text)) {
+        anchors.push({ kind: 'path', value, clause });
+      }
+    }
+    if (!ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
     for (const tokenMatch of clause.matchAll(BACKTICK_TOKEN_PATTERN)) {
       const value = tokenMatch[1]?.trim();
       if (!value || paths.includes(value) || !/^[A-Za-z_$][\w$]*$/.test(value)) continue;

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -59,7 +59,7 @@ export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpec
   ]);
   const anchors: TaskFreshnessAnchor[] = [];
 
-  for (const rawClause of text.split(/\r?\n/)) {
+  for (const rawClause of text.split(/\r?\n|(?<=[.!?])\s+/)) {
     const clause = rawClause.trim();
     if (!clause || !ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
     const paths = normalizedRepoPaths(clause);

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -31,7 +31,7 @@ const REPO_PATH_PATTERN = /(?:^|[\s`'"(])((?:\.github|corpus|docs|engine|package
 const BACKTICK_TOKEN_PATTERN = /`([^`]+)`/g;
 const ANCHOR_CLAUSE_PATTERN = /\b(?:already exists?|existing|do not create|must not create|without creating)\b/i;
 const CREATE_PATH_PATTERN = /\b(?:create|creating)\b/i;
-const PATH_INTENT_BOUNDARY_PATTERN = /\s*;\s*|(?:,\s*|\s+)\b(?:but|and)\s+(?=(?:do not create|must not create|without creating|create|creating|existing)\b)|,\s*(?=(?:do not create|must not create|without creating|create|creating|existing)\b)/i;
+const PATH_INTENT_MARKER_PATTERN = /\b(?:do not create|must not create|without creating|create|creating|existing)\b/gi;
 const GUARDED_MARKER_PATTERN = /guarded-behavior:\s*([A-Za-z0-9][\w-]*)/gi;
 const GUARDED_PROSE_PATTERN = /guarded behavior(?:\s+(?:id|marker))?\s*(?:`|"|')?([A-Za-z0-9][\w-]*)/gi;
 const REMOTE_REPORT_MARKER = '__INVOKER_TASK_FRESHNESS_STALE__';
@@ -62,11 +62,31 @@ function pathIntent(text: string): PathIntent {
 }
 
 function pathIntentRegions(clause: string): Array<{ text: string; intent: PathIntent }> {
-  return clause
-    .split(PATH_INTENT_BOUNDARY_PATTERN)
-    .map(text => text.trim())
-    .filter(Boolean)
-    .map(text => ({ text, intent: pathIntent(text) }));
+  const boundaries = new Set<number>([0, clause.length]);
+  for (let index = 0; index < clause.length; index += 1) {
+    if (clause[index] === ';') boundaries.add(index + 1);
+  }
+  for (const match of clause.matchAll(PATH_INTENT_MARKER_PATTERN)) {
+    const markerIndex = match.index;
+    if (markerIndex === 0) continue;
+    let cursor = markerIndex - 1;
+    while (cursor >= 0 && /\s/.test(clause[cursor]!)) cursor -= 1;
+    if (clause[cursor] === ',') {
+      boundaries.add(markerIndex);
+      continue;
+    }
+    const precedingWordEnd = cursor + 1;
+    while (cursor >= 0 && /[A-Za-z]/.test(clause[cursor]!)) cursor -= 1;
+    const precedingWord = clause.slice(cursor + 1, precedingWordEnd).toLowerCase();
+    if (precedingWord === 'and' || precedingWord === 'but') boundaries.add(markerIndex);
+  }
+  const sortedBoundaries = [...boundaries].sort((left, right) => left - right);
+  const regions: Array<{ text: string; intent: PathIntent }> = [];
+  for (let index = 1; index < sortedBoundaries.length; index += 1) {
+    const text = clause.slice(sortedBoundaries[index - 1], sortedBoundaries[index]).trim();
+    if (text) regions.push({ text, intent: pathIntent(text) });
+  }
+  return regions;
 }
 
 export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpecification {

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -35,6 +35,7 @@ const PATH_INTENT_MARKER_PATTERN = /\b(?:do not create|must not create|without c
 const GUARDED_MARKER_PATTERN = /guarded-behavior:\s*([A-Za-z0-9][\w-]*)/gi;
 const GUARDED_PROSE_PATTERN = /guarded behavior(?:\s+(?:id|marker))?\s*(?:`|"|')?([A-Za-z0-9][\w-]*)/gi;
 const REMOTE_REPORT_MARKER = '__INVOKER_TASK_FRESHNESS_STALE__';
+const SENTENCE_BOUNDARY_PATTERN = /\r?\n|(?<=[.!?]["')\]]*)\s+/;
 
 type PathIntent = 'existing' | 'create' | 'reference';
 
@@ -97,7 +98,7 @@ export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpec
   ]);
   const anchors: TaskFreshnessAnchor[] = [];
 
-  for (const rawClause of text.split(/\r?\n|(?<=[.!?])\s+/)) {
+  for (const rawClause of text.split(SENTENCE_BOUNDARY_PATTERN)) {
     const clause = rawClause.trim();
     if (!clause) continue;
     const paths = normalizedRepoPaths(clause);


### PR DESCRIPTION
## Summary

Classify each path-bearing prompt region as `existing`, `create`, or `reference` before collecting freshness anchors.

Only explicit existing/do-not-create regions become required filesystem anchors; a create target in the same sentence stays outside the anchor set.

## Review Claim

Mixed instructions retain existing paths as freshness anchors without treating same-sentence create targets as pre-existing files.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Explicit existing/do-not-create contradictions still reject the task; create and ordinary reference paths do not become existence anchors. Snapshot drift, guarded-behavior checks, symbol anchors, and local/SSH parity remain unchanged.

## Slice Rationale

The intent classifier and its regression cases are one behavior change at the task-specification boundary.

## Non-goals

No status mapping, snapshot lifecycle, UI, public interface, documentation, or unrelated cleanup changes.

## Architecture

### Before

```mermaid
graph LR
    A["Prompt clause"] --> B["Any existing marker anchors every path in the clause"]
```

### After

```mermaid
graph LR
    A["Prompt clause"] --> B["Path-intent regions"]
    B --> C["Existing paths become anchors"]
    B --> D["Create/reference paths remain references"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Pre-fix period-separated repro: `pnpm --filter @invoker/execution-engine test -- task-specification-preflight.test.ts` — `Test Files 1 failed (1)`; `Tests 1 failed | 11 passed (12)`; exit 1.
- [x] Pre-fix mixed-intent repro: targeted Vitest file with `but create`, `and create`, and semicolon/list cases — `Test Files 1 failed (1)`; `Tests 3 failed | 13 passed (16)`; exit 1.
- [x] Current branch: `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-specification-preflight.test.ts` — `Test Files 1 passed (1)`; `Tests 16 passed (16)`; exit 0.
- [x] `pnpm --filter @invoker/execution-engine build` — `ESM Build success`; `DTS Build success`; exit 0.
- [x] `pnpm check:comments` — `[comments] Checked added source lines; no disallowed comments found.`; exit 0.
- [ ] Full execution-engine suite has 14 failures in four auto-fix/worker-ledger test files; the identical 14 failures reproduce on untouched `origin/master`, so this PR relies on the focused regression plus build and comment gates.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merged-PR-commit>`
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tasks fail preflight before agent execution; incorrect parsing could wrongly block or allow stale specs, though evaluation and git/guard logic are otherwise unchanged.
> 
> **Overview**
> **Task freshness parsing** no longer treats every repo path in an “existing / do not create” clause as a required filesystem anchor when the same clause also tells the agent to **create** another file.
> 
> `parseTaskFreshnessSpecification` now splits prompt text on sentence boundaries (including after quoted/parenthesized sentences), subdivides each clause into **path-intent regions** (semicolons, commas before `create`, and `and`/`but` before create markers), and only adds **path anchors** from regions classified as **existing** (explicit “already exists”, “existing”, “do not create”, etc.). Create and plain reference regions stay in `referencedPaths` but are not existence anchors.
> 
> Regression tests cover mixed sentences (`but create` / `and create`), list items with semicolons, quoted boundaries, and standalone “do not create” paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1370c349e3f6a554d7ee37d17fbc7801ae2b9f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->