### PR TITLE
[Fix E2E focus isolation](1) Keep hidden windows inactive

### DIFF
--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -180,7 +180,7 @@ describe('window-lifecycle', () => {
     expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
   });
 
-  it('maps and focuses e2e compositor windows', () => {
+  it('maps e2e compositor windows without showing or focusing them by default', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
     const recordStartupMark = vi.fn();
     const setUiInteractive = vi.fn();
@@ -203,8 +203,9 @@ describe('window-lifecycle', () => {
     expect(options.skipTaskbar).toBe(true);
     expect(options.x).toBeUndefined();
     expect(options.y).toBeUndefined();
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).not.toHaveBeenCalled();
     expect(recordStartupMark).toHaveBeenCalledWith('window.mapped');
 
@@ -212,9 +213,9 @@ describe('window-lifecycle', () => {
     expect(readyHandler).toBeDefined();
     readyHandler?.();
 
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).toHaveBeenCalledWith(true);
     expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
     expect(recordStartupMark).toHaveBeenCalledWith('window.show');

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -163,7 +163,7 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     const mapWindow = (): void => {
       if (mainWindow.isDestroyed() || windowMapped) return;
       windowMapped = true;
-      if (keepE2eWindowHidden && deps.enableTestCompositor) {
+      if (deps.hideE2eWindow && deps.enableTestCompositor && !showVisualProofWindow) {
         mainWindow.showInactive();
       } else if (!keepE2eWindowHidden) {
         mainWindow.show();


### PR DESCRIPTION
## Summary

Default-hidden Electron Playwright windows remain compositor-backed and mapped without being shown or focused.

Explicit-visible tests retain their existing visible behavior while ordinary local runs stop interrupting the developer’s active application.

## Review Claim

Default-hidden E2E window presentation can preserve renderer frames without making the BrowserWindow visible or focused.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Production, explicit-visible, headless, and visual-proof window behavior remains unchanged, and compositor-backed rendering remains enabled.

## Slice Rationale

BrowserWindow mapping and focus are one presentation decision owned by the window lifecycle module.

## Non-goals

No app-level macOS Dock policy, UI-content redesign, persistence changes, compositor disablement, or unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/window-lifecycle.test.ts`
- [ ] `pnpm run check:comments`
- [ ] The terminal proof slice runs the ordinary Playwright spec with the real macOS frontmost observer.

</details>

## Visual Proof

Visual proof capture was unavailable because the repository visual-proof command was missing from the configured application bundle. The macOS frontmost observer is authoritative for this attention-isolation claim; screenshots are supplemental only.

![Supplemental Invoker plan graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260901-77ec3e/neutral-chrome-home-graph.png)

Manually inspected: No capture was available to inspect; this section does not claim screenshots prove macOS frontmost state.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`.
- Post-revert steps: Rerun focused window-lifecycle coverage and the ordinary Playwright attention observer.
- Data migration? No.

</details>
