### PR TITLE
fix(e2e): preserve profile across detached owner bootstrap

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -19,7 +19,7 @@ import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 import { registerTrackedBrowserUserDataDir } from './browser-process-registry.js';
 import { killOwnedProcessGroup } from './process-group.js';
-import { cleanupStandaloneOwnersForTestDir } from './headless-client.js';
+import { cleanupStandaloneOwnersForTestDir, e2eDevelopmentProfileEnv } from './headless-client.js';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
@@ -231,6 +231,7 @@ exit 64
       ],
       env: {
         ...process.env,
+        ...e2eDevelopmentProfileEnv(testDir, electronUserDataDir, configPath, ipcSocketPath),
         NODE_ENV: 'test',
         INVOKER_TEST_WORKFLOW_IDS: '1',
         INVOKER_DISABLE_SLACK: '1',

--- a/packages/app/e2e/fixtures/headless-client.ts
+++ b/packages/app/e2e/fixtures/headless-client.ts
@@ -4,9 +4,33 @@ import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { setTimeout as delay } from 'node:timers/promises';
 import { promisify } from 'node:util';
 import { resolveRepoRoot } from '@invoker/contracts';
+import { resolveOwnerChildProfileEnv } from '../../src/headless-owner-bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
+
+export function e2eDevelopmentProfileEnv(
+  testDir: string,
+  electronUserDataDir: string,
+  configPath: string,
+  ipcSocketPath: string,
+): Record<string, string> {
+  return resolveOwnerChildProfileEnv({
+    INVOKER_RUNTIME_KIND: 'source-development',
+    INVOKER_DEVELOPMENT_PROFILE: '1',
+    INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1',
+    INVOKER_SOURCE_ROOT: repoRoot,
+    INVOKER_PROFILE_ID: path.basename(testDir),
+    INVOKER_DB_DIR: testDir,
+    INVOKER_USER_DATA_DIR: electronUserDataDir,
+    INVOKER_IPC_SOCKET: ipcSocketPath,
+    INVOKER_REPO_CONFIG_PATH: configPath,
+    INVOKER_ENV_PATH: path.join(testDir, '.env'),
+    INVOKER_LOG_PATH: path.join(testDir, 'invoker.log'),
+    INVOKER_API_PORT: '0',
+    INVOKER_WEB_PORT: '0',
+  });
+}
 
 type StandaloneOwnerProcess = {
   pid: number;
@@ -23,6 +47,12 @@ export function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
   return {
     ...process.env,
+    ...e2eDevelopmentProfileEnv(
+      testDir,
+      path.join(testDir, 'headless-electron-user-data'),
+      configPath,
+      ipcSocketPath,
+    ),
     NODE_ENV: 'test',
     INVOKER_TEST_WORKFLOW_IDS: '1',
     TZ: 'UTC',

--- a/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
+++ b/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
@@ -21,9 +21,10 @@ vi.mock('node:child_process', async (importOriginal) => {
 import { readdir, readFile } from 'node:fs/promises';
 import { setTimeout as delay } from 'node:timers/promises';
 import { spawn } from 'node:child_process';
-import { cleanupStandaloneOwnersForTestDir } from '../../e2e/fixtures/headless-client.js';
+import { cleanupStandaloneOwnersForTestDir, headlessTestEnv } from '../../e2e/fixtures/headless-client.js';
 import {
   OwnerChildProfileError,
+  resolveDetachedOwnerCommand,
   resolveOwnerChildProfileEnv,
   spawnDetachedStandaloneOwner,
 } from '../headless-owner-bootstrap.js';
@@ -118,12 +119,59 @@ describe('detached owner child profile identity', () => {
     expect(childEnv).toEqual({ INVOKER_RUNTIME_KIND: 'packaged' });
   });
 
+  it('launches main.js directly when the parent process is Electron', () => {
+    expect(resolveDetachedOwnerCommand('/repo/checkout', {
+      executablePath: '/electron',
+      isElectron: true,
+      platform: 'linux',
+    })).toEqual({
+      command: '/electron',
+      args: [
+        '--no-sandbox',
+        '/repo/checkout/packages/app/dist/main.js',
+        '--headless',
+        'owner-serve',
+      ],
+    });
+  });
+
+  it('keeps the launcher wrapper when the parent process is Node', () => {
+    expect(resolveDetachedOwnerCommand('/repo/checkout', {
+      executablePath: '/node',
+      isElectron: false,
+      platform: 'linux',
+    })).toEqual({
+      command: '/node',
+      args: [
+        '/repo/checkout/scripts/electron.cjs',
+        '--no-sandbox',
+        '/repo/checkout/packages/app/dist/main.js',
+        '--headless',
+        'owner-serve',
+      ],
+    });
+  });
+
   it('passes the same source profile and disjoint locations from a source-development parent to the child', () => {
     const childEnv = resolveOwnerChildProfileEnv(sourceDevelopmentEnv);
 
     expect(childEnv).toEqual({ INVOKER_RUNTIME_KIND: 'source-development', ...sourceDevelopmentEnv });
     expect(childEnv.INVOKER_DB_DIR).not.toBe('/Users/dev/.invoker');
     expect(childEnv.INVOKER_IPC_SOCKET).not.toBe('/Users/dev/.invoker/ipc-transport.sock');
+  });
+
+  it('gives headless E2E clients a complete source-development profile', () => {
+    const testDir = '/tmp/invoker-headless-profile-test';
+    const env = headlessTestEnv(testDir);
+
+    expect(env).toMatchObject({
+      INVOKER_RUNTIME_KIND: 'source-development',
+      INVOKER_DEVELOPMENT_PROFILE: '1',
+      INVOKER_DEVELOPMENT_PROFILE_ACTIVE: '1',
+      INVOKER_DB_DIR: testDir,
+      INVOKER_IPC_SOCKET: `${testDir}/ipc-transport.sock`,
+      INVOKER_REPO_CONFIG_PATH: `${testDir}/e2e-config.json`,
+    });
   });
 
   it('fails before spawn when a source-development parent has a partial profile', () => {

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -99,6 +99,38 @@ export type OwnerBootstrapLock = {
   release: () => void;
 };
 
+type OwnerParentRuntime = {
+  executablePath: string;
+  isElectron: boolean;
+  platform: NodeJS.Platform;
+};
+
+export function resolveDetachedOwnerCommand(
+  repoRoot: string,
+  runtime: OwnerParentRuntime = {
+    executablePath: process.execPath,
+    isElectron: Boolean(process.versions.electron),
+    platform: process.platform,
+  },
+): { command: string; args: string[] } {
+  const mainJs = resolve(repoRoot, 'packages', 'app', 'dist', 'main.js');
+  const electronArgs = [
+    ...(runtime.platform === 'linux' ? ['--no-sandbox'] : []),
+    mainJs,
+    '--headless',
+    'owner-serve',
+  ];
+
+  if (runtime.isElectron) {
+    return { command: runtime.executablePath, args: electronArgs };
+  }
+
+  return {
+    command: runtime.executablePath,
+    args: [resolve(repoRoot, 'scripts', 'electron.cjs'), ...electronArgs],
+  };
+}
+
 export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBootstrapLock | null {
   const lockDir = join(invokerHomeRoot, OWNER_BOOTSTRAP_LOCK_DIR);
 
@@ -144,16 +176,8 @@ export function spawnDetachedStandaloneOwner(
   extraEnv: NodeJS.ProcessEnv = {},
 ): void {
   const profileEnv = resolveOwnerChildProfileEnv(process.env);
-  const electronLauncher = resolve(repoRoot, 'scripts', 'electron.cjs');
-  const mainJs = resolve(repoRoot, 'packages', 'app', 'dist', 'main.js');
-  const args = [
-    electronLauncher,
-    ...(process.platform === 'linux' ? ['--no-sandbox'] : []),
-    mainJs,
-    '--headless',
-    'owner-serve',
-  ];
-  const child = spawn(process.execPath, args, {
+  const childCommand = resolveDetachedOwnerCommand(repoRoot);
+  const child = spawn(childCommand.command, childCommand.args, {
     cwd: repoRoot,
     detached: true,
     stdio: 'ignore',


### PR DESCRIPTION
## Summary

Launch a detached owner directly when bootstrap already runs inside Electron, avoiding a nested Electron launcher process.

Give Electron and headless E2E clients the same complete source-development profile so they delegate to one isolated owner.

## Review Claim

Detached owner bootstrap preserves one runtime profile and one Electron process boundary during headless E2E delegation.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Node parents retain the launcher wrapper, Electron parents launch `main.js` directly, and packaged parents remain isolated from source-development settings.

Assumptions: This invariant is derived from the submitted repair workflow and is unconfirmed in this recovery session.

## Slice Rationale

The bootstrap selection, shared fixture profile, and regression proof form one local process-launch correction.

## Non-goals

- No scheduler or workflow retry policy changes.
- No production database or IPC path changes.
- No weakened responsiveness budgets.

## Architecture

### Before

```mermaid
graph TD
    A["Electron parent"] --> B["electron.cjs wrapper"]
    B --> C["detached owner"]
    D["headless E2E client with partial profile"] --> E["bootstrap rejection"]
```

### After

```mermaid
graph TD
    A["Electron parent"] --> C["detached owner main.js"]
    B["Node parent"] --> D["electron.cjs wrapper"]
    D --> C
    E["headless E2E client with complete profile"] --> C
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-client-fixture-cleanup.test.ts`
- [x] `pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL="repair-headless-thundering-herd-rebased" INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES="e2e/headless-thundering-herd.spec.ts" INVOKER_PLAYWRIGHT_ARGS="--reporter=line" bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Rerun the focused owner-bootstrap unit test and headless-thundering-herd E2E.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how detached owner processes are launched and which env vars E2E inherits; scoped to test/source-development bootstrap, but incorrect command or profile wiring could break owner delegation in CI.
> 
> **Overview**
> Fixes detached standalone owner bootstrap so **Electron parents** spawn `main.js` with `--headless owner-serve` directly instead of going through `scripts/electron.cjs`, while **Node parents** still use the launcher wrapper. Selection lives in new `resolveDetachedOwnerCommand`, which `spawnDetachedStandaloneOwner` now calls.
> 
> E2E harnesses share **`e2eDevelopmentProfileEnv`**, built via `resolveOwnerChildProfileEnv` with a full `source-development` identity (DB, IPC socket, config, ports, etc.). That env is merged into both the Playwright Electron fixture and **`headlessTestEnv`**, so GUI and headless E2E runs pass the same complete profile when delegating to an isolated owner instead of failing on partial settings.
> 
> Unit tests cover Electron vs Node command lines and assert headless E2E env includes the expected profile keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c14e97fc4038d3eff0f0a82810c8827deea2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching development profiles in Electron and headless test environments.
  * Detached owner processes now launch correctly across Electron and Node runtimes, including Linux sandbox handling.

* **Tests**
  * Added coverage for development profile environment setup and runtime-specific process launching.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->