### PR TITLE
[Fix E2E focus isolation](1) Keep hidden windows inactive

### DIFF
--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -180,7 +180,7 @@ describe('window-lifecycle', () => {
     expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
   });
 
-  it('maps and focuses e2e compositor windows', () => {
+  it('maps e2e compositor windows without showing or focusing them by default', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
     const recordStartupMark = vi.fn();
     const setUiInteractive = vi.fn();
@@ -203,8 +203,9 @@ describe('window-lifecycle', () => {
     expect(options.skipTaskbar).toBe(true);
     expect(options.x).toBeUndefined();
     expect(options.y).toBeUndefined();
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).not.toHaveBeenCalled();
     expect(recordStartupMark).toHaveBeenCalledWith('window.mapped');
 
@@ -212,9 +213,9 @@ describe('window-lifecycle', () => {
     expect(readyHandler).toBeDefined();
     readyHandler?.();
 
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).toHaveBeenCalledWith(true);
     expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
     expect(recordStartupMark).toHaveBeenCalledWith('window.show');

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -163,7 +163,7 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     const mapWindow = (): void => {
       if (mainWindow.isDestroyed() || windowMapped) return;
       windowMapped = true;
-      if (keepE2eWindowHidden && deps.enableTestCompositor) {
+      if (deps.hideE2eWindow && deps.enableTestCompositor && !showVisualProofWindow) {
         mainWindow.showInactive();
       } else if (!keepE2eWindowHidden) {
         mainWindow.show();


### PR DESCRIPTION
## Summary

Default-hidden Electron E2E windows stay compositor-backed and mapped without being shown or focused.

Explicit visible, production, headless, and visual-proof launches keep their existing presentation.

## Review Claim

Default-hidden Electron Playwright windows stay compositor-backed and mapped without being shown or focused; explicit visible tests retain the existing visible behavior.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Production, explicit-visible, headless, and visual-proof window behavior remains unchanged, and compositor-backed rendering remains enabled.

## Slice Rationale

BrowserWindow mapping and focus are one presentation decision owned by the window lifecycle module.

## Non-goals

This slice does not alter macOS Dock mode, UI content, profiles, persistence, compositor enablement, or unrelated window behavior.

## Architecture

### Before

```mermaid
graph TD
    A["Default-hidden E2E compositor window"] --> B["Show and focus BrowserWindow"]
```

### After

```mermaid
graph TD
    A["Default-hidden E2E compositor window"] --> B["Map with showInactive"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/window-lifecycle.test.ts` — 9 tests passed.
- [x] `pnpm run check:comments` — no disallowed added comments.
- [x] `node skills/verify/control-invoker.mjs doctor --json` — build and Playwright checks passed after building workspace packages.
- [x] `node skills/verify/control-invoker.mjs visual-proof capture-after` — captured 100 screenshots; the aggregate visual spec also reported unrelated snapshot and terminal-harness failures.

</details>

## Visual Proof

The screenshot is supplemental. A screenshot cannot identify which macOS application is frontmost; the operating-system frontmost-application observer is authoritative for that property.

![Explicit visual-proof mode renders the planning surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260901-3309c3/empty-state.png)

Manually inspected: the image shows Invoker's dark Planning surface with an empty plan, centered starter prompt, visible composer, and no clipped or overlapping controls.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7a61d9e3f0a811f293197808945b3376f41fd281`
- Post-revert steps: Re-run the focused window-lifecycle test.
- Data migration? No

</details>
