### PR TITLE
[CodeRabbit #11576 merge-node invariant](1) Enforce merge identity at graph mutation boundaries

### DIFF
--- a/packages/workflow-core/src/__tests__/graph-mutation.test.ts
+++ b/packages/workflow-core/src/__tests__/graph-mutation.test.ts
@@ -357,4 +357,37 @@ describe('applyGraphMutation', () => {
       }),
     ).toThrow(/runnerKind=ssh but no poolId/);
   });
+
+  it.each([
+    { label: 'isMergeNode=true with runnerKind omitted', isMergeNode: true },
+    { label: 'runnerKind=merge with isMergeNode=false', runnerKind: 'merge' as const, isMergeNode: false },
+  ])('repro: normalizes merge fields for $label', ({ runnerKind, isMergeNode }) => {
+    orchestrator.loadPlan({
+      name: `merge-invariant-${String(isMergeNode)}-${runnerKind ?? 'omitted'}`,
+      tasks: [{ id: 'A', description: 'A', command: 'echo A' }],
+    });
+    orchestrator.startExecution();
+
+    const sourceId = orchestrator.getAllTasks().find((task) => !task.config.isMergeNode)!.id;
+    const workflowId = orchestrator.getTask(sourceId)!.config.workflowId!;
+    const createdId = `${sourceId}-merge-mismatch`;
+
+    applyMutation(orchestrator, {
+      sourceNodeId: sourceId,
+      sourceDisposition: 'complete',
+      newNodes: [{
+        id: createdId,
+        description: 'Mismatched merge fields',
+        dependencies: [sourceId],
+        workflowId,
+        runnerKind,
+        isMergeNode,
+      }],
+      outputNodeId: createdId,
+    });
+
+    const created = orchestrator.getTask(createdId)!;
+    expect(created.config.isMergeNode).toBe(true);
+    expect(created.config.runnerKind).toBe('merge');
+  });
 });

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -205,6 +205,7 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
   // 3. Create new nodes
   for (const nodeDef of mutation.newNodes) {
     assertPoolRoutedGraphNodeHasPoolId(nodeDef);
+    const isMergeNode = nodeDef.isMergeNode === true || nodeDef.runnerKind === 'merge';
     const nodeBase = {
       workflowId: nodeDef.workflowId,
       parentTask: nodeDef.parentTask,
@@ -214,14 +215,14 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       command: nodeDef.command,
       isReconciliation: nodeDef.isReconciliation,
       requiresManualApproval: nodeDef.requiresManualApproval,
-      isMergeNode: nodeDef.isMergeNode,
+      isMergeNode,
       ...(nodeDef.poolId ? { poolId: nodeDef.poolId } : {}),
       ...(nodeDef.executionAgent ? { executionAgent: nodeDef.executionAgent } : {}),
       ...(nodeDef.executionModel ? { executionModel: nodeDef.executionModel } : {}),
       ...(nodeDef.maxTurns !== undefined ? { maxTurns: nodeDef.maxTurns } : {}),
     } as const;
     let nodeConfig: TaskConfig;
-    switch (nodeDef.runnerKind) {
+    switch (isMergeNode ? 'merge' : nodeDef.runnerKind) {
       case 'merge':
         nodeConfig = { ...nodeBase, runnerKind: 'merge' };
         break;


### PR DESCRIPTION
## Summary

Review and repair the still-open CodeRabbit finding from PR #11576.

The graph mutation path now derives merge identity consistently from the resolved node definition.

## Review Claim

Runner kind and merge-node identity agree when task configurations are created through graph mutations.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Merge semantics cannot be represented by an ordinary node, and ordinary nodes cannot masquerade as merge nodes.

## Slice Rationale

This slice isolates graph mutation creation so the boundary enforces the merge identity invariant locally.

## Non-goals

This slice does not redesign merge scheduling or alter valid merge creation and ordinary non-merge runners.

## Architecture

### Before

Graph mutations could resolve `isMergeNode` and `runnerKind` independently, allowing inconsistent task semantics.

### After

Graph mutations derive one merge identity and use it for both the task flag and runner configuration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm exec vitest run packages/workflow-graph/src/__tests__/types.test.ts packages/workflow-core/src/__tests__/graph-mutation.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
