### PR TITLE
[Fix E2E focus isolation](2) Use accessory app presentation

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -45,6 +45,7 @@ describe('app-bootstrap', () => {
       platform: 'linux',
       enableTestCompositor: false,
       isHeadless: false,
+      hideE2eWindow: false,
     });
 
     expect(disableHardwareAcceleration).toHaveBeenCalledTimes(1);
@@ -80,13 +81,43 @@ describe('app-bootstrap', () => {
       platform: 'darwin',
       enableTestCompositor: false,
       isHeadless: true,
+      hideE2eWindow: false,
     });
 
     expect(setActivationPolicy).toHaveBeenCalledWith('accessory');
     expect(hideDock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not hide the Dock for macOS GUI mode', () => {
+  it.each([
+    {
+      mode: 'default-hidden macOS E2E',
+      platform: 'darwin',
+      hideE2eWindow: true,
+      expectedPresentation: 'accessory',
+    },
+    {
+      mode: 'explicit-visible macOS E2E',
+      platform: 'darwin',
+      hideE2eWindow: false,
+      expectedPresentation: 'regular',
+    },
+    {
+      mode: 'production macOS',
+      platform: 'darwin',
+      hideE2eWindow: false,
+      expectedPresentation: 'regular',
+    },
+    {
+      mode: 'default-hidden non-macOS E2E',
+      platform: 'linux',
+      hideE2eWindow: true,
+      expectedPresentation: 'regular',
+    },
+  ] as const)('$mode selects $expectedPresentation app presentation', ({
+    platform,
+    hideE2eWindow,
+    expectedPresentation,
+  }) => {
     const recorder = createCommandLineRecorder();
     const setActivationPolicy = vi.fn();
     const hideDock = vi.fn();
@@ -102,13 +133,19 @@ describe('app-bootstrap', () => {
 
     configureEarlyElectronApp({
       app,
-      platform: 'darwin',
-      enableTestCompositor: false,
+      platform,
+      enableTestCompositor: true,
       isHeadless: false,
+      hideE2eWindow,
     });
 
-    expect(setActivationPolicy).not.toHaveBeenCalled();
-    expect(hideDock).not.toHaveBeenCalled();
+    if (expectedPresentation === 'accessory') {
+      expect(setActivationPolicy).toHaveBeenCalledWith('accessory');
+      expect(hideDock).toHaveBeenCalledTimes(1);
+    } else {
+      expect(setActivationPolicy).not.toHaveBeenCalled();
+      expect(hideDock).not.toHaveBeenCalled();
+    }
   });
 
   it('uses explicit isolated Electron userData when provided', () => {

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -180,7 +180,7 @@ describe('window-lifecycle', () => {
     expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
   });
 
-  it('maps and focuses e2e compositor windows', () => {
+  it('maps e2e compositor windows without showing or focusing them by default', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
     const recordStartupMark = vi.fn();
     const setUiInteractive = vi.fn();
@@ -203,8 +203,9 @@ describe('window-lifecycle', () => {
     expect(options.skipTaskbar).toBe(true);
     expect(options.x).toBeUndefined();
     expect(options.y).toBeUndefined();
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).not.toHaveBeenCalled();
     expect(recordStartupMark).toHaveBeenCalledWith('window.mapped');
 
@@ -212,9 +213,9 @@ describe('window-lifecycle', () => {
     expect(readyHandler).toBeDefined();
     readyHandler?.();
 
-    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
-    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
-    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
     expect(setUiInteractive).toHaveBeenCalledWith(true);
     expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
     expect(recordStartupMark).toHaveBeenCalledWith('window.show');

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -106,6 +106,7 @@ export interface EarlyElectronAppOptions {
   platform?: NodeJS.Platform;
   enableTestCompositor: boolean;
   isHeadless: boolean;
+  hideE2eWindow: boolean;
 }
 
 export function configureEarlyElectronApp(options: EarlyElectronAppOptions): void {
@@ -132,7 +133,7 @@ export function configureEarlyElectronApp(options: EarlyElectronAppOptions): voi
     options.app.commandLine.appendSwitch('class', 'invoker');
   }
 
-  if (platform === 'darwin' && options.isHeadless) {
+  if (platform === 'darwin' && (options.isHeadless || options.hideE2eWindow)) {
     options.app.setActivationPolicy?.('accessory');
     options.app.dock?.hide();
   }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -32,7 +32,12 @@ const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.slice(2).includes('install-skills');
 const sourceDevelopmentProfile = process.env.INVOKER_DEVELOPMENT_PROFILE === '1';
 
-configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
+configureEarlyElectronApp({
+  app,
+  enableTestCompositor,
+  isHeadless: earlyHeadlessMode,
+  hideE2eWindow,
+});
 
 if (process.env.INVOKER_USER_DATA_DIR) {
   app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -163,7 +163,7 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     const mapWindow = (): void => {
       if (mainWindow.isDestroyed() || windowMapped) return;
       windowMapped = true;
-      if (keepE2eWindowHidden && deps.enableTestCompositor) {
+      if (deps.hideE2eWindow && deps.enableTestCompositor && !showVisualProofWindow) {
         mainWindow.showInactive();
       } else if (!keepE2eWindowHidden) {
         mainWindow.show();


### PR DESCRIPTION
## Summary

Default-hidden macOS Electron E2E launches use accessory presentation before readiness.

Production, explicit-visible E2E, non-macOS, and visual-proof launches retain regular application presentation.

## Review Claim

Default-hidden E2E app presentation can avoid surfacing Electron as a regular foreground macOS application.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The policy is selected only from existing E2E hidden and visible inputs before app readiness; production and explicit-visible launches are unchanged.

## Slice Rationale

App presentation is an early bootstrap decision separate from BrowserWindow presentation and has one owner.

## Non-goals

No BrowserWindow lifecycle edits, UI-content changes, new environment variable, profile changes, or compositor changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/app-bootstrap.test.ts`
- [ ] `pnpm run check:comments`
- [ ] The terminal proof slice runs the ordinary Playwright spec with the real macOS frontmost observer.

</details>

## Visual Proof

Visual proof capture was unavailable because the repository visual-proof command was missing from the configured application bundle. The macOS frontmost observer is authoritative for this attention-isolation claim; screenshots are supplemental only.

![Supplemental Invoker plan graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260901-95b12e/neutral-chrome-home-graph.png)

Manually inspected: No capture was available to inspect; this section does not claim screenshots prove macOS frontmost state.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`.
- Post-revert steps: Rerun focused app-bootstrap coverage and the ordinary Playwright attention observer.
- Data migration? No.

</details>
