### PR TITLE
[Aggregate admin-bypass repair workflow](1) Group repairs by PR head

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -7,6 +7,7 @@ import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Sequence
 
 try:
     from .mergify_admin_requeue_headless_shell import run_headless
@@ -75,6 +76,16 @@ class AsyncRepairPlan:
 
 
 @dataclass(frozen=True)
+class RepairCheckSpec:
+    check_name: str
+    details_url: str
+    log_path: str
+    queue_only: bool
+    queue_pr_number: int
+    latest: MergifyQueueEvent | None
+
+
+@dataclass(frozen=True)
 class RepairSubmissionAcknowledgement:
     workflow_id: str | None = None
 
@@ -82,22 +93,32 @@ class RepairSubmissionAcknowledgement:
 _WORKFLOW_ID_RE = re.compile(r"(?:Workflow ID:|workflow:)\s*(wf-[^\s]+)")
 
 
-def _write_plan_header(*, name: str, base_branch: str, repo: str, merge_mode: str = "manual") -> str:
+def _write_plan_header(
+    *, name: str, base_branch: str, repo: str, merge_mode: str = "manual", on_finish: str = "none",
+    description: str | None = None,
+) -> str:
+    description_line = f"description: {_yaml_str(description)}\n" if description else ""
     return (
         f"name: {name}\n"
-        "onFinish: none\n"
+        f"onFinish: {on_finish}\n"
         f"mergeMode: {merge_mode}\n"
         f"repoUrl: {_yaml_str(_repo_url(repo))}\n"
         f"baseBranch: {_yaml_str(base_branch)}\n"
+        f"{description_line}"
         "tasks:\n"
     )
 
 
-def _repair_task_yaml(*, description: str, prompt: str, max_turns: int | None = 30) -> str:
+def _repair_task_yaml(
+    *, description: str, prompt: str, task_id: str = "repair", dependencies: str | None = None,
+    max_turns: int | None = 30,
+) -> str:
+    dependency_line = f"    dependencies: [{dependencies}]\n" if dependencies else ""
     max_turns_line = f"    maxTurns: {max_turns}\n" if max_turns is not None else ""
     return (
-        "  - id: repair\n"
+        f"  - id: {task_id}\n"
         f"    description: {_yaml_str(description)}\n"
+        f"{dependency_line}"
         f"{max_turns_line}"
         "    prompt: |\n"
         f"{_indent_block(prompt, 6)}\n"
@@ -263,6 +284,79 @@ def build_repair_check_plan(
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 
+def build_aggregated_repair_check_plan(
+    pr: PrSnapshot,
+    checks: Sequence[RepairCheckSpec],
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+    foreign: bool = False,
+) -> AsyncRepairPlan:
+    """Build one ordered workflow for all checks observed on one PR head.
+
+    Each repair task must commit locally and depends on the prior task, so the
+    next worker receives the previous worker's committed history. Only the
+    final task may push, and it retains the expected-head guard.
+    """
+    if not checks:
+        raise ValueError("at least one repair check is required")
+    name = f"admin-bypass-repair-aggregate-pr-{pr.number}-{start_head[:7]}"
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    previous_task = None
+    for index, spec in enumerate(checks, start=1):
+        prompt = (
+            "This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or "
+            "update a repro if the failure is reproducible.\n\n"
+            "Work from the checkout and committed history left by the preceding repair task. "
+            "If a code change fixes this check, commit it locally and do not push. If local proof "
+            "shows the check is already green on the current history, make no commit and exit 0.\n\n"
+            f"Repair PR #{pr.number} ({json.dumps(pr.title)}) on {repo}.\n"
+            f"PR URL: {pr.url}\nHead branch: {pr.head_ref_name} (initially at {start_head}), "
+            f"base branch: {pr.base_ref_name}\n\nFailed check: {spec.check_name}\n"
+            f"Details URL: {spec.details_url}\nJob log (tail):\n{_job_log_excerpt(spec.log_path)}\n"
+            f"Latest Mergify event: {json.dumps(dataclasses.asdict(spec.latest) if spec.latest else None, sort_keys=True)}\n"
+        )
+        if spec.queue_only:
+            prompt += f"Queue draft PR: #{spec.queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
+        task_id = f"repair-{index}"
+        yaml_text += _repair_task_yaml(
+            task_id=task_id,
+            dependencies=previous_task,
+            description=f"Repair PR #{pr.number} (failed check {spec.check_name})",
+            prompt=prompt,
+        )
+        previous_task = task_id
+
+    if foreign:
+        yaml_text += _safe_push_task_yaml(
+            task_id="safe-push", description=f"Safely push PR #{pr.number} only if its head did not move",
+            dependencies=previous_task or "", head_ref=pr.head_ref_name, start_head=start_head,
+            skip_if_prereq=False, foreign=True,
+        )
+    else:
+        normalize_command = (
+            "set -euo pipefail\n"
+            "python3 -B scripts/mergify_admin_requeue_repair_normalize.py \\\n"
+            f"  --repo {_shlex(repo)} --pr {pr.number} --check {_shlex(checks[-1].check_name)} \\\n"
+            f"  --start-head {_shlex(start_head)} --base {_shlex(pr.base_ref_name)} --trunk master\n"
+        )
+        yaml_text += (
+            "  - id: normalize\n"
+            f"    description: {_yaml_str(f'Normalize PR #{pr.number} aggregate repair commit')}\n"
+            f"    dependencies: [{previous_task}]\n"
+            "    command: |\n"
+            f"{_indent_block(normalize_command, 6)}\n"
+        )
+        previous_task = "normalize"
+        yaml_text += _safe_push_task_yaml(
+            task_id="safe-push", description=f"Safely push PR #{pr.number} only if its head did not move",
+            dependencies=previous_task, head_ref=pr.head_ref_name, start_head=start_head,
+            skip_if_prereq=True,
+        )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
 def _rebase_onto_master_prompt(pr: PrSnapshot, reason: str, start_head: str, *, onto: str | None = None) -> str:
     onto_ref = onto or pr.base_ref_name or "master"
     return (
@@ -363,7 +457,8 @@ def build_requeue_stuck_plan(
         f"Base branch: {pr.base_ref_name}\nRequeue attempts so far: {attempts}\n"
     )
     yaml_text = _write_plan_header(
-        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review"
+        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review", on_finish="pull_request",
+        description=f"Investigate and repair PR #{pr.number} when automated requeue attempts remain stuck.",
     )
     yaml_text += _repair_task_yaml(description=f"Investigate why PR #{pr.number} is stuck in the merge queue", prompt=prompt)
     yaml_text += _safe_push_task_yaml(

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -106,6 +106,43 @@ class AdminBypassRepairer:
             },
         )
 
+    def submit_aggregated_repair_plan(
+        self,
+        plan: async_repair.AsyncRepairPlan,
+        pr_number: int,
+        head_sha: str,
+        check_names: Sequence[str],
+        now: int | None,
+    ) -> None:
+        """Record every filing before submitting their single shared workflow."""
+        for check_name in check_names:
+            self.ledger.record(
+                "repair-check-pending", pr_number, head_sha, check_name, now,
+                meta={"planName": plan.plan_name, "dispatchState": "pending"},
+            )
+        try:
+            acknowledgement = async_repair.submit_async_repair_plan(plan)
+        except Exception as exc:
+            for check_name in check_names:
+                self.ledger.record(
+                    "repair-check-pending-settled", pr_number, head_sha, check_name, now,
+                    meta={"outcomeClass": "infra", "failurePhase": "submission", "dispatchState": "not-acknowledged",
+                          "planName": plan.plan_name, "error": str(exc)},
+                )
+            raise
+        metadata = {
+            "dispatchState": "acknowledged",
+            "planName": plan.plan_name,
+            **(
+                {"workflowId": acknowledgement.workflow_id}
+                if isinstance(acknowledgement, async_repair.RepairSubmissionAcknowledgement)
+                and isinstance(acknowledgement.workflow_id, str)
+                else {}
+            ),
+        }
+        for check_name in check_names:
+            self.ledger.record("repair-check", pr_number, head_sha, check_name, now, meta=metadata)
+
     def blocked_outcome(
         self,
         status: str,
@@ -175,7 +212,43 @@ class AdminBypassRepairer:
         except OSError:
             return False
 
+    def repair_checks(self, pr: PrSnapshot, check_names: Sequence[str], now: int | None = None) -> RepairOutcome:
+        if not check_names:
+            raise ValueError("at least one repair check is required")
+        latest = pr.latest_mergify
+        start_head = pr.head_ref_oid
+        specs = []
+        for check_name in check_names:
+            ctx = pr.checks.get(check_name)
+            queue_only = ctx is None and is_queue_only_required_check(check_name)
+            mergify_urls = mergify_check_urls(latest, check_name)
+            details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
+            if queue_only and not details_url:
+                return self.blocked_outcome(
+                    "blocked_invalid", check_name, start_head, start_head,
+                    errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
+                )
+            log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+            if queue_only and not self.job_log_has_evidence(log_path):
+                continue
+            specs.append(async_repair.RepairCheckSpec(
+                check_name=check_name, details_url=details_url, log_path=log_path,
+                queue_only=queue_only, queue_pr_number=latest.queue_pr_number if latest else 0, latest=latest,
+            ))
+        if not specs:
+            return self.blocked_outcome("queue_only_noop", check_names[0], start_head, start_head)
+        plan = async_repair.build_aggregated_repair_check_plan(
+            pr, specs, repo=self.repo, start_head=start_head, state_file=self.ledger.path, foreign=self.is_foreign,
+        )
+        self.submit_aggregated_repair_plan(plan, pr.number, start_head, [spec.check_name for spec in specs], now)
+        return self.blocked_outcome("submitted", ",".join(check_names), start_head, start_head)
+
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
+        # A single planner action can represent several simultaneous Mergify
+        # failures for this exact PR head. Collapse them before submission so
+        # only one workflow owns the branch and its terminal push.
+        if pr.latest_mergify and len(pr.latest_mergify.failing_checks) > 1:
+            return self.repair_checks(pr, pr.latest_mergify.failing_checks, now)
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
         queue_only = ctx is None and is_queue_only_required_check(check_name)

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -46,6 +46,28 @@ def pr(**kw):
 
 
 class AsyncRepairPlanTests(unittest.TestCase):
+    def test_aggregated_checks_are_ordered_and_have_one_guarded_terminal_push(self):
+        plan = async_repair.build_aggregated_repair_check_plan(
+            pr(),
+            [
+                async_repair.RepairCheckSpec("lint", "https://example.invalid/lint", "/missing/lint", False, 0, None),
+                async_repair.RepairCheckSpec("tests", "https://example.invalid/tests", "/missing/tests", False, 0, None),
+            ],
+            repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        doc = yaml.safe_load(plan.yaml_text)
+        self.assertEqual(
+            [task["id"] for task in doc["tasks"]],
+            ["repair-1", "repair-2", "normalize", "safe-push"],
+        )
+        self.assertEqual(doc["tasks"][1]["dependencies"], ["repair-1"])
+        self.assertEqual(doc["tasks"][2]["dependencies"], ["repair-2"])
+        self.assertEqual(doc["tasks"][3]["dependencies"], ["normalize"])
+        self.assertEqual(plan.yaml_text.count("git push origin"), 0)
+        self.assertEqual(plan.yaml_text.count("pr_worker_safe_push.py"), 1)
+        self.assertIn("--expected-head '" + HEAD + "'", plan.yaml_text)
+        self.assertIn("committed history left by the preceding repair task", plan.yaml_text)
+
     def test_all_three_plan_kinds_produce_parseable_yaml_with_expected_task_ids(self):
         checks_plan = async_repair.build_repair_check_plan(
             pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",


### PR DESCRIPTION
## Summary

Admin-bypass repair filings now aggregate failed checks by PR and captured head SHA.

The generated workflow runs repairs in order, commits between tasks, and performs one guarded terminal push.

## Review Claim

Admin-bypass repair filings produce one dependency-ordered workflow per PR/head SHA, with only the terminal task able to push.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

No repair task pushes independently; the final push refuses when the expected PR head has moved.

## Slice Rationale

Submission shape, grouping, and the direct regression coverage form one cohesive policy change.

## Non-goals

This slice does not change E2E regression watcher filing, Mergify policy, or unrelated worker scheduling.

## Architecture

### Before

Each failed check could create an independent repair workflow against the same PR branch.

### After

One workflow owns the PR/head repair sequence, and a guarded terminal task performs the accumulated push.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -B scripts/test_mergify_admin_requeue_async_repair.py`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: Rerun the focused admin-requeue test.
- Data migration? No

</details>
