### PR TITLE
[Silent catch policy](2) Propagate unexpected yaml import errors

### DIFF
--- a/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
+++ b/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
@@ -19,7 +19,12 @@ const __dirname = dirname(__filename);
 async function importYaml(scriptDir) {
   try {
     return await import('yaml');
-  } catch {}
+  } catch (error) {
+    const errorCode = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
+    if (errorCode !== 'ERR_MODULE_NOT_FOUND') {
+      throw error;
+    }
+  }
   const candidates = [
     process.env.INVOKER_REPO_ROOT,
     resolve(scriptDir, '../../..'),


### PR DESCRIPTION
## Summary

Makes the optional YAML fallback reject unexpected import failures instead of hiding them.

The expected missing-module case still reaches the bundled fallback resolution.

## Review Claim

Only an expected missing YAML module may fall through; all other import errors propagate.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Missing optional YAML falls back; every other import failure remains observable.

## Slice Rationale

This follow-up restores explicit error handling after the original CodeRabbit PR was merged.

## Non-goals

No changes to plan validation rules, fallback ordering, or unrelated error handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `INVOKER_REPO_ROOT=/Users/edbertchan/Documents/GitHub/Invoker bash scripts/test-plan-baseline-evidence-gate.sh`
- [x] `node --check skills/plan-to-invoker/scripts/check-planning-completeness.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 40e14d80ca`
- Post-revert steps: Rerun the focused baseline evidence gate.
- Data migration? No.

</details>
