### PR TITLE
[CI Failure Identity](1) Require structured CI failure identities

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -266,80 +266,6 @@ export function buildMarkerComment(sha, jobName, failureId = JOB_LEVEL_FAILURE_I
   return `<!-- ${buildMarker(sha, jobName, failureId)} -->`;
 }
 
-function stripGitRefListingLines(text) {
-  return text
-    .split('\n')
-    .filter((line) => !/\[(?:new branch|new tag)\]|\s->\s+(?:origin\/|refs\/)/.test(line))
-    .join('\n');
-}
-
-/**
- * Derive stable per-test / per-repro identities from a CI job log.
- * Multiple distinct failures under one job must each get their own repair
- * lifecycle (incident 2026-08-21: Mergify Admin Requeue stayed red on a new
- * repro after an earlier same-job repair had already been filed).
- */
-export function extractFailureIdentitiesFromLog(logText) {
-  const text = stripGitRefListingLines(String(logText ?? ''));
-  if (!text.trim()) return [];
-
-  const found = new Map();
-  const add = (id, kind, label, evidence) => {
-    const normalized = slugify(id, 96);
-    if (!normalized || normalized === 'ci-job') return;
-    if (found.has(normalized)) return;
-    found.set(normalized, {
-      failureId: normalized,
-      kind,
-      label: label || normalized,
-      evidence: evidence || '',
-    });
-  };
-
-  for (const match of text.matchAll(/(?:scripts\/repro\/)?(repro-[a-z0-9][a-z0-9._-]*)(?:\.sh)?/gi)) {
-    add(match[1].replace(/\.sh$/i, ''), 'repro', match[1], match[0]);
-  }
-  for (const match of text.matchAll(/\/tmp\/(repro-[a-z0-9][a-z0-9._-]*)\.[A-Za-z0-9]+\b/gi)) {
-    add(match[1], 'repro', match[1], match[0]);
-  }
-  for (const match of text.matchAll(/^(?:FAIL|ERROR):\s+([^\n(]+)/gm)) {
-    add(match[1].trim(), 'unittest', match[1].trim(), match[0]);
-  }
-  for (const match of text.matchAll(/\b(scripts\/test_[a-z0-9_]+\.py)\b/gi)) {
-    add(match[1], 'unittest-file', match[1], match[0]);
-  }
-  for (const match of text.matchAll(/FAIL\s+([^\n]+?\.test\.[jt]sx?[^\n]*)/g)) {
-    add(match[1].trim(), 'vitest', match[1].trim(), match[0]);
-  }
-  for (const match of text.matchAll(/\b((?:e2e|src)\/[^\s:]+\.(?:spec|test)\.[jt]sx?)\b/g)) {
-    add(match[1], 'playwright-or-vitest-file', match[1], match[0]);
-  }
-  for (const match of text.matchAll(/^\s*[×x]\s+(.+)$/gm)) {
-    const label = match[1].trim();
-    if (label.length >= 8 && label.length <= 160) add(label, 'test-title', label, match[0]);
-  }
-
-  if (found.size > 0) return Array.from(found.values());
-
-  const errorLine = text
-    .split(/\r?\n/)
-    .map((line) => line.replace(/^\S+\s+UNKNOWN STEP\s+\S+\s+/, '').trim())
-    .filter((line) => /(?:error|failed|cannot remove|exception)/i.test(line))
-    .at(-1);
-  if (errorLine) {
-    const fingerprint = slugify(errorLine.replace(/\b[0-9a-f]{7,}\b/gi, 'HEX').slice(0, 120), 72);
-    if (fingerprint && fingerprint !== 'ci-job') {
-      return [{
-        failureId: `err-${fingerprint}`,
-        kind: 'error-fingerprint',
-        label: errorLine.slice(0, 160),
-        evidence: errorLine,
-      }];
-    }
-  }
-  return [];
-}
-
 export function resolveJobFailureIdentities(job, opts = {}) {
   if (Array.isArray(job?.failureIdentities) && job.failureIdentities.length > 0) {
     return job.failureIdentities.map((entry) => {
@@ -357,11 +283,9 @@ export function resolveJobFailureIdentities(job, opts = {}) {
       };
     });
   }
-  const logText = typeof job?.logText === 'string'
-    ? job.logText
-    : (typeof opts.fetchJobLog === 'function' ? opts.fetchJobLog(job) : '');
-  const extracted = extractFailureIdentitiesFromLog(logText);
-  if (extracted.length > 0) return extracted;
+  // Plain CI logs are evidence, not identity. Without an explicit structured
+  // identity from the provider/reporter, keep the repair at job scope rather
+  // than guessing from paths or prose that may change after a rename.
   return [{
     failureId: JOB_LEVEL_FAILURE_ID,
     kind: 'job',
@@ -701,7 +625,7 @@ export function recordFailureFiled(state, failure, filedAt = new Date()) {
   return normalized;
 }
 
-function getVerifyCommandForFailure(failure, jobDefinitions) {
+export function getVerifyCommandForFailure(failure, jobDefinitions) {
   if (typeof failure?.verifyCommand === 'string' && failure.verifyCommand.trim()) {
     return failure.verifyCommand.trim();
   }

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -12,9 +12,9 @@ import {
   claimRepairFiling,
   CATSTACK_REPO_URL,
   DEFAULT_TARGET_REPO,
-  extractFailureIdentitiesFromLog,
   failureStorageKey,
   fileBugfixPlan,
+  getVerifyCommandForFailure,
   isCiRegressionReflectEnabled,
   getActionableFailures,
   groupFailuresBySha,
@@ -34,6 +34,7 @@ import {
   releaseRepairFilingClaim,
   repairFilingKind,
   resolveRepairFilingSubject,
+  resolveJobFailureIdentities,
   resolveStateDir,
   resolveTargetRepo,
   RECOVERY_COOLDOWN_MS,
@@ -1047,6 +1048,55 @@ describe('retired CI job filing gate', () => {
   });
 });
 
+describe('repair verification scope', () => {
+  it('keeps a real failed CI log at job scope', () => {
+    const artifact = JSON.parse(readFileSync(
+      'scripts/fixtures/real-ci/required-fast-vitest-workspace-99777174547.json',
+      'utf8',
+    ));
+    const identities = resolveJobFailureIdentities({
+      name: artifact.jobName,
+      conclusion: artifact.conclusion,
+      logText: artifact.logExcerpt.join('\n'),
+    });
+    assert.deepEqual(identities, [{
+      failureId: 'job',
+      kind: 'job',
+      label: artifact.jobName,
+      evidence: '',
+    }]);
+  });
+
+  it('does not infer a Playwright spec from failure prose', () => {
+    const command = "env INVOKER_PLAYWRIGHT_FILES='e2e/a.spec.ts e2e/b.spec.ts' bash scripts/test-suites/optional/40-playwright-app.sh";
+    const focused = getVerifyCommandForFailure({
+      jobName: 'playwright / 1-of-9',
+      failureId: 'e2e-headless-thundering-herd-spec-ts',
+      failureLabel: 'e2e/headless-thundering-herd.spec.ts',
+      verifyCommand: command,
+    }, new Map());
+    assert.equal(focused, command);
+  });
+
+  it('keeps Vitest workspace verification broad without structured identity', () => {
+    const focused = getVerifyCommandForFailure({
+      jobName: 'required-fast / Vitest Workspace',
+      failureId: 'packages-app-src-tests-start-ready-test-ts',
+      failureLabel: 'packages/app/src/__tests__/start-ready.test.ts',
+      verifyCommand: 'bash scripts/test-suites/required/10-vitest-workspace.sh',
+    }, new Map());
+    assert.equal(focused, 'bash scripts/test-suites/required/10-vitest-workspace.sh');
+  });
+
+  it('preserves the original command when no safe adapter exists', () => {
+    const command = 'bash scripts/test-suites/dangerous/10-docker-comprehensive.sh';
+    assert.equal(
+      getVerifyCommandForFailure({ jobName: 'docker / comprehensive', failureId: 'docker-failure', failureLabel: 'docker failure', verifyCommand: command }, new Map()),
+      command,
+    );
+  });
+});
+
 function makeRun({ headSha, jobName, conclusion, databaseId, jobDatabaseId, createdAt }) {
   return {
     headSha,
@@ -1346,30 +1396,6 @@ describe('a poison-pill failure must not abort the whole sweep', () => {
 
 describe('per-test failure identity under one CI job', () => {
   const jobName = 'required-fast / Mergify Admin Requeue';
-
-  it('extracts distinct repro identities from the production Mergify Admin Requeue log shape', () => {
-    const log = [
-      "Cloning into '/tmp/repro-babysit-pr-body-human-split.ERdycn/seed'...",
-      "To /tmp/repro-babysit-pr-body-human-split.ERdycn/origin.git",
-      "rm: cannot remove '/tmp/repro-babysit-pr-body-human-split.ERdycn/seed/.git/objects': Directory not empty",
-      '##[error]Process completed with exit code 1.',
-    ].join('\n');
-    const identities = extractFailureIdentitiesFromLog(log);
-    assert.equal(identities.some((entry) => entry.failureId.includes('repro-babysit-pr-body-human-split')), true);
-  });
-
-  it('ignores git ref-sync listings while preserving genuine failure identities', () => {
-    const log = [
-      '* [new branch]  experiment/wf-98378590220/repro-event-loop-block/390bb7f -> origin/experiment/wf-98378590220/repro-event-loop-block/390bb7f',
-      '* [new tag]  repro-asar-enotdir-snapshot -> repro-asar-enotdir-snapshot',
-      'FAIL packages/some-package/src/__tests__/real-distinct-failure.test.ts',
-    ].join('\n');
-    const identities = extractFailureIdentitiesFromLog(log);
-
-    assert.equal(identities.some((entry) => entry.failureId.includes('repro-event-loop-block')), false);
-    assert.equal(identities.some((entry) => entry.failureId.includes('repro-asar-enotdir')), false);
-    assert.equal(identities.some((entry) => entry.failureId.includes('real-distinct-failure')), true);
-  });
 
   it('reproduces the bug: two distinct repros under one job must each get their own repair lifecycle', () => {
     // Observed (pre-fix): after filing a repair for the first Mergify Admin

--- a/scripts/fixtures/real-ci/required-fast-vitest-workspace-99777174547.json
+++ b/scripts/fixtures/real-ci/required-fast-vitest-workspace-99777174547.json
@@ -1,0 +1,15 @@
+{
+  "source": "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/33482988343/job/99777174547",
+  "runId": 33482988343,
+  "jobId": 99777174547,
+  "jobName": "required-fast / Vitest Workspace",
+  "conclusion": "failure",
+  "capturedAt": "2026-09-01T07:41:57Z",
+  "logBytes": 5348748,
+  "logExcerpt": [
+    "2026-09-01T07:39:38.2108462Z Complete job name: required-fast / Vitest Workspace",
+    "2026-09-01T07:40:26.2682255Z Run bash scripts/test-suites/required/10-vitest-workspace.sh",
+    "2026-09-01T07:40:26.5950797Z FAIL: SKILL dogfooding rule must document the later PR publication command — missing in /home/runner/work/Invoker/Invoker/skills/plan-to-invoker/SKILL.md",
+    "2026-09-01T07:40:26.5965634Z ##[error]Process completed with exit code 1."
+  ]
+}


### PR DESCRIPTION
## Summary

CI repair no longer infers a test, file, or repro identity from raw CI log text.

Repairs narrow below job scope only when the CI provider or test reporter supplies an explicit structured identity.

## Review Claim

CI repair must not silently retarget work because a file was renamed or a reporter changed its log format.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This fixture is test-only, contains no secrets, and proves raw CI logs cannot create a narrower repair target.

## Slice Rationale

The shared CI regression watcher rejects brittle log-derived targeting, with coverage from a retained real GitHub Actions failure artifact.

## Non-goals

- Do not add a structured CI reporter in this slice.
- Do not change Invoker workflow submission or stacking behavior.
- Do not change job-level verification commands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`
- [x] `node --test --test-name-pattern='real failed CI log|repair verification scope' scripts/e2e-regression-watch.test.mjs`
- [x] Real artifact: GitHub Actions job `99777174547`, retained at `scripts/fixtures/real-ci/required-fast-vitest-workspace-99777174547.json`
- [x] `node scripts/lint-diff-atomicity.mjs --base origin/master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 1cd7d20a97`.
- Post-revert steps: None.
- Data migration? No.

</details>
