### PR TITLE
[Planner hardening 1: canonical repository identity](3) Compare canonical repository identities

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -466,7 +466,7 @@ describe('planning chat', () => {
     expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(REDACTED_VALID_PLAN_REPLY);
   });
 
-  it.fails.each([
+  it.each([
     {
       name: 'trailing slash and optional .git',
       selectedRepo: 'https://github.com/acme/widgets/',
@@ -507,7 +507,7 @@ describe('planning chat', () => {
     expect(plannerReplyOverride).toHaveBeenCalledTimes(1);
   });
 
-  it.fails('keeps the correction path for a genuinely different repository', async () => {
+  it('keeps the correction path for a genuinely different repository', async () => {
     const selectedRepo = 'https://github.com/acme/widgets/';
     const draftedRepo = 'git@github.com:other/widgets.git';
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -468,11 +468,45 @@ function planningRepositoryContext(session: InAppPlanningChatSession): string {
   ].join('\n');
 }
 
+function canonicalGitRepositoryIdentity(repoUrl: string): string {
+  const trimmed = repoUrl.trim();
+  const scpLike = /^git@([^:]+):(.+)$/i.exec(trimmed);
+  if (scpLike) {
+    return canonicalRemoteRepositoryIdentity(scpLike[1], scpLike[2]);
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!['http:', 'https:', 'ssh:'].includes(parsed.protocol)
+      || !parsed.host
+      || parsed.search
+      || parsed.hash) {
+      return trimmed;
+    }
+    return canonicalRemoteRepositoryIdentity(parsed.host, parsed.pathname);
+  } catch {
+    return trimmed;
+  }
+}
+
+function canonicalRemoteRepositoryIdentity(host: string, path: string): string {
+  const canonicalHost = host.toLowerCase();
+  const withoutGitSuffix = path
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/i, '');
+  const canonicalPath = canonicalHost === 'github.com'
+    ? withoutGitSuffix.toLowerCase()
+    : withoutGitSuffix;
+  return `${canonicalHost}/${canonicalPath}`;
+}
+
 async function silentRepoMismatch(
   session: InAppPlanningChatSession,
   planText: string,
 ): Promise<string | undefined> {
-  if (!session.repoUrl) return undefined;
+  const sessionRepoUrl = session.repoUrl;
+  if (!sessionRepoUrl) return undefined;
+  const sessionRepoIdentity = canonicalGitRepositoryIdentity(sessionRepoUrl);
   const { parsePlanSubmissionBundle } = await import('./plan-parser.js');
   const submission = parsePlanSubmissionBundle(planText);
   const userText = session.messages
@@ -483,7 +517,7 @@ async function silentRepoMismatch(
     .map((plan) => plan.repoUrl)
     .find((repoUrl): repoUrl is string => Boolean(
       repoUrl
-      && repoUrl !== session.repoUrl
+      && canonicalGitRepositoryIdentity(repoUrl) !== sessionRepoIdentity
       && !userText.includes(repoUrl),
     ));
 }


### PR DESCRIPTION
## Summary

Compare planning-session and drafted remotes by canonical Git repository identity.

Equivalent transport, trailing-slash, and `.git` spellings retain the selected repository while different repositories still trigger correction.

## Review Claim

Equivalent spellings of one Git repository no longer trigger correction, while a genuinely different owner or repository still does.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Normalization changes comparison only; checkout, authentication, session binding, and rejection of a different owner or repository remain unchanged.

## Slice Rationale

The comparator and the directly affected expectation flips form one locally reviewable planner-boundary behavior slice.

## Non-goals

No repository rebinding, checkout, authentication, planner prompt, documentation, or broad URL-normalization changes.

## Architecture

### Before

```mermaid
graph LR
    S["Bound repository URL"] --> C["Raw string comparison"]
    D["Drafted repository URL"] --> C
    C --> R["Correction on any spelling difference"]
```

### After

```mermaid
graph LR
    S["Bound repository URL"] --> N["Canonical repository identity"]
    D["Drafted repository URL"] --> N
    N --> C["Identity comparison"]
    C --> R["Correction only for a different repository"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  85 passed (85)`
- [x] `pnpm run check:comments`
  - `[comments] Checked added source lines; no disallowed comments found.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a43a992062adeb67ca9528c88cbffee239cfc385`
- Post-revert steps: Restore the expected-failure markers, then rerun the focused planner suite.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planner routing-only comparison change with focused tests; no auth, checkout, or rebinding behavior altered.
> 
> **Overview**
> **In-app planning** no longer treats equivalent remote URL spellings as a silent repository change when validating drafted YAML against the session binding.
> 
> `silentRepoMismatch` now compares **canonical repository identities** (via new `canonicalGitRepositoryIdentity` / `canonicalRemoteRepositoryIdentity`) instead of raw strings. Trailing slashes, optional `.git`, and common HTTPS vs `git@host:path` forms for the same remote are treated as the same repo; a different owner or repo name still triggers the existing correction/reject path. Session binding, checkout, and the rule that skips mismatch when the user explicitly named the drafted URL in chat are unchanged.
> 
> Tests that were marked expected-failure (`it.fails`) for equivalent spellings and for a genuinely different repo are now normal passing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce521fffac7da48654d52bb6a958f1f2174e546e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->