### PR TITLE
[CodeRabbit #11576 Docker plan pool discard](1) Docker parser pool conflict

### DIFF
--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -495,6 +495,11 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
         `Task "${task.id}" sets "dockerImage"/"poolId" but ${ownerLabel.toLowerCase()} has "scratch: true" — scratch tasks always run in a plain temp directory.`,
       );
     }
+    if (task.dockerImage && (planPoolId !== undefined || task.poolId !== undefined)) {
+      throw new PlanParseError(
+        `Task "${task.id}" sets "dockerImage" but its plan/task also sets "poolId" — Docker tasks do not run in execution pools.`,
+      );
+    }
 
     if (task.externalDependencies !== undefined) {
       throw new PlanParseError(

--- a/packages/workflow-core/src/__tests__/repro-docker-plan-pool-validation.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-docker-plan-pool-validation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { parsePlan, PlanParseError } from '../plan-parser.js';
+
+describe('Docker plan-level pool validation', () => {
+  it('rejects a plan-level pool when the task is Docker-routed', () => {
+    const yaml = `
+name: Docker plan pool
+repoUrl: git@github.com:example/repo.git
+poolId: ssh-pool
+tasks:
+  - id: docker-task
+    description: Run in Docker
+    command: echo ok
+    dockerImage: node:20
+`;
+
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId|poolId.*dockerImage/);
+  });
+});

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -407,6 +407,11 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     if (scratch && (task.dockerImage || task.poolId)) {
       throw new PlanParseError(`Task "${task.id}" sets "dockerImage"/"poolId" but the plan has "scratch: true" — scratch tasks always run in a plain temp directory.`);
     }
+    if (task.dockerImage && (planPoolId !== undefined || task.poolId !== undefined)) {
+      throw new PlanParseError(
+        `Task "${task.id}" sets "dockerImage" but its plan/task also sets "poolId" — Docker tasks do not run in execution pools.`,
+      );
+    }
 
     if (task.externalDependencies !== undefined) {
       throw new PlanParseError(


### PR DESCRIPTION
## Summary

Docker task parsing now blocks a plan-level pool declaration as well as a task-level pool declaration.

This prevents Docker configuration from silently discarding a pool declaration before task creation.

## Review Claim

Docker task parsing blocks both plan-level and task-level `poolId` declarations before task creation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Docker configuration cannot silently discard pool declarations, while pool-free Docker tasks remain valid.

## Slice Rationale

This slice keeps the parser branch and focused regression together so the Docker configuration conflict is reviewed locally.

## Non-goals

No executor implementation changes, pool implementation changes, or changes to Docker tasks without pool declarations.

## Architecture

### Before

```mermaid
graph TD
    A["Docker task with plan.poolId"] --> B["Task creation"]
    B --> C["Pool declaration discarded"]
```

### After

```mermaid
graph TD
    A["Docker task with plan.poolId"] --> B["Parser blocks conflict"]
    B --> C["No task created"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm exec vitest run packages/workflow-core/src/__tests__/repro-docker-plan-pool-validation.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` or equivalent
- Post-revert steps: None
- Data migration? No

</details>
