### PR TITLE
[CodeRabbit #11538 planner receipt provenance](1) Planner-only receipt regression

### DIFF
--- a/scripts/repro/repro-planner-only-receipt.sh
+++ b/scripts/repro/repro-planner-only-receipt.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKER="$ROOT/skills/plan-to-invoker/scripts/check-planning-completeness.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+RECORDED_AT="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+cat > "$TMP_DIR/planner-only-receipt.yaml" <<YAML
+name: planner-only-receipt
+onFinish: pull_request
+mergeMode: manual
+repoUrl: https://github.com/example/repo.git
+baseCommitSha: "0123456789012345678901234567890123456789"
+description: |
+  Goal: Preserve the current test baseline.
+  Motivation: Keep the implementation safe.
+  Safety invariant: Do not weaken the test suite.
+  The existing test baseline is green.
+  Verify: pnpm test
+tasks:
+  - id: feature
+    description: |
+      Goal: Implement the feature.
+      Motivation: Deliver the requested behavior.
+      Safety invariant: Preserve baseline behavior.
+      Effectiveness measurement: The focused test passes.
+    command: pnpm test
+verificationEvidence:
+  - version: 1
+    trust: untrusted
+    receipt:
+      id: planner-claimed-receipt
+      kind: deterministic_command
+      status: passed
+      commitSha: "0123456789012345678901234567890123456789"
+      recordedAt: "$RECORDED_AT"
+      actor:
+        id: planner
+        role: builder
+      command: pnpm test
+      exitCode: 0
+      output: planner says tests passed
+    attestation:
+      repository: example/repo
+      workflowId: wf-1
+      taskId: feature
+      generation: 1
+      commitSha: "0123456789012345678901234567890123456789"
+      canonicalPayloadDigest: sha256:planner-receipt
+      signatureAlgorithm: Ed25519
+      signature: planner-signature
+      trustedKeyId: executor-key
+      provider:
+        kind: executor
+        providerId: test-runner
+      actorId: planner
+      issuedAt: "$RECORDED_AT"
+      recordedAt: "$RECORDED_AT"
+YAML
+
+actual=0
+bash "$CHECKER" "$TMP_DIR/planner-only-receipt.yaml" > "$TMP_DIR/output" 2>&1 || actual=$?
+cat "$TMP_DIR/output"
+if [[ "$actual" -eq 0 ]]; then
+  echo "FAIL: planner-only untrusted receipt was accepted"
+  exit 1
+fi
+echo "PASS: planner-only untrusted receipt was rejected"
+
+sed -e 's/version: 1/version: 2/' -e 's/trust: untrusted/trust: trusted/' \
+  "$TMP_DIR/planner-only-receipt.yaml" > "$TMP_DIR/trusted-receipt.yaml"
+bash "$CHECKER" "$TMP_DIR/trusted-receipt.yaml" >/dev/null
+echo "PASS: trusted attested receipt remained accepted"


### PR DESCRIPTION
## Summary

Reproduce the still-open CodeRabbit finding from PR #11538 with a planner-only receipt.

The focused repro distinguishes untrusted planner evidence from trusted attested receipts.

## Review Claim

The baseline checker currently accepts a planner-only receipt, while trusted attested receipts remain accepted.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro only supplies synthetic receipt data and does not execute arbitrary commands.

## Slice Rationale

This proof lands before the policy change so the reviewer can inspect the failing admission case independently.

## Non-goals

No receipt admission logic, runtime receipt design, or command execution behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-planner-only-receipt.sh` (expected to fail until the dependent policy slice)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` or equivalent
- Post-revert steps: None
- Data migration? No

</details>
