### PR TITLE
test(e2e): wait for running persistence task before stop

### DIFF
--- a/packages/app/e2e/persistence-recovery.spec.ts
+++ b/packages/app/e2e/persistence-recovery.spec.ts
@@ -31,18 +31,10 @@ test.describe('Persistence recovery', () => {
   test('stop marks workflow as failed in DB', async ({ page }) => {
     // Load and start a slow plan
     await loadPlan(page, SLOW_PLAN);
-    await page.evaluate(() => window.invoker.start());
+    await startPlan(page);
 
     // Wait for the slow task to start running
-    await page.waitForFunction(
-      async () => {
-        const result = await window.invoker.getTasks();
-        const tasks = Array.isArray(result) ? result : result.tasks;
-        return tasks.some((t: any) => (t.id === 'slow-task' || t.id.endsWith('/slow-task')) && t.status === 'running');
-      },
-      null,
-      { timeout: 10000 },
-    );
+    await waitForTaskStatus(page, 'slow-task', 'running', 10_000);
 
     // Stop while running. This preserves the workflow record while failing
     // in-flight work, unlike clear/delete-all which intentionally removes it.


### PR DESCRIPTION
## Summary

Wait for the persistence recovery fixture’s slow task to enter the running state before stopping the workflow.

Reuse the established E2E helpers so the wait cannot resolve on an unobserved asynchronous predicate.

## Review Claim

The persistence recovery E2E now observes the running task before exercising workflow stop.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only synchronization in one persistence recovery E2E changes; production code, assertions, and workflow stop behavior remain unchanged.

Assumptions: This invariant comes from the submitted repair workflow and is unconfirmed in this recovery session.

## Slice Rationale

This keeps the deterministic CI repair confined to the failing E2E case.

## Non-goals

- No product behavior changes.
- No assertion weakening or test skipping.
- No unrelated E2E cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Rerun the Playwright 8-of-9 shard.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only E2E synchronization; no production code or assertion changes.
> 
> **Overview**
> The **persistence recovery** E2E case that stops a workflow mid-run now uses shared fixtures instead of ad hoc IPC calls.
> 
> **`startPlan`** replaces a direct `window.invoker.start()` call (it goes through the same start path as other E2E tests). The inline **`waitForFunction`** that polled `getTasks()` for `slow-task` in **`running`** is replaced by **`waitForTaskStatus`** with a 10s timeout, so the test only calls **stop** after the slow task is actually running.
> 
> Assertions and production behavior are unchanged; this is synchronization to reduce flaky CI on that stop-while-running scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6aae30174529671fb4d9a25b3b678394102a49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->