### PR TITLE
[Review Publication](1) Use Codex-only authoring

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1333,6 +1333,49 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('publishReviewStackWithMakePrSkill does not invoke Claude when Codex is registered', async () => {
+      const codexAgent = {
+        name: 'codex',
+        stdinMode: 'ignore',
+        bundledSkillRoot: '/tmp/codex-skills',
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'var b=["## Summary","","x","","## Review Claim","","x","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","x","","## Slice Rationale","","x","","## Non-goals","- none","","## Test Plan","- [x] x","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))'],
+          sessionId: 'sess-codex',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const claudeAgent = {
+        name: 'claude',
+        stdinMode: 'ignore',
+        bundledSkillRoot: '/tmp/claude-skills',
+        bundledSkills: ['make-pr'],
+        buildCommand: () => { throw new Error('Claude must not be invoked'); },
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: { logEvent: vi.fn() } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: (name: string) => name === 'codex' ? codexAgent : name === 'claude' ? claudeAgent : undefined,
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      const result = await (executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-codex-only', title: 'Stack', baseBranch: 'master', featureBranch: 'plan/feature',
+        workflowSummary: 'summary', cwd: '/tmp', mergeNodeTaskId: '__merge__wf-codex-only', expectedGeneration: 1,
+      });
+
+      expect(result.agentName).toBe('codex');
+      expect(result.artifacts).toHaveLength(1);
+    });
+
     it('publishReviewStackWithMakePrSkill uses preferred agent then falls back to another make-pr agent', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1553,9 +1553,8 @@ export class TaskRunner {
       throw new Error('make-pr skill is required to publish Invoker review stacks');
     }
 
-    const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
-    const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
-    const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const codex = this.executionAgentRegistry.get('codex');
+    const orderedAgents = codex ? [codex] : [];
     const logProgress = (
       level: 'debug' | 'info' | 'warn' | 'error',
       message: string,


### PR DESCRIPTION
## Summary

Keep Invoker review-stack publication on the canonical Codex make-pr path.

This prevents Claude and OMP fallback attempts from turning a malformed Codex response into a 20-minute merge-gate timeout.

## Review Claim

Invoker review-stack publication invokes Codex only and never falls through to another make-pr agent.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Review-stack publication invokes only the configured Codex make-pr path; it does not alter task execution, merge semantics, PR schema validation, or non-Invoker repositories.

## Slice Rationale

The failure is isolated to Invoker review-stack publication; generic task authoring fallback behavior remains unchanged.

## Non-goals

- Does not change Codex output schema or PR body validation.
- Does not change task execution defaults, merge semantics, or non-Invoker repositories.
- Does not change the general PR-body authoring fallback chain.

## Architecture

### Before

```mermaid
graph TD
    A["review-stack publication"] --> B["configured or registered make-pr agents"]
```

### After

```mermaid
graph TD
    A["review-stack publication"] --> B["Codex make-pr agent"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts --reporter=verbose`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm run check:comments`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
