### PR TITLE
[Rename default execution agent config to harness](3) Document canonical harness configuration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,7 +184,7 @@ Minimal example:
 ```json
 {
   "maxConcurrency": 6,
-  "defaultExecutionAgent": "codex",
+  "defaultExecutionHarness": "codex",
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
   "autoFixCi": false,

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -2,7 +2,7 @@
   "comment": "Example Invoker configuration file",
   "description": "Default location: ~/.invoker/config.json. For repo-specific configs, set INVOKER_REPO_CONFIG_PATH when launching Invoker.",
   "maxConcurrency": 6,
-  "defaultExecutionAgent": "codex",
+  "defaultExecutionHarness": "codex",
 
 
   "executors": {

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -260,27 +260,56 @@ describe('loadConfig', () => {
     expect(resolveDefaultExecutionAgent(config)).toBe('claude');
   });
 
+  it.each([
+    ['canonical-only', { defaultExecutionHarness: 'claude' }, 'claude'],
+    ['legacy-only', { defaultExecutionAgent: 'claude' }, 'claude'],
+    ['both keys prefer canonical', { defaultExecutionHarness: 'omp', defaultExecutionAgent: 'claude' }, 'omp'],
+  ])('resolves %s flat execution harness', (_label, values, expected) => {
+    writeUserConfig(values);
+    expect(resolveDefaultExecutionAgent(loadConfig())).toBe(expected);
+  });
+
+  it('uses the canonical harness for the flat default model when both keys exist', () => {
+    writeUserConfig({
+      defaultExecutionHarness: 'omp',
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'chatgpt-5.4',
+    });
+    expect(resolveDefaultTaskExecutionSettings(loadConfig())).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
+
+  it('preserves the legacy harness alias and its model', () => {
+    writeUserConfig({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' });
+    expect(resolveDefaultTaskExecutionSettings(loadConfig())).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
+
   it('falls back to the built-in default execution agent', () => {
     expect(resolveDefaultExecutionAgent({})).toBe('codex');
-    expect(resolveDefaultExecutionAgent({ defaultExecutionAgent: '   ' })).toBe('codex');
+    expect(resolveDefaultExecutionAgent({ defaultExecutionHarness: '   ' })).toBe('codex');
   });
 
 
   it('reads default execution settings from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
-      JSON.stringify({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' }),
+      JSON.stringify({ defaultExecutionHarness: 'omp', defaultExecutionModel: 'chatgpt-5.4' }),
     );
     const config = loadConfig();
-    expect(config.defaultExecutionAgent).toBe('omp');
+    expect(config.defaultExecutionHarness).toBe('omp');
     expect(config.defaultExecutionModel).toBe('chatgpt-5.4');
   });
 
   it('resolves built-in task execution defaults when config values are blank', () => {
-    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: '  ', defaultExecutionModel: '   ' })).toEqual({
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionHarness: '  ', defaultExecutionModel: '   ' })).toEqual({
       executionAgent: 'codex',
     });
-    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' })).toEqual({
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionHarness: 'omp', defaultExecutionModel: 'chatgpt-5.4' })).toEqual({
       executionAgent: 'omp',
       executionModel: 'chatgpt-5.4',
     });
@@ -288,16 +317,16 @@ describe('loadConfig', () => {
   it('only reuses the default model when auto-fix stays on the default agent', () => {
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'omp',
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBe('chatgpt-5.4');
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'codex',
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
     expect(resolveAutoFixExecutionModel({
-      defaultExecutionAgent: 'omp',
+      defaultExecutionHarness: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
   });
@@ -305,12 +334,12 @@ describe('loadConfig', () => {
     expect(resolveAutoFixExecutionModel({
       autoFixAgent: 'cursor',
       autoFixExecutionModel: 'grok-4.5',
-      defaultExecutionAgent: 'codex',
+      defaultExecutionHarness: 'codex',
       defaultExecutionModel: 'gpt-5.5',
     })).toBe('grok-4.5');
     // Fleet defaults are untouched — a task without autoFixAgent still resolves to codex/gpt-5.5.
     expect(resolveDefaultTaskExecutionSettings({
-      defaultExecutionAgent: 'codex',
+      defaultExecutionHarness: 'codex',
       defaultExecutionModel: 'gpt-5.5',
     })).toEqual({ executionAgent: 'codex', executionModel: 'gpt-5.5' });
   });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -341,9 +341,9 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
     throw new Error('defaultExecution.executionModel requires defaultExecution.executionAgent');
   }
 
-  const flatExecutionAgent = config.defaultExecutionAgent;
-  const hasFlatExecutionAgent = typeof flatExecutionAgent === 'string' && flatExecutionAgent.trim().length > 0;
-  if (config.defaultExecutionModel !== undefined && !hasFlatExecutionAgent) {
+  const flatExecutionHarness = config.defaultExecutionHarness ?? config.defaultExecutionAgent;
+  const hasFlatExecutionHarness = typeof flatExecutionHarness === 'string' && flatExecutionHarness.trim().length > 0;
+  if (config.defaultExecutionModel !== undefined && !hasFlatExecutionHarness) {
     throw new Error('defaultExecutionModel requires defaultExecutionAgent');
   }
 
@@ -359,7 +359,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   }
 
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
-  validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
+  validateConfiguredModel(flatExecutionHarness, config.defaultExecutionModel);
   validatePrMaintenanceTargetRepos(config);
   validateE2eAutoFixTargetRepos(config);
   validateCrossRepoResearchConfig(config);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -337,7 +337,7 @@ export interface InvokerConfig {
   /**
    * Preferred execution agent for resolve-conflict (git merge conflicts).
    * When unset, resolve-conflict uses the entry-point path default
-   * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
+   * (explicit CLI/UI agent, then defaultExecutionHarness / autoFixAgent).
    */
   conflictResolutionAgent?: string;
   /**
@@ -346,7 +346,7 @@ export interface InvokerConfig {
    * so conflict resolution can use a cheaper model than normal task work.
    */
   conflictResolutionModel?: string;
-  /** Default execution harness for prompt-backed tasks when the task does not override it. */
+  defaultExecutionHarness?: string;
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
@@ -703,7 +703,7 @@ export function loadConfig(): InvokerConfig {
   return materializeResolvedConfig(validateInvokerConfig(config));
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
-  const configured = config.defaultExecutionAgent?.trim();
+  const configured = (config.defaultExecutionHarness ?? config.defaultExecutionAgent)?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
 }
 
@@ -760,7 +760,7 @@ export interface DefaultTaskExecutionSettings {
 }
 
 export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): DefaultTaskExecutionSettings {
-  const configuredAgent = config.defaultExecutionAgent?.trim();
+  const configuredAgent = (config.defaultExecutionHarness ?? config.defaultExecutionAgent)?.trim();
   const configuredModel = config.defaultExecutionModel?.trim();
   return {
     executionAgent: configuredAgent && configuredAgent.length > 0 ? configuredAgent : BUILT_IN_DEFAULT_EXECUTION_AGENT,

--- a/scripts/migrate-default-execution-harness.mjs
+++ b/scripts/migrate-default-execution-harness.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const localPath = process.env.INVOKER_REPO_CONFIG_PATH?.trim() || join(homedir(), '.invoker', 'config.json');
+const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+const backupSuffix = `.bak.default-execution-harness-${timestamp}`;
+
+function migrateJson(text, label) {
+  const config = JSON.parse(text);
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    throw new Error(`${label} must contain a JSON object`);
+  }
+  if (config.defaultExecutionHarness === undefined && config.defaultExecutionAgent !== undefined) {
+    config.defaultExecutionHarness = config.defaultExecutionAgent;
+  }
+  delete config.defaultExecutionAgent;
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+function migrateLocal() {
+  if (!existsSync(localPath)) {
+    console.log(`LOCAL skipped missing ${localPath}`);
+    return null;
+  }
+  const original = readFileSync(localPath, 'utf8');
+  const migrated = migrateJson(original, localPath);
+  if (migrated === original) {
+    console.log(`LOCAL unchanged ${localPath}`);
+    return null;
+  }
+  const backup = `${localPath}${backupSuffix}`;
+  renameSync(localPath, backup);
+  writeFileSync(localPath, migrated, { mode: 0o600 });
+  console.log(`LOCAL migrated ${localPath} backup=${backup}`);
+  console.log(JSON.stringify({ defaultExecutionHarness: JSON.parse(migrated).defaultExecutionHarness, defaultExecutionModel: JSON.parse(migrated).defaultExecutionModel }));
+}
+
+function remoteScript(configPath, backupSuffixValue) {
+  return `
+set -eu
+config_path=$(printf '%s' "$1")
+backup_path="${configPath}${backupSuffixValue}"
+node - "$config_path" "$backup_path" <<'NODE'
+const fs = require('node:fs');
+const [configPath, backupPath] = process.argv.slice(2);
+if (!fs.existsSync(configPath)) { console.log('REMOTE skipped missing ' + configPath); process.exit(0); }
+const original = fs.readFileSync(configPath, 'utf8');
+const config = JSON.parse(original);
+if (!config || typeof config !== 'object' || Array.isArray(config)) throw new Error(configPath + ' must contain a JSON object');
+if (config.defaultExecutionHarness === undefined && config.defaultExecutionAgent !== undefined) config.defaultExecutionHarness = config.defaultExecutionAgent;
+delete config.defaultExecutionAgent;
+const migrated = JSON.stringify(config, null, 2) + '\\n';
+if (migrated === original) { console.log('REMOTE unchanged ' + configPath); process.exit(0); }
+fs.renameSync(configPath, backupPath);
+fs.writeFileSync(configPath, migrated, { mode: 0o600 });
+console.log('REMOTE migrated ' + configPath + ' backup=' + backupPath);
+console.log(JSON.stringify({ defaultExecutionHarness: config.defaultExecutionHarness, defaultExecutionModel: config.defaultExecutionModel }));
+NODE
+`;
+}
+
+const local = migrateLocal();
+if (process.argv.includes('--local-only')) process.exit(0);
+
+const localConfig = JSON.parse(readFileSync(localPath, 'utf8'));
+for (const [id, target] of Object.entries(localConfig.remoteTargets ?? {})) {
+  if (!id.includes('digital_ocean') || !target?.host || !target?.user || !target?.sshKeyPath) continue;
+  const remoteConfigPath = `${target.remoteInvokerHome || '~/.invoker'}/config.json`;
+  const expandedPath = remoteConfigPath.startsWith('~/') ? `$HOME/${remoteConfigPath.slice(2)}` : remoteConfigPath;
+  const command = remoteScript(expandedPath, backupSuffix);
+  try {
+    const output = execFileSync('ssh', [
+      '-i', target.sshKeyPath,
+      '-p', String(target.port || 22),
+      '-o', 'ConnectTimeout=15',
+      '-o', 'BatchMode=yes',
+      `${target.user}@${target.host}`,
+      'bash', '-s', '--', expandedPath,
+    ], { input: command, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    process.stdout.write(`${id} ${output}`);
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message;
+    console.error(`${id} FAILED ${detail}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Refresh two Invoker guides with the `defaultExecutionHarness` spelling.

## Review Claim

Use the requested setting name consistently in both guides.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice contains documentation-only edits.

## Slice Rationale

Keep these edits as the final stack slice.

## Non-goals

- Do not change code files.
- Do not add new guides.
- Do not change unrelated documentation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:comments`
- [ ] `bash scripts/scrub-handoff-artifacts.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
