### PR TITLE
[Stale-spec anchor scope](1) Scope anchors to sentences

### DIFF
--- a/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
+++ b/packages/execution-engine/src/__tests__/task-specification-preflight.test.ts
@@ -81,6 +81,16 @@ describe('stale task specification preflight', () => {
     });
   });
 
+  it('does not inherit an earlier anchor marker in a later create sentence', () => {
+    const specification = parseTaskFreshnessSpecification('packages/ui/src/App.tsx already exists; do not create it. Create packages/ui/src/NewPanel.tsx.');
+
+    expect(specification.anchors).toEqual([{
+      kind: 'path',
+      value: 'packages/ui/src/App.tsx',
+      clause: 'packages/ui/src/App.tsx already exists; do not create it.',
+    }]);
+  });
+
   it('allows unrelated base changes and current-base attempts', () => {
     const specification = parseTaskFreshnessSpecification(CAMERA_TASK);
 

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -59,7 +59,7 @@ export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpec
   ]);
   const anchors: TaskFreshnessAnchor[] = [];
 
-  for (const rawClause of text.split(/\r?\n/)) {
+  for (const rawClause of text.split(/\r?\n|(?<=[.!?])\s+/)) {
     const clause = rawClause.trim();
     if (!clause || !ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
     const paths = normalizedRepoPaths(clause);


### PR DESCRIPTION
## Summary

Freshness routing treated every path on a flattened line as pre-existing when any earlier sentence used an anchor marker.

It now evaluates sentence boundaries, preserving explicit anchors while excluding later create targets.

## Review Claim

Anchor extraction applies an existing/do-not-create marker only within its sentence.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Explicit pre-existing/do-not-create path contradictions still block the task. Create instructions, snapshot comparisons, guarded-behavior checks, and local/SSH parity remain unchanged.

## Slice Rationale

The parser correction and its directly affected regression test are one routing behavior claim. No status mapping, lifecycle, or interface changes are bundled.

## Non-goals

This does not change snapshot capture, task-state mapping, UI rendering, error text, guarded-behavior detection, or unrelated freshness rules.

## Architecture

### Before

```mermaid
graph LR
    A["Physical line"] --> B["One anchor clause"]
    B --> C["Every path inherits any anchor marker"]
```

### After

```mermaid
graph LR
    A["Physical line"] --> B["Sentence clauses"]
    B --> C["Only same-sentence paths inherit an anchor marker"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- task-specification-preflight.test.ts` — failed 1/12 before the production edit, then passed 12/12 after it.
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm run check:comments`
- [ ] `pnpm --filter @invoker/execution-engine test` — 1,845 passed, 14 failed, 1 skipped. The same 14 failures reproduce on untouched `origin/master` in four auto-fix/worker-ledger files.

</details>

## Visual Proof

Not applicable: this changes parser classification without changing rendering. A screenshot would not prove which repository path became an anchor; the exact parser regression above is the literal evidence.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8bbf1df9d1`
- Post-revert steps: None
- Data migration? No

</details>
