### PR TITLE
[Typed task freshness (1) contract round-trip](1) Task configuration type

### DIFF
--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -26,6 +26,15 @@ export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 
+export interface TaskFreshnessSpec {
+  readonly watchPaths?: readonly string[];
+  readonly pathPreconditions?: readonly {
+    readonly path: string;
+    readonly expected: 'present' | 'absent';
+  }[];
+  readonly guardedBehaviorIds?: readonly string[];
+}
+
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
@@ -50,6 +59,7 @@ export interface BaseTaskConfig {
   readonly executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   readonly maxTurns?: number;
+  readonly freshness?: TaskFreshnessSpec;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Defines optional `TaskFreshnessSpec` metadata on task configuration.

The shape covers watched paths, explicit path expectations, and guarded behavior identifiers.

## Review Claim

Approve the shared optional task-freshness type on `BaseTaskConfig`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new field is optional, so task configuration that omits freshness keeps its existing shape and behavior.

## Slice Rationale

The lowest shared type lands first so every later carrier depends on one definition.

## Non-goals

No parsing, persistence, work request, or executor behavior changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-graph build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting later slices.
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: None.
- Data migration? No.

</details>

