### PR TITLE
[Planner hardening 1: canonical repository identity](1) Align planner draft redaction assertions

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -55,6 +55,8 @@ tasks:
     command: echo second`;
 
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+const PLAN_DRAFT_PLACEHOLDER = '_(Plan drafted — see the review card for the full plan.)_';
+const REDACTED_VALID_PLAN_REPLY = `Here is the plan.\n\n${PLAN_DRAFT_PLACEHOLDER}`;
 
 const INTERRUPTED_TURN_SYSTEM_LINE = {
   role: 'system',
@@ -425,7 +427,7 @@ describe('planning chat', () => {
     expect(spawnPlanner).not.toHaveBeenCalled();
   });
 
-  it('returns the raw draft reply and keeps a draft plan summary for valid YAML', async () => {
+  it('redacts the raw draft reply and keeps a draft plan summary for valid YAML', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();
 
@@ -441,14 +443,13 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: REDACTED_VALID_PLAN_REPLY,
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
       draftPlanText: expect.stringContaining('name: Mock Plan'),
     });
-    expect(result.ok && result.reply).toContain('```yaml');
-    expect(result.ok && result.reply).toContain('name: Mock Plan');
-    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN);
+    expect(result.ok && result.reply).not.toContain('```yaml');
+    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(REDACTED_VALID_PLAN_REPLY);
   });
 
   it('keeps unauthorized YAML from becoming draft-ready and refuses submit', async () => {
@@ -471,7 +472,7 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: REDACTED_VALID_PLAN_REPLY,
       draftPlanAvailable: false,
     });
     if (!result.ok) throw new Error(result.error);
@@ -679,7 +680,9 @@ tasks:
         planningSessionStore: adapter,
       });
       if (!second.ok) throw new Error(second.error);
-      expect(second.reply).toBe(critiqueReplyWithYaml);
+      expect(second.reply).toBe(
+        `Sure, that step is optional if you already have the schema.\n\n${PLAN_DRAFT_PLACEHOLDER}`,
+      );
 
       expect(sessions.get(first.sessionId)?.draftPlanText).toBe(planA);
       expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');


### PR DESCRIPTION
## Summary

Align three planning-chat assertions with the current redacted draft reply contract.

This restores a green focused baseline before repository-identity coverage is added.

## Review Claim

The focused planner suite now asserts the redacted reply contract already produced by the runtime.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only existing test expectations change; runtime code, stored drafts, and planner responses remain untouched.

## Slice Rationale

The baseline assertion correction is isolated so repository-identity proof starts from a passing suite.

## Non-goals

No runtime behavior, repository comparison, documentation, or runner changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  82 passed (82)`
- [x] `pnpm run check:comments`
  - `[comments] Checked added source lines; no disallowed comments found.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4d14d8ca8b23c82e003e4ea8dbfe79ddc9099389`
- Post-revert steps: Rerun the focused in-app planner test file.
- Data migration? No

</details>
