### PR TITLE
Fix E2E focus isolation (3): Prove attention isolation

### DIFF
--- a/scripts/repro/repro-e2e-attention-isolation.sh
+++ b/scripts/repro/repro-e2e-attention-isolation.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT/packages/app"
+
+echo "repro: hidden macOS E2E windows must stay inactive and use accessory presentation"
+pnpm exec vitest run src/__tests__/app-bootstrap.test.ts src/__tests__/window-lifecycle.test.ts
+echo "PASS: hidden E2E window keeps accessory policy and never takes focus"


### PR DESCRIPTION
## Summary

Adds one repro script that proves hidden macOS E2E windows never steal focus.

The script runs the two existing unit suites that assert the accessory presentation and inactive show path landed in #11536 and #11549.

Run it to get a single pass or fail answer for the attention-isolation fix without reading the tests.

## Review Claim

`scripts/repro/repro-e2e-attention-isolation.sh` runs the app-bootstrap and window-lifecycle unit tests and exits 0 only when both pass.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds one new script under `scripts/repro/` and touches no product, test, or CI files, so app behavior and CI gating are unchanged.

## Slice Rationale

The fix slices (#11536, #11549) already merged. This is the standalone proof entry point for that fix, kept separate so it is reviewable on its own.

## Non-goals

Does not change `packages/app` product code, the unit tests it runs, or any CI workflow. Does not run Playwright.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/repro/repro-e2e-attention-isolation.sh` (exit 0)
- [x] `bash scripts/repro/repro-e2e-attention-isolation.sh` (2 files, 32 tests passed, exit 0)
- [x] `pnpm run check:types` (exit 0)
- [x] `node scripts/check-added-comments.mjs --base origin/master` (exit 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert the single commit; it only adds `scripts/repro/repro-e2e-attention-isolation.sh`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds one bash repro script only; no product, test, or CI behavior changes.
> 
> **Overview**
> Adds **`scripts/repro/repro-e2e-attention-isolation.sh`**, a standalone repro entry point for the already-merged macOS hidden-window focus fix (#11536, #11549).
> 
> The script `cd`s into `packages/app` and runs Vitest on `app-bootstrap.test.ts` and `window-lifecycle.test.ts`, exiting successfully only when both suites pass—giving a single pass/fail check without reading the tests or running Playwright.
> 
> No changes to app code, those tests, or CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0b9268e997b3e806beefa50a90ceaa5861d02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->