### PR TITLE
[Rename default execution agent config to harness](1)[REFACTOR: Rename Config Key] Canonical harness configuration

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -260,27 +260,56 @@ describe('loadConfig', () => {
     expect(resolveDefaultExecutionAgent(config)).toBe('claude');
   });
 
+  it.each([
+    ['canonical-only', { defaultExecutionHarness: 'claude' }, 'claude'],
+    ['legacy-only', { defaultExecutionAgent: 'claude' }, 'claude'],
+    ['both keys prefer canonical', { defaultExecutionHarness: 'omp', defaultExecutionAgent: 'claude' }, 'omp'],
+  ])('resolves %s flat execution harness', (_label, values, expected) => {
+    writeUserConfig(values);
+    expect(resolveDefaultExecutionAgent(loadConfig())).toBe(expected);
+  });
+
+  it('uses the canonical harness for the flat default model when both keys exist', () => {
+    writeUserConfig({
+      defaultExecutionHarness: 'omp',
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'chatgpt-5.4',
+    });
+    expect(resolveDefaultTaskExecutionSettings(loadConfig())).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
+
+  it('preserves the legacy harness alias and its model', () => {
+    writeUserConfig({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' });
+    expect(resolveDefaultTaskExecutionSettings(loadConfig())).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
+
   it('falls back to the built-in default execution agent', () => {
     expect(resolveDefaultExecutionAgent({})).toBe('codex');
-    expect(resolveDefaultExecutionAgent({ defaultExecutionAgent: '   ' })).toBe('codex');
+    expect(resolveDefaultExecutionAgent({ defaultExecutionHarness: '   ' })).toBe('codex');
   });
 
 
   it('reads default execution settings from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
-      JSON.stringify({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' }),
+      JSON.stringify({ defaultExecutionHarness: 'omp', defaultExecutionModel: 'chatgpt-5.4' }),
     );
     const config = loadConfig();
-    expect(config.defaultExecutionAgent).toBe('omp');
+    expect(config.defaultExecutionHarness).toBe('omp');
     expect(config.defaultExecutionModel).toBe('chatgpt-5.4');
   });
 
   it('resolves built-in task execution defaults when config values are blank', () => {
-    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: '  ', defaultExecutionModel: '   ' })).toEqual({
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionHarness: '  ', defaultExecutionModel: '   ' })).toEqual({
       executionAgent: 'codex',
     });
-    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' })).toEqual({
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionHarness: 'omp', defaultExecutionModel: 'chatgpt-5.4' })).toEqual({
       executionAgent: 'omp',
       executionModel: 'chatgpt-5.4',
     });
@@ -288,16 +317,16 @@ describe('loadConfig', () => {
   it('only reuses the default model when auto-fix stays on the default agent', () => {
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'omp',
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBe('chatgpt-5.4');
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'codex',
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
     expect(resolveAutoFixExecutionModel({
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
   });
@@ -305,12 +334,12 @@ describe('loadConfig', () => {
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'cursor',
       autoFixExecutionModel: 'grok-4.5',
-      defaultExecutionAgent: 'codex',
+      defaultExecutionHarness: 'codex',
       defaultExecutionModel: 'gpt-5.5',
     })).toBe('grok-4.5');
     // Fleet defaults are untouched — a task without autoFixAgent still resolves to codex/gpt-5.5.
     expect(resolveDefaultTaskExecutionSettings({
-      defaultExecutionAgent: 'codex',
+      defaultExecutionHarness: 'codex',
       defaultExecutionModel: 'gpt-5.5',
     })).toEqual({ executionAgent: 'codex', executionModel: 'gpt-5.5' });
   });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -341,9 +341,9 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
     throw new Error('defaultExecution.executionModel requires defaultExecution.executionAgent');
   }
 
-  const flatExecutionAgent = config.defaultExecutionAgent;
-  const hasFlatExecutionAgent = typeof flatExecutionAgent === 'string' && flatExecutionAgent.trim().length > 0;
-  if (config.defaultExecutionModel !== undefined && !hasFlatExecutionAgent) {
+  const flatExecutionHarness = config.defaultExecutionHarness ?? config.defaultExecutionAgent;
+  const hasFlatExecutionHarness = typeof flatExecutionHarness === 'string' && flatExecutionHarness.trim().length > 0;
+  if (config.defaultExecutionModel !== undefined && !hasFlatExecutionHarness) {
     throw new Error('defaultExecutionModel requires defaultExecutionAgent');
   }
 
@@ -359,7 +359,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   }
 
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
-  validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
+  validateConfiguredModel(flatExecutionHarness, config.defaultExecutionModel);
   validatePrMaintenanceTargetRepos(config);
   validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -337,7 +337,7 @@ export interface InvokerConfig {
   /**
    * Preferred execution agent for resolve-conflict (git merge conflicts).
    * When unset, resolve-conflict uses the entry-point path default
-   * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
+   * (explicit CLI/UI agent, then defaultExecutionHarness / autoFixAgent).
    */
   conflictResolutionAgent?: string;
   /**
@@ -346,7 +346,7 @@ export interface InvokerConfig {
    * so conflict resolution can use a cheaper model than normal task work.
    */
   conflictResolutionModel?: string;
-  /** Default execution harness for prompt-backed tasks when the task does not override it. */
+  defaultExecutionHarness?: string;
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
@@ -703,7 +703,7 @@ export function loadConfig(): InvokerConfig {
   return materializeResolvedConfig(validateInvokerConfig(config));
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
-  const configured = config.defaultExecutionAgent?.trim();
+  const configured = (config.defaultExecutionHarness ?? config.defaultExecutionAgent)?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
 }
 
@@ -760,7 +760,7 @@ export interface DefaultTaskExecutionSettings {
 }
 
 export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): DefaultTaskExecutionSettings {
-  const configuredAgent = config.defaultExecutionAgent?.trim();
+  const configuredAgent = (config.defaultExecutionHarness ?? config.defaultExecutionAgent)?.trim();
   const configuredModel = config.defaultExecutionModel?.trim();
   return {
     executionAgent: configuredAgent && configuredAgent.length > 0 ? configuredAgent : BUILT_IN_DEFAULT_EXECUTION_AGENT,


### PR DESCRIPTION
## Summary

Make `defaultExecutionHarness` the canonical flat configuration key.

Keep `defaultExecutionAgent` accepted temporarily so existing configurations resolve the same harness and model.

## Review Claim

Rename the flat default launcher setting to `defaultExecutionHarness` while retaining `defaultExecutionAgent` as a compatibility alias.

## Review Lane

refactor

## Review Unit

validation-policy

## Safety Invariant

Canonical and legacy keys resolve identically; canonical-key precedence is deterministic; task-level `executionAgent` behavior is unchanged.

## Slice Rationale

Keep configuration parsing, resolution, input checks, and focused tests together as one behavior-preserving slice.

## Non-goals

- Do not alter model selection or task persistence.
- Do not rename task-level `executionAgent`.
- Behavior unchanged for existing settings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/config.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
