### PR TITLE
[Fix E2E focus isolation](2) Use accessory mode for hidden macOS E2E

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -45,6 +45,7 @@ describe('app-bootstrap', () => {
       platform: 'linux',
       enableTestCompositor: false,
       isHeadless: false,
+      hideE2eWindow: false,
     });
 
     expect(disableHardwareAcceleration).toHaveBeenCalledTimes(1);
@@ -80,13 +81,43 @@ describe('app-bootstrap', () => {
       platform: 'darwin',
       enableTestCompositor: false,
       isHeadless: true,
+      hideE2eWindow: false,
     });
 
     expect(setActivationPolicy).toHaveBeenCalledWith('accessory');
     expect(hideDock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not hide the Dock for macOS GUI mode', () => {
+  it.each([
+    {
+      mode: 'default-hidden macOS E2E',
+      platform: 'darwin',
+      hideE2eWindow: true,
+      expectedPresentation: 'accessory',
+    },
+    {
+      mode: 'explicit-visible macOS E2E',
+      platform: 'darwin',
+      hideE2eWindow: false,
+      expectedPresentation: 'regular',
+    },
+    {
+      mode: 'production macOS',
+      platform: 'darwin',
+      hideE2eWindow: false,
+      expectedPresentation: 'regular',
+    },
+    {
+      mode: 'default-hidden non-macOS E2E',
+      platform: 'linux',
+      hideE2eWindow: true,
+      expectedPresentation: 'regular',
+    },
+  ] as const)('$mode selects $expectedPresentation app presentation', ({
+    platform,
+    hideE2eWindow,
+    expectedPresentation,
+  }) => {
     const recorder = createCommandLineRecorder();
     const setActivationPolicy = vi.fn();
     const hideDock = vi.fn();
@@ -102,13 +133,19 @@ describe('app-bootstrap', () => {
 
     configureEarlyElectronApp({
       app,
-      platform: 'darwin',
-      enableTestCompositor: false,
+      platform,
+      enableTestCompositor: true,
       isHeadless: false,
+      hideE2eWindow,
     });
 
-    expect(setActivationPolicy).not.toHaveBeenCalled();
-    expect(hideDock).not.toHaveBeenCalled();
+    if (expectedPresentation === 'accessory') {
+      expect(setActivationPolicy).toHaveBeenCalledWith('accessory');
+      expect(hideDock).toHaveBeenCalledTimes(1);
+    } else {
+      expect(setActivationPolicy).not.toHaveBeenCalled();
+      expect(hideDock).not.toHaveBeenCalled();
+    }
   });
 
   it('uses explicit isolated Electron userData when provided', () => {

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -180,7 +180,7 @@ describe('window-lifecycle', () => {
     expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
   });
 
-  it('maps and focuses e2e compositor windows', () => {
+  it('maps e2e compositor windows without showing or focusing them by default', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
     const recordStartupMark = vi.fn();
     const setUiInteractive = vi.fn();
@@ -203,8 +203,9 @@ describe('window-lifecycle', () => {
     expect(options.skipTaskbar).toBe(true);
     expect(options.x).toBeUndefined();
     expect(options.y).toBeUndefined();
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).not.toHaveBeenCalled();
     expect(recordStartupMark).toHaveBeenCalledWith('window.mapped');
 
@@ -212,9 +213,9 @@ describe('window-lifecycle', () => {
     expect(readyHandler).toBeDefined();
     readyHandler?.();
 
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).toHaveBeenCalledWith(true);
     expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
     expect(recordStartupMark).toHaveBeenCalledWith('window.show');

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -106,6 +106,7 @@ export interface EarlyElectronAppOptions {
   platform?: NodeJS.Platform;
   enableTestCompositor: boolean;
   isHeadless: boolean;
+  hideE2eWindow: boolean;
 }
 
 export function configureEarlyElectronApp(options: EarlyElectronAppOptions): void {
@@ -132,7 +133,7 @@ export function configureEarlyElectronApp(options: EarlyElectronAppOptions): voi
     options.app.commandLine.appendSwitch('class', 'invoker');
   }
 
-  if (platform === 'darwin' && options.isHeadless) {
+  if (platform === 'darwin' && (options.isHeadless || options.hideE2eWindow)) {
     options.app.setActivationPolicy?.('accessory');
     options.app.dock?.hide();
   }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -32,7 +32,12 @@ const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.slice(2).includes('install-skills');
 const sourceDevelopmentProfile = process.env.INVOKER_DEVELOPMENT_PROFILE === '1';
 
-configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
+configureEarlyElectronApp({
+  app,
+  enableTestCompositor,
+  isHeadless: earlyHeadlessMode,
+  hideE2eWindow,
+});
 
 if (process.env.INVOKER_USER_DATA_DIR) {
   app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -163,7 +163,7 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     const mapWindow = (): void => {
       if (mainWindow.isDestroyed() || windowMapped) return;
       windowMapped = true;
-      if (keepE2eWindowHidden && deps.enableTestCompositor) {
+      if (deps.hideE2eWindow && deps.enableTestCompositor && !showVisualProofWindow) {
         mainWindow.showInactive();
       } else if (!keepE2eWindowHidden) {
         mainWindow.show();


### PR DESCRIPTION


Depends-On: #11536

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/E2E and macOS presentation-only; production GUI (`hideE2eWindow: false`) behavior is unchanged aside from an explicit new bootstrap option.
> 
> **Overview**
> Improves **E2E focus isolation on macOS** by treating default hidden test runs like headless startup: when `hideE2eWindow` is true, `configureEarlyElectronApp` now sets **accessory** activation policy and hides the Dock, not only when `--headless` is used.
> 
> `main.ts` derives **`hideE2eWindow`** from `NODE_ENV === 'test'` unless `INVOKER_E2E_HIDE_WINDOW=0` (matching visible E2E), and passes it into early bootstrap. Tests were expanded with a parameterized matrix for macOS vs Linux and hidden vs visible E2E.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670e7a55afeafd97c112b9184f3fe6d69e444b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->