### PR TITLE
Fix workflow-resume batch drain

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
@@ -39,6 +39,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   const adapters: SQLiteAdapter[] = [];
 
   afterEach(() => {
+    vi.useRealTimers();
     for (const adapter of adapters.splice(0)) {
       adapter.close();
     }
@@ -776,6 +777,38 @@ describe('PersistedWorkflowMutationCoordinator', () => {
 
     expect(new Set([first, ...duplicates])).toEqual(new Set([first]));
     expect(adapter.listWorkflowMutationIntents('wf-1')).toHaveLength(1);
+  });
+
+  it('drains independent deferred start-ready intents from one batch timer', async () => {
+    vi.useFakeTimers();
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    for (const workflowId of ['wf-1', 'wf-2']) {
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: workflowId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    const started: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, _args, context) => {
+        started.push(context.workflowId);
+      },
+    );
+
+    coordinator.submit('wf-1', 'normal', 'invoker:start-ready', [{}], { deferDrain: true });
+    coordinator.submit('wf-2', 'normal', 'invoker:start-ready', [{}], { deferDrain: true });
+    expect(started).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(started).toEqual(['wf-1', 'wf-2']);
+    expect(adapter.listWorkflowMutationIntents(undefined, ['completed'])).toHaveLength(2);
   });
 
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -125,6 +125,24 @@ describe('workflow resume worker tick', () => {
     expect(args).toEqual([{}]);
   });
 
+  it('defers draining each independent workflow intent during a batch scan', async () => {
+    const h = harness({
+      workflows: [
+        { id: 'wf-1', tasks: [makeTask({ id: 'wf-1/task', status: 'pending' as TaskState['status'] })] },
+        { id: 'wf-2', tasks: [makeTask({ id: 'wf-2/task', status: 'pending' as TaskState['status'] })] },
+      ],
+    });
+
+    await h.tick(POLL_CTX);
+
+    expect(h.submit).toHaveBeenCalledTimes(2);
+    expect(h.submit.mock.calls.map((call) => call[0])).toEqual(['wf-1', 'wf-2']);
+    expect(h.submit.mock.calls.map((call) => call[4])).toEqual([
+      { deferDrain: true },
+      { deferDrain: true },
+    ]);
+  });
+
   it('skips pending work whose local dependencies are not completed', async () => {
     const h = harness({
       workflows: [

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -144,6 +144,7 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
         'normal',
         WORKFLOW_RESUME_COMMAND_CHANNEL,
         [{}],
+        { deferDrain: true },
       );
       options.ledger.markSubmitted(workflowId, nowMs + cooldownMs);
       options.store.logEvent?.(candidate.readyTaskId, 'recovery.worker.submit', {


### PR DESCRIPTION
## Summary

The workflow-resume worker now defers coordinator draining while retaining one persisted start-ready intent per workflow.

One coalesced drain trigger handles the batch, reducing repeated IPC wakeups without changing workflow-level isolation.

## Review Claim

Deferred scheduling batches the coordinator wakeup without combining workflow mutations.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Each workflow retains an independent persisted `invoker:start-ready` intent, workflow-level ordering, coalescing, cooldown behavior, and failure isolation. Only the drain trigger is batched; execution is not made unbounded or globally shared.

## Slice Rationale

The worker and coordinator changes form one behavior slice because the scheduling boundary and its caller must change together to preserve existing intent behavior.

## Non-goals

No change to workflow eligibility, dependency semantics, retry or recreate policy, worker cadence, or E2E and PR worker behavior.

## Architecture

### Before

```mermaid
graph TD
    A["workflow-resume discovers workflows"] --> B["each intent request wakes a coordinator drain"]
```

### After

```mermaid
graph TD
    A["workflow-resume discovers workflows"] --> B["independent persisted intents"]
    B --> C["one coalesced coordinator drain trigger"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine test -- src/__tests__/workflow-resume-worker.test.ts`
- [ ] `pnpm --filter @invoker/app test -- src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 26717c5f1633929aea01acacf05fd9ab171b010f`
- Post-revert steps: Re-run the targeted worker and coordinator tests.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how start-ready intents are scheduled during resume polls; behavior is covered by new unit tests and only affects workflow mutation drain timing.
> 
> **Overview**
> Fixes **workflow resume batch drain scheduling** so a single poll that finds ready work on many workflows does not trigger an immediate per-workflow drain for each submit.
> 
> The workflow resume worker now passes **`{ deferDrain: true }`** when enqueueing `invoker:start-ready` intents, matching the coordinator’s deferred batch timer so independent workflows drain together instead of serializing drain work inline during the scan.
> 
> Tests cover the resume worker submit options and coordinator behavior: two deferred start-ready intents for different workflows run after one timer tick (~25ms), with fake timers reset in `afterEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26717c5f1633929aea01acacf05fd9ab171b010f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->