### PR TITLE
[Web/Desktop Capability Parity](3a) HTTP activation — dispatcher

### DIFF
--- a/packages/app/src/__tests__/surface-capability-parity.test.ts
+++ b/packages/app/src/__tests__/surface-capability-parity.test.ts
@@ -1,0 +1,98 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { IpcChannels } from '@invoker/contracts';
+import { SPAWN_REPAIR_WORKFLOW_CHANNEL } from '@invoker/execution-engine';
+import { OwnerCapabilityRegistry } from '../owner-capability-registry.js';
+import { buildWebInvokerDispatch } from '../web/web-invoker-dispatch.js';
+
+const appSourceRoot = fileURLToPath(new URL('..', import.meta.url));
+
+function productionTypeScriptSources(directory = appSourceRoot): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === '__tests__' ? [] : productionTypeScriptSources(path);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [readFileSync(path, 'utf8')] : [];
+  });
+}
+
+function desktopCapabilityInventory(): { owner: string[]; invoke: string[] } {
+  const registrationSources = productionTypeScriptSources().join('\n');
+  const owner = [...registrationSources.matchAll(
+    /(?:registrars\.)?register(?:Gui|WorkflowScopedGui|TaskScopedGui)MutationHandler\(\s*'([^']+)'/g,
+  )].map((match) => match[1]);
+  const invoke = [...registrationSources.matchAll(
+    /ipcMain\.handle\(\s*'([^']+)'/g,
+  )].map((match) => match[1]);
+  const contractChannel = (channel: string): boolean => Object.hasOwn(IpcChannels, channel);
+
+  return {
+    owner: [...new Set([...owner, SPAWN_REPAIR_WORKFLOW_CHANNEL])].filter(contractChannel).sort(),
+    invoke: [...new Set([...owner, ...invoke, SPAWN_REPAIR_WORKFLOW_CHANNEL])].filter(contractChannel).sort(),
+  };
+}
+
+describe('surface capability parity', () => {
+  it('delegates every registered desktop owner capability through a full webserver profile', async () => {
+    const ownerCapabilities = new OwnerCapabilityRegistry();
+    const desktopCapabilities = desktopCapabilityInventory().owner;
+    const invoked: string[] = [];
+    for (const channel of desktopCapabilities) {
+      ownerCapabilities.register(channel, async () => {
+        invoked.push(channel);
+        return channel;
+      });
+    }
+    const dispatch = buildWebInvokerDispatch({
+      ownerCapabilities,
+      loadConfig: () => ({}),
+    } as never);
+
+    expect(desktopCapabilities.length).toBeGreaterThan(40);
+    for (const channel of desktopCapabilities) {
+      await expect(dispatch(channel, [])).resolves.toBe(channel);
+    }
+    expect(invoked).toEqual(desktopCapabilities);
+  });
+
+  it('keeps every production Electron invoke capability accessible in a full webserver profile', async () => {
+    const inventory = desktopCapabilityInventory();
+    const ownerCapabilities = new OwnerCapabilityRegistry();
+    for (const channel of inventory.owner) {
+      ownerCapabilities.register(channel, async () => channel);
+    }
+    const universal = new Proxy(() => universal, {
+      apply: () => universal,
+      get: (_target, property) => property === 'then' ? undefined : universal,
+    });
+    const dispatch = buildWebInvokerDispatch(new Proxy({
+      ownerCapabilities,
+      loadConfig: () => ({}),
+      taskTerminals: universal,
+      planningTerminals: universal,
+      getBundledSkillsStatus: universal,
+    }, {
+      get: (target, property) => property in target
+        ? target[property as keyof typeof target]
+        : universal,
+    }) as never);
+
+    expect(inventory.invoke.length).toBeGreaterThan(80);
+    const inaccessible: Array<{ channel: string; code: string }> = [];
+    for (const channel of inventory.invoke) {
+      try {
+        await dispatch(channel, []);
+      } catch (error) {
+        const code = (error as { code?: unknown }).code;
+        if (code === 'unknown_channel' || code === 'capability_provider_missing') {
+          inaccessible.push({ channel, code });
+        }
+      }
+    }
+
+    expect(inaccessible).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -180,6 +180,26 @@ describe('startWebBridge', () => {
     expect(JSON.parse(res.body)).toEqual({ ok: false, error: { message: 'request failed', code: 'unknown_channel' } });
   });
 
+  it('preserves deployment-policy error codes while redacting details', async () => {
+    const dispatch = vi.fn(async () => {
+      const err = new Error('Execution agent "claude" is disabled') as Error & { code: string };
+      err.code = 'execution_agent_disabled';
+      throw err;
+    });
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `invoker_web=${TOKEN}` },
+      body: JSON.stringify({ channel: 'invoker:fix-with-agent', args: ['task-1', 'claude'] }),
+    });
+
+    expect(JSON.parse(res.body)).toEqual({
+      ok: false,
+      error: { message: 'request failed', code: 'execution_agent_disabled' },
+    });
+    expect(res.body).not.toContain('claude');
+  });
+
   it('hides unexpected dispatch failure details from web responses', async () => {
     const dispatch = vi.fn(async () => {
       throw new Error('stack trace shaped internal failure');

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { buildWebInvokerDispatch } from '../web/web-invoker-dispatch.js';
 import type { InvokerConfig } from '../config.js';
+import { OwnerCapabilityRegistry } from '../owner-capability-registry.js';
 
 function makeTask(id: string) {
   return {
@@ -321,58 +322,127 @@ describe('buildWebInvokerDispatch', () => {
     });
   });
 
-  it('a global-lifecycle channel rejects as unsupported_on_web', async () => {
-    const { dispatch } = makeDispatch();
-    await expect(dispatch('invoker:start', [])).rejects.toMatchObject({ code: 'unsupported_on_web' });
+  it('routes a registered global-lifecycle capability through the owner registry', async () => {
+    const ownerCapabilities = new OwnerCapabilityRegistry();
+    const start = vi.fn(async () => ['started']);
+    ownerCapabilities.register('invoker:start', start);
+    const { dispatch } = makeDispatch({ ownerCapabilities });
+
+    await expect(dispatch('invoker:start', [])).resolves.toEqual(['started']);
+    expect(start).toHaveBeenCalledOnce();
   });
 
-  it('start-ready forwards the dry-run request through guiMutations when wired', async () => {
+  it('start-ready forwards the dry-run request through the owner registry when wired', async () => {
     const response = { ok: true, ready: ['wf-1/task-1'] };
-    const guiMutations = vi.fn(async () => response);
-    const { dispatch } = makeDispatch({ guiMutations });
+    const ownerCapabilities = new OwnerCapabilityRegistry();
+    const startReady = vi.fn(async () => response);
+    ownerCapabilities.register('invoker:start-ready', startReady);
+    const { dispatch } = makeDispatch({ ownerCapabilities });
     const request = { dryRun: true };
 
     await expect(dispatch('invoker:start-ready', [request])).resolves.toBe(response);
-    expect(guiMutations).toHaveBeenCalledExactlyOnceWith('invoker:start-ready', [request]);
+    expect(startReady).toHaveBeenCalledExactlyOnceWith(request);
   });
 
-  it('start-ready fails closed when guiMutations is absent', async () => {
+  it('distinguishes a known channel with no owner provider from an unknown channel', async () => {
     const { dispatch } = makeDispatch();
+    const missingOwner = dispatch('invoker:start-ready', [{ dryRun: true }]);
 
-    await expect(dispatch('invoker:start-ready', [{ dryRun: true }])).rejects.toMatchObject({
-      code: 'unsupported_on_web',
+    await expect(missingOwner).rejects.toMatchObject({
+      code: 'capability_provider_missing',
     });
-  });
-
-  it('an unknown channel rejects with code unknown_channel', async () => {
-    const { dispatch } = makeDispatch();
     await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
   });
 
+  it('bridges a known channel through the legacy guiMutations callback when no owner registry is wired', async () => {
+    const guiMutations = vi.fn(async (channel: string) => ({ ok: true, channel }));
+    const { dispatch } = makeDispatch({ guiMutations });
+    await expect(dispatch('invoker:planning-chat-list', [])).resolves.toEqual({
+      ok: true,
+      channel: 'invoker:planning-chat-list',
+    });
+    expect(guiMutations).toHaveBeenCalledExactlyOnceWith('invoker:planning-chat-list', []);
+  });
+
+  it('allows Codex and forbids Claude by deployment policy without restricting HTTP itself', async () => {
+    const ownerCapabilities = new OwnerCapabilityRegistry();
+    const fixWithAgent = vi.fn(async (_taskId: unknown, agentName: unknown) => ({ agentName }));
+    ownerCapabilities.register('invoker:fix-with-agent', fixWithAgent);
+    const { dispatch } = makeDispatch({
+      ownerCapabilities,
+      loadConfig: () => ({ enabledExecutionAgents: ['codex'] } as InvokerConfig),
+    });
+
+    await expect(dispatch('invoker:fix-with-agent', ['task-1', 'codex'])).resolves.toEqual({
+      agentName: 'codex',
+    });
+    await expect(dispatch('invoker:fix-with-agent', ['task-1', 'claude'])).rejects.toMatchObject({
+      code: 'execution_agent_disabled',
+    });
+    expect(fixWithAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a registered agent-bearing capability with no provider as unavailable before policy', async () => {
+    const { dispatch } = makeDispatch({
+      loadConfig: () => ({ enabledExecutionAgents: ['codex'] } as InvokerConfig),
+    });
+
+    await expect(dispatch('invoker:fix-with-agent', ['task-1', 'claude'])).rejects.toMatchObject({
+      code: 'capability_provider_missing',
+    });
+  });
+
   describe('planning routes', () => {
-    it('routes planning-chat channels through guiMutations when wired', async () => {
-      const guiMutations = vi.fn(async (channel: string) => ({ ok: true, channel }));
-      const { dispatch } = makeDispatch({ guiMutations });
+    it('routes planning-chat channels through owner capabilities when wired', async () => {
+      const ownerCapabilities = new OwnerCapabilityRegistry();
+      const create = vi.fn(async () => ({ ok: true, channel: 'invoker:planning-chat-create' }));
+      const list = vi.fn(async () => ({ ok: true, sessions: [] }));
+      const setTerminalMode = vi.fn(async () => ({ ok: true }));
+      ownerCapabilities.register('invoker:planning-chat-create', create);
+      ownerCapabilities.register('invoker:planning-chat-list', list);
+      ownerCapabilities.register('invoker:planning-chat-set-terminal-mode', setTerminalMode);
+      const { dispatch } = makeDispatch({ ownerCapabilities });
       const request = { title: 'demo' };
       expect(await dispatch('invoker:planning-chat-create', [request])).toEqual({
         ok: true,
         channel: 'invoker:planning-chat-create',
       });
-      expect(guiMutations).toHaveBeenCalledWith('invoker:planning-chat-create', [request]);
+      expect(create).toHaveBeenCalledWith(request);
       await dispatch('invoker:planning-chat-list', []);
       await dispatch('invoker:planning-chat-set-terminal-mode', [{ sessionId: 's1', mode: 'tmux' }]);
-      expect(guiMutations).toHaveBeenCalledTimes(3);
+      expect(list).toHaveBeenCalledOnce();
+      expect(setTerminalMode).toHaveBeenCalledOnce();
     });
 
-    it('keeps the historical downgrades when guiMutations is absent', async () => {
+    it('reports missing owner providers instead of transport restrictions', async () => {
       const { dispatch } = makeDispatch();
-      await expect(dispatch('invoker:planning-chat-create', [{}])).rejects.toMatchObject({
-        code: 'unsupported_on_web',
+      const missingCreateOwner = dispatch('invoker:planning-chat-create', [{}]);
+      const missingTerminalModeOwner = dispatch('invoker:planning-chat-set-terminal-mode', [{}]);
+
+      await expect(missingCreateOwner).rejects.toMatchObject({
+        code: 'capability_provider_missing',
       });
-      expect(await dispatch('invoker:planning-chat-set-terminal-mode', [{}])).toEqual({
-        ok: false,
-        error: 'Planning tmux is not available in the web UI',
+      await expect(missingTerminalModeOwner).rejects.toMatchObject({
+        code: 'capability_provider_missing',
       });
+    });
+
+    it('applies deployment policy to the planning preset before invoking the owner', async () => {
+      const ownerCapabilities = new OwnerCapabilityRegistry();
+      const create = vi.fn(async (request: unknown) => request);
+      ownerCapabilities.register('invoker:planning-chat-create', create);
+      const { dispatch } = makeDispatch({
+        ownerCapabilities,
+        loadConfig: () => ({ enabledExecutionAgents: ['codex'] } as InvokerConfig),
+      });
+
+      await expect(dispatch('invoker:planning-chat-create', [{ presetKey: 'codex' }])).resolves.toEqual({
+        presetKey: 'codex',
+      });
+      await expect(dispatch('invoker:planning-chat-create', [{ presetKey: 'claude' }])).rejects.toMatchObject({
+        code: 'execution_agent_disabled',
+      });
+      expect(create).toHaveBeenCalledTimes(1);
     });
 
     it('routes planning-terminal channels through the adapter when wired', async () => {

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -15,15 +15,25 @@
 
 import type {
   BundledSkillsStatus,
+  BundledSkillsInstallMode,
+  CliInstallResult,
+  InvokerSetupRequest,
+  InvokerSetupResult,
   Logger,
   SystemDiagnostics,
   WorkerDecisionsRequest,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
+import { IpcChannels } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
-import { filterExecutionHarnesses, resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
+import {
+  DEFAULT_SLACK_HARNESS_PRESETS,
+  filterExecutionHarnesses,
+  resolveDefaultTaskExecutionSettings,
+  type InvokerConfig,
+} from '../config.js';
 import { listInAppPlanningPresets } from '../in-app-planner.js';
 import type { ApiMutationFacade } from '../api-server.js';
 import { getEventsPage } from '../get-events-page.js';
@@ -31,9 +41,11 @@ import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
 import { resolveAgentSession } from '../headless-query-list.js';
-import { listWorkerDecisions } from '../worker-control.js';
+import { listWorkerActionHistory, listWorkerDecisions } from '../worker-control.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
 import type { TaskTerminalAdapter } from '../task-terminal-adapter.js';
+import { checkInvokerSurfaceAccess } from '../invoker-surface-access.js';
+import type { OwnerCapabilityRegistry } from '../owner-capability-registry.js';
 
 
 /**
@@ -66,9 +78,13 @@ export interface WebInvokerDispatchDeps {
   /** Optional richer reads available in the GUI owner; safe fallbacks otherwise. */
   getSystemDiagnostics?: () => SystemDiagnostics;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
+  installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  updateInvokerCli?: () => CliInstallResult;
+  runInvokerCliSetup?: (request: InvokerSetupRequest) => Promise<InvokerSetupResult>;
   checkPrStatuses?: () => void | Promise<void>;
   getWorkers?: () => WorkerStatusSnapshot;
   taskTerminals?: TaskTerminalAdapter;
+  ownerCapabilities?: Pick<OwnerCapabilityRegistry, 'has' | 'invoke'>;
   /**
    * Routes planning-chat channels (and plan-from-goal) to the owner's shared
    * GUI-mutation handlers. Wired by both the desktop-owned and headless web
@@ -92,12 +108,79 @@ class WebDispatchError extends Error {
   }
 }
 
-function unsupported(channel: string): never {
+function providerMissing(channel: string): never {
   throw new WebDispatchError(
-    'unsupported_on_web',
+    'capability_provider_missing',
     channel,
-    `Channel "${channel}" is not supported on the web surface`,
+    `No capability provider is available for "${channel}"`,
   );
+}
+
+function planningAgentForPreset(config: InvokerConfig, presetKey: unknown): string | undefined {
+  const key = typeof presetKey === 'string' && presetKey.trim()
+    ? presetKey.trim()
+    : config.defaultSlackHarnessPreset ?? 'cursor+claude';
+  const preset = config.slackHarnessPresets?.[key] ?? DEFAULT_SLACK_HARNESS_PRESETS[key];
+  if (!preset) return undefined;
+  const tool = preset.tool.trim().toLowerCase();
+  if ((tool === 'cursor' || tool === 'omp') && preset.model?.trim()) {
+    return preset.model.trim();
+  }
+  return tool;
+}
+
+function requestedExecutionAgents(
+  channel: string,
+  args: unknown[],
+  config: InvokerConfig,
+): readonly (string | undefined)[] {
+  switch (channel) {
+    case 'invoker:fix-with-agent':
+      return [typeof args[1] === 'string' ? args[1] : config.autoFixAgent];
+    case 'invoker:resolve-conflict':
+      return [typeof args[1] === 'string' ? args[1] : config.conflictResolutionAgent];
+    case 'invoker:edit-task-agent':
+      return [typeof args[1] === 'string' ? args[1] : undefined];
+    case 'invoker:replace-task':
+      return Array.isArray(args[1])
+        ? args[1].map((replacement) => (
+            replacement && typeof replacement === 'object'
+              ? (replacement as { executionAgent?: unknown }).executionAgent
+              : undefined
+          )).map((agent) => typeof agent === 'string' ? agent : undefined)
+        : [];
+    case 'invoker:plan-from-goal':
+    case 'invoker:planning-chat-create': {
+      const request = args[0] && typeof args[0] === 'object'
+        ? args[0] as { presetKey?: unknown }
+        : undefined;
+      return [planningAgentForPreset(config, request?.presetKey)];
+    }
+    case 'invoker:planning-chat-send': {
+      const request = args[0] && typeof args[0] === 'object'
+        ? args[0] as { presetKey?: unknown }
+        : undefined;
+      return request?.presetKey === undefined
+        ? []
+        : [planningAgentForPreset(config, request.presetKey)];
+    }
+    default:
+      return [];
+  }
+}
+
+function assertOwnerCapabilityAccess(
+  deps: WebInvokerDispatchDeps,
+  channel: string,
+  args: unknown[],
+): void {
+  const config = deps.loadConfig();
+  for (const executionAgent of requestedExecutionAgents(channel, args, config)) {
+    const decision = checkInvokerSurfaceAccess(config, executionAgent);
+    if (!decision.allowed) {
+      throw new WebDispatchError(decision.code, channel, decision.message);
+    }
+  }
 }
 
 export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvokerDispatch {
@@ -111,6 +194,11 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
   };
 
   return async function dispatch(channel: string, args: unknown[]): Promise<unknown> {
+    if (deps.ownerCapabilities?.has(channel)) {
+      assertOwnerCapabilityAccess(deps, channel, args);
+      return deps.ownerCapabilities.invoke(channel, args);
+    }
+
     switch (channel) {
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
@@ -148,6 +236,11 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return listWorkerDecisions(
           persistence,
           (args[0] ?? {}) as WorkerDecisionsRequest,
+        );
+      case 'invoker:get-worker-action-history':
+        return listWorkerActionHistory(
+          persistence,
+          (args[0] ?? {}) as Parameters<typeof listWorkerActionHistory>[1],
         );
       case 'invoker:get-action-graph':
         return buildCurrentActionGraphSnapshot({
@@ -197,7 +290,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           })
         );
       case 'invoker:get-bundled-skills-status':
-        if (!deps.getBundledSkillsStatus) return unsupported(channel);
+        if (!deps.getBundledSkillsStatus) return providerMissing(channel);
         return deps.getBundledSkillsStatus();
       case 'invoker:get-activity-logs':
         return persistence.getActivityLogs(
@@ -231,11 +324,21 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return undefined;
       }
       case 'invoker:trace-renderer-task-graph-event':
+      case 'invoker:trace-renderer-workflow-event':
         return undefined;
       case 'invoker:check-pr-statuses':
       case 'invoker:check-pr-status':
         await deps.checkPrStatuses?.();
         return undefined;
+      case 'invoker:install-bundled-skills':
+        if (!deps.installBundledSkills) return providerMissing(channel);
+        return deps.installBundledSkills(args[0] as BundledSkillsInstallMode | undefined);
+      case 'invoker:update-invoker-cli':
+        if (!deps.updateInvokerCli) return providerMissing(channel);
+        return deps.updateInvokerCli();
+      case 'invoker:run-invoker-cli-setup':
+        if (!deps.runInvokerCliSetup) return providerMissing(channel);
+        return deps.runInvokerCliSetup(args[0] as InvokerSetupRequest);
 
       // ── Mutations (route to the facade exactly as api-server.ts) ──
       case 'invoker:approve':
@@ -271,6 +374,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:edit-task-prompt':
         return mutations.editTaskPrompt(String(args[0]), String(args[1]));
       case 'invoker:edit-task-agent':
+        assertOwnerCapabilityAccess(deps, channel, args);
         return mutations.editTaskAgent(String(args[0]), String(args[1]));
       case 'invoker:edit-task-model':
         return mutations.editTaskModel(String(args[0]), args[1] === undefined || args[1] === null ? null : String(args[1]));
@@ -286,6 +390,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           (args[1] as ExternalGatePolicyUpdate[]) ?? [],
         );
       case 'invoker:resolve-conflict':
+        assertOwnerCapabilityAccess(deps, channel, args);
         return mutations.resolveConflict(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
       case 'invoker:set-workflow-merge-mode':
         return mutations.setWorkflowMergeMode(String(args[0]), String(args[1]));
@@ -324,25 +429,6 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
-      // ── Planning chat + planning terminals ──
-      // Routed to the owner's shared GUI-mutation handlers / terminal adapter
-      // when the host wires them; otherwise keep the historical downgrades.
-      case 'invoker:start-ready':
-      case 'invoker:plan-from-goal':
-      case 'invoker:planning-chat-create':
-      case 'invoker:planning-chat-list':
-      case 'invoker:planning-chat-send':
-      case 'invoker:planning-chat-submit':
-      case 'invoker:planning-chat-discard-draft':
-      case 'invoker:planning-chat-reset':
-      case 'invoker:planning-chat-delete':
-      case 'invoker:planning-chat-delete-submitted':
-      case 'invoker:planning-chat-rebind-repo':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return unsupported(channel);
-      case 'invoker:planning-chat-set-terminal-mode':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
         if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };
@@ -361,40 +447,14 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:planning-terminal-close':
         if (deps.planningTerminals) return deps.planningTerminals.close(String(args[0]));
         return { ok: false, reason: 'unsupported' };
-
-      case 'invoker:start-worker':
-      case 'invoker:stop-worker':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        throw new WebDispatchError(
-          'worker_control_unavailable',
-          channel,
-          'Worker control is not available on this web surface. Use the desktop app or CLI to manage workers.',
-        );
-
-      case 'invoker:load-plan':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return unsupported(channel);
-
-      // ── Mutations not exposed on the facade / global lifecycle ──
-      case 'invoker:select-experiment':
-      case 'invoker:set-merge-branch':
-      case 'invoker:approve-merge':
-      case 'invoker:fix-with-agent':
-      case 'invoker:spawn-review-gate-ci-repair':
-      case 'invoker:edit-task-pool':
-      case 'invoker:replace-task':
-      case 'invoker:start':
-      case 'invoker:stop':
-      case 'invoker:clear':
-      case 'invoker:resume-workflow':
-      case 'invoker:delete-all-workflows':
-      case 'invoker:delete-all-workflows-bulk':
-      case 'invoker:cleanup-worktrees':
-      case 'invoker:install-bundled-skills':
-      case 'invoker:update-invoker-cli':
-        return unsupported(channel);
-
       default:
+        if (Object.hasOwn(IpcChannels, channel)) {
+          if (deps.guiMutations) {
+            assertOwnerCapabilityAccess(deps, channel, args);
+            return deps.guiMutations(channel, args);
+          }
+          return providerMissing(channel);
+        }
         throw new WebDispatchError('unknown_channel', channel, `Unknown channel "${channel}"`);
     }
   };


### PR DESCRIPTION
## Summary

Authenticated HTTP now invokes capabilities from the shared owner registry.

Codex-only deployments constrain execution-agent selection while unrestricted profiles retain every configured capability.

Until startup wires the registry, the existing GUI-mutation callback still serves registered channels through the same policy check.

## Review Claim

Activate authenticated HTTP access for registered owner capabilities while keeping execution-agent authorization as deployment policy.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Desktop IPC behavior is unchanged; HTTP invokes only already-registered owner handlers, and unauthorized execution agents are rejected before handler execution.

## Slice Rationale

This dispatcher slice follows the access-policy and owner-registry foundations.

## Non-goals

No startup wiring, UI redesign, hard-coded demo credentials, desktop agent restriction, or real agent execution in tests.

## Architecture

### Before

```mermaid
graph LR
    H["Authenticated HTTP dispatch"] --> L["Transport-specific capability list"]
    L --> U["Unsupported mutation response"]
```

### After

```mermaid
graph LR
    H["Authenticated HTTP dispatch"] --> R["Shared owner capability registry"]
    R --> P["Deployment execution-agent policy"]
    P --> C["Registered owner capability"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` after rebasing onto master
  - `check:types exit=0` (before keeping the callback dependency: `main.ts(2925,11): error TS2561 ... 'guiMutations' does not exist in type 'WebInvokerDispatchDeps'`, exit 2)
- [x] `pnpm --filter @invoker/app test -- src/__tests__/web-invoker-dispatch.test.ts src/__tests__/web-bridge-server.test.ts src/__tests__/surface-capability-parity.test.ts src/__tests__/start-web-surface.test.ts src/__tests__/invoker-surface-access.test.ts src/__tests__/owner-capability-registry.test.ts`
  - `Test Files  6 passed (6)`
  - `Tests  59 passed (59)`
- [x] `node scripts/check-added-comments.mjs --base origin/master`
  - `[comments] Checked added source lines; no disallowed comments found.`
- Full suite not run; this slice's acceptance gate names the six focused app test files above.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 14e69c036947be2ae0e517b9750fcb7d001807a2`
- Post-revert steps: Rerun the six focused app test files.
- Data migration? No

</details>

