### PR TITLE
[Workflow drain evaluation](1) Align workflow mutation queue timestamps

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3573,11 +3573,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     args: unknown[],
     priority: WorkflowMutationPriority,
   ): number {
+    const createdAt = new Date().toISOString();
     this.execRun(
       `INSERT INTO workflow_mutation_intents (
-        workflow_id, channel, args_json, priority, status
-      ) VALUES (?, ?, ?, ?, 'queued')`,
-      [workflowId, channel, JSON.stringify(args), priority],
+        workflow_id, channel, args_json, priority, status, created_at
+      ) VALUES (?, ?, ?, ?, 'queued', ?)`,
+      [workflowId, channel, JSON.stringify(args), priority, createdAt],
     );
     const row = this.queryOne('SELECT MAX(id) AS id FROM workflow_mutation_intents');
     return Number(row?.id ?? 0);


### PR DESCRIPTION
## Summary

Writes workflow mutation intent creation timestamps with millisecond precision to match persisted start timestamps.

This makes queue wait measurements represent actual time spent waiting instead of SQLite second-boundary artifacts.

## Review Claim

Workflow mutation queue latency can be measured accurately from persisted timestamps.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Only the timestamp representation changes; intent ordering, status transitions, leasing, and handler execution remain unchanged.

## Slice Rationale

This is the foundation slice for the follow-up CI evaluation, which depends on trustworthy persisted queue timings.

## Non-goals

- No concurrency cap or scheduler policy changes.
- No production database migration.
- No live DigitalOcean deployment.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts -t 'workflow mutation' --reporter=verbose`
- [x] `pnpm --filter @invoker/app build`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f36239e01a`
- Post-revert steps: None
- Data migration? No

</details>