### PR TITLE
Transient transport failures (1) classify them on every runner kind

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -10,6 +10,7 @@ import type { TaskState } from '@invoker/workflow-core';
 import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from './fixtures/pr-6976-oauth-session-expired.js';
 import {
   buildRepoMirrorRepairScript,
+  classifyGenericSshInfraFailure,
   createInfraRepairTick,
   deriveCorruptWorktreeAdminPathFromWorkspace,
   extractCorruptMirrorPath,
@@ -747,6 +748,14 @@ describe('infra-repair worker', () => {
         }),
       }),
     ]));
+  });
+});
+
+describe('classifyGenericSshInfraFailure', () => {
+  it('returns infra classes and ignores the transient transport class', () => {
+    expect(classifyGenericSshInfraFailure('No space left on device')).toBe('ssh-disk-full');
+    expect(classifyGenericSshInfraFailure('ssh transport failed exit=255')).toBeUndefined();
+    expect(classifyGenericSshInfraFailure(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/execution-engine/src/__tests__/task-runner-launch-support.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-support.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isRetryableSshStartupTransportError } from '../task-runner-launch-support.js';
+
+describe('isRetryableSshStartupTransportError', () => {
+  it.each([
+    ['exit=255', true],
+    ['exit 255', true],
+    ['ssh transport failed', true],
+    ['connection timed out', true],
+    ['operation timed out', true],
+    ['connection reset', true],
+    ['broken pipe', true],
+    ['banner exchange', true],
+    ['kex_exchange_identification', true],
+    ['remote session terminated unexpectedly', true],
+    ['exit=1', false],
+    ['ordinary task failure', false],
+  ])('%s => %s', (message, expected) => {
+    expect(isRetryableSshStartupTransportError(message)).toBe(expected);
+  });
+});

--- a/packages/execution-engine/src/task-runner-launch-support.ts
+++ b/packages/execution-engine/src/task-runner-launch-support.ts
@@ -7,7 +7,7 @@
  */
 
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
 /** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 export const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -83,14 +83,5 @@ export function computePoolMemberCooldownMs(consecutiveFailures: number): number
 
 export function isRetryableSshStartupTransportError(err: unknown): boolean {
   const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
-  const lower = message.toLowerCase();
-  return lower.includes('exit=255')
-    || lower.includes('ssh transport failed')
-    || lower.includes('connection timed out')
-    || lower.includes('operation timed out')
-    || lower.includes('connection reset')
-    || lower.includes('broken pipe')
-    || lower.includes('banner exchange')
-    || lower.includes('kex_exchange_identification')
-    || lower.includes('remote session terminated unexpectedly');
+  return FailureClassifier.isTransientTransportError(message);
 }

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -367,7 +367,8 @@ export function listInfraRepairScanCandidates(
 }
 
 export function classifyGenericSshInfraFailure(errorText: unknown): InfraRepairReason | undefined {
-  return FailureClassifier.classifyError(typeof errorText === 'string' ? errorText : undefined);
+  const failureClass = FailureClassifier.classifyError(typeof errorText === 'string' ? errorText : undefined);
+  return FailureClassifier.isSshInfra(failureClass) ? failureClass : undefined;
 }
 
 function resolveRemoteTargetId(

--- a/packages/workflow-core/src/__tests__/finalize-failed-task-classification.test.ts
+++ b/packages/workflow-core/src/__tests__/finalize-failed-task-classification.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'vitest';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('finalize failed task classification', () => {
+  it('persists classifications for docker and local runner kinds', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    orchestrator.loadPlan({
+      name: 'finalize-classification',
+      onFinish: 'none',
+      tasks: [
+        { id: 'docker-task', description: 'docker', command: 'x', runnerKind: 'docker' },
+        { id: 'local-task', description: 'local', command: 'x', runnerKind: 'worktree' },
+      ],
+    });
+    const tasks = orchestrator.getAllTasks().filter((task) => !task.config.isMergeNode);
+    const dockerTask = tasks.find((task) => task.id.endsWith('/docker-task'))!;
+    const localTask = tasks.find((task) => task.id.endsWith('/local-task'))!;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: dockerTask.id,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'No space left on device' },
+    }));
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: localTask.id,
+      status: 'failed',
+      outputs: { exitCode: 255, error: 'SSH transport failed (exit 255): connection reset by peer.' },
+    }));
+
+    expect(persistence.getTaskEntry(dockerTask.id)?.task.execution.failureClass).toBe('ssh-disk-full');
+    expect(persistence.getTaskEntry(localTask.id)?.task.execution.failureClass).toBe('ssh-transport-transient');
+  });
+});

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -209,10 +209,7 @@ export function finalizeFailedTaskImpl(
     throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
   }
 
-  const failureClass = executionFields.failureClass
-    ?? (existing.config.runnerKind === 'ssh'
-      ? FailureClassifier.classifyError(executionFields.error)
-      : undefined);
+  const failureClass = executionFields.failureClass ?? FailureClassifier.classifyError(executionFields.error);
 
   const changes: TaskStateChanges = {
     status: 'failed',

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -77,6 +77,13 @@ describe('FailureClassifier.classifyError', () => {
     )).toBeUndefined();
   });
 
+  it('classifies transport failures after definitive infrastructure checks miss', () => {
+    expect(FailureClassifier.classifyError('SSH transport failed (exit 255): connection reset by peer.'))
+      .toBe('ssh-transport-transient');
+    expect(FailureClassifier.classifyError('SSH remote script failed (exit=1, phase=run_task)'))
+      .toBeUndefined();
+  });
+
   it('returns undefined for ordinary code failures and non-strings', () => {
     expect(FailureClassifier.classifyError('AssertionError: expected 1 to be 2')).toBeUndefined();
     expect(FailureClassifier.classifyError(undefined)).toBeUndefined();

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -31,7 +31,7 @@ export class FailureClassifier {
    * Matches are narrow and exact by design — an unknown failure is a code
    * failure, not an infra failure.
    */
-  static classifyError(errorText: string | undefined): SshInfraFailureClass | undefined {
+  static classifyError(errorText: string | undefined): FailureClass | undefined {
     if (typeof errorText !== 'string') return undefined;
     if (errorText.includes('.invoker/env.sh') && errorText.includes('not a valid identifier')) {
       return 'ssh-env-invalid-export';
@@ -66,7 +66,25 @@ export class FailureClassifier {
     if (errorText.includes('No space left on device')) {
       return 'ssh-disk-full';
     }
+    if (this.isTransientTransportError(errorText)) {
+      return 'ssh-transport-transient';
+    }
     return undefined;
+  }
+
+  static isTransientTransportError(text: unknown): boolean {
+    if (typeof text !== 'string') return false;
+    const lower = text.toLowerCase();
+    return lower.includes('exit=255')
+      || lower.includes('exit 255')
+      || lower.includes('ssh transport failed')
+      || lower.includes('connection timed out')
+      || lower.includes('operation timed out')
+      || lower.includes('connection reset')
+      || lower.includes('broken pipe')
+      || lower.includes('banner exchange')
+      || lower.includes('kex_exchange_identification')
+      || lower.includes('remote session terminated unexpectedly');
   }
 
   /** True when the failure was a liveness stall (owned by the requeue worker). */

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -215,10 +215,16 @@ export type SshInfraFailureClass =
   | 'ssh-oauth-session-expired'
   | 'ssh-disk-full';
 
-export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
+export type TransientFailureClass = 'ssh-transport-transient';
+
+export type FailureClass = 'liveness_stall' | SshInfraFailureClass | TransientFailureClass;
 
 export function isLivenessFailureClass(failureClass: FailureClass | undefined): boolean {
   return failureClass === 'liveness_stall';
+}
+
+export function isTransientFailureClass(failureClass: FailureClass | undefined): boolean {
+  return failureClass === 'ssh-transport-transient';
 }
 
 export interface TaskExecution {


### PR DESCRIPTION
## Summary

Add a transient SSH transport failure class and make failed-task classification independent of runner kind.

## Review Claim

Transport faults are classified consistently across startup and mid-run paths without changing existing infrastructure classes.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The seven existing infrastructure matchers remain byte-identical and run first. The transient matcher is fallback-only, and no worker consumes it in this slice.

## Slice Rationale

Classification is the foundation; requeue admission and member-cooldown wiring remain separate slices.

## Non-goals

No requeue-worker, pool-member, stall-reaper, strike-counter, UI, docs, or direct SQL changes. The infra-repair worker only gains a type guard so it keeps ignoring the transient class.

## Architecture

### Before

Startup retry detection and mid-run finalization used separate transport vocabularies, and finalization classified only SSH runners.

### After

FailureClassifier owns the transport vocabulary. Startup detection delegates to it, and finalization classifies errors for every runner kind.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] pnpm --filter @invoker/workflow-graph test --run src/__tests__/failure-classifier.test.ts
- [ ] pnpm --filter @invoker/workflow-core test --run src/__tests__/finalize-failed-task-classification.test.ts
- [ ] pnpm --filter @invoker/execution-engine test --run src/__tests__/task-runner-launch-support.test.ts

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: git revert <sha>.
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Classification-only change with existing infra matchers unchanged first; broader finalize classification persists new metadata but no worker acts on transient class yet.
> 
> **Overview**
> Introduces **`ssh-transport-transient`** as a persisted failure class and centralizes transport matching in **`FailureClassifier.isTransientTransportError`**, used as a **fallback** only after the existing seven SSH infra matchers.
> 
> **Finalize path:** `finalizeFailedTaskImpl` now runs **`FailureClassifier.classifyError`** for every runner kind (not only `ssh`), so docker/worktree failures like disk-full or transport errors get the same `execution.failureClass` as SSH tasks.
> 
> **Startup path:** `isRetryableSshStartupTransportError` delegates to the classifier instead of duplicating substring checks (including **`exit 255`**).
> 
> **Infra-repair:** `classifyGenericSshInfraFailure` returns classes only when **`FailureClassifier.isSshInfra`** is true, so transient transport is classified on the task but **not** treated as infra-repair work in this slice.
> 
> Tests cover classifier transport rules, launch-support retry detection, finalize persistence across runner kinds, and infra-repair ignoring transient errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58983d7048a7778bf3d37364e77acf32b610b8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of transient SSH connection failures, including timeouts, resets, and broken connections.
  * Failure classifications are now consistently recorded for failed tasks across supported runner types.
  * SSH infrastructure errors are less likely to be misclassified when error details are missing or unrelated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->