### PR TITLE
Align workflow mutation queue timestamps

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3573,11 +3573,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     args: unknown[],
     priority: WorkflowMutationPriority,
   ): number {
+    const createdAt = new Date().toISOString();
     this.execRun(
       `INSERT INTO workflow_mutation_intents (
-        workflow_id, channel, args_json, priority, status
-      ) VALUES (?, ?, ?, ?, 'queued')`,
-      [workflowId, channel, JSON.stringify(args), priority],
+        workflow_id, channel, args_json, priority, status, created_at
+      ) VALUES (?, ?, ?, ?, 'queued', ?)`,
+      [workflowId, channel, JSON.stringify(args), priority, createdAt],
     );
     const row = this.queryOne('SELECT MAX(id) AS id FROM workflow_mutation_intents');
     return Number(row?.id ?? 0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single insert-path change in the SQLite adapter with no API surface change; main effect is consistent timestamp format for mutation intents.
> 
> **Overview**
> **`enqueueWorkflowMutationIntent`** now writes **`created_at`** explicitly as a JavaScript ISO timestamp (`new Date().toISOString()`) on insert, instead of relying on the table default `datetime('now')`.
> 
> That aligns enqueue time with the other workflow mutation queue fields already set in application code (e.g. `started_at`, `completed_at`, eviction `completed_at`), avoiding mixed SQLite space-format vs ISO strings on the same queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a118d3f4b6dd041061e3b3db89cb44902b6c199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->