### PR TITLE
[Web/Desktop Capability Parity](1) access policy

### DIFF
--- a/packages/app/src/__tests__/invoker-surface-access.test.ts
+++ b/packages/app/src/__tests__/invoker-surface-access.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkInvokerSurfaceAccess,
+  INVOKER_SURFACE_ACCESS_DENIAL_CODE,
+} from '../invoker-surface-access.js';
+
+describe('checkInvokerSurfaceAccess', () => {
+  it('allows any execution agent when deployment configuration is unrestricted', () => {
+    expect(checkInvokerSurfaceAccess({}, 'claude')).toEqual({ allowed: true });
+  });
+
+  it('allows an explicitly enabled Codex execution agent', () => {
+    expect(checkInvokerSurfaceAccess({ enabledExecutionAgents: ['codex'] }, 'codex')).toEqual({ allowed: true });
+  });
+
+  it('uses the built-in default when the execution agent is omitted', () => {
+    expect(checkInvokerSurfaceAccess({ enabledExecutionAgents: ['codex'] })).toEqual({ allowed: true });
+  });
+
+  it('uses the configured default when the execution-agent input is empty', () => {
+    expect(checkInvokerSurfaceAccess({
+      defaultExecutionAgent: 'omp',
+      enabledExecutionAgents: ['omp'],
+    }, '   ')).toEqual({ allowed: true });
+  });
+
+  it('treats an empty configured allowlist as unrestricted', () => {
+    expect(checkInvokerSurfaceAccess({ enabledExecutionAgents: [] }, 'claude')).toEqual({ allowed: true });
+  });
+
+  it('denies a disabled Claude execution agent with a web-compatible error code', () => {
+    expect(checkInvokerSurfaceAccess({ enabledExecutionAgents: ['codex'] }, 'claude')).toEqual({
+      allowed: false,
+      code: INVOKER_SURFACE_ACCESS_DENIAL_CODE,
+      message: 'Execution agent "claude" is disabled by deployment configuration',
+    });
+    expect(INVOKER_SURFACE_ACCESS_DENIAL_CODE).toBe('execution_agent_disabled');
+  });
+});

--- a/packages/app/src/invoker-surface-access.ts
+++ b/packages/app/src/invoker-surface-access.ts
@@ -1,0 +1,34 @@
+import {
+  resolveDefaultTaskExecutionSettings,
+  resolveEnabledExecutionAgents,
+  type InvokerConfig,
+} from './config.js';
+
+export const INVOKER_SURFACE_ACCESS_DENIAL_CODE = 'execution_agent_disabled' as const;
+
+export type InvokerSurfaceAccessDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly code: typeof INVOKER_SURFACE_ACCESS_DENIAL_CODE;
+      readonly message: string;
+    };
+
+export function checkInvokerSurfaceAccess(
+  config: InvokerConfig,
+  executionAgent?: string,
+): InvokerSurfaceAccessDecision {
+  const requestedAgent = executionAgent?.trim();
+  const effectiveAgent = requestedAgent || resolveDefaultTaskExecutionSettings(config).executionAgent;
+  const enabledAgents = resolveEnabledExecutionAgents(config);
+
+  if (!enabledAgents || enabledAgents.has(effectiveAgent.toLowerCase())) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    code: INVOKER_SURFACE_ACCESS_DENIAL_CODE,
+    message: `Execution agent "${effectiveAgent}" is disabled by deployment configuration`,
+  };
+}


### PR DESCRIPTION
## Summary

Add a dormant, transport-neutral access-policy boundary.

It separates deployment authorization from handler availability and transport framing. No caller is rewired in this slice.

## Review Claim

Add one transport-neutral execution-agent access policy with full capability access by default and configuration-driven agent restrictions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The policy is dormant in this slice; no Electron IPC or HTTP caller changes behavior.

## Slice Rationale

The policy is foundational and independently reviewable before either transport is rewired.

## Non-goals

No dispatcher wiring, handler refactor, UI changes, or deployment secrets.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/invoker-surface-access.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: None
- Data migration? No

</details>
