### PR TITLE
[Required executor pool (2)](5) Persisted invariant

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher-bad-poolmember-crash-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher-bad-poolmember-crash-repro.test.ts
@@ -30,6 +30,7 @@ describe('LaunchDispatcher + real TaskRunner: bad poolMemberId does not crash th
       persistence: persistence as any,
       messageBus: new InMemoryBus(),
       maxConcurrency: 4,
+      availablePoolIds: ['mixed-local-ssh'],
     });
 
     orchestrator.loadPlan({

--- a/packages/app/src/__tests__/rebase-and-retry.test.ts
+++ b/packages/app/src/__tests__/rebase-and-retry.test.ts
@@ -17,7 +17,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import type { WorkResponse } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import { TaskRunner, ExecutorRegistry, WorktreeExecutor } from '@invoker/execution-engine';
 import { rebaseRecreate } from '../workflow-actions.js';
 
@@ -77,9 +77,9 @@ function makeTaskState(overrides: {
     status: overrides.status ?? 'pending',
     dependencies: overrides.dependencies ?? [],
     createdAt: new Date(),
-    config: { ...overrides.config },
+    config: resolveTaskConfig(overrides.config ?? {}),
     execution: { ...overrides.execution },
-  } as TaskState;
+  };
 }
 
 describe('rebase-recreate: pool mirror cleanup before restart', { timeout: 120_000 }, () => {

--- a/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
+++ b/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
@@ -91,7 +91,7 @@ describe('spawnReviewGateCiRepairWorkflow', () => {
   let h: TestHarness;
 
   beforeEach(() => {
-    h = createTestHarness();
+    h = createTestHarness({ availablePoolIds: ['remote_digital_ocean_1'] });
   });
 
   it('spawns one repair workflow and leaves the source merge gate untouched', async () => {
@@ -168,7 +168,7 @@ describe('spawnReviewGateCiRepairWorkflow', () => {
   });
 
   it('throws explicit branch and base-branch errors', async () => {
-    const branchHarness = createTestHarness();
+    const branchHarness = createTestHarness({ availablePoolIds: ['remote_digital_ocean_1'] });
     const noBranchPlan: PlanDefinition = {
       ...SOURCE_PLAN,
       featureBranch: undefined,
@@ -209,7 +209,7 @@ describe('spawnReviewGateCiRepairWorkflow', () => {
       logger,
     })).rejects.toThrow('Review-gate CI repair requires a branch to checkout.');
 
-    const baseHarness = createTestHarness();
+    const baseHarness = createTestHarness({ availablePoolIds: ['remote_digital_ocean_1'] });
     const noBasePlan: PlanDefinition = {
       ...SOURCE_PLAN,
       baseBranch: undefined,

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -1,5 +1,5 @@
 import type { SQLiteAdapter, Workflow, WorkerActionWrite } from '@invoker/data-store';
-import type { TaskState } from '@invoker/workflow-core';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, type TaskState } from '@invoker/workflow-core';
 import { ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS, PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS } from './worker-control.js';
 import {
   buildRecoveryWorkerAuditPayload,
@@ -52,7 +52,7 @@ function makeTask(id: string, status: TaskState['status']): TaskState {
     status,
     dependencies: [],
     createdAt: new Date('2026-07-01T00:00:00.000Z'),
-    config: {},
+    config: { runnerKind: 'worktree', poolId: BUILT_IN_LOCAL_EXECUTION_POOL_ID },
     execution: status === 'completed'
       ? { exitCode: 0, completedAt: new Date('2026-07-01T00:00:01.000Z') }
       : {},

--- a/packages/data-store/src/__tests__/event-type-counters.test.ts
+++ b/packages/data-store/src/__tests__/event-type-counters.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { DatabaseSync } from 'node:sqlite';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { resolveTaskConfig } from '@invoker/workflow-core';
 import type { Workflow } from '../adapter.js';
 
 // event_type_counters makes countEventsByTypes O(types) instead of a linear
@@ -27,7 +28,7 @@ function makeTask(id: string) {
     status: 'pending' as const,
     dependencies: [],
     createdAt: new Date(),
-    config: { workflowId: 'wf', command: 'echo test' },
+    config: resolveTaskConfig({ workflowId: 'wf', command: 'echo test' }),
     execution: {},
   };
 }

--- a/packages/data-store/src/__tests__/find-review-gate-by-pr.test.ts
+++ b/packages/data-store/src/__tests__/find-review-gate-by-pr.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 
 /**
  * findReviewGateByPr maps a published GitHub PR back to its Invoker workflow via
@@ -43,7 +43,7 @@ describe('SQLiteAdapter.findReviewGateByPr', () => {
       status: overrides.status ?? 'completed',
       dependencies: [],
       createdAt: new Date(),
-      config: { workflowId, isMergeNode: true },
+      config: resolveTaskConfig({ workflowId, isMergeNode: true }),
       execution: {
         reviewId: overrides.reviewId,
         reviewUrl: overrides.reviewUrl,
@@ -96,7 +96,7 @@ describe('SQLiteAdapter.findReviewGateByPr', () => {
     adapter.saveWorkflow(makeWorkflow('wf-nonmerge'));
     const task = makeMergeTask('wf-nonmerge', { reviewId: '555' });
     task.id = 'task-regular';
-    task.config = { workflowId: 'wf-nonmerge', isMergeNode: false };
+    task.config = resolveTaskConfig({ workflowId: 'wf-nonmerge', isMergeNode: false });
     adapter.saveTask('wf-nonmerge', task);
 
     expect(adapter.findReviewGateByPr('555')).toBeUndefined();

--- a/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
+++ b/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 
 const RECOVERY_TYPES = [
   'recovery.worker.wakeup',
@@ -41,7 +41,7 @@ function makeTask(id: string): TaskState {
     status: 'pending',
     dependencies: [],
     createdAt: new Date('2026-07-01T00:00:00.000Z'),
-    config: {},
+    config: resolveTaskConfig(),
     execution: {},
     taskStateVersion: 1,
   };

--- a/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
+++ b/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 
 describe('migrateGatePolicyApprovedToCompleted', () => {
   let tmpDir: string;
@@ -34,7 +34,7 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
       status: 'pending',
       dependencies: [],
       createdAt: new Date(),
-      config: {},
+      config: resolveTaskConfig(),
       execution: {},
       taskStateVersion: 1,
       ...overrides,

--- a/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
+++ b/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
@@ -8,7 +8,7 @@
  * Or: bash scripts/repro-task-db-state.sh
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { Orchestrator } from '@invoker/workflow-core';
+import { Orchestrator, resolveTaskConfig } from '@invoker/workflow-core';
 import type { OrchestratorMessageBus, TaskState } from '@invoker/workflow-core';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
@@ -51,7 +51,7 @@ describe('Orchestrator + SQLite worker response persistence', () => {
       status: 'pending',
       dependencies: [],
       createdAt: new Date(),
-      config: { workflowId: wf.id, command: 'true' },
+      config: resolveTaskConfig({ workflowId: wf.id, command: 'true' }),
       execution: {},
     };
   }
@@ -225,7 +225,7 @@ describe('Protocol failure persistence (SQLite roundtrip)', () => {
       status: 'pending',
       dependencies: [],
       createdAt: new Date(),
-      config: { workflowId: wf.id, command: 'true' },
+      config: resolveTaskConfig({ workflowId: wf.id, command: 'true' }),
       execution: {},
     };
   }

--- a/packages/data-store/src/__tests__/owner-boundary.test.ts
+++ b/packages/data-store/src/__tests__/owner-boundary.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
+import { resolveTaskConfig } from '@invoker/workflow-core';
 
 /**
  * Regression tests for owner-boundary enforcement.
@@ -239,7 +240,7 @@ describe('owner boundary enforcement', () => {
         status: 'pending' as const,
         dependencies: [],
         createdAt: new Date(),
-        config: { workflowId: 'wf-boundary-test', command: 'echo test' },
+        config: resolveTaskConfig({ workflowId: 'wf-boundary-test', command: 'echo test' }),
         execution: {},
       };
 
@@ -272,7 +273,7 @@ describe('owner boundary enforcement', () => {
         status: 'pending' as const,
         dependencies: [],
         createdAt: new Date(),
-        config: { workflowId: 'wf-boundary-test', command: 'echo test' },
+        config: resolveTaskConfig({ workflowId: 'wf-boundary-test', command: 'echo test' }),
         execution: {},
       };
       owner.saveTask('wf-boundary-test', testTask);

--- a/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
+++ b/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { resolveTaskConfig } from '@invoker/workflow-core';
 import { SQLITE_MAX_VARIABLE_NUMBER } from '../sqlite-workflow-repository.js';
 
 const WORKFLOW_COUNT_ABOVE_LIMIT = SQLITE_MAX_VARIABLE_NUMBER + 100;
@@ -38,7 +39,7 @@ describe('SQL variables limit (ui-read-scale)', () => {
           status: 'pending',
           dependencies: [],
           createdAt: new Date(),
-          config: { workflowId: `wf-${i}` },
+          config: resolveTaskConfig({ workflowId: `wf-${i}` }),
           execution: {},
           taskStateVersion: 1,
         });

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter, isLaunchDispatchCandidateStale, runWithFreedStatement, assertOwnerCapabilityForWritableOpen } from '../sqlite-adapter.js';
 import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord, InAppPlanningSessionRecord } from '../adapter.js';
-import { createAttempt, assertWorkflowConsistent, assertWorkflowPatchConsistent } from '@invoker/workflow-core';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, createAttempt, resolveTaskConfig, assertWorkflowConsistent, assertWorkflowPatchConsistent } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 describe('SQLiteAdapter', () => {
@@ -27,16 +27,17 @@ describe('SQLiteAdapter', () => {
   };
 
   function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
+    const { config, ...taskOverrides } = overrides;
     return {
       id,
       description: `Task ${id}`,
       status: 'pending',
       dependencies: [],
       createdAt: new Date(),
-      config: {},
+      config: resolveTaskConfig(config ?? {}),
       execution: {},
       taskStateVersion: 1,
-      ...overrides,
+      ...taskOverrides,
     };
   }
 
@@ -866,7 +867,7 @@ describe('SQLiteAdapter', () => {
     it('persists poolMemberId through updateTask and getPoolMemberId', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('ssh-task', {
-        config: { runnerKind: 'ssh' },
+        config: { runnerKind: 'ssh', poolId: 'ssh-pool' },
       }));
 
       adapter.updateTask('ssh-task', {
@@ -1027,6 +1028,76 @@ describe('SQLiteAdapter', () => {
 
         const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
         expect(tableColumns(reopened, 'tasks')).toContain('freshness');
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects direct SQL writes that violate resolved executor routing', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const db = (adapter as any).db;
+
+      expect(() => db.run(
+        `INSERT INTO tasks (id, workflow_id, description, runner_kind, pool_id)
+         VALUES ('bad-pooled-insert', 'wf-1', 'missing pool', 'worktree', NULL)`,
+      )).toThrow('tasks executor routing invariant violated');
+      expect(() => db.run(
+        `INSERT INTO tasks (id, workflow_id, description, runner_kind, pool_id)
+         VALUES ('bad-docker-insert', 'wf-1', 'docker with pool', 'docker', 'local-worktree')`,
+      )).toThrow('tasks executor routing invariant violated');
+      expect(() => db.run(
+        `INSERT INTO tasks (id, workflow_id, description, runner_kind, pool_id)
+         VALUES ('bad-null-kind-insert', 'wf-1', 'no runner kind', NULL, 'local-worktree')`,
+      )).toThrow('tasks executor routing invariant violated');
+
+      adapter.saveTask('wf-1', makeTask('valid-task'));
+      expect(() => db.run(
+        `UPDATE tasks SET pool_id = NULL WHERE id = 'valid-task'`,
+      )).toThrow('tasks executor routing invariant violated');
+    });
+
+    it('backfills compatible legacy ordinary rows without changing lifecycle data', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-pool-invariant-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const legacy = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        legacy.saveWorkflow(testWorkflow);
+        (legacy as any).db.run('DROP TRIGGER trg_tasks_executor_routing_insert');
+        (legacy as any).db.run('DROP TRIGGER trg_tasks_executor_routing_update');
+        (legacy as any).db.run(
+          `INSERT INTO tasks (
+             id, workflow_id, description, status, blocked_by, dependencies,
+             command, runner_kind, pool_id, started_at, last_heartbeat_at,
+             execution_generation, task_state_version
+           ) VALUES (
+             'legacy-task', 'wf-1', 'Legacy ordinary task', 'running', 'upstream', '["dep-a"]',
+             'echo legacy', 'worktree', NULL, '2026-08-01T01:02:03.000Z',
+             '2026-08-01T01:02:04.000Z', 7, 11
+           )`,
+        );
+        (legacy as any).dirty = true;
+        legacy.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        const task = reopened.loadTask('legacy-task');
+        expect(task).toMatchObject({
+          status: 'running',
+          dependencies: ['dep-a'],
+          config: {
+            runnerKind: 'worktree',
+            poolId: BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+            command: 'echo legacy',
+          },
+          execution: {
+            blockedBy: 'upstream',
+            generation: 7,
+            startedAt: new Date('2026-08-01T01:02:03.000Z'),
+            lastHeartbeatAt: new Date('2026-08-01T01:02:04.000Z'),
+          },
+          taskStateVersion: 11,
+        });
         reopened.close();
       } finally {
         rmSync(dir, { recursive: true, force: true });
@@ -3433,14 +3504,17 @@ describe('SQLiteAdapter', () => {
   });
 
   describe('saveTask null defaults', () => {
-    it('stores SQL NULL (not string literals) for missing optional fields', () => {
+    it('stores the resolved built-in pool while leaving runtime fields SQL NULL', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1'));
 
       const loaded = adapter.loadTasks('wf-1');
       const task = loaded[0];
 
-      expect(task.config.runnerKind).toBeUndefined();
+      expect(task.config).toMatchObject({
+        runnerKind: 'worktree',
+        poolId: BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+      });
       expect(task.execution.agentSessionId).toBeUndefined();
       expect(task.execution.workspacePath).toBeUndefined();
       expect(task.execution.containerId).toBeUndefined();
@@ -4887,7 +4961,7 @@ describe('SQLiteAdapter', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('ssh-old', {
         status: 'completed',
-        config: { runnerKind: 'ssh' },
+        config: { runnerKind: 'ssh', poolId: 'ssh-pool' },
         execution: { workspacePath: '~/.invoker/worktrees/ssh-old', branch: 'experiment/ssh-old' },
       }));
       adapter.logEvent('ssh-old', 'task.executor.selected', { runnerKind: 'ssh', poolMemberId: 'remote-old' });
@@ -4903,9 +4977,9 @@ describe('SQLiteAdapter', () => {
 
     it('does not repair missing SSH pool member ids from malformed or empty event payloads', () => {
       adapter.saveWorkflow(testWorkflow);
-      adapter.saveTask('wf-1', makeTask('ssh-empty', { config: { runnerKind: 'ssh' } }));
+      adapter.saveTask('wf-1', makeTask('ssh-empty', { config: { runnerKind: 'ssh', poolId: 'ssh-pool' } }));
       adapter.logEvent('ssh-empty', 'task.executor.selected', { runnerKind: 'ssh', poolMemberId: '  ' });
-      adapter.saveTask('wf-1', makeTask('ssh-bad', { config: { runnerKind: 'ssh' } }));
+      adapter.saveTask('wf-1', makeTask('ssh-bad', { config: { runnerKind: 'ssh', poolId: 'ssh-pool' } }));
       (adapter as any).db.run(
         `INSERT INTO events (task_id, event_type, payload) VALUES ('ssh-bad', 'task.executor.selected', '{')`,
       );

--- a/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+++ b/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 
 const WORKFLOW_ID = 'wf-stale-downstream-dispatch';
 const UPSTREAM_ID = `${WORKFLOW_ID}/verify`;
@@ -38,10 +38,10 @@ function makeTask(
     createdAt: new Date('2026-06-03T00:00:00.000Z'),
     taskStateVersion: 1,
     ...rest,
-    config: {
+    config: resolveTaskConfig({
       workflowId: WORKFLOW_ID,
       ...overrideConfig,
-    },
+    }),
     execution: {
       ...overrideExecution,
     },

--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createAttempt } from '@invoker/workflow-core';
+import { createAttempt, resolveTaskConfig } from '@invoker/workflow-core';
 import type { TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { WorkflowSaveInput } from '../adapter.js';
@@ -47,7 +47,7 @@ describe('sync journal', () => {
       status,
       dependencies: [],
       createdAt: new Date('2026-07-28T00:00:00.000Z'),
-      config: {},
+      config: resolveTaskConfig(),
       execution: {},
       taskStateVersion: 1,
     };

--- a/packages/data-store/src/__tests__/sync-merge.test.ts
+++ b/packages/data-store/src/__tests__/sync-merge.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { Attempt, TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type Attempt, type TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { WorkflowSaveInput } from '../adapter.js';
 import type { SqliteExecutor } from '../sqlite-executor.js';
@@ -31,7 +31,7 @@ function makeTask(id = 'task-1', status: TaskState['status'] = 'pending'): TaskS
     status,
     dependencies: [],
     createdAt: new Date(T0),
-    config: {},
+    config: resolveTaskConfig(),
     execution: { generation: 0 },
     taskStateVersion: 1,
   };

--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter, GET_EVENTS_DEFAULT_LIMIT } from '../sqlite-adapter.js';
+import { resolveTaskConfig } from '@invoker/workflow-core';
 
 describe('getEvents default limit (ui-read-scale)', () => {
   let tmpDir: string;
@@ -24,7 +25,7 @@ describe('getEvents default limit (ui-read-scale)', () => {
       status: 'running',
       dependencies: [],
       createdAt: new Date(),
-      config: { workflowId: 'wf-1' },
+      config: resolveTaskConfig({ workflowId: 'wf-1' }),
       execution: {},
       taskStateVersion: 1,
     });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1008,11 +1008,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   private resolveOutputDir(dbPath: string | null): string {
-    const invokerHome = process.env.INVOKER_DB_DIR ?? (dbPath ? dirname(dbPath) : join(homedir(), '.invoker'));
-    if (!dbPath && !process.env.INVOKER_DB_DIR) {
+    const isEphemeral = dbPath === null || dbPath === SQLITE_EPHEMERAL_DATABASE;
+    if (isEphemeral) {
       return join(tmpdir(), `invoker-output-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
     }
-    return join(invokerHome, 'task-output');
+    return join(dirname(dbPath), 'task-output');
   }
 
   private configureConnection(fileBacked: boolean): void {

--- a/packages/data-store/src/sqlite-migrations.ts
+++ b/packages/data-store/src/sqlite-migrations.ts
@@ -1,4 +1,4 @@
-import type { ExternalDependency } from '@invoker/workflow-core';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, type ExternalDependency } from '@invoker/workflow-core';
 import {
   COLUMN_MIGRATIONS,
   POST_MIGRATION_STATEMENTS,
@@ -73,6 +73,9 @@ export function migrate(exec: SqliteExecutor, reconcileTerminalSessionInvariants
   dropTaskAutoFixAttemptsColumn(exec);
 
   if (!exec.readOnly) {
+    exec.run('DROP TRIGGER IF EXISTS trg_tasks_executor_routing_insert');
+    exec.run('DROP TRIGGER IF EXISTS trg_tasks_executor_routing_update');
+    migrateTaskExecutorPoolInvariant(exec);
     reconcileTerminalSessionInvariants();
   }
 
@@ -87,6 +90,51 @@ export function migrate(exec: SqliteExecutor, reconcileTerminalSessionInvariants
     migrateTaskExternalDependenciesToWorkflows(exec);
     runCompatibilityMigration(exec);
   }
+}
+
+export function migrateTaskExecutorPoolInvariant(exec: SqliteExecutor): void {
+  exec.runTransaction(() => {
+    exec.run(
+      `UPDATE tasks
+          SET runner_kind = 'merge', pool_id = NULL, pool_member_id = NULL
+        WHERE is_merge_node = 1`,
+    );
+    exec.run(
+      `UPDATE tasks
+          SET runner_kind = 'docker', pool_id = NULL, pool_member_id = NULL
+        WHERE COALESCE(is_merge_node, 0) = 0
+          AND (runner_kind = 'docker' OR docker_image IS NOT NULL)`,
+    );
+    exec.run(
+      `UPDATE tasks
+          SET pool_id = NULL, pool_member_id = NULL
+        WHERE runner_kind = 'scratch'`,
+    );
+    exec.run(
+      `UPDATE tasks
+          SET runner_kind = CASE
+                WHEN COALESCE(TRIM(pool_id), '') = '' THEN 'worktree'
+                WHEN TRIM(pool_id) = ? THEN 'worktree'
+                ELSE 'ssh'
+              END,
+              pool_id = CASE
+                WHEN COALESCE(TRIM(pool_id), '') = '' THEN ?
+                ELSE TRIM(pool_id)
+              END
+        WHERE COALESCE(is_merge_node, 0) = 0
+          AND docker_image IS NULL
+          AND (runner_kind IS NULL OR TRIM(runner_kind) = '')`,
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID, BUILT_IN_LOCAL_EXECUTION_POOL_ID],
+    );
+    exec.run(
+      `UPDATE tasks
+          SET pool_id = ?
+        WHERE runner_kind = 'worktree'
+          AND docker_image IS NULL
+          AND COALESCE(TRIM(pool_id), '') = ''`,
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID],
+    );
+  });
 }
 
 /**

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -15,7 +15,7 @@ import type {
   ExternalDependencyChange,
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
-import { normalizeRunnerKind } from '@invoker/workflow-core';
+import { assertResolvedTaskConfig, normalizeRunnerKind } from '@invoker/workflow-core';
 import type { WorkerActionRecord, Workflow } from './adapter.js';
 import type {
   TaskLaunchDispatch,
@@ -56,40 +56,60 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
 
 export function mapRowToTask(row: any): TaskState {
   const normalizedStatus = row.status as TaskStatus;
+  const runnerKind = normalizeRunnerKind(row.runner_kind ?? undefined);
+  const baseConfig = {
+    workflowId: row.workflow_id ?? undefined,
+    parentTask: row.parent_task ?? undefined,
+    command: row.command ?? undefined,
+    prompt: row.prompt ?? undefined,
+    ...(row.freshness ? { freshness: JSON.parse(row.freshness) } : {}),
+    externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
+    experimentPrompt: row.experiment_prompt ?? undefined,
+    pivot: row.pivot === 1 ? true : undefined,
+    experimentVariants: row.experiment_variants ? JSON.parse(row.experiment_variants) : undefined,
+    isReconciliation: row.is_reconciliation === 1 ? true : undefined,
+    requiresManualApproval: row.requires_manual_approval === 1 ? true : undefined,
+    featureBranch: row.feature_branch ?? undefined,
+    executionModel: row.execution_model ?? undefined,
+    isMergeNode: row.is_merge_node === 1 ? true : undefined,
+    summary: row.summary ?? undefined,
+    problem: row.problem ?? undefined,
+    approach: row.approach ?? undefined,
+    testPlan: row.test_plan ?? undefined,
+    reproCommand: row.repro_command ?? undefined,
+    fixPrompt: row.fix_prompt ?? undefined,
+    fixContext: row.fix_context ?? undefined,
+    executionAgent: row.execution_agent ?? undefined,
+  } as const;
+  let config: unknown;
+  switch (runnerKind) {
+    case 'worktree':
+    case 'ssh':
+      config = {
+        ...baseConfig,
+        runnerKind,
+        poolId: row.pool_id ?? undefined,
+        ...((row.pool_member_id ?? undefined) ? { poolMemberId: row.pool_member_id } : {}),
+      };
+      break;
+    case 'docker':
+      config = { ...baseConfig, runnerKind, dockerImage: row.docker_image ?? undefined };
+      break;
+    case 'merge':
+    case 'scratch':
+      config = { ...baseConfig, runnerKind };
+      break;
+    default:
+      config = { ...baseConfig, runnerKind };
+  }
+  assertResolvedTaskConfig(config);
   return {
     id: row.id,
     description: row.description,
     status: normalizedStatus,
     dependencies: JSON.parse(row.dependencies || '[]'),
     createdAt: new Date(row.created_at),
-    config: {
-      workflowId: row.workflow_id ?? undefined,
-      parentTask: row.parent_task ?? undefined,
-      command: row.command ?? undefined,
-      prompt: row.prompt ?? undefined,
-      ...(row.freshness ? { freshness: JSON.parse(row.freshness) } : {}),
-      externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
-      experimentPrompt: row.experiment_prompt ?? undefined,
-      pivot: row.pivot === 1 ? true : undefined,
-      experimentVariants: row.experiment_variants ? JSON.parse(row.experiment_variants) : undefined,
-      isReconciliation: row.is_reconciliation === 1 ? true : undefined,
-      requiresManualApproval: row.requires_manual_approval === 1 ? true : undefined,
-      featureBranch: row.feature_branch ?? undefined,
-      poolId: row.pool_id ?? undefined,
-      runnerKind: normalizeRunnerKind(row.runner_kind ?? undefined),
-      ...((row.pool_member_id ?? undefined) ? { poolMemberId: row.pool_member_id } : {}),
-      dockerImage: row.docker_image ?? undefined,
-      executionModel: row.execution_model ?? undefined,
-      isMergeNode: row.is_merge_node === 1 ? true : undefined,
-      summary: row.summary ?? undefined,
-      problem: row.problem ?? undefined,
-      approach: row.approach ?? undefined,
-      testPlan: row.test_plan ?? undefined,
-      reproCommand: row.repro_command ?? undefined,
-      fixPrompt: row.fix_prompt ?? undefined,
-      fixContext: row.fix_context ?? undefined,
-      executionAgent: row.execution_agent ?? undefined,
-    },
+    config,
     execution: {
       blockedBy: row.blocked_by ?? undefined,
       inputPrompt: row.input_prompt ?? undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -685,6 +685,30 @@ export const COLUMN_MIGRATIONS = [
  * dispatch index. Order preserved from the original `migrate()` body.
  */
 export const POST_MIGRATION_STATEMENTS = [
+  'DROP TRIGGER IF EXISTS trg_tasks_executor_routing_insert',
+  'DROP TRIGGER IF EXISTS trg_tasks_executor_routing_update',
+  `CREATE TRIGGER trg_tasks_executor_routing_insert
+    BEFORE INSERT ON tasks
+    WHEN COALESCE((
+      (NEW.runner_kind IN ('worktree', 'ssh') AND COALESCE(TRIM(NEW.pool_id), '') <> '' AND NEW.docker_image IS NULL)
+      OR (NEW.runner_kind = 'docker' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+      OR (NEW.runner_kind = 'merge' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+      OR (NEW.runner_kind = 'scratch' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+    ), 0) = 0
+    BEGIN
+      SELECT RAISE(ABORT, 'tasks executor routing invariant violated');
+    END`,
+  `CREATE TRIGGER trg_tasks_executor_routing_update
+    BEFORE UPDATE OF runner_kind, pool_id, pool_member_id, docker_image ON tasks
+    WHEN COALESCE((
+      (NEW.runner_kind IN ('worktree', 'ssh') AND COALESCE(TRIM(NEW.pool_id), '') <> '' AND NEW.docker_image IS NULL)
+      OR (NEW.runner_kind = 'docker' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+      OR (NEW.runner_kind = 'merge' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+      OR (NEW.runner_kind = 'scratch' AND NEW.pool_id IS NULL AND NEW.pool_member_id IS NULL)
+    ), 0) = 0
+    BEGIN
+      SELECT RAISE(ABORT, 'tasks executor routing invariant violated');
+    END`,
   'DROP INDEX IF EXISTS idx_attempts_node',
   'CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)',

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -11,9 +11,11 @@
 import type { TaskState, TaskStateChanges, Attempt, TaskExecution, WorkflowDerivedStatus, WorkflowRollupTaskSummary } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
+  applyTaskConfigPatch,
   computeWorkflowRollupFromSummaries,
   isDiscardedAttempt,
   normalizeRunnerKind,
+  resolveTaskConfig,
 } from '@invoker/workflow-core';
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
@@ -193,8 +195,11 @@ export class SqliteTaskAttemptRepository {
   // ── Task CRUD ────────────────────────────────────────────
 
   saveTask(workflowId: string, task: TaskState): void {
+    const cfg = resolveTaskConfig(task.config);
+    if (cfg !== task.config) {
+      task = { ...task, config: cfg };
+    }
     assertTaskConsistent(task);
-    const cfg = task.config;
     const exec = task.execution;
     const columns = [
       'id', 'workflow_id', 'description', 'status', 'blocked_by', 'dependencies',
@@ -328,7 +333,7 @@ export class SqliteTaskAttemptRepository {
       exec.isFixingWithAI ? 1 : 0,
       exec.generation ?? 0,
       exec.selectedAttemptId ?? null,
-      (cfg as { poolMemberId?: string }).poolMemberId ?? null,
+      cfg.poolMemberId ?? null,
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
       cfg.executionModel ?? null,
@@ -382,6 +387,8 @@ export class SqliteTaskAttemptRepository {
   ): void {
     const taskId = beforeTask.id;
 
+    applyTaskConfigPatch(beforeTask.config, changes.config);
+
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -399,7 +406,7 @@ export class SqliteTaskAttemptRepository {
     }
 
     if (changes.config) {
-      const config = changes.config as Record<string, unknown>;
+      const config = changes.config;
       const configMap: Record<string, string> = {
         workflowId: 'workflow_id',
         parentTask: 'parent_task',
@@ -431,13 +438,13 @@ export class SqliteTaskAttemptRepository {
       for (const [key, col] of Object.entries(configMap)) {
         if (key in config) {
           setClauses.push(`${col} = ?`);
-          values.push(config[key] ?? null);
+          values.push(Reflect.get(config, key) ?? null);
         }
       }
       for (const [key, col] of Object.entries(configBoolMap)) {
         if (key in config) {
           setClauses.push(`${col} = ?`);
-          values.push(config[key] ? 1 : 0);
+          values.push(Reflect.get(config, key) ? 1 : 0);
         }
       }
       if ('experimentVariants' in changes.config) {

--- a/packages/execution-engine/src/__tests__/branch-chain.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-chain.test.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import type { WorkResponse } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import { TaskRunner, ExecutorRegistry, WorktreeExecutor } from '../index.js';
 
 function createTempRepo(): string {
@@ -163,9 +163,9 @@ describe('A→B→C branch chain', { timeout: 120_000 }, () => {
       status: overrides.status ?? 'pending',
       dependencies: overrides.dependencies ?? [],
       createdAt: new Date(),
-      config: { ...overrides.config },
+      config: resolveTaskConfig(overrides.config ?? {}),
       execution: { ...overrides.execution },
-    } as TaskState;
+    };
   }
 
   function buildChain(config: ChainConfig): {

--- a/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 
 function makeTask(overrides: {
   id?: string;
@@ -29,9 +29,9 @@ function makeTask(overrides: {
     status: overrides.status ?? 'pending',
     dependencies: [],
     createdAt: new Date(),
-    config: { ...overrides.config },
+    config: resolveTaskConfig(overrides.config ?? {}),
     execution: { ...overrides.execution },
-  } as TaskState;
+  };
 }
 
 function makeRunner() {

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -241,6 +241,7 @@ branch refs/heads/${branch}
       config: {
         command: 'pnpm test',
         runnerKind: 'ssh' as const,
+        poolId: 'remote-fix-pool',
         poolMemberId: 'remote-1',
       },
     };
@@ -260,6 +261,9 @@ branch refs/heads/${branch}
           remoteInvokerHome: '/home/invoker/.invoker',
           managedWorkspaces: true,
         },
+      }),
+      executionPoolsProvider: () => ({
+        'remote-fix-pool': { members: [{ type: 'ssh' as const, id: 'remote-1' }] },
       }),
     });
     const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({

--- a/packages/execution-engine/src/__tests__/resolve-selected-remote-target-id-cost.test.ts
+++ b/packages/execution-engine/src/__tests__/resolve-selected-remote-target-id-cost.test.ts
@@ -49,7 +49,7 @@ describe('resolveSelectedRemoteTargetId bounded event lookup', () => {
       status: 'failed',
       dependencies: [],
       createdAt: new Date(),
-      config: { runnerKind: 'ssh' },
+      config: { runnerKind: 'ssh', poolId: 'ssh-fixture' },
       execution: {},
       taskStateVersion: 1,
     };

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import {
   buildWorktreeCorruptRepairScript,
   deriveCorruptWorktreeAdminPathFromWorkspace,
@@ -25,7 +25,7 @@ function makeTask(overrides: {
   config?: Partial<TaskState['config']>;
   execution?: Partial<TaskState['execution']>;
 } = {}): TaskState {
-  const config = overrides.config?.runnerKind === 'ssh' && !overrides.config.poolId
+  const inputConfig = overrides.config?.runnerKind === 'ssh' && !overrides.config.poolId
     ? { ...overrides.config, poolId: 'ssh-fixture' }
     : overrides.config;
   return {
@@ -34,9 +34,9 @@ function makeTask(overrides: {
     status: overrides.status ?? 'pending',
     dependencies: [],
     createdAt: new Date(),
-    config: { ...config },
+    config: resolveTaskConfig(inputConfig ?? {}),
     execution: { ...overrides.execution },
-  } as TaskState;
+  };
 }
 
 describe('SSH worktree metadata repro', () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -8,7 +8,7 @@ import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { getCurrentRequiredReviewArtifacts } from '../task-runner-review-gate.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SshExecutor } from '../ssh-executor.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody, validateReviewStackPrBodyAgainstLocalDiff } from '../pr-authoring.js';
@@ -24,15 +24,18 @@ function makeTask(overrides: {
   config?: Partial<TaskState['config']>;
   execution?: Partial<TaskState['execution']>;
 } = {}): TaskState {
+  const inputConfig = overrides.config?.runnerKind === 'ssh' && !overrides.config.poolId
+    ? { ...overrides.config, poolId: 'ssh-fixture' }
+    : overrides.config;
   return {
     id: overrides.id ?? 'test',
     description: overrides.description ?? 'Test task',
     status: overrides.status ?? 'pending',
     dependencies: overrides.dependencies ?? [],
     createdAt: overrides.createdAt ?? new Date(),
-    config: { ...overrides.config },
+    config: resolveTaskConfig(inputConfig ?? {}),
     execution: { ...overrides.execution },
-  } as TaskState;
+  };
 }
 
 function createExecutorWithTasks(tasks: Map<string, TaskState>): TaskRunner {
@@ -58,6 +61,14 @@ function createMockLogger(): Logger {
   };
   (logger.child as any).mockReturnValue(logger);
   return logger;
+}
+
+function sshFixturePool(...memberIds: string[]) {
+  return () => ({
+    'ssh-fixture': {
+      members: memberIds.map((id) => ({ type: 'ssh' as const, id })),
+    },
+  });
 }
 
 const tempWorkspaces: string[] = [];
@@ -743,6 +754,7 @@ describe('TaskRunner', () => {
             sshKeyPath: '/tmp/test-key',
           },
         }),
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       await runner.publishApprovedFix(task);
@@ -803,6 +815,7 @@ describe('TaskRunner', () => {
             sshKeyPath: '/tmp/test-key',
           },
         }),
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
       const selectExecutorSpy = vi.spyOn(runner, 'selectExecutor');
       const originalSelectExecutor = TaskRunner.prototype.selectExecutor.bind(runner);
@@ -2745,6 +2758,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: provider,
+        executionPoolsProvider: sshFixturePool('do-droplet'),
       });
 
       const task = makeTask({
@@ -2790,6 +2804,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: provider,
+        executionPoolsProvider: sshFixturePool('do-droplet'),
       });
 
       const task = makeTask({
@@ -2919,6 +2934,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         remoteTargetsProvider: provider,
+        executionPoolsProvider: sshFixturePool('missing-target'),
       });
 
       const task = makeTask({
@@ -3524,6 +3540,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
+        executionPoolsProvider: sshFixturePool('remote-a', 'remote-b'),
       });
 
       const task1 = makeTask({
@@ -3639,6 +3656,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
+        executionPoolsProvider: sshFixturePool('remote-a'),
       });
 
       const task1 = makeTask({
@@ -3658,14 +3676,14 @@ describe('TaskRunner', () => {
       expect(executor1.executor).not.toBe(executor2.executor);
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('throws when an SSH pool has no selectable member', () => {
+    it('throws when an SSH pool has no selectable member', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => ({}),
+        executionPoolsProvider: sshFixturePool(),
       });
 
       const task = makeTask({
@@ -3691,6 +3709,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
+        executionPoolsProvider: sshFixturePool('remote-unknown'),
       });
 
       const task = makeTask({
@@ -3872,8 +3891,7 @@ describe('TaskRunner', () => {
       expect(handleWorkerResponse).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('logs explicit SSH member selection through its concrete pool', async () => {
+    it('logs explicit SSH member selection through its concrete pool', async () => {
       const sshExecutor = createCompletingExecutor('ssh', {
         workspacePath: '/remote/worktrees/task-explicit',
         branch: 'experiment/task-explicit',
@@ -3897,6 +3915,7 @@ describe('TaskRunner', () => {
         remoteTargetsProvider: () => ({
           'remote-b': { host: 'dev.example.com', user: 'dev', sshKeyPath: '/secret/dev-key' },
         }),
+        executionPoolsProvider: sshFixturePool('remote-b'),
       });
 
       await runner.executeTask(task);
@@ -3915,8 +3934,7 @@ describe('TaskRunner', () => {
       }));
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('logs configured worktree executor selection reason', async () => {
+    it('logs configured worktree executor selection reason', async () => {
       const worktreeExecutor = createCompletingExecutor('worktree', {
         workspacePath: '/tmp/worktree/task-local',
         branch: 'experiment/task-local',
@@ -3949,8 +3967,7 @@ describe('TaskRunner', () => {
       }));
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('rejects a missing SSH pool without falling back to worktree', async () => {
+    it('rejects a missing SSH pool without falling back to worktree', async () => {
       const worktreeExecutor = createCompletingExecutor('worktree', {
         workspacePath: '/tmp/worktree/task-fallback',
         branch: 'experiment/task-fallback',
@@ -4024,6 +4041,7 @@ describe('TaskRunner', () => {
           getAll: () => [badExecutor],
         } as any,
         cwd: '/tmp',
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       await executor.executeTask(task);
@@ -4091,6 +4109,7 @@ describe('TaskRunner', () => {
           getAll: () => [managedSshExecutor],
         } as any,
         cwd: '/tmp',
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       await executor.executeTask(task);
@@ -4110,8 +4129,7 @@ describe('TaskRunner', () => {
       });
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('persists metadata on error path when executor.start throws', async () => {
+    it('persists metadata on error path when executor.start throws', async () => {
       const failingExecutor = {
         type: 'ssh',
         start: vi.fn().mockRejectedValue(Object.assign(
@@ -4153,6 +4171,7 @@ describe('TaskRunner', () => {
           getAll: () => [failingExecutor],
         } as any,
         cwd: '/tmp',
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       await executor.executeTask(task);
@@ -4299,8 +4318,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('allows BYO mode executor with workspacePath but no branch', async () => {
+    it('allows BYO mode executor with workspacePath but no branch', async () => {
       const byoExecutor = {
         type: 'ssh',
         start: vi.fn().mockResolvedValue({
@@ -4346,6 +4364,7 @@ describe('TaskRunner', () => {
           getAll: () => [byoExecutor],
         } as any,
         cwd: '/tmp',
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       await executor.executeTask(task);
@@ -5673,6 +5692,7 @@ describe('TaskRunner', () => {
         } as any,
         cwd: '/tmp',
         callbacks: { onHeartbeat },
+        executionPoolsProvider: sshFixturePool('remote-1'),
       });
 
       const pending = runner.executeTask(runningTask);

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { TaskRunner, type LaunchOutboxAck, type TaskRunnerCallbacks } from '../task-runner.js';
 import { ResourceLimitError } from '../repo-pool.js';
@@ -18,16 +18,17 @@ function makeLogger(): Logger {
 }
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, ...taskOverrides } = overrides;
   return {
     id: 'wf-d/t1',
     description: 'launch-dispatch test task',
     status: 'pending',
     dependencies: [],
     createdAt: new Date(),
-    config: { workflowId: 'wf-d' },
+    config: resolveTaskConfig({ workflowId: 'wf-d', ...config }),
     execution: { selectedAttemptId: 'attempt-1', generation: 1, phase: 'launching' },
-    ...overrides,
-  } as TaskState;
+    ...taskOverrides,
+  };
 }
 
 interface RunnerEnv {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -8,7 +8,7 @@ import { assertCompletedDependencyHasBranch } from '../task-runner-prepare.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
 import { WorktreeExecutor } from '../worktree-executor.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
@@ -25,15 +25,18 @@ function makeTask(overrides: {
   config?: Partial<TaskState['config']>;
   execution?: Partial<TaskState['execution']>;
 } = {}): TaskState {
+  const inputConfig = overrides.config?.runnerKind === 'ssh' && !overrides.config.poolId
+    ? { ...overrides.config, poolId: 'ssh-fixture' }
+    : overrides.config;
   return {
     id: overrides.id ?? 'test',
     description: overrides.description ?? 'Test task',
     status: overrides.status ?? 'pending',
     dependencies: overrides.dependencies ?? [],
     createdAt: overrides.createdAt ?? new Date(),
-    config: { ...overrides.config },
+    config: resolveTaskConfig(inputConfig ?? {}),
     execution: { ...overrides.execution },
-  } as TaskState;
+  };
 }
 
 function createExecutorWithTasks(tasks: Map<string, TaskState>): TaskRunner {
@@ -1211,6 +1214,9 @@ describe('TaskRunner', () => {
         persistence: { updateTask: vi.fn() } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ssh-fixture': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
         callbacks: { onComplete },
       });
 
@@ -1362,8 +1368,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('persists startup metadata from executor errors before failing task', async () => {
+    it('persists startup metadata from executor errors before failing task', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();
       const orchestrator = {
@@ -1391,12 +1396,15 @@ describe('TaskRunner', () => {
         persistence: { updateTask } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ssh-fixture': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       const task = makeTask({
         id: 'failing-start',
         status: 'running',
-        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        config: { command: 'echo hi', runnerKind: 'ssh' },
       });
       await executor.executeTask(task);
 
@@ -1454,13 +1462,16 @@ describe('TaskRunner', () => {
         executorRegistry: registry as any,
         cwd: '/tmp',
         callbacks: { onLaunchFailed },
+        executionPoolsProvider: () => ({
+          'ssh-fixture': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       // Task was launched with attempt-1 but orchestrator now shows attempt-2
       const task = makeTask({
         id: 'stale-1',
         status: 'running',
-        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        config: { command: 'echo hi', runnerKind: 'ssh' },
         execution: { selectedAttemptId: 'attempt-1', generation: 0 },
       });
       await runner.executeTask(task);
@@ -1516,7 +1527,7 @@ describe('TaskRunner', () => {
       const task = makeTask({
         id: 'stale-gen',
         status: 'running',
-        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        config: { command: 'echo hi', runnerKind: 'ssh' },
         execution: { generation: 1 },
       });
       await runner.executeTask(task);
@@ -1532,8 +1543,7 @@ describe('TaskRunner', () => {
       expect(onLaunchFailed).not.toHaveBeenCalled();
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('still persists metadata and emits response when lineage is current', async () => {
+    it('still persists metadata and emits response when lineage is current', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();
       // Orchestrator returns a task with matching lineage
@@ -1567,12 +1577,15 @@ describe('TaskRunner', () => {
         executorRegistry: registry as any,
         cwd: '/tmp',
         callbacks: { onLaunchFailed },
+        executionPoolsProvider: () => ({
+          'ssh-fixture': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       const task = makeTask({
         id: 'current-1',
         status: 'running',
-        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        config: { command: 'echo hi', runnerKind: 'ssh' },
         execution: { selectedAttemptId: 'attempt-1', generation: 0 },
       });
       await runner.executeTask(task);
@@ -1638,7 +1651,7 @@ describe('TaskRunner', () => {
       const task = makeTask({
         id: 'inner-stale',
         status: 'running',
-        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        config: { command: 'echo hi', runnerKind: 'ssh' },
         execution: { selectedAttemptId: 'attempt-old', generation: 0 },
       });
       await runner.executeTask(task);
@@ -3071,8 +3084,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('recreates feature branch on retry after previous failed attempt', async () => {
+    it('recreates feature branch on retry after previous failed attempt', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -3490,8 +3502,7 @@ describe('TaskRunner', () => {
   });
 
   describe('manual merge mode', () => {
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('executeMergeNode skips final merge when mergeMode=manual', async () => {
+    it('executeMergeNode skips final merge when mergeMode=manual', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -3647,8 +3658,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('executeMergeNode skips squash-merge and creates PR when mergeMode=external_review', async () => {
+    it('executeMergeNode skips squash-merge and creates PR when mergeMode=external_review', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -4007,8 +4017,7 @@ console.log(JSON.stringify(out));
       expect(providerBody).toContain('![after](https://img.example.test/after--merge-gate-no-inline-approve.png)');
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('executeMergeNode goes to review_ready when mergeMode=manual and onFinish=none', async () => {
+    it('executeMergeNode goes to review_ready when mergeMode=manual and onFinish=none', async () => {
       const orchestrator = {
         getTask: () => null,
         getAllTasks: () => [],
@@ -4096,8 +4105,7 @@ console.log(JSON.stringify(out));
       expect(orchestrator.setTaskAwaitingApproval).not.toHaveBeenCalled();
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('executeMergeNode creates PR when mergeMode=external_review and onFinish=none', async () => {
+    it('executeMergeNode creates PR when mergeMode=external_review and onFinish=none', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -4558,8 +4566,7 @@ console.log(JSON.stringify(out));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-    it.fails('executeMergeNode goes to review_ready when mergeMode=manual and no featureBranch', async () => {
+    it('executeMergeNode goes to review_ready when mergeMode=manual and no featureBranch', async () => {
       const orchestrator = {
         getTask: () => null,
         getAllTasks: () => [],

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -1185,21 +1185,23 @@ export async function executeMergeNodeImpl(
 ): Promise<void> {
   const result = await runMergeGateActionImpl(host, task);
   const { response } = result;
-  const legacyConfig = {
+  const mergeConfig: TaskStateChanges['config'] = {
     ...(result.taskChanges.config ?? {}),
-    runnerKind: 'worktree',
-  } as TaskStateChanges['config'];
-  const legacyChanges: TaskStateChanges = {
+    runnerKind: 'merge',
+    poolId: undefined,
+    poolMemberId: undefined,
+  };
+  const mergeChanges: TaskStateChanges = {
     status: result.taskChanges.status,
     dependencies: result.taskChanges.dependencies,
     execution: result.taskChanges.execution,
-    config: legacyConfig,
+    config: mergeConfig,
   };
 
-  updateMergeGateMetadataIfCurrent(host, task.id, legacyChanges, captureMergeGateLineage(task));
+  updateMergeGateMetadataIfCurrent(host, task.id, mergeChanges, captureMergeGateLineage(task));
 
   if (response.status === 'review_ready') {
-    setMergeGateReviewReady(host, task.id, legacyChanges, {
+    setMergeGateReviewReady(host, task.id, mergeChanges, {
       selectedAttemptId: task.execution.selectedAttemptId,
       generation: task.execution.generation ?? 0,
     });

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -13,7 +13,11 @@
 import { resolve } from 'node:path';
 
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import {
+  assertResolvedTaskConfig,
+  BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+  type TaskState,
+} from '@invoker/workflow-core';
 import type { Executor, ExecutorHandle } from './executor.js';
 import { ResourceLimitError } from './repo-pool.js';
 import { traceExecution } from './exec-trace.js';
@@ -134,18 +138,18 @@ function memoryPoolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKe
 }
 
 export function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
+  const countFn = host.persistence.countExecutionResourceLeases?.bind(host.persistence);
+  const listFn = host.persistence.listExecutionResourceLeases?.bind(host.persistence);
+  if (!countFn && !listFn) return undefined;
   const target = host.getRemoteTargets()[member.id];
   if (!target) return undefined;
   const resourceKey = sshResourceKey(target);
-  const countFn = host.persistence.countExecutionResourceLeases?.bind(host.persistence);
   if (countFn) return countFn(resourceKey);
-  const listFn = host.persistence.listExecutionResourceLeases?.bind(host.persistence);
-  if (!listFn) return undefined;
   const nowIso = new Date().toISOString();
-  return listFn().filter((lease) => (
+  return listFn?.().filter((lease) => (
     lease.resourceKey === resourceKey
     && (!lease.leaseExpiresAt || lease.leaseExpiresAt > nowIso)
-  )).length;
+  )).length ?? 0;
 }
 
 function poolMemberLoad(host: TaskRunnerPoolHost, poolId: string, member: ExecutionPoolMember): number {
@@ -357,13 +361,15 @@ export function acquirePoolSelectionLease(host: TaskRunnerPoolHost, task: TaskSt
     host.persistence.renewExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
     return true;
   }
+  const claimLease = host.persistence.claimExecutionResourceLease?.bind(host.persistence);
+  if (!claimLease) return true;
   const target = host.getRemoteTargets()[selection.member.id];
   if (!target) return true;
   const pool = host.getExecutionPools()[selection.poolId];
   const maxHolders = pool ? poolMemberLimit(pool, selection.member) : undefined;
   const resourceKey = sshResourceKey(target);
   const holderId = leaseHolderId(host, task.id, attemptId);
-  const acquired = host.persistence.claimExecutionResourceLease?.({
+  const acquired = claimLease({
     resourceKey,
     resourceType: 'ssh',
     holderId,
@@ -375,7 +381,7 @@ export function acquirePoolSelectionLease(host: TaskRunnerPoolHost, task: TaskSt
       runnerInstanceId: host.runnerInstanceId,
       pid: process.pid,
     },
-  }) ?? true;
+  });
   if (!acquired) {
     host.persistence.logEvent?.(task.id, 'task.executor.deferred', {
       reason: 'ssh-resource-lease-held',
@@ -448,7 +454,7 @@ function executorSelectionReason(
         poolMemberId: poolSelection.member.id,
       };
     }
-    if ((task.config as { poolMemberId?: string }).poolMemberId) {
+    if (task.config.poolMemberId) {
       return { type: 'explicitPoolMemberId' };
     }
     if (task.config.poolId) {
@@ -457,13 +463,7 @@ function executorSelectionReason(
   }
 
   if (executor.type === 'worktree') {
-    if (task.config.runnerKind === 'ssh' && task.config.poolId) {
-      return { type: 'sshPoolFallbackToWorktree', poolId: task.config.poolId };
-    }
-    if (task.config.runnerKind === 'worktree') {
-      return { type: 'configuredWorktree' };
-    }
-    return { type: 'defaultWorktree' };
+    return { type: 'poolId', poolId: task.config.poolId };
   }
 
   if (executor.type === 'docker') {
@@ -475,8 +475,7 @@ function executorSelectionReason(
 
 export function selectedRemoteTargetId(host: TaskRunnerPoolHost, task: TaskState, poolSelection: PoolSelection | undefined): string | undefined {
   if (poolSelection?.member.type === 'ssh') return poolSelection.member.id;
-  return (task.config as { poolMemberId?: string }).poolMemberId
-    ?? (task.config.poolId && host.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
+  return task.config.poolMemberId;
 }
 
 // ── Executor selection ───────────────────────────────────
@@ -604,12 +603,15 @@ export function selectExecutor(
   task: TaskState,
   excludedPoolMemberKeys: Set<string> = new Set(),
 ): SelectedExecutor {
+  if (!task.config.isMergeNode) {
+    assertResolvedTaskConfig(task.config);
+  }
   let effectiveType = task.config.isMergeNode
     ? 'merge'
     : task.config.runnerKind;
   let selectedPoolMemberId: string | undefined;
   let selectedWorktreeTargetId: string | undefined;
-  const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+  const explicitPoolMemberId = task.config.poolMemberId;
   let resolvedExecution: ResolvedExecutionSelection = {
     executionAgent: host.resolveExecutionAgent(task),
     executionModel: host.resolveExecutionModel(task),
@@ -636,51 +638,51 @@ export function selectExecutor(
     return { executor: scratch, resolvedExecution, selectedPoolMemberId: undefined };
   }
 
-  if (task.config.poolId && explicitPoolMemberId) {
+  if (!task.config.isMergeNode && (task.config.runnerKind === 'worktree' || task.config.runnerKind === 'ssh') && explicitPoolMemberId) {
     const pool = host.getExecutionPools()[task.config.poolId];
+    if (!pool) {
+      throw new Error(`Task ${task.id} references missing execution pool "${task.config.poolId}"`);
+    }
     const member = pool?.members.find((candidate) => candidate.id === explicitPoolMemberId);
-    if (pool && member) {
-      if (
-        excludedPoolMemberKeys.has(poolMemberKey(member))
-        || !poolMemberHasCapacity(host, task.config.poolId, pool, member)
-        || !reservePoolMemberSelection(host, task, task.config.poolId, pool, member, resolvedExecution)
-      ) {
-        throw poolCapacityError(host, task, task.config.poolId, pool, excludedPoolMemberKeys);
-      }
-      effectiveType = member.type;
-      selectedPoolMemberId = member.id;
-      selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
+    if (!member) {
+      throw new Error(`Task ${task.id} references poolMemberId="${explicitPoolMemberId}" outside execution pool "${task.config.poolId}"`);
     }
-  } else if (task.config.poolId) {
+    if (
+      excludedPoolMemberKeys.has(poolMemberKey(member))
+      || !poolMemberHasCapacity(host, task.config.poolId, pool, member)
+      || !reservePoolMemberSelection(host, task, task.config.poolId, pool, member, resolvedExecution)
+    ) {
+      throw poolCapacityError(host, task, task.config.poolId, pool, excludedPoolMemberKeys);
+    }
+    effectiveType = member.type;
+    selectedPoolMemberId = member.id;
+    selectedWorktreeTargetId = member.type === 'worktree' && member.id !== BUILT_IN_LOCAL_EXECUTION_POOL_ID
+      ? member.id
+      : undefined;
+  } else if (!task.config.isMergeNode && (task.config.runnerKind === 'worktree' || task.config.runnerKind === 'ssh')) {
     const pool = host.getExecutionPools()[task.config.poolId];
-    if (pool) {
-      const attempted = new Set(excludedPoolMemberKeys);
-      let reserved: PoolSelection | undefined;
-      while (true) {
-        const member = selectPoolMember(host, task.config.poolId, pool, attempted);
-        if (!member) break;
-        reserved = reservePoolMemberSelection(host, task, task.config.poolId, pool, member, resolvedExecution);
-        if (reserved) {
-          effectiveType = member.type;
-          selectedPoolMemberId = member.id;
-          selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
-          break;
-        }
-        attempted.add(poolMemberKey(member));
-      }
-      if (!reserved) {
-        throw poolCapacityError(host, task, task.config.poolId, pool, attempted);
-      }
+    if (!pool) {
+      throw new Error(`Task ${task.id} references missing execution pool "${task.config.poolId}"`);
     }
-  }
-  if (
-    effectiveType === 'ssh'
-    && task.config.poolId
-    && !selectedPoolMemberId
-    && !explicitPoolMemberId
-    && !host.getRemoteTargets()[task.config.poolId]
-  ) {
-    effectiveType = 'worktree';
+    const attempted = new Set(excludedPoolMemberKeys);
+    let reserved: PoolSelection | undefined;
+    while (true) {
+      const member = selectPoolMember(host, task.config.poolId, pool, attempted);
+      if (!member) break;
+      reserved = reservePoolMemberSelection(host, task, task.config.poolId, pool, member, resolvedExecution);
+      if (reserved) {
+        effectiveType = member.type;
+        selectedPoolMemberId = member.id;
+        selectedWorktreeTargetId = member.type === 'worktree' && member.id !== BUILT_IN_LOCAL_EXECUTION_POOL_ID
+          ? member.id
+          : undefined;
+        break;
+      }
+      attempted.add(poolMemberKey(member));
+    }
+    if (!reserved) {
+      throw poolCapacityError(host, task, task.config.poolId, pool, attempted);
+    }
   }
 
   if (effectiveType) {
@@ -759,8 +761,7 @@ export function selectExecutor(
       const remoteTargets = host.getRemoteTargets();
       const targetId =
         selectedPoolMemberId
-        ?? (task.config as { poolMemberId?: string }).poolMemberId
-        ?? (task.config.poolId && remoteTargets[task.config.poolId] ? task.config.poolId : undefined);
+        ?? task.config.poolMemberId;
       if (!targetId) {
         throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
       }

--- a/packages/test-kit/src/test-harness.ts
+++ b/packages/test-kit/src/test-harness.ts
@@ -85,6 +85,7 @@ export interface TestHarness {
 export function createTestHarness(opts?: {
   maxConcurrency?: number;
   mergeGateProvider?: MergeGateProvider;
+  availablePoolIds?: string[];
 }): TestHarness {
   const persistence = new InMemoryPersistence();
   const bus = new InMemoryBus();
@@ -92,6 +93,7 @@ export function createTestHarness(opts?: {
     persistence,
     messageBus: bus,
     maxConcurrency: opts?.maxConcurrency ?? 10,
+    availablePoolIds: opts?.availablePoolIds,
   });
 
   const executorRegistry = new ExecutorRegistry();

--- a/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
@@ -12,7 +12,7 @@ import {
   type OrchestratorPersistence,
   type OrchestratorMessageBus,
 } from '../orchestrator.js';
-import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt } from '../task-types.js';
+import { applyTaskConfigPatch, computeWorkflowRollup, resolveTaskConfig, type TaskState, type TaskStateChanges, type Attempt } from '../task-types.js';
 
 // ── In-memory fixtures (focused, mirrors orchestrator.test.ts) ──
 
@@ -50,7 +50,10 @@ class InMemoryPersistence implements OrchestratorPersistence {
     return wf ? { repoUrl: wf.repoUrl } : undefined;
   }
   saveTask(workflowId: string, task: TaskState): void {
-    this.tasks.set(task.id, { workflowId, task });
+    this.tasks.set(task.id, {
+      workflowId,
+      task: { ...task, config: resolveTaskConfig(task.config) },
+    });
   }
   getTaskEntry(taskId: string): { workflowId: string; task: TaskState } | undefined {
     return this.tasks.get(taskId);
@@ -62,9 +65,9 @@ class InMemoryPersistence implements OrchestratorPersistence {
       ...entry.task,
       ...(changes.status !== undefined ? { status: changes.status } : {}),
       ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
-      config: { ...entry.task.config, ...changes.config },
+      config: applyTaskConfigPatch(entry.task.config, changes.config),
       execution: { ...entry.task.execution, ...changes.execution },
-    } as TaskState;
+    };
   }
   listWorkflows() { return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status })); }
   loadTasks(workflowId: string): TaskState[] {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -3,7 +3,7 @@ import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-inp
 import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator, PlanConflictError, descriptionForMergeNode, isWorkerResponseGenerationValid } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import { computeWorkflowRollup } from '../task-types.js';
+import { applyTaskConfigPatch, BUILT_IN_LOCAL_EXECUTION_POOL_ID, computeWorkflowRollup, resolveTaskConfig } from '../task-types.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 
@@ -128,7 +128,10 @@ class InMemoryPersistence implements OrchestratorPersistence {
   }
 
   saveTask(workflowId: string, task: TaskState): void {
-    this.tasks.set(task.id, { workflowId, task });
+    this.tasks.set(task.id, {
+      workflowId,
+      task: { ...task, config: resolveTaskConfig(task.config) },
+    });
   }
 
   /** Resolve bare plan-local id to the single matching persisted key when unambiguous (test helper). */
@@ -167,10 +170,10 @@ class InMemoryPersistence implements OrchestratorPersistence {
         ...entry.task,
         ...(changes.status !== undefined ? { status: changes.status } : {}),
         ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
-        config: { ...entry.task.config, ...changes.config },
+        config: applyTaskConfigPatch(entry.task.config, changes.config),
         execution: { ...entry.task.execution, ...changes.execution },
         taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
-      } as TaskState;
+      };
     }
   }
 
@@ -1320,6 +1323,28 @@ describe('Orchestrator', () => {
       expect(persistence.tasks.has(sid(orchestrator, 0, 't2'))).toBe(true);
     });
 
+    it('persists a concrete built-in pool through save and reload when plan input omits poolId', () => {
+      orchestrator.loadPlan({
+        name: 'persisted-pool-default',
+        repoUrl: 'git@github.com:test/repo.git',
+        tasks: [{ id: 't1', description: 'Repository task', command: 'echo hello' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+
+      const reloaded = new Orchestrator({
+        persistence,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 3,
+        resolveRepoDefaultBranch: () => repoDefaultBranch,
+      });
+      reloaded.syncFromDb(workflowId);
+
+      expect(reloaded.getTask('t1')?.config).toMatchObject({
+        runnerKind: 'worktree',
+        poolId: 'local-worktree',
+      });
+    });
+
     it('allows two workflows to reuse the same YAML task ids (scoped runtime ids differ)', () => {
       orchestrator.loadPlan({
         name: 'plan-A',
@@ -1437,7 +1462,7 @@ describe('Orchestrator', () => {
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.runnerKind).toBe('worktree');
-        expect(task!.config.poolId).toBeUndefined();
+        expect(task!.config.poolId).toBe(BUILT_IN_LOCAL_EXECUTION_POOL_ID);
       });
 
       it('validates regex rule matching pnpm test', () => {
@@ -1672,8 +1697,7 @@ describe('Orchestrator', () => {
         });
       });
 
-      // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-      it.fails('logs default worktree routing when no pool or docker rule applies', () => {
+      it('logs default worktree routing when no pool or docker rule applies', () => {
         const persistence = new InMemoryPersistence();
         const routedOrchestrator = new Orchestrator({
           persistence,
@@ -1740,8 +1764,7 @@ describe('Orchestrator', () => {
         expect(task!.config.poolId).toBe('ci-pool');
       });
 
-      // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-      it.fails('throws when route strategy target pool is not configured', () => {
+      it('throws when route strategy target pool is not configured', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
@@ -1778,7 +1801,7 @@ describe('Orchestrator', () => {
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.runnerKind).toBe('worktree');
-        expect(task!.config.poolId).toBeUndefined();
+        expect(task!.config.poolId).toBe(BUILT_IN_LOCAL_EXECUTION_POOL_ID);
       });
 
       it('keeps heavyweightCommandRouting as compatibility alias to route strategy', () => {
@@ -4374,7 +4397,7 @@ describe('Orchestrator', () => {
 
       const task = orchestrator.getTask('t1');
       expect(task?.config.poolId).toBe('mixed-local-ssh');
-      expect(task?.config.runnerKind).toBeUndefined();
+      expect(task?.config.runnerKind).toBe('ssh');
       expect(task?.config.poolMemberId).toBeUndefined();
       expect(persistence.getTaskEntry('t1')?.task.config.poolId).toBe('mixed-local-ssh');
     });

--- a/packages/workflow-core/src/executor-routing.ts
+++ b/packages/workflow-core/src/executor-routing.ts
@@ -1,4 +1,4 @@
-import type { RunnerKind } from '@invoker/workflow-graph';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, type RunnerKind } from '@invoker/workflow-graph';
 
 /**
  * A single routing rule that validates task pool placement against command patterns.
@@ -162,19 +162,23 @@ export function resolveExecutorRouting(
   defaultPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
   availablePoolIds: Set<string>,
-): { poolId?: string; reason: ExecutorRoutingReason } {
-  if (defaultPoolId && availablePoolIds.size > 0 && !availablePoolIds.has(defaultPoolId)) {
+): { poolId: string; reason: ExecutorRoutingReason } {
+  const configuredDefaultPoolId = defaultPoolId ?? BUILT_IN_LOCAL_EXECUTION_POOL_ID;
+  if (!configuredDefaultPoolId.trim() || !availablePoolIds.has(configuredDefaultPoolId)) {
     throw new Error(
-      `Task "${taskId}" cannot use defaultPoolId="${defaultPoolId}" because it is not defined in executionPools.`,
+      `Task "${taskId}" cannot use defaultPoolId="${configuredDefaultPoolId}" because it is not defined in executionPools.`,
     );
   }
 
-  const initialPoolId = planPoolId ?? defaultPoolId;
-  const initialReason: ExecutorRoutingReason = initialPoolId
-    ? { type: 'poolId', poolId: initialPoolId }
-    : { type: 'defaultWorktree' };
+  const initialPoolId = planPoolId ?? configuredDefaultPoolId;
+  const initialReason: ExecutorRoutingReason = { type: 'poolId', poolId: initialPoolId };
 
   if (!command || rules.length === 0) {
+    if (!initialPoolId.trim() || !availablePoolIds.has(initialPoolId)) {
+      throw new Error(
+        `Task "${taskId}" cannot use poolId="${initialPoolId}" because it is not defined in executionPools.`,
+      );
+    }
     return {
       poolId: initialPoolId,
       reason: initialReason,
@@ -214,6 +218,12 @@ export function resolveExecutorRouting(
     enforcementRules,
   );
 
+  if (!effectivePoolId.trim() || !availablePoolIds.has(effectivePoolId)) {
+    throw new Error(
+      `Task "${taskId}" cannot use poolId="${effectivePoolId}" because it is not defined in executionPools.`,
+    );
+  }
+
   return {
     poolId: effectivePoolId,
     reason,
@@ -224,7 +234,6 @@ export type ExecutorRoutingReason =
   | { type: 'dockerImage' }
   | { type: 'poolId'; poolId: string }
   | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
-  | { type: 'defaultWorktree' }
   | { type: 'scratch' };
 
 export function buildExecutorRoutedPayload(

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -13,7 +13,7 @@
 
 import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, RunnerKind } from '@invoker/workflow-graph';
 import type { GraphMutation, GraphMutationNodeDef, OrchestratorPersistence, OrchestratorMessageBus } from './orchestrator.js';
-import { createTaskState } from '@invoker/workflow-graph';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, createTaskState } from '@invoker/workflow-graph';
 import { findLeafTaskIds } from '@invoker/workflow-graph';
 
 const TASK_DELTA_CHANNEL = 'task.delta';
@@ -178,14 +178,14 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
   const baseChanges: TaskStateChanges = mutation.sourceDisposition === 'complete'
     ? { status: 'completed' as const, execution: { completedAt: new Date() } }
     : { status: 'stale' as const };
-  // Spreading two Partial<TaskConfig> values widens beyond what TS can assign
-  // back to the discriminated union, but the runtime value is correct.
-  const sourceChanges = {
+  const sourceChanges: TaskStateChanges = {
     ...baseChanges,
     ...mutation.sourceChanges,
-    config: { ...baseChanges.config, ...mutation.sourceChanges?.config },
+    ...(mutation.sourceChanges?.config
+      ? { config: { ...mutation.sourceChanges.config } }
+      : {}),
     execution: { ...baseChanges.execution, ...mutation.sourceChanges?.execution },
-  } as TaskStateChanges;
+  };
   const updatedSource = host.writeAndSync(mutation.sourceNodeId, sourceChanges);
   const sourceDelta: TaskDelta = {
     type: 'updated',
@@ -216,7 +216,6 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       isReconciliation: nodeDef.isReconciliation,
       requiresManualApproval: nodeDef.requiresManualApproval,
       isMergeNode,
-      ...(nodeDef.poolId ? { poolId: nodeDef.poolId } : {}),
       ...(nodeDef.executionAgent ? { executionAgent: nodeDef.executionAgent } : {}),
       ...(nodeDef.executionModel ? { executionModel: nodeDef.executionModel } : {}),
       ...(nodeDef.maxTurns !== undefined ? { maxTurns: nodeDef.maxTurns } : {}),
@@ -224,9 +223,11 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
     let nodeConfig: TaskConfig;
     switch (isMergeNode ? 'merge' : nodeDef.runnerKind) {
       case 'merge':
+        if (nodeDef.poolId !== undefined) throw new Error(`Graph mutation merge node "${nodeDef.id}" cannot declare poolId`);
         nodeConfig = { ...nodeBase, runnerKind: 'merge' };
         break;
       case 'docker':
+        if (nodeDef.poolId !== undefined) throw new Error(`Graph mutation Docker node "${nodeDef.id}" cannot declare poolId`);
         nodeConfig = {
           ...nodeBase,
           runnerKind: 'docker',
@@ -234,10 +235,21 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
         };
         break;
       case 'ssh':
-        nodeConfig = { ...nodeBase, runnerKind: 'ssh' };
+        if (!nodeDef.poolId?.trim()) {
+          throw new Error(`Graph mutation node "${nodeDef.id}" has runnerKind=ssh but no poolId`);
+        }
+        nodeConfig = { ...nodeBase, runnerKind: 'ssh', poolId: nodeDef.poolId };
+        break;
+      case 'scratch':
+        if (nodeDef.poolId !== undefined) throw new Error(`Graph mutation scratch node "${nodeDef.id}" cannot declare poolId`);
+        nodeConfig = { ...nodeBase, runnerKind: 'scratch' };
         break;
       default:
-        nodeConfig = { ...nodeBase, runnerKind: nodeDef.runnerKind };
+        nodeConfig = {
+          ...nodeBase,
+          runnerKind: nodeDef.poolId && nodeDef.poolId !== BUILT_IN_LOCAL_EXECUTION_POOL_ID ? 'ssh' : 'worktree',
+          poolId: nodeDef.poolId ?? BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+        };
         break;
     }
     const task = createTaskState(nodeDef.id, nodeDef.description, nodeDef.dependencies, nodeConfig);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -21,7 +21,7 @@ import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
 import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ExternalGatePolicy, TaskStatus, TaskHeartbeatSource, TaskFreshnessSpec } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
-import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass, computeWorkflowRollup } from '@invoker/workflow-graph';
+import { applyTaskConfigPatch, BUILT_IN_LOCAL_EXECUTION_POOL_ID, createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass, computeWorkflowRollup } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -846,8 +846,11 @@ export class Orchestrator {
       ...(config.executorRoutingRules ?? []),
       ...buildHeavyweightRoutingRules('config', config.heavyweightCommandRouting),
     ];
-    this.availablePoolIds = new Set(config.availablePoolIds ?? []);
-    this.defaultPoolId = config.defaultPoolId;
+    this.availablePoolIds = new Set([
+      BUILT_IN_LOCAL_EXECUTION_POOL_ID,
+      ...(config.availablePoolIds ?? []),
+    ]);
+    this.defaultPoolId = config.defaultPoolId ?? BUILT_IN_LOCAL_EXECUTION_POOL_ID;
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
     this.launchDeferralBackoffMs = config.launchDeferralBackoffMs;
     this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
@@ -917,9 +920,7 @@ export class Orchestrator {
       ...existing,
       ...(changes.status !== undefined ? { status: changes.status } : {}),
       ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
-      // Type assertion: spread widens the discriminated union but the runtime
-      // value preserves the correct runnerKind discriminant from existing.config.
-      config: { ...existing.config, ...changes.config } as TaskConfig,
+      config: applyTaskConfigPatch(existing.config, changes.config),
       execution: { ...existing.execution, ...changes.execution },
       taskStateVersion: existing.taskStateVersion + 1,
     };
@@ -1510,25 +1511,7 @@ export class Orchestrator {
     const validatedTasks: TaskState[] = [];
     const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
-      // Scratch plans never resolve a pool: no clone, no config-level default
-      // pool, no routing rule can ever hijack a scratch task's runnerKind.
-      const resolvedRouting: ReturnType<typeof resolveExecutorRouting> = plan.scratch
-        ? { poolId: undefined, reason: { type: 'scratch' } }
-        : resolveExecutorRouting(
-            taskDef.id,
-            taskDef.command,
-            taskDef.poolId ?? plan.poolId,
-            this.defaultPoolId,
-            this.executorRoutingRules,
-            this.availablePoolIds,
-          );
-      const effectivePoolId = resolvedRouting.poolId;
-
       const scopedId = localToScoped.get(taskDef.id)!;
-      resolvedRoutingByTaskId.set(
-        scopedId,
-        taskDef.dockerImage ? { type: 'dockerImage' } : resolvedRouting.reason,
-      );
       const scopedDeps = (taskDef.dependencies ?? []).map((dep) => {
         const s = localToScoped.get(dep);
         if (!s) {
@@ -1548,17 +1531,33 @@ export class Orchestrator {
         executionModel: taskDef.executionModel,
         maxTurns: taskDef.maxTurns,
         ...(taskDef.freshness !== undefined ? { freshness: taskDef.freshness } : {}),
-        poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
       if (plan.scratch) {
+        if (taskDef.poolId !== undefined || plan.poolId !== undefined) {
+          throw new Error(`Scratch task "${taskDef.id}" cannot declare poolId`);
+        }
         taskConfig = { ...baseConfig, runnerKind: 'scratch' as const };
+        resolvedRoutingByTaskId.set(scopedId, { type: 'scratch' });
       } else if (taskDef.dockerImage) {
+        if (taskDef.poolId !== undefined || plan.poolId !== undefined) {
+          throw new Error(`Docker task "${taskDef.id}" cannot declare poolId`);
+        }
         taskConfig = { ...baseConfig, runnerKind: 'docker' as const, dockerImage: taskDef.dockerImage };
-      } else if (effectivePoolId) {
-        taskConfig = { ...baseConfig, runnerKind: 'ssh' as const };
+        resolvedRoutingByTaskId.set(scopedId, { type: 'dockerImage' });
       } else {
-        taskConfig = { ...baseConfig, runnerKind: 'worktree' as const };
+        const resolvedRouting = resolveExecutorRouting(
+          taskDef.id,
+          taskDef.command,
+          taskDef.poolId ?? plan.poolId,
+          this.defaultPoolId,
+          this.executorRoutingRules,
+          this.availablePoolIds,
+        );
+        taskConfig = resolvedRouting.poolId === BUILT_IN_LOCAL_EXECUTION_POOL_ID
+          ? { ...baseConfig, runnerKind: 'worktree' as const, poolId: resolvedRouting.poolId }
+          : { ...baseConfig, runnerKind: 'ssh' as const, poolId: resolvedRouting.poolId };
+        resolvedRoutingByTaskId.set(scopedId, resolvedRouting.reason);
       }
       const task = createTaskState(
         scopedId,
@@ -1623,10 +1622,14 @@ export class Orchestrator {
     for (const task of validatedTasks) {
       this.createAndSync(task);
       this.persistence.logEvent?.(task.id, 'task.created');
+      const routingReason = resolvedRoutingByTaskId.get(task.id);
+      if (!routingReason) {
+        throw new Error(`Task "${task.id}" is missing resolved executor routing`);
+      }
       this.persistence.logEvent?.(task.id, 'task.executor.routed', buildExecutorRoutedPayload(
-        task.config.runnerKind ?? 'worktree',
+        task.config.runnerKind,
         task.config.poolId,
-        task.config.dockerImage ? { type: 'dockerImage' } : resolvedRoutingByTaskId.get(task.id) ?? { type: 'defaultWorktree' },
+        routingReason,
       ));
       deltas.push({ type: 'created', task });
     }
@@ -2851,7 +2854,7 @@ export class Orchestrator {
       const deps = hasInternalDeps
         ? rt.dependencies!.map((d) => scopeLocal(d))
         : [...task.dependencies];
-      const rtRunnerKind = normalizeRunnerKind(rt.runnerKind) ?? task.config.runnerKind ?? 'worktree';
+      const rtRunnerKind = normalizeRunnerKind(rt.runnerKind) ?? task.config.runnerKind;
       const rtBase = {
         workflowId: wfId,
         command: rt.command,
@@ -2859,8 +2862,10 @@ export class Orchestrator {
         executionAgent: rt.executionAgent ?? task.config.executionAgent,
         executionModel: rt.executionModel ?? task.config.executionModel,
         maxTurns: rt.maxTurns ?? task.config.maxTurns,
-        poolId: task.config.poolId,
       } as const;
+      const inheritedPoolId = task.config.runnerKind === 'worktree' || task.config.runnerKind === 'ssh'
+        ? task.config.poolId
+        : BUILT_IN_LOCAL_EXECUTION_POOL_ID;
       // Replacement tasks inherit executor config from the parent task.
       // The switch narrows the config so TS accepts the correct variant.
       let rtConfig: TaskConfig;
@@ -2872,16 +2877,25 @@ export class Orchestrator {
           };
           break;
         case 'ssh':
-          rtConfig = ({
-            ...rtBase, runnerKind: 'ssh',
-            poolMemberId: task.config.runnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined,
-          } as unknown) as TaskConfig;
+          rtConfig = {
+            ...rtBase,
+            runnerKind: 'ssh',
+            poolId: inheritedPoolId,
+            poolMemberId: task.config.runnerKind === 'ssh' ? task.config.poolMemberId : undefined,
+          };
           break;
         case 'scratch':
           rtConfig = { ...rtBase, runnerKind: 'scratch' as const };
           break;
+        case 'merge':
+          throw new Error(`Replacement task "${rt.id}" cannot use runnerKind=merge`);
         default:
-          rtConfig = { ...rtBase, runnerKind: 'worktree' as const };
+          rtConfig = {
+            ...rtBase,
+            runnerKind: 'worktree' as const,
+            poolId: inheritedPoolId,
+            poolMemberId: task.config.runnerKind === 'worktree' ? task.config.poolMemberId : undefined,
+          };
           break;
       }
       const newTask = createTaskState(scopedId, rt.description, deps, rtConfig);

--- a/packages/workflow-core/src/orchestrator/task-edits.ts
+++ b/packages/workflow-core/src/orchestrator/task-edits.ts
@@ -16,7 +16,7 @@
  */
 
 import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus } from '@invoker/workflow-graph';
-import { normalizeRunnerKind } from '@invoker/workflow-graph';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, normalizeRunnerKind } from '@invoker/workflow-graph';
 import {
   OrchestratorError,
   OrchestratorErrorCode,
@@ -116,6 +116,9 @@ export function editTaskTypeImpl(
   if (task.config.isMergeNode) throw new Error(`Cannot change executor type of merge node ${taskId}`);
 
   const effectiveType = normalizeRunnerKind(runnerKind) ?? runnerKind;
+  if (effectiveType === 'merge') {
+    throw new Error(`Cannot change task "${taskId}" to merge executor type`);
+  }
 
   // SSH requires repoUrl on the workflow to clone onto the remote host
   if (effectiveType === 'ssh' && task.config.workflowId && host.persistence.loadWorkflow) {
@@ -129,8 +132,7 @@ export function editTaskTypeImpl(
   }
 
   const oldRunnerKind = task.config.runnerKind;
-  const oldPoolMemberId =
-    oldRunnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined;
+  const oldPoolMemberId = oldRunnerKind === 'ssh' ? task.config.poolMemberId : undefined;
   const newPoolMemberId = effectiveType === 'ssh' ? poolMemberId : undefined;
   const hostKey = (et: string | undefined, rid: string | undefined): string =>
     et === 'ssh' ? `ssh:${rid ?? ''}` : 'local';
@@ -142,12 +144,16 @@ export function editTaskTypeImpl(
     host.cancelTask(taskId);
   }
 
-  const configPatch: Record<string, unknown> = { runnerKind: effectiveType };
-  if (effectiveType === 'ssh') {
-    configPatch.poolMemberId = poolMemberId;
-  } else {
-    configPatch.poolMemberId = undefined;
-  }
+  const inheritedPoolId = task.config.runnerKind === 'worktree' || task.config.runnerKind === 'ssh'
+    ? task.config.poolId
+    : BUILT_IN_LOCAL_EXECUTION_POOL_ID;
+  const configPatch: NonNullable<TaskStateChanges['config']> = effectiveType === 'ssh'
+    ? { runnerKind: 'ssh', poolId: inheritedPoolId, poolMemberId, dockerImage: undefined }
+    : effectiveType === 'worktree'
+      ? { runnerKind: 'worktree', poolId: inheritedPoolId, poolMemberId: undefined, dockerImage: undefined }
+      : effectiveType === 'docker'
+        ? { runnerKind: 'docker', poolId: undefined, poolMemberId: undefined }
+        : { runnerKind: 'scratch', poolId: undefined, poolMemberId: undefined, dockerImage: undefined };
   const typeChanges: TaskStateChanges = { config: configPatch };
   const typeBefore = host.stateGetTask(taskId)!;
   const typeUpdated = host.writeAndSync(taskId, typeChanges);
@@ -166,6 +172,9 @@ export function editTaskPoolImpl(host: TaskEditHost, taskId: string, poolId: str
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   if (task.config.isMergeNode) throw new Error(`Cannot change executor pool of merge node ${taskId}`);
+  if (task.config.runnerKind === 'docker' || task.config.runnerKind === 'scratch') {
+    throw new Error(`Cannot change executor pool of ${task.config.runnerKind} task ${taskId}`);
+  }
   if (!poolId || !host.availablePoolIds.has(poolId)) {
     throw new Error(
       `Cannot switch task "${taskId}" to poolId="${poolId}": pool is not defined in executionPools. ` +
@@ -180,9 +189,9 @@ export function editTaskPoolImpl(host: TaskEditHost, taskId: string, poolId: str
   const poolChanges: TaskStateChanges = {
     config: {
       poolId,
-      runnerKind: undefined,
+      runnerKind: poolId === BUILT_IN_LOCAL_EXECUTION_POOL_ID ? 'worktree' : 'ssh',
       poolMemberId: undefined,
-    } as TaskStateChanges['config'],
+    },
   };
   const poolBefore = host.stateGetTask(taskId)!;
   const poolUpdated = host.writeAndSync(taskId, poolChanges);

--- a/packages/workflow-core/src/state-invariants.ts
+++ b/packages/workflow-core/src/state-invariants.ts
@@ -1,4 +1,5 @@
 import type { ExternalDependency, ExternalDependencyChange, TaskState } from '@invoker/workflow-graph';
+import { assertResolvedTaskConfig } from '@invoker/workflow-graph';
 
 export interface WorkflowInvariantLike {
   readonly id?: unknown;
@@ -151,4 +152,5 @@ export function assertTaskConsistent(task: TaskState): void {
   if (!nonEmptyString(task.id)) {
     throw new Error('task.id must be a non-empty string');
   }
+  assertResolvedTaskConfig(task.config);
 }

--- a/packages/workflow-graph/src/__tests__/types.test.ts
+++ b/packages/workflow-graph/src/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createTaskState, createAttempt } from '../types.js';
+import { applyTaskConfigPatch, assertResolvedTaskConfig, createAttempt, createTaskState, resolveTaskConfig } from '../types.js';
 import type { TaskConfig } from '../types.js';
 
 describe('createTaskState', () => {
@@ -19,12 +19,27 @@ describe('createTaskState', () => {
     expect(task.execution).toEqual({ generation: 0 });
   });
 
-  // TODO(#11576): drop .fails once the persisted executor-pool invariant lands.
-  it.fails('defaults to the built-in local pool config and empty execution', () => {
+  it('defaults to the built-in local pool config and empty execution', () => {
     const task = createTaskState('t2', 'plain task', []);
 
     expect(task.config).toEqual({ runnerKind: 'worktree', poolId: 'local-worktree' });
     expect(task.execution).toEqual({ generation: 0 });
+  });
+
+  it('rejects a config patch that pairs runnerKind and isMergeNode inconsistently', () => {
+    const merge: TaskConfig = { runnerKind: 'merge' };
+    expect(() => applyTaskConfigPatch(merge, { executionAgent: 'codex' }))
+      .not.toThrow();
+    expect(() => applyTaskConfigPatch(merge, { isMergeNode: false }))
+      .toThrow('must pair with isMergeNode=true');
+    const worktree = resolveTaskConfig({ runnerKind: 'worktree' });
+    expect(() => applyTaskConfigPatch(worktree, { isMergeNode: true }))
+      .toThrow('must pair with isMergeNode=false');
+  });
+
+  it('tolerates a stale isMergeNode/runnerKind mismatch when reading an already-persisted config', () => {
+    expect(() => assertResolvedTaskConfig({ runnerKind: 'worktree', poolId: 'local-worktree', isMergeNode: true }))
+      .not.toThrow();
   });
 
   it('copies dependencies without shared reference', () => {

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -65,10 +65,6 @@ export interface BaseTaskConfig {
   readonly freshness?: TaskFreshnessSpec;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
-  /** Execution pool identifier for shared queue/drain scheduling across substrates. */
-  readonly poolId?: string;
-  /** Legacy direct SSH pool member selection used by editable runner controls. */
-  readonly poolMemberId?: string;
   /**
    * Fix-session prompt override carried on the failed task across the
    * `failed` → `fixing_with_ai` → `failed` cycle (Step 10 of the
@@ -85,34 +81,95 @@ export interface BaseTaskConfig {
   readonly fixContext?: string;
 }
 
-export interface WorktreeTaskConfig extends BaseTaskConfig {
-  readonly runnerKind?: 'worktree';
+interface PooledRepositoryTaskConfig extends BaseTaskConfig {
+  readonly poolId: string;
+  readonly poolMemberId?: string;
   readonly dockerImage?: never;
 }
 
-export interface DockerTaskConfig extends BaseTaskConfig {
+export interface WorktreeTaskConfig extends PooledRepositoryTaskConfig {
+  readonly runnerKind: 'worktree';
+}
+
+export interface SshTaskConfig extends PooledRepositoryTaskConfig {
+  readonly runnerKind: 'ssh';
+}
+
+interface NonPoolTaskConfig extends BaseTaskConfig {
+  readonly poolId?: never;
+  readonly poolMemberId?: never;
+}
+
+export interface DockerTaskConfig extends NonPoolTaskConfig {
   readonly runnerKind: 'docker';
   readonly dockerImage?: string;
 }
 
-export interface SshTaskConfig extends BaseTaskConfig {
-  readonly runnerKind: 'ssh';
-  readonly dockerImage?: never;
-}
-
 /** Internal-only config for merge gate nodes. */
-export interface MergeTaskConfig extends BaseTaskConfig {
+export interface MergeTaskConfig extends NonPoolTaskConfig {
   readonly runnerKind: 'merge';
   readonly dockerImage?: never;
 }
 
 /** No-repo config: task runs in a plain temp directory, no git involved. */
-export interface ScratchTaskConfig extends BaseTaskConfig {
+export interface ScratchTaskConfig extends NonPoolTaskConfig {
   readonly runnerKind: 'scratch';
   readonly dockerImage?: never;
 }
 
 export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig | ScratchTaskConfig;
+
+export type TaskConfigPatch = Partial<BaseTaskConfig> & {
+  readonly runnerKind?: TaskConfig['runnerKind'];
+  readonly poolId?: string;
+  readonly poolMemberId?: string;
+  readonly dockerImage?: string;
+};
+
+export function assertResolvedTaskConfig(config: unknown): asserts config is TaskConfig {
+  if (typeof config !== 'object' || config === null) {
+    throw new Error('Task config must be an object');
+  }
+  const candidate = config as Record<string, unknown>;
+  const runnerKind = candidate.runnerKind;
+  const poolId = candidate.poolId;
+  const hasConcretePool = typeof poolId === 'string' && poolId.trim().length > 0;
+
+  if (runnerKind === 'worktree' || runnerKind === 'ssh') {
+    if (!hasConcretePool) {
+      throw new Error(`Task config runnerKind=${runnerKind} requires a non-empty poolId`);
+    }
+    if (candidate.dockerImage !== undefined) {
+      throw new Error(`Task config runnerKind=${runnerKind} cannot declare dockerImage`);
+    }
+    return;
+  }
+
+  if (runnerKind === 'docker' || runnerKind === 'merge' || runnerKind === 'scratch') {
+    if (poolId !== undefined || candidate.poolMemberId !== undefined) {
+      throw new Error(`Task config runnerKind=${runnerKind} cannot declare poolId or poolMemberId`);
+    }
+    if (runnerKind !== 'docker' && candidate.dockerImage !== undefined) {
+      throw new Error(`Task config runnerKind=${runnerKind} cannot declare dockerImage`);
+    }
+    return;
+  }
+
+  throw new Error(`Task config has invalid runnerKind=${JSON.stringify(runnerKind)}`);
+}
+
+export function applyTaskConfigPatch(config: TaskConfig, patch: TaskConfigPatch | undefined): TaskConfig {
+  if (!patch) return config;
+  const candidate: unknown = { ...config, ...patch };
+  if ('isMergeNode' in patch || 'runnerKind' in patch) {
+    const merged = candidate as { isMergeNode?: boolean; runnerKind?: unknown };
+    if ((merged.isMergeNode === true) !== (merged.runnerKind === 'merge')) {
+      throw new Error(`Task config patch runnerKind=${JSON.stringify(merged.runnerKind)} must pair with isMergeNode=${merged.runnerKind === 'merge'}`);
+    }
+  }
+  assertResolvedTaskConfig(candidate);
+  return candidate;
+}
 
 export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
 
@@ -321,7 +378,7 @@ export interface TaskStateChanges {
   readonly description?: string;
   readonly status?: TaskStatus;
   readonly dependencies?: readonly string[];
-  readonly config?: Partial<TaskConfig>;
+  readonly config?: TaskConfigPatch;
   readonly execution?: Partial<TaskExecution>;
 }
 
@@ -332,9 +389,27 @@ export type TaskDelta =
   | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number; readonly streamSequence?: number }
   | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number; readonly streamSequence?: number };
 
-// ── Task Create Options (alias for TaskConfig) ──────────────
+export type TaskCreateOptions = TaskConfigPatch;
 
-export type TaskCreateOptions = TaskConfig;
+export function resolveTaskConfig(options: TaskCreateOptions = {}): TaskConfig {
+  const runnerKind = (options.isMergeNode ? 'merge' : undefined)
+    ?? (options.runnerKind === 'scratch' ? 'scratch' : undefined)
+    ?? (options.dockerImage !== undefined ? 'docker' : undefined)
+    ?? options.runnerKind
+    ?? (options.poolId && options.poolId !== BUILT_IN_LOCAL_EXECUTION_POOL_ID ? 'ssh' : 'worktree');
+  let candidate: unknown;
+  if (runnerKind === 'worktree') {
+    candidate = { ...options, runnerKind, poolId: options.poolId ?? BUILT_IN_LOCAL_EXECUTION_POOL_ID };
+  } else if (runnerKind === 'ssh') {
+    candidate = { ...options, runnerKind };
+  } else if (runnerKind === 'docker') {
+    candidate = { ...options, runnerKind, poolId: undefined, poolMemberId: undefined };
+  } else {
+    candidate = { ...options, runnerKind, poolId: undefined, poolMemberId: undefined, dockerImage: undefined };
+  }
+  assertResolvedTaskConfig(candidate);
+  return candidate;
+}
 
 function resolveInitialTaskTimestamp(): Date {
   if (process.env.NODE_ENV === 'test' && process.env.INVOKER_TEST_FIXED_NOW) {
@@ -351,13 +426,14 @@ export function createTaskState(
   dependencies: string[],
   options: TaskCreateOptions = {},
 ): TaskState {
+  const config = resolveTaskConfig(options);
   return {
     id,
     description,
     status: 'pending',
     dependencies: [...dependencies],
     createdAt: resolveInitialTaskTimestamp(),
-    config: { ...options },
+    config,
     execution: { generation: 0 },
     taskStateVersion: 1,
   };


### PR DESCRIPTION
## Summary

A task that omitted its execution pool used to route to storage and reload as `undefined`. Nothing downstream enforced a real pool.

Now a pool-dispatched task cannot be routed without a concrete pool id. Docker, merge, and scratch tasks stay pool-free by design; they never enter pool routing.

Plan loading resolves an omitted pool before the task is constructed, so routing always sees a real id.

SQLite migrates old null-pool rows to the built-in local pool and blocks any new null-pool write.

Merge gates now keep `runnerKind: merge` after the gate action instead of being rewritten as worktree tasks.

Task output files now sit next to their file-backed database, and in-memory databases get a private temp directory even when `INVOKER_DB_DIR` is set. Two existing adapter tests already expect this.

A direct `saveTask` call with an unresolved config (empty, or a bare `poolId`) now resolves it the same way plan loading does, instead of throwing.

This keeps existing callers working. It still blocks a genuinely inconsistent write, such as a merge-flagged task that also declares a pool.

A merge gate is routed by its own flag, not by `runnerKind`. `selectExecutor` no longer requires a pool id for a merge-gate task.

That must still work on legacy rows where the flag and `runnerKind` disagree.

The previous slice marked the flipped test expectations as failing; this slice drops those markers.

## Review Claim

Approve that pool-dispatched task routing requires a concrete pool id end to end: plan resolution, SQLite migration and enforcement, and executor member selection.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Explicit pools keep precedence over defaults. An unknown pool id fails before any workflow or task write. Docker, merge, and scratch task variants carry no pool field. Legacy ordinary repository rows migrate to the built-in local pool without changing terminal status, dependencies, or attempt history.

## Slice Rationale

Runtime routing and persistence land together here because an intermediate branch that accepts a pool-less task in memory, but cannot round-trip it through storage, is not a safe place to pause review.

## Non-goals

No inspector styling or visual fixture changes. No changes to pool member selection strategy. Docker does not become a pool member.

## Architecture

### Before

A test file could build a task config by hand — a plain object literal with no runner kind, or a worktree-typed config with no pool — and pass it straight into a runner or a repository save call.

### After

The same hand-built configs now go through the same defaulting step a loaded plan already used. A test that still supplies its own runner kind and pool keeps that exact value; only the missing pieces get filled in.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/data-store test`
- [ ] `pnpm --filter @invoker/workflow-core test`
- [ ] `pnpm --filter @invoker/execution-engine test -- task-runner`
- [ ] `pnpm --filter @invoker/execution-engine test`
- [ ] `pnpm --filter @invoker/app test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — the SQLite migration only backfills legacy null-pool rows to the built-in local pool; it does not need to be undone to revert this PR

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core task routing, SQLite schema/triggers, and migration of existing task rows—mis-routing or failed migration could block launches or strand running tasks on wrong executors.
> 
> **Overview**
> **Pool-dispatched tasks must carry a concrete `poolId` from plan load through SQLite and into `TaskRunner` selection.** Omitted pools default to the built-in local pool (`local-worktree`) via `resolveTaskConfig` / `applyTaskConfigPatch`; docker, merge, and scratch configs explicitly forbid pool fields.
> 
> **Persistence and routing behavior tighten together:** SQLite migrates legacy null-pool rows, adds insert/update triggers that abort invalid `runner_kind`/`pool_id` combinations, and `saveTask` resolves config before write. The orchestrator always treats the built-in pool as available, resolves routing at `loadPlan`, and pool edits set `runnerKind` to worktree vs ssh from the target pool. **Merge gates stop being rewritten as worktree** after gate actions (`runnerKind: 'merge'`).
> 
> **Execution engine:** `selectExecutor` drops SSH→worktree fallback for missing pools, requires configured pools for worktree/ssh, and asserts resolved config for non-merge tasks. Task output directories for ephemeral DBs use a private temp path; file-backed DBs use `dirname(db)` + `task-output`.
> 
> Tests and harnesses adopt `resolveTaskConfig`, pass `availablePoolIds` where remote pools are used, and previously `.fails` expectations for #11576 are now normal passing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54b30c20a6b24cd733d42c333c9e8332f5d0c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->