### PR TITLE
Align workflow mutation queue timestamps

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3573,11 +3573,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     args: unknown[],
     priority: WorkflowMutationPriority,
   ): number {
+    const createdAt = new Date().toISOString();
     this.execRun(
       `INSERT INTO workflow_mutation_intents (
-        workflow_id, channel, args_json, priority, status
-      ) VALUES (?, ?, ?, ?, 'queued')`,
-      [workflowId, channel, JSON.stringify(args), priority],
+        workflow_id, channel, args_json, priority, status, created_at
+      ) VALUES (?, ?, ?, ?, 'queued', ?)`,
+      [workflowId, channel, JSON.stringify(args), priority, createdAt],
     );
     const row = this.queryOne('SELECT MAX(id) AS id FROM workflow_mutation_intents');
     return Number(row?.id ?? 0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field insert change in the SQLite adapter with no API or queue semantics changes.
> 
> **Overview**
> **`enqueueWorkflowMutationIntent`** now writes **`created_at`** at insert time using **`new Date().toISOString()`**, instead of leaving the column to the SQLite default.
> 
> That aligns new queued intents with the ISO timestamps already used when intents are claimed, completed, failed, or evicted, so **`WorkflowMutationIntent.createdAt`** is consistent for ordering and observability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdb19c8245bd484e16133607f08a6f908d893fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->