### PR TITLE
Require final PR body validation before publication

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -1075,8 +1075,6 @@ async function main() {
     console.error(`UI-impacting files changed; requiring visual proof: ${uiImpactingFiles.join(', ')}`);
   }
 
-  await assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles, diffText });
-  printPrBodyWarnings(body, changedFiles, diffText);
   body = await injectImages(body, args.dryRun);
 
   const requestedUpdatePath = Boolean(args.update || args.updateExisting);
@@ -1100,6 +1098,11 @@ async function main() {
   if (isStackedPrContext(args.base, mergifyState)) {
     assertValidStackPrTitle(args.title, reviewLane);
   }
+
+  // Validate the final body after stack-specific publication gates and image
+  // injection, immediately before any push or GitHub PR mutation.
+  await assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles, diffText });
+  printPrBodyWarnings(body, changedFiles, diffText);
 
   if (!nwo) {
     nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -1429,6 +1429,30 @@ function testCreatePrDryRunMatchesCiBodyValidation() {
   }
 }
 
+function testSummaryOnlyAndMissingBodiesBlockPublication() {
+  for (const body of [
+    '## Summary\n\nCursor-generated summary only.\n',
+    '',
+  ]) {
+    const harness = createHarness();
+    try {
+      const { work } = createRepo(harness);
+      createTrackedBranch(work, 'feature/invalid-body');
+      commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+      writeFileSync(join(work, 'pr-body.md'), body);
+
+      const result = runCreatePr(work, harness, [...baseArgs(), '--dry-run']);
+
+      assert(result.status === 1, `invalid PR body should block publication\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      assert(result.stderr.includes('PR body does not match the canonical review-compression schema.'), 'invalid body should report schema rejection');
+      expectNoPush(harness, 'invalid PR body');
+      expectNoGhCalls(harness, 'invalid PR body');
+    } finally {
+      rmSync(harness.root, { recursive: true, force: true });
+    }
+  }
+}
+
 function testDiffComputationFailureBlocksPrCreation() {
   const harness = createHarness();
   try {
@@ -1491,6 +1515,7 @@ const tests = [
   testNonMergifyPrAllowsPlanBase,
   testDiffAtomicityBlocksMixedDiff,
   testCreatePrDryRunMatchesCiBodyValidation,
+  testSummaryOnlyAndMissingBodiesBlockPublication,
   testDiffComputationFailureBlocksPrCreation,
   testHelpMentionsStackUpdateFlow,
 ];


### PR DESCRIPTION
## Summary

PR publication checks the final body immediately before push or GitHub mutation.

Invalid summary-only and missing bodies now have explicit regression coverage.

## Review Claim

Publication cannot create or update a PR with an incomplete body.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Only the final PR-body check ordering and its publication-blocking regression test change.

## Slice Rationale

Keep publication safety enforcement separate from product runtime behavior.

## Non-goals

- Do not change PR body schema rules.
- Do not change stack splitting behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-create-pr-stack-workflow.mjs`
- [ ] `node scripts/test-pr-diff-atomicity.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 7782afb8e7`.
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only ordering change in create-pr with added tests; PR body schema rules and stack behavior are unchanged.
> 
> **Overview**
> **`create-pr`** now runs canonical PR body validation on the **final** body—after Mergify/stack publication gates, stack title checks, and **`injectImages`**—and only then allows **`git push`** or GitHub create/update.
> 
> That closes a gap where an early check could pass on a draft body while publication would still push or mutate a PR with an incomplete or schema-invalid body (including post-injection content).
> 
> A new stack-workflow regression test asserts **summary-only** and **empty** bodies fail with the schema error and perform **no** push or **`gh`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc21ebeede34a7572bd5a3e3a3d35443d0b38d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->