### PR TITLE
[Typed task freshness](2) runtime decision — contract

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -114,6 +114,7 @@ export type ResponseStatus =
   | 'review_ready'
   | 'failed'
   | 'needs_input'
+  | 'stale'
   | 'spawn_experiments'
   | 'select_experiment';
 

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -233,7 +233,7 @@ export function validateWorkResponse(res: unknown): ValidationResult {
     return { valid: false, error: 'executionGeneration is required and must be a non-negative integer' };
   }
 
-  const validStatuses = ['completed', 'review_ready', 'failed', 'needs_input', 'spawn_experiments', 'select_experiment'];
+  const validStatuses = ['completed', 'review_ready', 'failed', 'needs_input', 'stale', 'spawn_experiments', 'select_experiment'];
   if (!validStatuses.includes(r.status as string)) {
     return { valid: false, error: `status must be one of: ${validStatuses.join(', ')}` };
   }


### PR DESCRIPTION
## Summary

Add the typed freshness field required by the runtime decision.

The contract remains optional so tasks without freshness metadata keep their existing behavior.

## Review Claim

Approve the typed contract boundary used by runtime freshness evaluation.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The field is optional, and omitting it preserves existing task shapes and execution inputs.

## Slice Rationale

The contract is isolated so runtime consumers can depend on one stable typed representation.

## Non-goals

No executor decision logic, no prompt parsing, and no unrelated status changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- Existing contract validation suite.
- Runtime freshness tests in the dependent slice.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <contract-commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-only addition of an optional response status; omitting it preserves prior behavior, and validation simply widens the allowed status set.
> 
> **Overview**
> Extends the worker **`WorkResponse`** contract so executors can report **`status: 'stale'`** when runtime freshness evaluation decides an attempt is no longer valid.
> 
> **`ResponseStatus`** in `types.ts` gains the **`stale`** variant, and **`validateWorkResponse`** accepts it alongside the existing terminal and control statuses (`completed`, `failed`, `needs_input`, etc.). No new required fields or **`dagMutation`** rules are tied to **`stale`** in this slice—only the typed boundary and validation allowlist change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 300ddcf4e131157bed06ca8ad335bf2a27a911db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->