### PR TITLE
[Typed task freshness](2) runtime decision — routing

### DIFF
--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -96,6 +96,7 @@ function attemptStatusToActionStatus(status: Attempt['status']): ActionGraphNode
       return 'pending';
     case 'needs_input':
       return 'waiting';
+    case 'stale':
     case 'superseded':
       return 'cancelled';
   }

--- a/packages/data-store/src/sync-merge.ts
+++ b/packages/data-store/src/sync-merge.ts
@@ -227,6 +227,7 @@ const ATTEMPT_STATUS_RANK: Record<string, number> = {
   claimed: 1,
   running: 2,
   needs_input: 3,
+  stale: 4,
   superseded: 4,
   failed: 4,
   cancelled: 4,

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -213,7 +213,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
         requestId: request.requestId,
         actionId: request.actionId,
         executionGeneration: request.executionGeneration,
-        status: 'needs_input',
+        status: 'stale',
         outputs: {
           exitCode: 1,
           error: message,
@@ -231,13 +231,10 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     workspacePath: string,
   ): Promise<string | undefined> {
     if (request.actionType !== 'ai_task') return undefined;
-    const taskText = [request.inputs.description, request.inputs.prompt]
-      .filter((value): value is string => Boolean(value?.trim()))
-      .join('\n');
     const output = await this.execRemoteCapture(buildRemoteTaskFreshnessScript({
       cwd: workspacePath,
       snapshotCommit: request.inputs.specificationSnapshotCommit,
-      taskText,
+      freshness: request.inputs.freshness,
     }), 'task_freshness_preflight');
     const report = parseRemoteTaskFreshnessReport(output);
     return report

--- a/packages/execution-engine/src/task-specification-preflight.ts
+++ b/packages/execution-engine/src/task-specification-preflight.ts
@@ -1,368 +1,84 @@
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import type { TaskFreshnessSpec } from '@invoker/workflow-core';
 import { buildRemotePathNormalizeFunction } from './remote-shell-fragments.js';
-
-export interface TaskFreshnessAnchor {
-  kind: 'path' | 'symbol';
-  value: string;
-  clause: string;
-}
-
-export interface TaskFreshnessSpecification {
-  referencedPaths: string[];
-  guardedBehaviorIds: string[];
-  anchors: TaskFreshnessAnchor[];
-}
 
 export type TaskFreshnessDecision =
   | { status: 'current' }
-  | {
-      status: 'stale';
-      snapshotCommit?: string;
-      currentCommit: string;
-      changedReferencedPaths: string[];
-      changedGuardedBehaviorIds: string[];
-      missingAnchors: TaskFreshnessAnchor[];
-      snapshotUnavailable?: boolean;
-      message: string;
-    };
+  | { status: 'stale'; snapshotCommit?: string; currentCommit: string; changedReferencedPaths: string[]; changedGuardedBehaviorIds: string[]; missingPathPreconditions: string[]; snapshotUnavailable?: boolean; message: string };
 
-const REPO_PATH_PATTERN = /(?:^|[\s`'"(])((?:\.github|corpus|docs|engine|packages|scripts|tests)\/[A-Za-z0-9_@./-]+)/g;
-const BACKTICK_TOKEN_PATTERN = /`([^`]+)`/g;
-const ANCHOR_CLAUSE_PATTERN = /\b(?:already exists?|existing|do not create|must not create|without creating)\b/i;
-const CREATE_PATH_PATTERN = /\b(?:create|creating)\b/i;
-const PATH_INTENT_MARKER_PATTERN = /\b(?:do not create|must not create|without creating|create|creating|existing)\b/gi;
-const GUARDED_MARKER_PATTERN = /guarded-behavior:\s*([A-Za-z0-9][\w-]*)/gi;
-const GUARDED_PROSE_PATTERN = /guarded behavior(?:\s+(?:id|marker))?\s*(?:`|"|')?([A-Za-z0-9][\w-]*)/gi;
 const REMOTE_REPORT_MARKER = '__INVOKER_TASK_FRESHNESS_STALE__';
-const SENTENCE_BOUNDARY_PATTERN = /\r?\n|(?<=[.!?]["')\]]*)\s+/;
-
-type PathIntent = 'existing' | 'create' | 'reference';
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function uniqueSorted(values: Iterable<string>): string[] {
-  return [...new Set(values)].sort();
-}
-
-function normalizedRepoPaths(text: string): string[] {
-  const paths: string[] = [];
-  for (const match of text.matchAll(REPO_PATH_PATTERN)) {
-    const value = match[1]?.replace(/[),.;:]+$/, '');
-    if (value && !value.split('/').includes('..')) paths.push(value);
-  }
-  return uniqueSorted(paths);
-}
-
-function pathIntent(text: string): PathIntent {
-  if (ANCHOR_CLAUSE_PATTERN.test(text)) return 'existing';
-  if (CREATE_PATH_PATTERN.test(text)) return 'create';
-  return 'reference';
-}
-
-function pathIntentRegions(clause: string): Array<{ text: string; intent: PathIntent }> {
-  const boundaries = new Set<number>([0, clause.length]);
-  for (let index = 0; index < clause.length; index += 1) {
-    if (clause[index] === ';') boundaries.add(index + 1);
-  }
-  for (const match of clause.matchAll(PATH_INTENT_MARKER_PATTERN)) {
-    const markerIndex = match.index;
-    if (markerIndex === 0) continue;
-    let cursor = markerIndex - 1;
-    while (cursor >= 0 && /\s/.test(clause[cursor]!)) cursor -= 1;
-    if (clause[cursor] === ',') {
-      boundaries.add(markerIndex);
-      continue;
-    }
-    const precedingWordEnd = cursor + 1;
-    while (cursor >= 0 && /[A-Za-z]/.test(clause[cursor]!)) cursor -= 1;
-    const precedingWord = clause.slice(cursor + 1, precedingWordEnd).toLowerCase();
-    if (precedingWord === 'and' || precedingWord === 'but') boundaries.add(markerIndex);
-  }
-  const sortedBoundaries = [...boundaries].sort((left, right) => left - right);
-  const regions: Array<{ text: string; intent: PathIntent }> = [];
-  for (let index = 1; index < sortedBoundaries.length; index += 1) {
-    const text = clause.slice(sortedBoundaries[index - 1], sortedBoundaries[index]).trim();
-    if (text) regions.push({ text, intent: pathIntent(text) });
-  }
-  return regions;
-}
-
-export function parseTaskFreshnessSpecification(text: string): TaskFreshnessSpecification {
-  const referencedPaths = normalizedRepoPaths(text);
-  const guardedBehaviorIds = uniqueSorted([
-    ...[...text.matchAll(GUARDED_MARKER_PATTERN)].map(match => match[1]!),
-    ...[...text.matchAll(GUARDED_PROSE_PATTERN)].map(match => match[1]!),
-  ]);
-  const anchors: TaskFreshnessAnchor[] = [];
-
-  for (const rawClause of text.split(SENTENCE_BOUNDARY_PATTERN)) {
-    const clause = rawClause.trim();
-    if (!clause) continue;
-    const paths = normalizedRepoPaths(clause);
-    for (const region of pathIntentRegions(clause)) {
-      if (region.intent !== 'existing') continue;
-      for (const value of normalizedRepoPaths(region.text)) {
-        anchors.push({ kind: 'path', value, clause });
-      }
-    }
-    if (!ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
-    for (const tokenMatch of clause.matchAll(BACKTICK_TOKEN_PATTERN)) {
-      const value = tokenMatch[1]?.trim();
-      if (!value || paths.includes(value) || !/^[A-Za-z_$][\w$]*$/.test(value)) continue;
-      anchors.push({ kind: 'symbol', value, clause });
-    }
-  }
-
-  const dedupedAnchors = new Map<string, TaskFreshnessAnchor>();
-  for (const anchor of anchors) dedupedAnchors.set(`${anchor.kind}:${anchor.value}`, anchor);
-
-  return {
-    referencedPaths,
-    guardedBehaviorIds,
-    anchors: [...dedupedAnchors.values()].sort((left, right) =>
-      `${left.kind}:${left.value}`.localeCompare(`${right.kind}:${right.value}`)),
-  };
-}
+const uniqueSorted = (values: Iterable<string>) => [...new Set(values)].sort();
+const staleMessage = (snapshot: string | undefined, current: string, details: string) =>
+  `Stale task specification blocked before agent execution (snapshot=${snapshot ?? 'none'}, current=${current}): ${details}. Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.`;
 
 export function evaluateTaskFreshness(args: {
-  snapshotCommit?: string;
-  currentCommit: string;
-  specification: TaskFreshnessSpecification;
-  changedPaths: string[];
-  changedGuardedBehaviorIds: string[];
-  missingAnchors: TaskFreshnessAnchor[];
+  snapshotCommit?: string; currentCommit: string; specification?: TaskFreshnessSpec;
+  changedPaths: string[]; changedGuardedBehaviorIds: string[]; missingPathPreconditions: string[];
 }): TaskFreshnessDecision {
-  const {
-    snapshotCommit,
-    currentCommit,
-    specification,
-    changedPaths,
-    changedGuardedBehaviorIds,
-    missingAnchors,
-  } = args;
-  const commitsDiffer = Boolean(snapshotCommit && snapshotCommit !== currentCommit);
-  const referencedPathSet = new Set(specification.referencedPaths);
-  const guardedIdSet = new Set(specification.guardedBehaviorIds);
-  const changedReferencedPaths = commitsDiffer
-    ? uniqueSorted(changedPaths.filter(path => referencedPathSet.has(path)))
-    : [];
-  const changedRelevantGuardIds = commitsDiffer
-    ? uniqueSorted(changedGuardedBehaviorIds.filter(id => guardedIdSet.has(id)))
-    : [];
-
-  if (
-    changedReferencedPaths.length === 0
-    && changedRelevantGuardIds.length === 0
-    && missingAnchors.length === 0
-  ) {
-    return { status: 'current' };
-  }
-
-  const mismatchDetails = [
-    changedReferencedPaths.length > 0
-      ? `changed referenced paths: ${changedReferencedPaths.join(', ')}`
-      : undefined,
-    changedRelevantGuardIds.length > 0
-      ? `changed guarded behaviors: ${changedRelevantGuardIds.join(', ')}`
-      : undefined,
-    missingAnchors.length > 0
-      ? `absent existing/do-not-create anchors: ${missingAnchors.map(anchor => `${anchor.kind}:${anchor.value}`).join(', ')}`
-      : undefined,
-  ].filter((value): value is string => Boolean(value));
-
-  return {
-    status: 'stale',
-    snapshotCommit,
-    currentCommit,
-    changedReferencedPaths,
-    changedGuardedBehaviorIds: changedRelevantGuardIds,
-    missingAnchors,
-    message:
-      `Stale task specification blocked before agent execution `
-      + `(snapshot=${snapshotCommit ?? 'none'}, current=${currentCommit}): ${mismatchDetails.join('; ')}. `
-      + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.',
-  };
+  const spec = args.specification;
+  if (!spec) return { status: 'current' };
+  const differs = Boolean(args.snapshotCommit && args.snapshotCommit !== args.currentCommit);
+  const changedReferencedPaths = differs ? uniqueSorted(args.changedPaths.filter(path => (spec.watchPaths ?? []).includes(path))) : [];
+  const changedGuardedBehaviorIds = differs ? uniqueSorted(args.changedGuardedBehaviorIds.filter(id => (spec.guardedBehaviorIds ?? []).includes(id))) : [];
+  const missingPathPreconditions = uniqueSorted(args.missingPathPreconditions);
+  if (!changedReferencedPaths.length && !changedGuardedBehaviorIds.length && !missingPathPreconditions.length) return { status: 'current' };
+  const details = [
+    changedReferencedPaths.length && `changed watched paths: ${changedReferencedPaths.join(', ')}`,
+    changedGuardedBehaviorIds.length && `changed guarded behaviors: ${changedGuardedBehaviorIds.join(', ')}`,
+    missingPathPreconditions.length && `path preconditions failed: ${missingPathPreconditions.join(', ')}`,
+  ].filter(Boolean).join('; ');
+  return { status: 'stale', snapshotCommit: args.snapshotCommit, currentCommit: args.currentCommit, changedReferencedPaths, changedGuardedBehaviorIds, missingPathPreconditions, message: staleMessage(args.snapshotCommit, args.currentCommit, details) };
 }
 
 export async function inspectTaskFreshness(args: {
-  cwd: string;
-  snapshotCommit?: string;
-  taskText: string;
-  runGit: (gitArgs: string[]) => Promise<string>;
-  pathExists?: (absolutePath: string) => Promise<boolean>;
-  symbolExists?: (symbol: string, commit: string) => Promise<boolean>;
+  cwd: string; snapshotCommit?: string; freshness?: TaskFreshnessSpec;
+  runGit: (gitArgs: string[]) => Promise<string>; pathExists?: (absolutePath: string) => Promise<boolean>;
 }): Promise<TaskFreshnessDecision> {
-  const specification = parseTaskFreshnessSpecification(args.taskText);
   const currentCommit = (await args.runGit(['rev-parse', 'HEAD'])).trim();
-  const commitsDiffer = Boolean(args.snapshotCommit && args.snapshotCommit !== currentCommit);
-  if (commitsDiffer) {
-    try {
-      await args.runGit(['cat-file', '-e', `${args.snapshotCommit!}^{commit}`]);
-    } catch {
-      return {
-        status: 'stale',
-        snapshotCommit: args.snapshotCommit,
-        currentCommit,
-        changedReferencedPaths: [],
-        changedGuardedBehaviorIds: [],
-        missingAnchors: [],
-        snapshotUnavailable: true,
-        message:
-          `Stale task specification blocked before agent execution `
-          + `(snapshot=${args.snapshotCommit}, current=${currentCommit}): snapshot commit is unavailable. `
-          + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.',
-      };
-    }
+  if (!args.freshness) return { status: 'current' };
+  const differs = Boolean(args.snapshotCommit && args.snapshotCommit !== currentCommit);
+  if (differs) {
+    try { await args.runGit(['cat-file', '-e', `${args.snapshotCommit!}^{commit}`]); }
+    catch { return { status: 'stale', snapshotCommit: args.snapshotCommit, currentCommit, changedReferencedPaths: [], changedGuardedBehaviorIds: [], missingPathPreconditions: [], snapshotUnavailable: true, message: staleMessage(args.snapshotCommit, currentCommit, 'snapshot commit is unavailable') }; }
   }
-  const changedPaths = commitsDiffer
-    ? (await args.runGit(['diff', '--name-only', args.snapshotCommit!, currentCommit, '--']))
-      .split(/\r?\n/)
-      .map(path => path.trim())
-      .filter(Boolean)
-    : [];
-
+  const changedPaths = differs ? (await args.runGit(['diff', '--name-only', args.snapshotCommit!, currentCommit, '--'])).split(/\r?\n/).map(value => value.trim()).filter(Boolean) : [];
   const changedGuardedBehaviorIds: string[] = [];
-  if (commitsDiffer && specification.guardedBehaviorIds.length > 0 && changedPaths.length > 0) {
+  if (differs && (args.freshness.guardedBehaviorIds?.length ?? 0) && changedPaths.length) {
     const diff = await args.runGit(['diff', '--unified=0', args.snapshotCommit!, currentCommit, '--', ...changedPaths]);
-    for (const id of specification.guardedBehaviorIds) {
-      const marker = `guarded-behavior: ${id}`;
-      const ownerPaths = new Set<string>();
-      for (const commit of [args.snapshotCommit!, currentCommit]) {
-        try {
-          const matches = await args.runGit(['grep', '-l', '-F', '-e', marker, commit, '--']);
-          for (const rawPath of matches.split(/\r?\n/).map(value => value.trim()).filter(Boolean)) {
-            ownerPaths.add(rawPath.startsWith(`${commit}:`) ? rawPath.slice(commit.length + 1) : rawPath);
-          }
-        } catch {
-          continue;
-        }
-      }
-      if (diff.includes(marker) || changedPaths.some(path => ownerPaths.has(path))) {
-        changedGuardedBehaviorIds.push(id);
-      }
-    }
+    for (const id of args.freshness.guardedBehaviorIds ?? []) if (diff.includes(`guarded-behavior: ${id}`)) changedGuardedBehaviorIds.push(id);
   }
-
-  const pathExists = args.pathExists ?? (async (absolutePath: string) => {
-    try {
-      await access(absolutePath);
-      return true;
-    } catch {
-      return false;
-    }
-  });
-  const symbolExists = args.symbolExists ?? (async (symbol: string, commit: string) => {
-    try {
-      await args.runGit(['grep', '-F', '-e', symbol, commit, '--']);
-      return true;
-    } catch {
-      return false;
-    }
-  });
-  const missingAnchors: TaskFreshnessAnchor[] = [];
-  for (const anchor of specification.anchors) {
-    const exists = anchor.kind === 'path'
-      ? await pathExists(resolve(args.cwd, anchor.value))
-      : await symbolExists(anchor.value, currentCommit);
-    if (!exists) missingAnchors.push(anchor);
+  const pathExists = args.pathExists ?? (async (path: string) => { try { await access(path); return true; } catch { return false; } });
+  const missingPathPreconditions: string[] = [];
+  for (const precondition of args.freshness.pathPreconditions ?? []) {
+    const exists = await pathExists(resolve(args.cwd, precondition.path));
+    if ((precondition.expected === 'present' && !exists) || (precondition.expected === 'absent' && exists)) missingPathPreconditions.push(`${precondition.path} expected ${precondition.expected}`);
   }
-
-  return evaluateTaskFreshness({
-    snapshotCommit: args.snapshotCommit,
-    currentCommit,
-    specification,
-    changedPaths,
-    changedGuardedBehaviorIds,
-    missingAnchors,
-  });
+  return evaluateTaskFreshness({ snapshotCommit: args.snapshotCommit, currentCommit, specification: args.freshness, changedPaths, changedGuardedBehaviorIds, missingPathPreconditions });
 }
 
-export interface RemoteTaskFreshnessReport {
-  currentCommit: string;
-  reasons: string[];
-}
+const shellQuote = (value: string) => `'${value.replace(/'/g, `\'"'"'`)}'`;
+export interface RemoteTaskFreshnessReport { currentCommit: string; reasons: string[]; }
 
-export function buildRemoteTaskFreshnessScript(args: {
-  cwd: string;
-  snapshotCommit?: string;
-  taskText: string;
-}): string {
-  const specification = parseTaskFreshnessSpecification(args.taskText);
-  const lines = [
-    'set -euo pipefail',
-    buildRemotePathNormalizeFunction(),
-    `CWD=$(normalize_remote_path ${shellQuote(args.cwd)})`,
-    'cd "$CWD"',
-    'CURRENT_COMMIT=$(git rev-parse HEAD)',
-    'STALE_REASONS=""',
-    'append_stale_reason() {',
-    '  if [[ -n "$STALE_REASONS" ]]; then STALE_REASONS="$STALE_REASONS|$1"; else STALE_REASONS=$1; fi',
-    '}',
-  ];
-
-  for (const anchor of specification.anchors) {
-    if (anchor.kind === 'path') {
-      lines.push(
-        `if [[ ! -e ${shellQuote(anchor.value)} ]]; then append_stale_reason ${shellQuote(`anchor:path:${anchor.value}`)}; fi`,
-      );
-    } else {
-      lines.push(
-        `if ! git grep -F -q -e ${shellQuote(anchor.value)} "$CURRENT_COMMIT" --; then append_stale_reason ${shellQuote(`anchor:symbol:${anchor.value}`)}; fi`,
-      );
-    }
-  }
-
+export function buildRemoteTaskFreshnessScript(args: { cwd: string; snapshotCommit?: string; freshness?: TaskFreshnessSpec }): string {
+  const spec = args.freshness;
+  if (!spec) return ': # no typed freshness metadata\n';
+  const lines = ['set -euo pipefail', buildRemotePathNormalizeFunction(), `CWD=$(normalize_remote_path ${shellQuote(args.cwd)})`, 'cd "$CWD"', 'CURRENT_COMMIT=$(git rev-parse HEAD)', 'STALE_REASONS=""', 'append_stale_reason() { if [[ -n "$STALE_REASONS" ]]; then STALE_REASONS="$STALE_REASONS|$1"; else STALE_REASONS=$1; fi; }'];
+  for (const p of spec.pathPreconditions ?? []) { const test = p.expected === 'present' ? '-e' : '! -e'; lines.push(`if [[ ${test} ${shellQuote(p.path)} ]]; then :; else append_stale_reason ${shellQuote(`path:${p.path}:expected-${p.expected}`)}; fi`); }
   if (args.snapshotCommit) {
-    lines.push(
-      `SNAPSHOT_COMMIT=${shellQuote(args.snapshotCommit)}`,
-      'if [[ "$SNAPSHOT_COMMIT" != "$CURRENT_COMMIT" ]]; then',
-      '  if ! git cat-file -e "$SNAPSHOT_COMMIT^{commit}" 2>/dev/null; then',
-      "    append_stale_reason 'snapshot-unavailable'",
-      '  else',
-      '    CHANGED_PATHS=$(git diff --name-only "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)',
-    );
-    for (const path of specification.referencedPaths) {
-      lines.push(
-        `    if printf '%s\n' "$CHANGED_PATHS" | grep -F -x -q -- ${shellQuote(path)}; then append_stale_reason ${shellQuote(`path:${path}`)}; fi`,
-      );
-    }
-    if (specification.guardedBehaviorIds.length > 0) {
-      lines.push('    GUARDED_DIFF=$(git diff --unified=0 "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)');
-      for (const id of specification.guardedBehaviorIds) {
-        lines.push(
-          `    if printf '%s\n' "$GUARDED_DIFF" | grep -F -q -- ${shellQuote(`guarded-behavior: ${id}`)}; then append_stale_reason ${shellQuote(`guard:${id}`)}; fi`,
-        );
-      }
-    }
+    lines.push(`SNAPSHOT_COMMIT=${shellQuote(args.snapshotCommit)}`, 'if [[ "$SNAPSHOT_COMMIT" != "$CURRENT_COMMIT" ]]; then', '  if ! git cat-file -e "$SNAPSHOT_COMMIT^{commit}" 2>/dev/null; then append_stale_reason snapshot-unavailable; else', '    CHANGED_PATHS=$(git diff --name-only "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)');
+    for (const path of spec.watchPaths ?? []) lines.push(`    if printf '%s\\n' "$CHANGED_PATHS" | grep -F -x -q -- ${shellQuote(path)}; then append_stale_reason ${shellQuote(`path:${path}`)}; fi`);
+    if (spec.guardedBehaviorIds?.length) { lines.push('    GUARDED_DIFF=$(git diff --unified=0 "$SNAPSHOT_COMMIT" "$CURRENT_COMMIT" --)'); for (const id of spec.guardedBehaviorIds) lines.push(`    if printf '%s\\n' "$GUARDED_DIFF" | grep -F -q -- ${shellQuote(`guarded-behavior: ${id}`)}; then append_stale_reason ${shellQuote(`guard:${id}`)}; fi`); }
     lines.push('  fi', 'fi');
   }
-
-  lines.push(
-    'if [[ -n "$STALE_REASONS" ]]; then',
-    `  printf '%s\\t%s\\t%s\\n' ${shellQuote(REMOTE_REPORT_MARKER)} "$CURRENT_COMMIT" "$STALE_REASONS"`,
-    'fi',
-  );
+  lines.push('if [[ -n "$STALE_REASONS" ]]; then', `  printf '%s\\t%s\\t%s\\n' ${shellQuote(REMOTE_REPORT_MARKER)} "$CURRENT_COMMIT" "$STALE_REASONS"`, 'fi');
   return `${lines.join('\n')}\n`;
 }
 
 export function parseRemoteTaskFreshnessReport(output: string): RemoteTaskFreshnessReport | undefined {
-  const prefix = `${REMOTE_REPORT_MARKER}\t`;
-  const line = output.split(/\r?\n/).find(value => value.startsWith(prefix));
+  const line = output.split(/\r?\n/).find(value => value.startsWith(`${REMOTE_REPORT_MARKER}\t`));
   if (!line) return undefined;
-  const [, currentCommit = '', rawReasons = ''] = line.split('\t');
-  const reasons = rawReasons.split('|').map(value => value.trim()).filter(Boolean);
-  if (!currentCommit || reasons.length === 0) return undefined;
-  return { currentCommit, reasons };
+  const [, currentCommit = '', rawReasons = ''] = line.split('\t'); const reasons = rawReasons.split('|').filter(Boolean);
+  return currentCommit && reasons.length ? { currentCommit, reasons } : undefined;
 }
-
-export function formatRemoteTaskFreshnessMessage(
-  snapshotCommit: string | undefined,
-  report: RemoteTaskFreshnessReport,
-): string {
-  return `Stale task specification blocked before agent execution `
-    + `(snapshot=${snapshotCommit ?? 'none'}, current=${report.currentCommit}): ${report.reasons.join(', ')}. `
-    + 'Required action: replan/recreate from current repository state; do not reconstruct an absent baseline.';
-}
+export const formatRemoteTaskFreshnessMessage = (snapshot: string | undefined, report: RemoteTaskFreshnessReport) => staleMessage(snapshot, report.currentCommit, report.reasons.join(', '));

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -435,13 +435,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     }
 
     if (request.actionType === 'ai_task') {
-      const taskText = [request.inputs.description, request.inputs.prompt]
-        .filter((value): value is string => Boolean(value?.trim()))
-        .join('\n');
       const freshness = await inspectTaskFreshness({
         cwd: acquired.worktreePath,
         snapshotCommit: request.inputs.specificationSnapshotCommit,
-        taskText,
+        freshness: request.inputs.freshness,
         runGit: args => this.execGitSimple(args, acquired.worktreePath),
       });
       if (freshness.status === 'stale') {
@@ -475,7 +472,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
             requestId: request.requestId,
             actionId: request.actionId,
             executionGeneration: request.executionGeneration,
-            status: 'needs_input',
+            status: 'stale',
             outputs: {
               exitCode: 1,
               error: freshness.message,

--- a/packages/workflow-core/src/attempt-policy.ts
+++ b/packages/workflow-core/src/attempt-policy.ts
@@ -14,6 +14,7 @@ export const DISCARDED_ATTEMPT_STATUSES: readonly AttemptStatus[] = [
 export const OUTCOME_TERMINAL_ATTEMPT_STATUSES: readonly AttemptStatus[] = [
   'completed',
   'failed',
+  'stale',
 ];
 
 export function isActiveAttemptStatus(status: AttemptStatus | undefined): boolean {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -102,6 +102,7 @@ import {
   handleReviewReadyImpl,
   handleFailedImpl,
   handleNeedsInputImpl,
+  handleStaleImpl,
   handleSpawnExperimentsImpl,
   handleSelectExperimentImpl,
   checkExperimentCompletionImpl,
@@ -1809,6 +1810,8 @@ export class Orchestrator {
         return this.handleFailed(canonicalTaskId, parsed);
       case 'needs_input':
         return this.handleNeedsInput(canonicalTaskId, parsed);
+      case 'stale':
+        return this.handleStale(canonicalTaskId, parsed);
       case 'spawn_experiments':
         return this.handleSpawnExperiments(canonicalTaskId, parsed);
       case 'select_experiment':
@@ -3901,6 +3904,13 @@ export class Orchestrator {
     parsed: Extract<ParsedResponse, { type: 'needs_input' }>,
   ): TaskState[] {
     return handleNeedsInputImpl(this as unknown as TransitionHost, taskId, parsed);
+  }
+
+  private handleStale(
+    taskId: string,
+    parsed: Extract<ParsedResponse, { type: 'stale' }>,
+  ): TaskState[] {
+    return handleStaleImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   private handleSpawnExperiments(

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -340,6 +340,22 @@ export function handleNeedsInputImpl(
   return [];
 }
 
+export function handleStaleImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'stale' }>,
+): TaskState[] {
+  const changes: TaskStateChanges = { status: 'stale', execution: { exitCode: parsed.exitCode, error: parsed.error } };
+  const before = host.stateGetTask(taskId)!;
+  const updated = host.writeAndSync(taskId, changes);
+  const attemptId = updated.execution.selectedAttemptId;
+  if (attemptId) host.taskRepository.updateAttempt(attemptId, { status: 'stale', error: parsed.error });
+  const delta = host.buildUpdateDelta(before, updated, changes);
+  host.persistence.logEvent?.(taskId, 'task.stale', changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+  return host.autoStartUnblockedTasks();
+}
+
 function resolveSpawnPivotSourceChanges(
   parentTask: TaskState | undefined,
   host: TransitionHost,

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -71,6 +71,13 @@ export type ParsedResponse =
       prompt: string;
     }
   | {
+      type: 'stale';
+      taskId: string;
+      exitCode: number;
+      error?: string;
+      summary?: string;
+    }
+  | {
       type: 'spawn_experiments';
       taskId: string;
       variants: ParsedVariantDef[];
@@ -143,6 +150,15 @@ export class ResponseHandler {
           type: 'needs_input',
           taskId: actionId,
           prompt: outputs.summary ?? 'Task requires input',
+        };
+
+      case 'stale':
+        return {
+          type: 'stale',
+          taskId: actionId,
+          exitCode: outputs.exitCode ?? 1,
+          error: outputs.error,
+          summary: outputs.summary,
         };
 
       case 'spawn_experiments': {

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -367,6 +367,7 @@ export type AttemptStatus =
   | 'completed'
   | 'failed'
   | 'needs_input'
+  | 'stale'
   | 'superseded';
 
 // ── Attempt (immutable execution record) ────────────────────

--- a/packages/workflow-graph/src/validity.ts
+++ b/packages/workflow-graph/src/validity.ts
@@ -107,6 +107,7 @@ export function deriveNodeStatus(
     case 'completed': return 'completed';
     case 'failed': return 'failed';
     case 'needs_input': return 'needs_input';
+    case 'stale': return 'stale';
     case 'superseded': return 'stale';
     default: return node.status;
   }


### PR DESCRIPTION
## Summary

Consume structured freshness data in local and SSH execution paths.

Deterministic mismatches now use the existing terminal task state instead of requesting human input.

An attempt that ends in a freshness mismatch is recorded with its own terminal attempt status, alongside completed and failed.

## Review Claim

Approve identical local and SSH runtime decisions from structured task data and repository facts.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Missing typed metadata is non-blocking, prompt wording is never inspected, and local and SSH decisions match for the same facts.

## Slice Rationale

Execution consumption and completion mapping form one runtime control-flow claim after the prerequisite slice.

## Non-goals

No planner prompt changes, no new natural-language parser, and no unrelated status refactor.

## Test Plan

<details>
<summary>Test Plan</summary>

- Focused executor and response-handler tests in the dependent slice.
- Local and SSH parity coverage for typed freshness decisions.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <routing-commit-sha>`
- Post-revert steps: Re-run focused executor tests.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task lifecycle routing and preflight gating for AI tasks, but behavior is deterministic, local/SSH-aligned, and only applies when typed freshness metadata is present.
> 
> **Overview**
> **Task freshness preflight now consumes structured `TaskFreshnessSpec` on work requests** (`watchPaths`, `guardedBehaviorIds`, `pathPreconditions`) instead of parsing description/prompt text. Missing metadata skips the check; local `inspectTaskFreshness` and SSH remote scripts share the same rules.
> 
> When preflight fails, **worktree and SSH executors complete with `stale` rather than `needs_input`**, before the agent runs. The response handler and orchestrator add a **`stale` transition** that marks the task and selected attempt terminal, logs `task.stale`, and unblocks downstream work like other outcomes.
> 
> Supporting updates: **`stale` as an attempt status** in workflow-graph, outcome-terminal attempt policy, sync merge ranking, action-graph diagnostics (stale attempts shown as cancelled), and validity mapping from attempt to task status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e67d9c1c0d1d6442ee5fb2d2e5fba12d145022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->