### PR TITLE
[Harness config migration](1) Guard execution harness config migration by consumer capability

### DIFF
--- a/scripts/migrate-default-execution-harness.mjs
+++ b/scripts/migrate-default-execution-harness.mjs
@@ -9,7 +9,13 @@ const localPath = process.env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homedir()
 const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 const backupSuffix = `.bak.default-execution-harness-${timestamp}`;
 
-function migrateJson(text, label) {
+export function migrateJson(text, label, { consumerSupportsHarness = false } = {}) {
+  if (!consumerSupportsHarness) {
+    throw new Error(
+      'Refusing defaultExecutionHarness migration: installed consumer capability was not proven. ' +
+      'Re-run after deploying a consumer that supports defaultExecutionHarness with --consumer-supports-harness.',
+    );
+  }
   const config = JSON.parse(text);
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
     throw new Error(`${label} must contain a JSON object`);
@@ -21,13 +27,13 @@ function migrateJson(text, label) {
   return `${JSON.stringify(config, null, 2)}\n`;
 }
 
-function migrateLocal() {
+function migrateLocal(consumerSupportsHarness) {
   if (!existsSync(localPath)) {
     console.log(`LOCAL skipped missing ${localPath}`);
     return null;
   }
   const original = readFileSync(localPath, 'utf8');
-  const migrated = migrateJson(original, localPath);
+  const migrated = migrateJson(original, localPath, { consumerSupportsHarness });
   if (migrated === original) {
     console.log(`LOCAL unchanged ${localPath}`);
     return null;
@@ -63,28 +69,36 @@ NODE
 `;
 }
 
-const local = migrateLocal();
-if (process.argv.includes('--local-only')) process.exit(0);
+export function runMigration(argv = process.argv.slice(2)) {
+  const consumerSupportsHarness = argv.includes('--consumer-supports-harness');
+  if (argv.includes('--local-only')) {
+    migrateLocal(consumerSupportsHarness);
+    return;
+  }
 
-const localConfig = JSON.parse(readFileSync(localPath, 'utf8'));
-for (const [id, target] of Object.entries(localConfig.remoteTargets ?? {})) {
-  if (!id.includes('digital_ocean') || !target?.host || !target?.user || !target?.sshKeyPath) continue;
-  const remoteConfigPath = `${target.remoteInvokerHome || '~/.invoker'}/config.json`;
-  const expandedPath = remoteConfigPath.startsWith('~/') ? `$HOME/${remoteConfigPath.slice(2)}` : remoteConfigPath;
-  const command = remoteScript(expandedPath, backupSuffix);
-  try {
-    const output = execFileSync('ssh', [
-      '-i', target.sshKeyPath,
-      '-p', String(target.port || 22),
-      '-o', 'ConnectTimeout=15',
-      '-o', 'BatchMode=yes',
-      `${target.user}@${target.host}`,
-      'bash', '-s', '--', expandedPath,
-    ], { input: command, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
-    process.stdout.write(`${id} ${output}`);
-  } catch (error) {
-    const detail = error.stderr?.toString().trim() || error.message;
-    console.error(`${id} FAILED ${detail}`);
-    process.exitCode = 1;
+  migrateLocal(consumerSupportsHarness);
+  const localConfig = JSON.parse(readFileSync(localPath, 'utf8'));
+  for (const [id, target] of Object.entries(localConfig.remoteTargets ?? {})) {
+    if (!id.includes('digital_ocean') || !target?.host || !target?.user || !target?.sshKeyPath) continue;
+    const remoteConfigPath = `${target.remoteInvokerHome || '~/.invoker'}/config.json`;
+    const expandedPath = remoteConfigPath.startsWith('~/') ? `$HOME/${remoteConfigPath.slice(2)}` : remoteConfigPath;
+    const command = remoteScript(expandedPath, backupSuffix);
+    try {
+      const output = execFileSync('ssh', [
+        '-i', target.sshKeyPath,
+        '-p', String(target.port || 22),
+        '-o', 'ConnectTimeout=15',
+        '-o', 'BatchMode=yes',
+        `${target.user}@${target.host}`,
+        'bash', '-s', '--', expandedPath,
+      ], { input: command, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+      process.stdout.write(`${id} ${output}`);
+    } catch (error) {
+      const detail = error.stderr?.toString().trim() || error.message;
+      console.error(`${id} FAILED ${detail}`);
+      process.exitCode = 1;
+    }
   }
 }
+
+if (import.meta.url === `file://${process.argv[1]}`) runMigration();

--- a/scripts/test-migrate-default-execution-harness.mjs
+++ b/scripts/test-migrate-default-execution-harness.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { migrateJson } from './migrate-default-execution-harness.mjs';
+
+const legacy = JSON.stringify({ defaultExecutionAgent: 'codex', defaultExecutionModel: 'gpt-5.6-luna' });
+assert.throws(
+  () => migrateJson(legacy, 'fixture', { consumerSupportsHarness: false }),
+  /installed consumer capability was not proven/,
+);
+assert.deepEqual(
+  JSON.parse(migrateJson(legacy, 'fixture', { consumerSupportsHarness: true })),
+  { defaultExecutionModel: 'gpt-5.6-luna', defaultExecutionHarness: 'codex' },
+);
+console.log('PASS: migration refuses legacy-key deletion without consumer capability proof');
+console.log('PASS: migration renames legacy key after consumer capability proof');


### PR DESCRIPTION
## Summary

The execution-harness migration now fails closed unless deployment explicitly proves that the installed consumer understands `defaultExecutionHarness`.

The legacy key remains untouched when that proof is absent, preventing an older consumer from losing its only usable default.

## Review Claim

The migration cannot delete `defaultExecutionAgent` before consumer capability is proven.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Without `--consumer-supports-harness`, migration performs no config rewrite and preserves the legacy key; with the flag, it copies the legacy value to the canonical key before deletion.

Assumption: deployment owns the capability assertion and invokes the migration only after installing the compatible consumer.

## Slice Rationale

This is the compatibility gate for the existing configuration migration, isolated from consumer parsing and runtime behavior.

## Non-goals

- No live DigitalOcean configuration changes.
- No change to task-level `executionAgent`.
- No automatic consumer upgrade or capability discovery.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-migrate-default-execution-harness.mjs`
- [x] `node scripts/lint-pr-diff-atomicity.mjs --base origin/master`
- [x] `git diff --cached --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

