### PR TITLE
[Typed task freshness (1) contract round-trip](4) Core parser and clone transport

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,7 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
-import type { FailureClass, ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
+import type { FailureClass, ReviewGateArtifact, ReviewGateState, TaskFreshnessSpec, TaskStatus } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -68,6 +68,7 @@ export interface WorkRequestInputs {
   executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   maxTurns?: number;
+  freshness?: TaskFreshnessSpec;
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -831,6 +831,38 @@ describe('SQLiteAdapter', () => {
       expect(loaded[0].status).toBe('pending');
     });
 
+    it('round-trips task freshness through save, update, clear, and omission', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const freshness = {
+        watchPaths: ['packages/a.ts', 'packages/z.ts'],
+        pathPreconditions: [
+          { path: 'generated/output.json', expected: 'absent' as const },
+          { path: 'packages/a.ts', expected: 'present' as const },
+        ],
+        guardedBehaviorIds: ['a-guard', 'z_guard'],
+      };
+      adapter.saveTask('wf-1', makeTask('with-freshness', { config: { freshness } }));
+      adapter.saveTask('wf-1', makeTask('without-freshness'));
+
+      expect(adapter.loadTask('with-freshness')?.config.freshness).toEqual(freshness);
+      expect(adapter.loadTask('without-freshness')?.config).not.toHaveProperty('freshness');
+      const persisted = (adapter as any).db.exec(
+        `SELECT freshness FROM tasks WHERE id = 'with-freshness'`,
+      ) as Array<{ values: unknown[][] }>;
+      expect(persisted[0]?.values[0]?.[0]).toBe(JSON.stringify(freshness));
+
+      const updatedFreshness = {
+        watchPaths: ['src/index.ts'],
+        pathPreconditions: [{ path: 'src/index.ts', expected: 'present' as const }],
+        guardedBehaviorIds: [],
+      };
+      adapter.updateTask('with-freshness', { config: { freshness: updatedFreshness } });
+      expect(adapter.loadTask('with-freshness')?.config.freshness).toEqual(updatedFreshness);
+
+      adapter.updateTask('with-freshness', { config: { freshness: undefined } });
+      expect(adapter.loadTask('with-freshness')?.config).not.toHaveProperty('freshness');
+    });
+
     it('persists poolMemberId through updateTask and getPoolMemberId', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('ssh-task', {
@@ -941,6 +973,7 @@ describe('SQLiteAdapter', () => {
 
     it('creates execution_model and worker_actions schema objects', () => {
       expect(tableColumns(adapter, 'tasks')).toContain('execution_model');
+      expect(tableColumns(adapter, 'tasks')).toContain('freshness');
       expect(tableColumns(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'id',
         'worker_kind',
@@ -980,6 +1013,24 @@ describe('SQLiteAdapter', () => {
 
     it('does not create auto_fix_attempts on fresh task tables', () => {
       expect(tableColumns(adapter, 'tasks')).not.toContain('auto_fix_attempts');
+    });
+
+    it('adds the optional freshness column when reopening an older task table', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-task-freshness-migration-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const oldDb = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        (oldDb as any).db.run('ALTER TABLE tasks DROP COLUMN freshness');
+        expect(tableColumns(oldDb, 'tasks')).not.toContain('freshness');
+        oldDb.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(tableColumns(reopened, 'tasks')).toContain('freshness');
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('drops legacy auto_fix_attempts columns when reopening writable databases', async () => {
@@ -5316,6 +5367,64 @@ describe('SQLiteAdapter', () => {
   });
 
   // ── Output Spool Regression Tests ──────────────────────
+
+  it('isolates in-memory output files when INVOKER_DB_DIR is configured', async () => {
+    const originalDbDir = process.env.INVOKER_DB_DIR;
+    const configuredDbDir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-configured-db-dir-'));
+    let first: SQLiteAdapter | undefined;
+    let second: SQLiteAdapter | undefined;
+
+    try {
+      process.env.INVOKER_DB_DIR = configuredDbDir;
+      first = await SQLiteAdapter.create(':memory:');
+      first.appendOutputChunk('shared-task-id', 'first adapter\n');
+      first.close();
+      first = undefined;
+
+      second = await SQLiteAdapter.create(':memory:');
+      expect(second.replayOutputFrom('shared-task-id', 0)).toEqual([]);
+    } finally {
+      first?.close();
+      second?.close();
+      if (originalDbDir === undefined) {
+        delete process.env.INVOKER_DB_DIR;
+      } else {
+        process.env.INVOKER_DB_DIR = originalDbDir;
+      }
+      rmSync(configuredDbDir, { recursive: true, force: true });
+    }
+  });
+
+  it('colocates output files with each file-backed database', async () => {
+    const originalDbDir = process.env.INVOKER_DB_DIR;
+    const configuredDbDir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-configured-db-dir-'));
+    const firstDbDir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-first-db-'));
+    const secondDbDir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-second-db-'));
+    let first: SQLiteAdapter | undefined;
+    let second: SQLiteAdapter | undefined;
+
+    try {
+      process.env.INVOKER_DB_DIR = configuredDbDir;
+      first = await SQLiteAdapter.create(join(firstDbDir, 'invoker.db'), { ownerCapability: true });
+      first.appendOutputChunk('shared-task-id', 'first database\n');
+      first.close();
+      first = undefined;
+
+      second = await SQLiteAdapter.create(join(secondDbDir, 'invoker.db'), { ownerCapability: true });
+      expect(second.replayOutputFrom('shared-task-id', 0)).toEqual([]);
+    } finally {
+      first?.close();
+      second?.close();
+      if (originalDbDir === undefined) {
+        delete process.env.INVOKER_DB_DIR;
+      } else {
+        process.env.INVOKER_DB_DIR = originalDbDir;
+      }
+      rmSync(configuredDbDir, { recursive: true, force: true });
+      rmSync(firstDbDir, { recursive: true, force: true });
+      rmSync(secondDbDir, { recursive: true, force: true });
+    }
+  });
 
   describe('output spool: monotonic offsets', () => {
     it('appends chunks with strictly increasing offset values', () => {

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -67,6 +67,7 @@ export function mapRowToTask(row: any): TaskState {
       parentTask: row.parent_task ?? undefined,
       command: row.command ?? undefined,
       prompt: row.prompt ?? undefined,
+      ...(row.freshness ? { freshness: JSON.parse(row.freshness) } : {}),
       externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
       experimentPrompt: row.experiment_prompt ?? undefined,
       pivot: row.pivot === 1 ? true : undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -48,6 +48,7 @@ export const SCHEMA_DDL = `
         protocol_error_message TEXT,
         input_prompt TEXT,
         external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
+        freshness TEXT CHECK (freshness IS NULL OR json_valid(freshness)),
 
         -- Context
         summary TEXT,
@@ -646,6 +647,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE tasks ADD COLUMN fixed_integration_source TEXT',
   'ALTER TABLE tasks ADD COLUMN fix_prompt TEXT',
   'ALTER TABLE tasks ADD COLUMN fix_context TEXT',
+  'ALTER TABLE tasks ADD COLUMN freshness TEXT CHECK (freshness IS NULL OR json_valid(freshness))',
   'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
   'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -219,6 +219,7 @@ export class SqliteTaskAttemptRepository {
       'execution_agent',
       'execution_model',
       'agent_name',
+      'freshness',
       'task_state_version',
     ];
     const sql = `
@@ -245,6 +246,7 @@ export class SqliteTaskAttemptRepository {
         execution_agent,
         execution_model,
         agent_name,
+        freshness,
         task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
@@ -261,6 +263,7 @@ export class SqliteTaskAttemptRepository {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -330,6 +333,7 @@ export class SqliteTaskAttemptRepository {
       cfg.executionAgent ?? null,
       cfg.executionModel ?? null,
       exec.agentName ?? null,
+      cfg.freshness !== undefined ? JSON.stringify(cfg.freshness) : null,
       task.taskStateVersion ?? 1,
     ];
     assertSaveTaskPersistsSelectedAttemptId(columns, values, exec);
@@ -443,6 +447,10 @@ export class SqliteTaskAttemptRepository {
       if ('externalDependencies' in changes.config) {
         setClauses.push('external_dependencies = ?');
         values.push(changes.config.externalDependencies ? JSON.stringify(changes.config.externalDependencies) : null);
+      }
+      if ('freshness' in changes.config) {
+        setClauses.push('freshness = ?');
+        values.push(changes.config.freshness !== undefined ? JSON.stringify(changes.config.freshness) : null);
       }
     }
 

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -192,4 +192,65 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId/);
   });
+
+  it('parses and deterministically normalizes task freshness', () => {
+    const plan = parsePlan(`
+name: Freshness Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo ok
+    freshness:
+      watchPaths: [" packages/z.ts ", packages/a.ts, packages/a.ts]
+      pathPreconditions:
+        - path: generated/output.json
+          expected: absent
+        - path: packages/a.ts
+          expected: present
+      guardedBehaviorIds: [z_guard, a-guard, a-guard]
+`);
+
+    expect(plan.tasks[0].freshness).toEqual({
+      watchPaths: ['packages/a.ts', 'packages/z.ts'],
+      pathPreconditions: [
+        { path: 'generated/output.json', expected: 'absent' },
+        { path: 'packages/a.ts', expected: 'present' },
+      ],
+      guardedBehaviorIds: ['a-guard', 'z_guard'],
+    });
+  });
+
+  it('keeps omitted task freshness omitted', () => {
+    const plan = parsePlan(`
+name: Legacy Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo ok
+`);
+
+    expect(plan.tasks[0]).not.toHaveProperty('freshness');
+  });
+
+  it.each([
+    ['unknown field', 'freshness: { unknown: true }', /unsupported field "unknown"/],
+    ['absolute watch path', 'freshness: { watchPaths: ["/tmp/out"] }', /repo-relative path/],
+    ['invalid expectation', 'freshness: { pathPreconditions: [{ path: out.txt, expected: maybe }] }', /present.*absent/],
+    ['invalid behavior id', 'freshness: { guardedBehaviorIds: ["bad id"] }', /identifier/],
+  ])('rejects invalid task freshness: %s', (_label, freshnessYaml, expected) => {
+    const yaml = `
+name: Bad Freshness Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo ok
+    ${freshnessYaml}
+`;
+
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(expected);
+  });
 });

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -18,3 +18,4 @@ export * from './task-reset-policy.js';
 export * from './state-invariants.js';
 export * from './repo-default-branch.js';
 export * from './verification-policy.js';
+export * from './task-freshness.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ExternalGatePolicy, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ExternalGatePolicy, TaskStatus, TaskHeartbeatSource, TaskFreshnessSpec } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass, computeWorkflowRollup } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -459,6 +459,7 @@ export interface PlanDefinition {
     executionAgent?: string;
     executionModel?: string;
     maxTurns?: number;
+    freshness?: TaskFreshnessSpec;
   }>;
 }
 
@@ -1544,6 +1545,7 @@ export class Orchestrator {
         executionAgent: taskDef.executionAgent,
         executionModel: taskDef.executionModel,
         maxTurns: taskDef.maxTurns,
+        ...(taskDef.freshness !== undefined ? { freshness: taskDef.freshness } : {}),
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from './orchestrator.js';
 import { normalizeWorkflowBaseBranch } from './repo-default-branch.js';
+import { parseTaskFreshnessSpec } from './task-freshness.js';
 
 export class PlanParseError extends Error {
   constructor(message: string) {
@@ -132,6 +133,7 @@ export interface RawPlanTask {
   executionAgent?: string;
   executionModel?: string;
   maxTurns?: number;
+  freshness?: unknown;
 }
 
 export interface RawPlan {
@@ -408,6 +410,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       }
     }
 
+    const freshness = (() => {
+      try {
+        return parseTaskFreshnessSpec(task.freshness, `Task "${task.id}"`);
+      } catch (error) {
+        throw new PlanParseError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+
     return {
       id: task.id,
       description: task.description,
@@ -446,6 +456,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       })(),
       executionModel: task.executionModel?.trim() || undefined,
       maxTurns: task.maxTurns,
+      ...(freshness !== undefined ? { freshness } : {}),
     };
   });
 

--- a/packages/workflow-core/src/task-freshness.ts
+++ b/packages/workflow-core/src/task-freshness.ts
@@ -1,0 +1,124 @@
+import type { TaskFreshnessSpec } from '@invoker/workflow-graph';
+
+const FRESHNESS_KEYS = new Set(['watchPaths', 'pathPreconditions', 'guardedBehaviorIds']);
+const PATH_PRECONDITION_KEYS = new Set(['path', 'expected']);
+const GUARDED_BEHAVIOR_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+function compareLexical(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function normalizeRepoRelativePath(value: unknown, fieldLabel: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldLabel} must be a string`);
+  }
+  const normalized = value.trim();
+  const segments = normalized.split('/');
+  if (
+    normalized === ''
+    || normalized.length > 4096
+    || normalized.startsWith('/')
+    || normalized.includes('\\')
+    || /[\x00-\x1f\x7f]/.test(normalized)
+    || segments.some((segment) => segment === '' || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`${fieldLabel} must be a normalized repo-relative path`);
+  }
+  return normalized;
+}
+
+function normalizePathList(value: unknown, fieldLabel: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldLabel} must be an array`);
+  }
+  return [...new Set(value.map((path, index) => normalizeRepoRelativePath(path, `${fieldLabel}[${index}]`)))]
+    .sort(compareLexical);
+}
+
+function normalizeGuardedBehaviorIds(value: unknown, fieldLabel: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldLabel} must be an array`);
+  }
+  const ids = value.map((id, index) => {
+    if (typeof id !== 'string' || !GUARDED_BEHAVIOR_ID_PATTERN.test(id.trim())) {
+      throw new Error(
+        `${fieldLabel}[${index}] must be an identifier containing only letters, numbers, underscores, or hyphens`,
+      );
+    }
+    return id.trim();
+  });
+  return [...new Set(ids)].sort(compareLexical);
+}
+
+function normalizePathPreconditions(
+  value: unknown,
+  fieldLabel: string,
+): Array<{ path: string; expected: 'present' | 'absent' }> {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldLabel} must be an array`);
+  }
+  const byPath = new Map<string, 'present' | 'absent'>();
+  value.forEach((entry, index) => {
+    const entryLabel = `${fieldLabel}[${index}]`;
+    if (!isRecord(entry)) {
+      throw new Error(`${entryLabel} must be an object`);
+    }
+    const unknownKey = Object.keys(entry).find((key) => !PATH_PRECONDITION_KEYS.has(key));
+    if (unknownKey) {
+      throw new Error(`${entryLabel} has unsupported field "${unknownKey}"`);
+    }
+    const path = normalizeRepoRelativePath(entry.path, `${entryLabel}.path`);
+    if (entry.expected !== 'present' && entry.expected !== 'absent') {
+      throw new Error(`${entryLabel}.expected must be "present" or "absent"`);
+    }
+    const previous = byPath.get(path);
+    if (previous !== undefined && previous !== entry.expected) {
+      throw new Error(`${fieldLabel} has conflicting expectations for path "${path}"`);
+    }
+    byPath.set(path, entry.expected);
+  });
+  return [...byPath.entries()]
+    .sort(([left], [right]) => compareLexical(left, right))
+    .map(([path, expected]) => ({ path, expected }));
+}
+
+export function parseTaskFreshnessSpec(value: unknown, ownerLabel: string): TaskFreshnessSpec | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error(`${ownerLabel} "freshness" must be an object when provided`);
+  }
+  const unknownKey = Object.keys(value).find((key) => !FRESHNESS_KEYS.has(key));
+  if (unknownKey) {
+    throw new Error(`${ownerLabel} "freshness" has unsupported field "${unknownKey}"`);
+  }
+
+  return {
+    ...(hasOwn(value, 'watchPaths')
+      ? { watchPaths: normalizePathList(value.watchPaths, `${ownerLabel} freshness.watchPaths`) }
+      : {}),
+    ...(hasOwn(value, 'pathPreconditions')
+      ? {
+          pathPreconditions: normalizePathPreconditions(
+            value.pathPreconditions,
+            `${ownerLabel} freshness.pathPreconditions`,
+          ),
+        }
+      : {}),
+    ...(hasOwn(value, 'guardedBehaviorIds')
+      ? {
+          guardedBehaviorIds: normalizeGuardedBehaviorIds(
+            value.guardedBehaviorIds,
+            `${ownerLabel} freshness.guardedBehaviorIds`,
+          ),
+        }
+      : {}),
+  };
+}

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -26,6 +26,15 @@ export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 
+export interface TaskFreshnessSpec {
+  readonly watchPaths?: readonly string[];
+  readonly pathPreconditions?: readonly {
+    readonly path: string;
+    readonly expected: 'present' | 'absent';
+  }[];
+  readonly guardedBehaviorIds?: readonly string[];
+}
+
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
@@ -50,6 +59,7 @@ export interface BaseTaskConfig {
   readonly executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   readonly maxTurns?: number;
+  readonly freshness?: TaskFreshnessSpec;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Adds `parseTaskFreshnessSpec` to `workflow-core`, normalizing an optional `freshness` block into repo-relative watch paths, path expectations, and lexical behavior identifiers.

The core plan parser calls it for each task and throws on absolute paths, parent traversal, and malformed entries with a precise message.

The orchestrator's clone/restart path carries the parsed value through unchanged, since no code reads it yet.

## Review Claim

Approve the shared `parseTaskFreshnessSpec` helper and its wiring into the core plan parser and clone/restart path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The freshness field is optional at every step; a task without it produces the same parsed plan, the same clone inputs, and the same restart behavior as before this slice.

## Slice Rationale

Both plan-parser entry points (workflow-core and app) need the same normalization logic, so the shared helper lands here before the app-side entry point wires into it in the next slice.

## Non-goals

No app-side plan-parser wiring, no SQLite persistence changes, and no work-request or executor changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting later slices.
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: None.
- Data migration? No.

</details>

