### PR TITLE
[CodeRabbit #11538 line-scoped UNVERIFIED marker](1)

### DIFF
--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -6,7 +6,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validatePrBody, validatePrScope, visualProofNeedsAnimation } from './validate-pr-body.mjs';
+import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validateGuardedBehaviorMarkers, validatePrBody, validatePrScope, visualProofNeedsAnimation } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -1389,6 +1389,18 @@ const guardedBehaviorClaimedErrors = await validatePrBody(guardedBehaviorClaimed
 assert(
   !guardedBehaviorClaimedErrors.some((error) => error.includes('Guarded behavior "dag-surface-background-click-noop"')),
   'a diff touching a guarded-behavior marker line should pass when the PR body names the marker id in Safety Invariant or Non-goals',
+);
+
+const guardedBehaviorSubstringClaimErrors = validateGuardedBehaviorMarkers({
+  diffText: guardedBehaviorTouchingDiff,
+  body: validMinimal.replace(
+    'Only the refresh path changes.',
+    'Only not-dag-surface-background-click-noop-suffix changes.',
+  ),
+});
+assert(
+  guardedBehaviorSubstringClaimErrors.some((error) => error.includes('Guarded behavior "dag-surface-background-click-noop"')),
+  'a longer body token must not claim a guarded-behavior marker id by substring',
 );
 
 const guardedBehaviorNonTouchingErrors = await validatePrBody(validMinimal, { diffText: guardedBehaviorNonTouchingDiff });

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -348,7 +348,9 @@ export function validateGuardedBehaviorMarkers({ diffText = '', body = '' } = {}
   const claimedIds = `${getSectionBody(body, '## Safety Invariant')}\n${getSectionBody(body, '## Non-goals')}`;
   const errors = [];
   for (const marker of markers) {
-    if (!claimedIds.includes(marker.id)) {
+    const escapedId = marker.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const claimedIdPattern = new RegExp(`(?:^|[^A-Za-z0-9_-])${escapedId}(?=$|[^A-Za-z0-9_-])`);
+    if (!claimedIdPattern.test(claimedIds)) {
       errors.push(
         `Guarded behavior "${marker.id}" at ${marker.path}:${marker.line} is touched by this diff but not mentioned in ## Safety Invariant or ## Non-goals. Name it explicitly so reviewers know this decision is intentional.`,
       );


### PR DESCRIPTION
## Summary

Review and repair the still-open CodeRabbit finding from PR #11538.

The qualification marker now has an explicit line-level contract, so embedded text cannot exempt a present claim.

## Review Claim

UNVERIFIED: qualification must apply only at the beginning of a line.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only line-leading UNVERIFIED: suppresses the present-tense baseline claim; inline or embedded markers cannot exempt a present claim.

## Slice Rationale

This slice isolates one lexical boundary and its focused regression proof, keeping qualification parsing reviewable as one tooling-policy change.

## Non-goals

Do not remove case-insensitivity or optional post-marker whitespace.

Do not refactor unrelated planning or evidence-gate parsing.

The `dag-surface-background-click-noop` guarded behavior remains unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-baseline-evidence-gate.sh` (not present in this checkout)
- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/coderabbit-11538-pr.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: Rerun the focused evidence-gate test and review the marker contract.
- Data migration? No.

</details>
