### PR TITLE
[Daily release](1) Bump patch version for daily-20260901

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
-const VERSION = '0.0.17';
+const VERSION = '0.0.18';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -30,7 +30,7 @@ import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
 import { startLocalSmokeInject } from './local-smoke-inject.js';
-const VERSION = '0.0.17';
+const VERSION = '0.0.18';
 let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bump the patch version from 0.0.17 to 0.0.18 so the daily release can publish the merged aggregate repair workflow.

## Review Claim

The release metadata is synchronized across all published packages and the desktop/CLI version surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only version metadata changes; runtime source behavior is unchanged.

## Slice Rationale

The release workflow requires a versioned commit, and repository rules require that master changes land through a pull request.

## Non-goals

No runtime behavior, worker scheduling, queue configuration, or release workflow logic changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] pnpm run check:versions
- [ ] Release workflow on the merged version-bump commit

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7d5d60659a`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.0.18 across the application, command-line tools, integrations, and supporting packages.
  * Updated displayed version information to ensure all components report the same release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->