### PR TITLE
[Required executor pool](1) built-in local default

### DIFF
--- a/packages/app/scripts/verify-built-in-local-pool.sh
+++ b/packages/app/scripts/verify-built-in-local-pool.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd)
+cd "$repo_root"
+
+exec pnpm --filter @invoker/app test -- \
+  src/__tests__/config.test.ts \
+  -t 'materializes the built-in local worktree pool'

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -3,9 +3,12 @@ import type * as NodeOs from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
+  BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+  BUILT_IN_LOCAL_WORKTREE_TARGET_ID,
   filterExecutionHarnesses,
   filterPlanningPresets,
   loadConfig,
+  materializeResolvedConfig,
   resolveAutoFixExecutionModel,
   resolveAutoFixPoolId,
   resolveConfigFilePath,
@@ -51,9 +54,93 @@ function writeUserConfig(value: unknown): void {
 }
 
 describe('loadConfig', () => {
-  it('returns empty config when no files exist', () => {
+  it.each([
+    ['missing config file', false],
+    ['empty config object', true],
+  ])('materializes the built-in local worktree pool for %s', (_label, writeEmptyConfig) => {
+    if (writeEmptyConfig) writeUserConfig({});
+
     const config = loadConfig();
-    expect(config).toEqual({});
+    expect(config.worktreeTargets).toEqual({
+      [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: {},
+    });
+    expect(config.executionPools).toEqual({
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+        members: [{ type: 'worktree', id: BUILT_IN_LOCAL_WORKTREE_TARGET_ID }],
+      },
+    });
+    expect(config.defaultPoolId).toBe(BUILT_IN_LOCAL_EXECUTION_POOL_ID);
+  });
+
+  it('preserves explicit pools and explicit defaultPoolId while adding the built-in pool', () => {
+    writeUserConfig({
+      worktreeTargets: {
+        custom: { maxConcurrentTasks: 3 },
+      },
+      executionPools: {
+        custom: {
+          members: [{ type: 'worktree', id: 'custom' }],
+        },
+      },
+      defaultPoolId: 'custom',
+    });
+
+    const config = loadConfig();
+    expect(config.worktreeTargets?.custom).toEqual({ maxConcurrentTasks: 3 });
+    expect(config.executionPools?.custom).toEqual({
+      members: [{ type: 'worktree', id: 'custom' }],
+    });
+    expect(config.executionPools?.[BUILT_IN_LOCAL_EXECUTION_POOL_ID]).toEqual({
+      members: [{ type: 'worktree', id: BUILT_IN_LOCAL_WORKTREE_TARGET_ID }],
+    });
+    expect(config.defaultPoolId).toBe('custom');
+  });
+
+  it('accepts structurally identical reserved entries and materializes idempotently', () => {
+    const source = {
+      worktreeTargets: {
+        [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: {},
+      },
+      executionPools: {
+        [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+          members: [{ type: 'worktree' as const, id: BUILT_IN_LOCAL_WORKTREE_TARGET_ID }],
+        },
+      },
+    };
+
+    const resolved = materializeResolvedConfig(source);
+    expect(materializeResolvedConfig(resolved)).toEqual(resolved);
+    expect(source).toEqual({
+      worktreeTargets: { [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: {} },
+      executionPools: {
+        [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+          members: [{ type: 'worktree', id: BUILT_IN_LOCAL_WORKTREE_TARGET_ID }],
+        },
+      },
+    });
+  });
+
+  it.each([
+    [
+      'worktree target',
+      {
+        worktreeTargets: {
+          [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: { maxConcurrentTasks: 2 },
+        },
+      },
+    ],
+    [
+      'execution pool',
+      {
+        executionPools: {
+          [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+            members: [{ type: 'worktree' as const, id: 'custom' }],
+          },
+        },
+      },
+    ],
+  ])('fails closed for a conflicting reserved built-in %s', (_label, config) => {
+    expect(() => materializeResolvedConfig(config)).toThrow(/is reserved for Invoker's built-in local/);
   });
 
   it('reads user-level ~/.invoker/config.json', () => {
@@ -494,6 +581,7 @@ describe('loadConfig', () => {
         provisionCommand: 'pnpm install --frozen-lockfile',
         maxConcurrentTasks: 2,
       },
+      [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: {},
     });
   });
   it('reads defaultExecution from user config', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -607,6 +607,58 @@ export interface InvokerConfig {
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
   dbReaper?: DbReaperConfig;
 }
+
+export const BUILT_IN_LOCAL_WORKTREE_TARGET_ID = 'local-worktree';
+
+export const BUILT_IN_LOCAL_EXECUTION_POOL_ID = 'local-worktree';
+
+function isBuiltInLocalWorktreeTarget(
+  target: NonNullable<InvokerConfig['worktreeTargets']>[string],
+): boolean {
+  return Object.keys(target).length === 0;
+}
+
+function isBuiltInLocalExecutionPool(
+  pool: NonNullable<InvokerConfig['executionPools']>[string],
+): boolean {
+  if (Object.keys(pool).length !== 1 || pool.members.length !== 1) return false;
+  const [member] = pool.members;
+  return member.type === 'worktree'
+    && member.id === BUILT_IN_LOCAL_WORKTREE_TARGET_ID
+    && Object.keys(member).length === 2;
+}
+
+export function materializeResolvedConfig(config: InvokerConfig): InvokerConfig {
+  const reservedTarget = config.worktreeTargets?.[BUILT_IN_LOCAL_WORKTREE_TARGET_ID];
+  if (reservedTarget !== undefined && !isBuiltInLocalWorktreeTarget(reservedTarget)) {
+    throw new Error(
+      `worktreeTargets.${BUILT_IN_LOCAL_WORKTREE_TARGET_ID} is reserved for Invoker's built-in local worktree target`,
+    );
+  }
+
+  const reservedPool = config.executionPools?.[BUILT_IN_LOCAL_EXECUTION_POOL_ID];
+  if (reservedPool !== undefined && !isBuiltInLocalExecutionPool(reservedPool)) {
+    throw new Error(
+      `executionPools.${BUILT_IN_LOCAL_EXECUTION_POOL_ID} is reserved for Invoker's built-in local execution pool`,
+    );
+  }
+
+  return {
+    ...config,
+    worktreeTargets: {
+      ...config.worktreeTargets,
+      [BUILT_IN_LOCAL_WORKTREE_TARGET_ID]: {},
+    },
+    executionPools: {
+      ...config.executionPools,
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+        members: [{ type: 'worktree', id: BUILT_IN_LOCAL_WORKTREE_TARGET_ID }],
+      },
+    },
+    defaultPoolId: config.defaultPoolId ?? BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+  };
+}
+
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },
   'cursor+codex': { tool: 'cursor', model: 'codex' },
@@ -648,7 +700,7 @@ export function resolveConfigFileState(): { path: string; exists: boolean } {
 }
 export function loadConfig(): InvokerConfig {
   const config = readJsonSafe(resolveConfigFilePath());
-  return validateInvokerConfig(config);
+  return materializeResolvedConfig(validateInvokerConfig(config));
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();


### PR DESCRIPTION
## Summary

When no execution pool is configured, resolved configuration now provides a canonical local worktree target, pool, and default pool ID.

Explicit pools and default pool IDs remain authoritative. Conflicts with reserved built-in identities fail closed.

## Review Claim

Configuration validation materializes one built-in local pool for omitted values while preserving explicit configuration.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Explicit execution pools and an explicit defaultPoolId retain precedence; the built-in local entry is additive and cannot silently replace user configuration.

## Slice Rationale

This slice establishes default placement authority during configuration resolution; persistence enforcement and UI presentation remain downstream.

## Non-goals

- No TaskConfig type migration.
- No SQLite row migration.
- No inspector change.
- No alteration of explicit pool routing precedence.

## Architecture

### Before

```mermaid
graph TD
    A["loadConfig validates raw configuration"] --> B["Consumers may receive no pool or defaultPoolId"]
```

### After

```mermaid
graph TD
    A["loadConfig validates raw configuration"] --> B["materializeResolvedConfig adds reserved local entries when absent"] --> C["Consumers receive a concrete defaultPoolId"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash packages/app/scripts/verify-built-in-local-pool.sh`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/required-executor-pool-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert f2fb913bc`
- Post-revert steps: None.
- Data migration? No.

</details>
