### PR TITLE
[Typed task freshness (1) contract round-trip](2) Work request type

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,7 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
-import type { FailureClass, ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
+import type { FailureClass, ReviewGateArtifact, ReviewGateState, TaskFreshnessSpec, TaskStatus } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -68,6 +68,7 @@ export interface WorkRequestInputs {
   executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   maxTurns?: number;
+  freshness?: TaskFreshnessSpec;
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -26,6 +26,15 @@ export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 
+export interface TaskFreshnessSpec {
+  readonly watchPaths?: readonly string[];
+  readonly pathPreconditions?: readonly {
+    readonly path: string;
+    readonly expected: 'present' | 'absent';
+  }[];
+  readonly guardedBehaviorIds?: readonly string[];
+}
+
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;
@@ -50,6 +59,7 @@ export interface BaseTaskConfig {
   readonly executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   readonly maxTurns?: number;
+  readonly freshness?: TaskFreshnessSpec;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Adds an optional `freshness` field to `WorkRequestInputs`, typed as `TaskFreshnessSpec`.

This lets the orchestrator hand a typed freshness spec to an executor alongside the existing `freshWorkspace` flag.

No executor reads the field yet, so this only widens the transport shape.

## Review Claim

Approve threading the optional typed freshness field onto `WorkRequestInputs`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The field is optional and unread by every executor, so work requests that omit it build and dispatch exactly as before.

## Slice Rationale

The transport type depends on the task-configuration type from the prior slice and must land before persistence or dispatch code can carry the value.

## Non-goals

No SQLite persistence, no plan-parser changes, and no executor consumption of the field.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting later slices.
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: None.
- Data migration? No.

</details>

