### PR TITLE
[Planning PATH diagnostics](1) Clarify planning tool PATH diagnostics

### DIFF
--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
@@ -101,8 +103,9 @@ describe('checkDefaultPresetTool', () => {
   it('errors when the default preset tool is not on PATH', () => {
     const c = checkDefaultPresetTool(presets, 'cursor+claude', installed('omp'));
     expect(c.status).toBe('error');
-    expect(c.detail).toContain('cursor');
-    expect(c.remediation).toContain('defaultSlackHarnessPreset');
+    expect(c.detail).toBe('Default preset "cursor+claude" needs "cursor", which is not on Invoker\'s PATH');
+    expect(c.remediation).toBe("Make cursor available on Invoker's PATH (restart Invoker if it already works in a terminal), or set defaultSlackHarnessPreset to a preset whose tool is available");
+    expect(c.remediation).not.toMatch(/^Install /);
   });
 
   it('errors and lists valid keys when the default preset is undefined', () => {
@@ -114,13 +117,27 @@ describe('checkDefaultPresetTool', () => {
 
 describe('checkPlanningToolsPresent', () => {
   it('passes when any preset tool is installed', () => {
-    expect(checkPlanningToolsPresent(presets, installed('codex')).status).toBe('ok');
+    const c = checkPlanningToolsPresent(presets, installed('codex'));
+    expect(c.status).toBe('ok');
+    expect(c.detail).toBe("Available on Invoker's PATH: codex");
   });
 
-  it('errors when no planning tool is installed', () => {
+  it("reports PATH availability without claiming configured planning tools are uninstalled", () => {
     const c = checkPlanningToolsPresent(presets, installed('git'));
     expect(c.status).toBe('error');
-    expect(c.remediation).toContain('cursor');
+    expect(c.detail).toBe("Planning unavailable: none of the configured planner commands are on Invoker's PATH (cursor, omp, codex)");
+    expect(c.remediation).toBe("Make one of these commands available on Invoker's PATH: cursor, omp, codex. If it already works in a terminal, restart Invoker to refresh its shell environment; otherwise install it or configure another planning preset.");
+    expect(c.detail).not.toContain('installed');
+    expect(c.remediation).not.toMatch(/^Install /);
+  });
+});
+
+describe('invoker-setup planning availability guidance', () => {
+  it('distinguishes PATH visibility from installation state', () => {
+    const skill = readFileSync(new URL('../../../../skills/invoker-setup/SKILL.md', import.meta.url), 'utf8').replace(/\s+/g, ' ');
+    expect(skill).toContain("not available on Invoker's own `PATH`");
+    expect(skill).toContain('Do not report that command as uninstalled based on this probe alone');
+    expect(skill).toContain('restart Invoker to refresh its shell environment');
   });
 });
 
@@ -143,7 +160,8 @@ describe('buildReport / formatReport', () => {
   it('emits machine-readable JSON and shows remediation in text mode', () => {
     const report = buildReport([checkPlanningToolsPresent(presets, installed())]);
     expect(JSON.parse(formatReport(report, { json: true }))).toEqual(report);
-    expect(formatReport(report)).toContain('-> Install at least one');
+    const text = formatReport(report);
+    expect(text).toContain("-> Make one of these commands available on Invoker's PATH");
   });
 });
 

--- a/packages/contracts/src/prerequisites.ts
+++ b/packages/contracts/src/prerequisites.ts
@@ -111,8 +111,8 @@ export function checkDefaultPresetTool(
       id: 'default-preset',
       name: 'Default planning preset',
       status: 'error',
-      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on PATH`,
-      remediation: `Install ${preset.tool}, or set defaultSlackHarnessPreset to a preset whose tool is installed`,
+      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on Invoker's PATH`,
+      remediation: `Make ${preset.tool} available on Invoker's PATH (restart Invoker if it already works in a terminal), or set defaultSlackHarnessPreset to a preset whose tool is available`,
     };
   }
   return {
@@ -131,15 +131,15 @@ export function checkPlanningToolsPresent(
   const tools = [...new Set(Object.values(presets).map((p) => p.tool))];
   const installed = tools.filter(isInstalled);
   if (installed.length > 0) {
-    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Installed: ${installed.join(', ')}` };
+    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Available on Invoker's PATH: ${installed.join(', ')}` };
   }
   const wanted = tools.length ? tools.join(', ') : 'cursor, omp, codex';
   return {
     id: 'planning-tools',
     name: 'Planning tools',
     status: 'error',
-    detail: `No planning tool installed (need one of: ${wanted})`,
-    remediation: `Install at least one of: ${wanted}`,
+    detail: `Planning unavailable: none of the configured planner commands are on Invoker's PATH (${wanted})`,
+    remediation: `Make one of these commands available on Invoker's PATH: ${wanted}. If it already works in a terminal, restart Invoker to refresh its shell environment; otherwise install it or configure another planning preset.`,
   };
 }
 


### PR DESCRIPTION
## Summary

The readiness copy contract now reports planner availability against Invoker's PATH instead of inferring machine-wide installation state.

Remediation separates an outdated app environment from a genuinely unavailable planner.

## Review Claim

Readiness diagnostics describe the observed PATH boundary without claiming that a planner is not installed.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Only readiness text and focused assertions change; detection, severity, configuration, and runtime behavior remain unchanged.

## Slice Rationale

The generator and its focused coverage encode one diagnostic invariant and belong together. The setup skill wording follows in the next slice of this stack.

## Non-goals

- No PATH mutation or environment refresh.
- No planner installation or configuration changes.
- No detection, status, preset selection, or runtime changes.
- No setup skill wording changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/prerequisites.test.ts`
- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/system-diagnostics.test.ts`
- [x] `pnpm run check:types`
- [x] `node scripts/check-added-comments.mjs --base origin/master`
- [x] `git diff --check`
- [x] `PLANNING_COPY_VARIANT=before PLANNING_COPY_SCREENSHOT=/tmp/invoker-planning-copy-before.png pnpm --filter @invoker/app exec playwright test e2e/tmp-planning-path-copy-proof.spec.ts`
- [x] `PLANNING_COPY_VARIANT=after PLANNING_COPY_SCREENSHOT=/tmp/invoker-planning-copy-after.png pnpm --filter @invoker/app exec playwright test e2e/tmp-planning-path-copy-proof.spec.ts`

</details>

## Visual Proof

![Before: installation-state wording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260901-0d240d/invoker-planning-copy-before.png)

![After: Invoker PATH wording and remediation](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260901-0d240d/invoker-planning-copy-after.png)

Manually inspected: the before image says no planning tool is installed and tells the user to install Cursor; the after image names Invoker's PATH and shows restart-versus-install/configure remediation.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

