### PR TITLE
[Task filter](1) contract: filter tree types and validator

### DIFF
--- a/packages/contracts/src/__tests__/task-filter.test.ts
+++ b/packages/contracts/src/__tests__/task-filter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { TASK_FILTER_KEYS, validateTaskFilter } from '../task-filter.js';
+
+const validLeaf = { op: 'eq', key: 'status', value: 'failed' } as const;
+
+function expectReject(input: unknown, field: string) {
+  const result = validateTaskFilter(input);
+  expect(result.valid).toBe(false);
+  expect(result.error).toContain(field);
+}
+
+describe('validateTaskFilter', () => {
+  it('exports exactly the task column allowlist', () => {
+    expect(TASK_FILTER_KEYS).toEqual([
+      'id', 'workflow_id', 'status', 'failure_class', 'execution_agent', 'execution_model',
+      'pool_member_id', 'repo_url', 'branch', 'description', 'error', 'is_merge_node',
+      'created_at', 'started_at', 'completed_at', 'last_heartbeat_at',
+    ]);
+  });
+
+  it.each([
+    ['and', { op: 'and', filters: [validLeaf] }],
+    ['or', { op: 'or', filters: [validLeaf] }],
+    ['not', { op: 'not', filter: validLeaf }],
+    ['exists', { op: 'exists', key: 'error' }],
+    ['eq', validLeaf],
+    ['in', { op: 'in', key: 'status', values: ['queued', 'failed'] }],
+    ['contains', { op: 'contains', key: 'description', value: 'needle' }],
+    ['time_range with start', { op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00Z' }],
+    ['time_range with end', { op: 'time_range', key: 'created_at', end: '2026-01-02T00:00:00+00:00' }],
+    ['time_range with both bounds', { op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' }],
+  ])('accepts %s', (_, input) => {
+    expect(validateTaskFilter(input).valid).toBe(true);
+  });
+
+  it('accepts nested filters through depth 8', () => {
+    let input: unknown = validLeaf;
+    for (let i = 0; i < 7; i += 1) input = { op: 'not', filter: input };
+    expect(validateTaskFilter(input).valid).toBe(true);
+  });
+
+  it('rejects non-object input', () => {
+    for (const input of [null, undefined, 'filter', 42, []]) {
+      const result = validateTaskFilter(input);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('taskFilter');
+    }
+  });
+
+  it('rejects an unknown operation', () => expectReject({ op: 'like', key: 'status', value: 'failed' }, 'taskFilter.op'));
+  it('rejects an unknown key', () => expectReject({ op: 'eq', key: 'not_a_column', value: 'x' }, 'taskFilter.key'));
+  it('rejects empty logical lists', () => expectReject({ op: 'and', filters: [] }, 'taskFilter.filters'));
+  it('rejects empty in lists', () => expectReject({ op: 'in', key: 'status', values: [] }, 'taskFilter.values'));
+  it('rejects non-string contains values', () => expectReject({ op: 'contains', key: 'description', value: 1 }, 'taskFilter.value'));
+  it('rejects time ranges with no bound', () => expectReject({ op: 'time_range', key: 'created_at' }, 'taskFilter.start'));
+  it('rejects naive timestamps', () => expectReject({ op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00' }, 'taskFilter.start'));
+  it('rejects invalid timestamps', () => expectReject({ op: 'time_range', key: 'created_at', start: 'not-a-date' }, 'taskFilter.start'));
+  it('rejects reversed time ranges', () => expectReject({ op: 'time_range', key: 'created_at', start: '2026-01-02T00:00:00Z', end: '2026-01-01T00:00:00Z' }, 'taskFilter.start'));
+  it('rejects unknown fields to preserve the exact shape', () => expectReject({ op: 'exists', key: 'status', extra: true }, 'taskFilter.extra'));
+  it('rejects nesting deeper than 8', () => {
+    let input: unknown = validLeaf;
+    for (let i = 0; i < 8; i += 1) input = { op: 'not', filter: input };
+    expectReject(input, 'taskFilter.filter');
+  });
+});

--- a/packages/contracts/src/__tests__/task-filter.test.ts
+++ b/packages/contracts/src/__tests__/task-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { TASK_FILTER_KEYS, validateTaskFilter } from '../task-filter.js';
+import { TASK_FILTER_KEYS, TASK_FILTER_TIME_KEYS, validateTaskFilter } from '../task-filter.js';
 
 const validLeaf = { op: 'eq', key: 'status', value: 'failed' } as const;
 
@@ -18,6 +18,11 @@ describe('validateTaskFilter', () => {
     ]);
   });
 
+  it('exports only timestamp columns as time range keys', () => {
+    expect(TASK_FILTER_TIME_KEYS).toEqual(['created_at', 'started_at', 'completed_at', 'last_heartbeat_at']);
+    for (const key of TASK_FILTER_TIME_KEYS) expect(TASK_FILTER_KEYS).toContain(key);
+  });
+
   it.each([
     ['and', { op: 'and', filters: [validLeaf] }],
     ['or', { op: 'or', filters: [validLeaf] }],
@@ -29,6 +34,7 @@ describe('validateTaskFilter', () => {
     ['time_range with start', { op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00Z' }],
     ['time_range with end', { op: 'time_range', key: 'created_at', end: '2026-01-02T00:00:00+00:00' }],
     ['time_range with both bounds', { op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00Z', end: '2026-01-02T00:00:00Z' }],
+    ...TASK_FILTER_TIME_KEYS.map((key) => [`time_range on ${key}`, { op: 'time_range', key, start: '2026-01-01T00:00:00Z' }] as const),
   ])('accepts %s', (_, input) => {
     expect(validateTaskFilter(input).valid).toBe(true);
   });
@@ -52,6 +58,7 @@ describe('validateTaskFilter', () => {
   it('rejects empty logical lists', () => expectReject({ op: 'and', filters: [] }, 'taskFilter.filters'));
   it('rejects empty in lists', () => expectReject({ op: 'in', key: 'status', values: [] }, 'taskFilter.values'));
   it('rejects non-string contains values', () => expectReject({ op: 'contains', key: 'description', value: 1 }, 'taskFilter.value'));
+  it('rejects time ranges on non-timestamp keys', () => expectReject({ op: 'time_range', key: 'status', start: '2026-01-01T00:00:00Z' }, 'taskFilter.key'));
   it('rejects time ranges with no bound', () => expectReject({ op: 'time_range', key: 'created_at' }, 'taskFilter.start'));
   it('rejects naive timestamps', () => expectReject({ op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00' }, 'taskFilter.start'));
   it('rejects invalid timestamps', () => expectReject({ op: 'time_range', key: 'created_at', start: 'not-a-date' }, 'taskFilter.start'));

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -19,4 +19,5 @@ export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export * from './planning-surface.ts';
 export * from './verification-contract.ts';
+export * from './task-filter.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/task-filter.ts
+++ b/packages/contracts/src/task-filter.ts
@@ -1,0 +1,153 @@
+import type { ValidationResult } from './validation.ts';
+
+export const TASK_FILTER_KEYS = [
+  'id',
+  'workflow_id',
+  'status',
+  'failure_class',
+  'execution_agent',
+  'execution_model',
+  'pool_member_id',
+  'repo_url',
+  'branch',
+  'description',
+  'error',
+  'is_merge_node',
+  'created_at',
+  'started_at',
+  'completed_at',
+  'last_heartbeat_at',
+] as const;
+
+export type TaskFilterKey = (typeof TASK_FILTER_KEYS)[number];
+export type TaskFilterValue = string | number | boolean | null;
+
+export type TaskFilterNode =
+  | { op: 'and'; filters: TaskFilterNode[] }
+  | { op: 'or'; filters: TaskFilterNode[] }
+  | { op: 'not'; filter: TaskFilterNode }
+  | { op: 'exists'; key: TaskFilterKey }
+  | { op: 'eq'; key: TaskFilterKey; value: TaskFilterValue }
+  | { op: 'in'; key: TaskFilterKey; values: TaskFilterValue[] }
+  | { op: 'contains'; key: TaskFilterKey; value: string }
+  | { op: 'time_range'; key: TaskFilterKey; start?: string; end?: string };
+
+const taskFilterKeySet = new Set<string>(TASK_FILTER_KEYS);
+const filterOps = new Set(['and', 'or', 'not', 'exists', 'eq', 'in', 'contains', 'time_range']);
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isTaskFilterValue(value: unknown): value is TaskFilterValue {
+  return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+function hasOnlyFields(record: Record<string, unknown>, fields: readonly string[], path: string): ValidationResult {
+  const allowed = new Set(fields);
+  for (const field of Object.keys(record)) {
+    if (!allowed.has(field)) {
+      return { valid: false, error: `${path}.${field} is not allowed` };
+    }
+  }
+  return { valid: true };
+}
+
+function validateKey(value: unknown, path: string): ValidationResult {
+  if (typeof value !== 'string' || !taskFilterKeySet.has(value)) {
+    return { valid: false, error: `${path} must be a valid task filter key` };
+  }
+  return { valid: true };
+}
+
+function validateIsoTimestamp(value: unknown, path: string): ValidationResult {
+  if (typeof value !== 'string' || !isoTimestampPattern.test(value) || Number.isNaN(Date.parse(value))) {
+    return { valid: false, error: `${path} must be a timezone-qualified ISO timestamp` };
+  }
+  return { valid: true };
+}
+
+function validateNode(input: unknown, depth: number, path: string): ValidationResult {
+  if (depth > 8) {
+    return { valid: false, error: `${path} exceeds the maximum nesting depth of 8` };
+  }
+  if (!isRecord(input)) {
+    return { valid: false, error: `${path} must be an object` };
+  }
+  if (typeof input.op !== 'string' || !filterOps.has(input.op)) {
+    return { valid: false, error: `${path}.op must be a known task filter operation` };
+  }
+
+  const op = input.op;
+  if (op === 'and' || op === 'or') {
+    const fields = hasOnlyFields(input, ['op', 'filters'], path);
+    if (!fields.valid) return fields;
+    if (!Array.isArray(input.filters) || input.filters.length === 0) {
+      return { valid: false, error: `${path}.filters must be a non-empty array` };
+    }
+    for (let i = 0; i < input.filters.length; i += 1) {
+      const result = validateNode(input.filters[i], depth + 1, `${path}.filters[${i}]`);
+      if (!result.valid) return result;
+    }
+    return { valid: true };
+  }
+
+  if (op === 'not') {
+    const fields = hasOnlyFields(input, ['op', 'filter'], path);
+    if (!fields.valid) return fields;
+    return validateNode(input.filter, depth + 1, `${path}.filter`);
+  }
+
+  const fields = hasOnlyFields(
+    input,
+    op === 'exists' ? ['op', 'key'] : op === 'in' ? ['op', 'key', 'values'] : op === 'time_range' ? ['op', 'key', 'start', 'end'] : ['op', 'key', 'value'],
+    path,
+  );
+  if (!fields.valid) return fields;
+  const keyResult = validateKey(input.key, `${path}.key`);
+  if (!keyResult.valid) return keyResult;
+
+  if (op === 'exists') return { valid: true };
+  if (op === 'contains') {
+    return typeof input.value === 'string'
+      ? { valid: true }
+      : { valid: false, error: `${path}.value must be a string` };
+  }
+  if (op === 'eq') {
+    return isTaskFilterValue(input.value)
+      ? { valid: true }
+      : { valid: false, error: `${path}.value must be a scalar value` };
+  }
+  if (op === 'in') {
+    if (!Array.isArray(input.values) || input.values.length === 0) {
+      return { valid: false, error: `${path}.values must be a non-empty array` };
+    }
+    for (let i = 0; i < input.values.length; i += 1) {
+      if (!isTaskFilterValue(input.values[i])) {
+        return { valid: false, error: `${path}.values[${i}] must be a scalar value` };
+      }
+    }
+    return { valid: true };
+  }
+
+  if (input.start === undefined && input.end === undefined) {
+    return { valid: false, error: `${path}.start or ${path}.end is required` };
+  }
+  if (input.start !== undefined) {
+    const result = validateIsoTimestamp(input.start, `${path}.start`);
+    if (!result.valid) return result;
+  }
+  if (input.end !== undefined) {
+    const result = validateIsoTimestamp(input.end, `${path}.end`);
+    if (!result.valid) return result;
+  }
+  if (input.start !== undefined && input.end !== undefined && Date.parse(input.start as string) > Date.parse(input.end as string)) {
+    return { valid: false, error: `${path}.start must not be after ${path}.end` };
+  }
+  return { valid: true };
+}
+
+export function validateTaskFilter(input: unknown): ValidationResult {
+  return validateNode(input, 1, 'taskFilter');
+}

--- a/packages/contracts/src/task-filter.ts
+++ b/packages/contracts/src/task-filter.ts
@@ -19,7 +19,10 @@ export const TASK_FILTER_KEYS = [
   'last_heartbeat_at',
 ] as const;
 
+export const TASK_FILTER_TIME_KEYS = ['created_at', 'started_at', 'completed_at', 'last_heartbeat_at'] as const;
+
 export type TaskFilterKey = (typeof TASK_FILTER_KEYS)[number];
+export type TaskFilterTimeKey = (typeof TASK_FILTER_TIME_KEYS)[number];
 export type TaskFilterValue = string | number | boolean | null;
 
 export type TaskFilterNode =
@@ -30,9 +33,10 @@ export type TaskFilterNode =
   | { op: 'eq'; key: TaskFilterKey; value: TaskFilterValue }
   | { op: 'in'; key: TaskFilterKey; values: TaskFilterValue[] }
   | { op: 'contains'; key: TaskFilterKey; value: string }
-  | { op: 'time_range'; key: TaskFilterKey; start?: string; end?: string };
+  | { op: 'time_range'; key: TaskFilterTimeKey; start?: string; end?: string };
 
 const taskFilterKeySet = new Set<string>(TASK_FILTER_KEYS);
+const taskFilterTimeKeySet = new Set<string>(TASK_FILTER_TIME_KEYS);
 const filterOps = new Set(['and', 'or', 'not', 'exists', 'eq', 'in', 'contains', 'time_range']);
 const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -57,6 +61,13 @@ function hasOnlyFields(record: Record<string, unknown>, fields: readonly string[
 function validateKey(value: unknown, path: string): ValidationResult {
   if (typeof value !== 'string' || !taskFilterKeySet.has(value)) {
     return { valid: false, error: `${path} must be a valid task filter key` };
+  }
+  return { valid: true };
+}
+
+function validateTimeKey(value: unknown, path: string): ValidationResult {
+  if (typeof value !== 'string' || !taskFilterTimeKeySet.has(value)) {
+    return { valid: false, error: `${path} must be a task timestamp column` };
   }
   return { valid: true };
 }
@@ -105,7 +116,7 @@ function validateNode(input: unknown, depth: number, path: string): ValidationRe
     path,
   );
   if (!fields.valid) return fields;
-  const keyResult = validateKey(input.key, `${path}.key`);
+  const keyResult = op === 'time_range' ? validateTimeKey(input.key, `${path}.key`) : validateKey(input.key, `${path}.key`);
   if (!keyResult.valid) return keyResult;
 
   if (op === 'exists') return { valid: true };


### PR DESCRIPTION
## Summary

Define a shared task filter tree in `@invoker/contracts` for `and`, `or`, `not`, and five constrained leaf operators.

The contract uses a closed allowlist of existing task columns and a hand-rolled checker, without SQL or runtime wiring.

The focused validator tests cover accepted leaves and combinators, every documented rejection, and the allowlist boundary.

## Review Claim

The task filter contract accepts exactly the documented tree shape over allowlisted task columns and reports offending fields for unsupported input.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

No caller exists yet; the module has no SQL and no I/O; the allowlist only names columns that exist in the tasks table DDL or its column migrations.

## Slice Rationale

A fixed contract lets the SQL compiler and the surfaces be reviewed independently.

## Non-goals

No SQL, adapter method, headless, CLI, API, or workflow-level filter wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/contracts test -- --run src/__tests__/task-filter.test.ts`
- `node scripts/validate-pr-body.mjs --body-file /tmp/task-filter-contract.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-commit-sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New contracts-only validation with no runtime wiring; low blast radius unless future callers rely on the allowlist without updating it alongside schema changes.
> 
> **Overview**
> Adds a shared **task filter** contract in `@invoker/contracts`: typed filter trees (`and` / `or` / `not` plus leaf ops `exists`, `eq`, `in`, `contains`, `time_range`), closed allowlists for task columns and timestamp-only `time_range` keys, and `validateTaskFilter` with path-prefixed errors, strict object shapes, depth cap of 8, and timezone-qualified ISO bounds for time ranges.
> 
> Re-exports the module from `packages/contracts/src/index.ts`. Vitest coverage locks the allowlists and documents accepted/rejected shapes; no SQL, I/O, or callers in this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fb3332cfcddea45001aaf3dd983b5fd7a867aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->