### PR TITLE
[Daily Release](1) Bump patch version for daily-20260901

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
-const VERSION = '0.0.16';
+const VERSION = '0.0.17';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -30,7 +30,7 @@ import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
 import { startLocalSmokeInject } from './local-smoke-inject.js';
-const VERSION = '0.0.16';
+const VERSION = '0.0.17';
 let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Advance all synchronized package versions for the 2026-09-01 daily release cut.

## Review Claim

The nightly release should build and publish version 0.0.17 from this exact commit.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only synchronized version declarations change; runtime behavior and release workflow logic remain unchanged.

## Slice Rationale

The daily release workflow requires the version bump to land through a pull request before it can publish artifacts.

## Non-goals

- Do not change application behavior.
- Do not change release workflow logic.
- Do not deploy until the release workflow succeeds.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:versions`
- [ ] Daily release workflow for `master`
- [ ] `bash scripts/deploy-do1.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
