### PR TITLE
[Publication Authority](2) Align plan doctor with publication authority

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -219,6 +219,22 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow('mergeMode: "no_op"');
   });
 
+  it('rejects the incident plan that pairs onFinish none with external review', () => {
+    const yaml = `
+name: Hidden Publication Incident
+repoUrl: git@github.com:test/repo.git
+baseBranch: master
+onFinish: none
+mergeMode: external_review
+tasks:
+  - id: reflect
+    description: Apply one accepted reflection item
+    command: echo "reflect"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/external_review.*onFinish: none/);
+  });
+
   it('rejects a scratch plan task that sets poolId', () => {
     const yaml = `
 name: Bad Scratch Pool Plan

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from '@invoker/workflow-core';
-import { normalizeWorkflowBaseBranch, parseTaskFreshnessSpec } from '@invoker/workflow-core';
+import { normalizeWorkflowBaseBranch, parseTaskFreshnessSpec, planPublicationAuthorityViolation } from '@invoker/workflow-core';
 import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
@@ -408,6 +408,10 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     );
   }
   const rawMergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
+  const publicationAuthorityViolation = planPublicationAuthorityViolation(onFinish, rawMergeMode);
+  if (publicationAuthorityViolation) {
+    throw new PlanParseError(publicationAuthorityViolation);
+  }
   const mergeMode = rawMergeMode !== undefined
     ? normalizeMergeModeForPersistence(rawMergeMode)
     : undefined;

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -179,6 +179,22 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(/mergeMode: "no_op"/);
   });
 
+  it('rejects the incident plan that pairs onFinish none with external review', () => {
+    const yaml = `
+name: Hidden Publication Incident
+repoUrl: git@github.com:test/repo.git
+baseBranch: master
+onFinish: none
+mergeMode: external_review
+tasks:
+  - id: reflect
+    description: Apply one accepted reflection item
+    command: echo "reflect"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/external_review.*onFinish: none/);
+  });
+
   it('rejects a scratch plan task that sets dockerImage', () => {
     const yaml = `
 name: Bad Scratch Docker Plan

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -10,6 +10,16 @@ export class PlanParseError extends Error {
   }
 }
 
+export function planPublicationAuthorityViolation(
+  onFinish: PlanDefinition['onFinish'],
+  mergeMode: PlanDefinition['mergeMode'],
+): string | undefined {
+  if (onFinish === 'none' && mergeMode === 'external_review') {
+    return '"mergeMode: external_review" cannot be combined with "onFinish: none". External review publishes a pull request, while onFinish: none authorizes no publication.';
+  }
+  return undefined;
+}
+
 export function isPathSafeId(id: string): boolean {
   if (!id || typeof id !== 'string') return false;
   if (id.trim() === '') return false;
@@ -300,6 +310,10 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     );
   }
   const mergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
+  const publicationAuthorityViolation = planPublicationAuthorityViolation(onFinish, mergeMode);
+  if (publicationAuthorityViolation) {
+    throw new PlanParseError(publicationAuthorityViolation);
+  }
   const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
 
   if (scratch && raw.repoUrl !== undefined) {

--- a/skills/plan-to-invoker/fixtures/negative/edge-onfinish-none-external-review.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/edge-onfinish-none-external-review.yaml
@@ -1,0 +1,9 @@
+name: "Hidden publication incident"
+onFinish: none
+mergeMode: external_review
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: reflect
+    description: "Apply one accepted reflection item"
+    command: "echo reflect"
+    dependencies: []

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -686,6 +686,15 @@ function validatePlan(yamlContent, repoRoot) {
     });
   }
 
+  if (raw.onFinish === 'none' && raw.mergeMode === 'external_review') {
+    errors.push({
+      errorType: 'conflicting_fields',
+      field: 'mergeMode',
+      message: '"mergeMode: external_review" cannot be combined with "onFinish: none". External review publishes a pull request, while onFinish: none authorizes no publication.',
+      value: raw.mergeMode,
+    });
+  }
+
   if (raw.runnerKind !== undefined) {
     errors.push({
       errorType: 'unsupported_field',


### PR DESCRIPTION
## Summary

Teach the plan-to-invoker validator that a no-publication outcome cannot use external review.

An exact incident fixture keeps the planning tool aligned with runtime policy.

## Review Claim

The plan-to-invoker validator reports contradictory publication authority before review.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Assumptions: unconfirmed — Existing valid plans keep the same diagnostics; only `onFinish: none` plus `mergeMode: external_review` gains a deterministic conflict diagnostic.

## Slice Rationale

This slice owns planning-tool feedback and depends on the runtime authority rule below it.

## Non-goals

- Do not change runtime merge or PR publication behavior.
- Do not change the Electron E2E focus-isolation work.
- Do not merge this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 88baf3bfd0`
- Post-revert steps: None
- Data migration? No

</details>
