### PR TITLE
[Planner hardening 1: canonical repository identity](2) Capture repository identity regressions

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -54,6 +54,20 @@ tasks:
     dependencies: [first]
     command: echo second`;
 
+function validPlanForRepo(repoUrl: string): string {
+  return `Here is the plan.
+
+\`\`\`yaml
+name: Repository-bound plan
+repoUrl: ${repoUrl}
+onFinish: none
+tasks:
+  - id: preserve-binding
+    description: Preserve the selected repository binding
+    command: pnpm test
+\`\`\``;
+}
+
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 const PLAN_DRAFT_PLACEHOLDER = '_(Plan drafted — see the review card for the full plan.)_';
 const REDACTED_VALID_PLAN_REPLY = `Here is the plan.\n\n${PLAN_DRAFT_PLACEHOLDER}`;
@@ -450,6 +464,84 @@ describe('planning chat', () => {
     });
     expect(result.ok && result.reply).not.toContain('```yaml');
     expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(REDACTED_VALID_PLAN_REPLY);
+  });
+
+  it.fails.each([
+    {
+      name: 'trailing slash and optional .git',
+      selectedRepo: 'https://github.com/acme/widgets/',
+      draftedRepo: 'https://github.com/acme/widgets.git',
+    },
+    {
+      name: 'GitHub SSH and HTTPS spellings',
+      selectedRepo: 'git@github.com:acme/widgets.git',
+      draftedRepo: 'https://github.com/acme/widgets',
+    },
+  ])('preserves the selected repository across $name', async ({ selectedRepo, draftedRepo }) => {
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: `equivalent-repo-${sessions.size}`,
+      title: 'Equivalent repository spelling',
+      repoUrl: selectedRepo,
+      baseBranch: 'main',
+    });
+    sessions.set(session.id, session);
+    const plannerReplyOverride = vi.fn().mockResolvedValue(validPlanForRepo(draftedRepo));
+
+    const result = await sendPlanningChatMessage({
+      sessionId: session.id,
+      message: 'draft the full plan',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      draftPlanAvailable: true,
+      draftPlanText: expect.stringContaining(`repoUrl: ${draftedRepo}`),
+    });
+    expect(plannerReplyOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it.fails('keeps the correction path for a genuinely different repository', async () => {
+    const selectedRepo = 'https://github.com/acme/widgets/';
+    const draftedRepo = 'git@github.com:other/widgets.git';
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'different-repository',
+      title: 'Different repository',
+      repoUrl: selectedRepo,
+      baseBranch: 'main',
+    });
+    sessions.set(session.id, session);
+    const plannerReplyOverride = vi.fn()
+      .mockResolvedValueOnce(validPlanForRepo(draftedRepo))
+      .mockResolvedValueOnce(validPlanForRepo('https://github.com/acme/widgets.git'));
+
+    const result = await sendPlanningChatMessage({
+      sessionId: session.id,
+      message: 'draft the full plan',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+
+    expect(plannerReplyOverride).toHaveBeenCalledTimes(2);
+    expect(plannerReplyOverride.mock.calls[1]?.[0]).toContain(
+      `Draft rejected because it silently changed repositories to ${draftedRepo}.`,
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      draftPlanAvailable: true,
+      draftPlanText: expect.stringContaining('repoUrl: https://github.com/acme/widgets.git'),
+    });
   });
 
   it('keeps unauthorized YAML from becoming draft-ready and refuses submit', async () => {


### PR DESCRIPTION
## Summary

Add expected-failure coverage for equivalent Git URL spellings and correction of a genuinely different repository.

Both cases exercise the complete in-app planning boundary before production logic changes.

## Review Claim

The regressions demonstrate the raw-comparison failure while preserving coverage of genuine repository correction.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes tests only; expected-failure markers keep the branch green until the behavior slice lands.

## Slice Rationale

The failing behavior is captured before the implementation so reviewers can approve the evidence independently.

## Non-goals

No repository comparison logic, session binding, checkout behavior, authentication, or documentation changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  85 passed (85)`
- [x] `pnpm run check:comments`
  - `[comments] Checked added source lines; no disallowed comments found.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 136952169a5764fa143e2bc60e339796740f34d7`
- Post-revert steps: Rerun the focused in-app planner test file.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with expected-failure markers; no runtime behavior is modified.
> 
> **Overview**
> Adds **proof tests only** for in-app planning repository binding: a `validPlanForRepo` helper and three **`it.fails`** cases that stay green until canonical comparison lands.
> 
> The parameterized cases assert that when the session is bound to one Git URL spelling (HTTPS with trailing slash, or SSH) and the planner drafts YAML with an equivalent spelling (`.git`, other HTTPS form), the draft is accepted in **one** turn and `draftPlanText` keeps the planner’s `repoUrl`. A separate failing test locks in the **correction** path when the draft points at a truly different repo: a second planner call whose prompt includes the “silently changed repositories” rejection, then a corrected draft for the session repo.
> 
> No production planner or comparison logic changes in this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d9b66f2cf8f05be4a3e6c326761d5d424bcf9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->