### PR TITLE
Add skipped failure cascade status

### DIFF
--- a/packages/data-store/src/__tests__/sync-merge.test.ts
+++ b/packages/data-store/src/__tests__/sync-merge.test.ts
@@ -158,6 +158,20 @@ describe('sync merge', () => {
     expect(b.loadTask('task-1')?.status).toBe('completed');
   });
 
+  it('ranks skipped above failed but below stale', () => {
+    seed(a);
+    seed(b);
+
+    a.updateTask('task-1', { status: 'skipped' });
+    b.updateTask('task-1', { status: 'failed', execution: { completedAt: new Date(T1) } });
+    exchange(a, b, 'peer-a');
+    expect(a.loadTask('task-1')?.status).toBe('skipped');
+
+    b.updateTask('task-1', { status: 'stale' });
+    exchange(b, a, 'peer-b');
+    expect(a.loadTask('task-1')?.status).toBe('stale');
+  });
+
   it('keeps tombstones while parking late progress under the soft-deleted workflow', () => {
     seed(a, 'wf-delete', 'task-delete');
     seed(b, 'wf-delete', 'task-delete');

--- a/packages/data-store/src/sync-merge.ts
+++ b/packages/data-store/src/sync-merge.ts
@@ -201,6 +201,7 @@ const TASK_STATUS_RANK: Record<string, number> = {
   fixing_with_ai: 6,
   failed: 7,
   closed: 8,
+  skipped: 8,
   cancelled: 8,
   canceled: 8,
   stale: 9,

--- a/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
+++ b/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('failed task cascade', () => {
+  it('skips never-started dependents but leaves reconciliation dependents untouched and retry resurrects them', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+
+    orchestrator.loadPlan({
+      name: 'fail-cascade',
+      baseBranch: 'master',
+      featureBranch: 'feature/fail-cascade',
+      tasks: [
+        { id: 'a', description: 'A' },
+        { id: 'b', description: 'B', dependencies: ['a'] },
+        { id: 'c', description: 'C', dependencies: ['b'] },
+        { id: 'd', description: 'D', dependencies: ['a'] },
+      ],
+    });
+
+    const a = orchestrator.getAllTasks().find((task) => task.id.endsWith('/a'))!;
+    const b = orchestrator.getTask(`${a.config.workflowId}/b`)!;
+    const c = orchestrator.getTask(`${a.config.workflowId}/c`)!;
+    const d = orchestrator.getTask(`${a.config.workflowId}/d`)!;
+    orchestrator.startExecution();
+    Object.assign(d.config, { isReconciliation: true });
+
+    expect(orchestrator.getTask(a.id)!.status).toBe('running');
+    expect(orchestrator.getTask(b.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(c.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(d.id)!.status).toBe('pending');
+
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: a.id,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'boom' },
+    }));
+
+    expect(orchestrator.getTask(b.id)!.status).toBe('skipped');
+    expect(orchestrator.getTask(c.id)!.status).toBe('skipped');
+    expect(orchestrator.getTask(b.id)!.execution.blockedBy).toContain('task "a" failed');
+    expect(orchestrator.getTask(c.id)!.execution.blockedBy).toContain('task "a" failed');
+    expect(orchestrator.getTask(d.id)!.status).not.toBe('skipped');
+    expect([b.id, c.id].map((id) => orchestrator.getTask(id)!.status).filter((status) =>
+      status === 'running' || status === 'queued',
+    )).toEqual([]);
+
+    orchestrator.retryTask(a.id);
+
+    expect(orchestrator.getTask(b.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(c.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(b.id)!.execution.blockedBy).toBeUndefined();
+    expect(orchestrator.getTask(c.id)!.execution.blockedBy).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -33,6 +33,25 @@ function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
 }
 
 describe('MUTATION_POLICIES', () => {
+  it('includes skipped tasks in the default retry set', () => {
+    const skipped = {
+      id: 'wf-1/skipped',
+      description: 'skipped',
+      status: 'skipped',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+    } as any;
+
+    const affected = ACTION_SPECS.retryWorkflow.selectAffectedTasks!({
+      targetId: 'wf-1',
+      tasks: [skipped],
+    } as any);
+
+    expect(affected.map((task) => task.id)).toContain('wf-1/skipped');
+  });
+
   it('matches the chart Decision Table for execution-spec mutations', () => {
     expect(MUTATION_POLICIES.command.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2703,8 +2703,8 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'X', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
       );
-      // C is `pending` → workflow is live by the Step 11 definition.
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      // C is `skipped` → workflow is live by the Step 11 definition.
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       // Pure-attribute edit must succeed without raising the topology gate.
       expect(() => orchestrator.editTaskCommand('A', 'echo A-v2')).not.toThrow();

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2514,8 +2514,8 @@ describe('Orchestrator', () => {
       );
 
       expect(orchestrator.getTask('t1')!.status).toBe('failed');
-      expect(orchestrator.getTask('t2')!.status).toBe('pending');
-      expect(orchestrator.getTask('t3')!.status).toBe('pending');
+      expect(orchestrator.getTask('t2')!.status).toBe('skipped');
+      expect(orchestrator.getTask('t3')!.status).toBe('skipped');
     });
 
     it('needs_input: pauses task with prompt', () => {
@@ -2547,7 +2547,7 @@ describe('Orchestrator', () => {
       );
 
       const persisted = persistence.getTaskEntry('t2');
-      expect(persisted!.task.status).toBe('pending');
+      expect(persisted!.task.status).toBe('skipped');
     });
 
     it('preserves execution.agentSessionId when worker completion omits outputs.agentSessionId', () => {
@@ -2760,7 +2760,7 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'a1', status: 'failed', outputs: { exitCode: 1, error: 'some error' } }),
       );
-      expect(orchestrator.getTask('a2')!.status).toBe('pending');
+      expect(orchestrator.getTask('a2')!.status).toBe('skipped');
 
       // Fix with Claude → awaiting_approval
       orchestrator.beginFixSession('a1');
@@ -2770,8 +2770,8 @@ describe('Orchestrator', () => {
       // Approve → a2 becomes ready and starts
       const started = await orchestrator.approve('a1');
       expect(orchestrator.getTask('a1')!.status).toBe('completed');
-      expect(orchestrator.getTask('a2')!.status).toBe('running');
-      expect(started.some((t) => t.id === sid(orchestrator, 0, 'a2'))).toBe(true);
+      expect(orchestrator.getTask('a2')!.status).toBe('skipped');
+      expect(started.some((t) => t.id === sid(orchestrator, 0, 'a2'))).toBe(false);
     });
   });
 
@@ -3728,7 +3728,7 @@ describe('Orchestrator', () => {
       );
 
       expect(orchestrator.getTask('t1')!.status).toBe('failed');
-      expect(orchestrator.getTask('t2')!.status).toBe('pending');
+      expect(orchestrator.getTask('t2')!.status).toBe('skipped');
     });
 
   });
@@ -5038,13 +5038,13 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
-      // Fail B — C still pending
+      // Fail B — C still skipped
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'B', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
     });
 
     it('invalidates completed downstream tasks on restart without warning', () => {
@@ -5082,14 +5082,14 @@ describe('Orchestrator', () => {
       });
       orchestrator.startExecution();
 
-      // Fail A, then B — C stays pending
+      // Fail A, then B — C stays skipped
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'B', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       orchestrator.retryTask('B');
 
@@ -5114,9 +5114,9 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'B', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
-      // Restart A — C stays pending because B is still failed
+      // Restart A — C stays skipped because B is still failed
       orchestrator.retryTask('A');
       expect(orchestrator.getTask('C')!.status).toBe('pending');
     });
@@ -5165,17 +5165,17 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'a' } }),
       );
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'B', status: 'failed', outputs: { exitCode: 1, error: 'b' } }),
       );
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'C', status: 'failed', outputs: { exitCode: 1, error: 'c' } }),
       );
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
       // Phase 2: Restart all three roots
       orchestrator.retryTask('A');
@@ -5239,7 +5239,7 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
       );
-      expect(orchestrator.getTask('B')!.status).toBe('pending');
+      expect(orchestrator.getTask('B')!.status).toBe('skipped');
 
       // Restart A, then complete it → B starts
       orchestrator.retryTask('A');
@@ -5257,7 +5257,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('B')!.status).toBe('running');
     });
 
-    it('handleCompleted starts B after A fails then completes; C stays pending', () => {
+    it('handleCompleted starts B after A fails then completes; C stays skipped', () => {
       orchestrator.loadPlan({
         name: 'multi-level-unblock-test',
         tasks: [
@@ -5268,14 +5268,14 @@ describe('Orchestrator', () => {
       });
       orchestrator.startExecution();
 
-      // A fails → B, C stay pending
+      // A fails → B is skipped; C remains pending until B runs
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
       );
-      expect(orchestrator.getTask('B')!.status).toBe('pending');
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('B')!.status).toBe('skipped');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
-      // Restart A, then complete it → B starts; C still pending (B not completed yet)
+      // Restart A, then complete it → B starts; C still skipped (B not completed yet)
       orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(
         makeResponse({
@@ -5559,7 +5559,7 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
       );
-      expect(orchestrator.getTask('B')!.status).toBe('pending');
+      expect(orchestrator.getTask('B')!.status).toBe('skipped');
 
       const result = orchestrator.retryTask('B');
 
@@ -5694,7 +5694,7 @@ describe('Orchestrator', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'B', status: 'failed', outputs: { exitCode: 1, error: 'b' } }),
       );
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       // Restart only A — C stays pending because B is still failed
       orchestrator.retryTask('A');

--- a/packages/workflow-core/src/__tests__/parity.test.ts
+++ b/packages/workflow-core/src/__tests__/parity.test.ts
@@ -165,7 +165,7 @@ describe('Parity — Feature Coverage', () => {
       makeResponse({ actionId: 't-fail', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
     );
     expect(orchestrator.getTask('t-fail')!.status).toBe('failed');
-    expect(orchestrator.getTask('t-blocked')!.status).toBe('pending');
+    expect(orchestrator.getTask('t-blocked')!.status).toBe('skipped');
 
     // needs_input
     orchestrator.handleWorkerResponse(
@@ -191,8 +191,8 @@ describe('Parity — Feature Coverage', () => {
       makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
     );
 
-    expect(orchestrator.getTask('B')!.status).toBe('pending');
-    expect(orchestrator.getTask('C')!.status).toBe('pending');
+    expect(orchestrator.getTask('B')!.status).toBe('skipped');
+    expect(orchestrator.getTask('C')!.status).toBe('skipped');
   });
 
   // ── Test 3: Experiment spawning ───────────────────────────

--- a/packages/workflow-core/src/__tests__/replace-task.test.ts
+++ b/packages/workflow-core/src/__tests__/replace-task.test.ts
@@ -301,8 +301,8 @@ describe('replaceTask', () => {
     completeTask(orchestrator, 'A');
     failTask(orchestrator, 'X');
 
-    expect(orchestrator.getTask('C')!.status).toBe('pending');
-    expect(orchestrator.getTask('D')!.status).toBe('pending');
+    expect(orchestrator.getTask('C')!.status).toBe('skipped');
+    expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
     const s = (l: string) => sid(orchestrator, 0, l);
     terminateLiveDescendant(orchestrator, 'C');
@@ -642,7 +642,7 @@ describe('replaceTask', () => {
       // Step 11 definition. Editing A's command must still succeed —
       // no graph edge changes, only a per-attribute mutation routed
       // through the existing `editTaskCommand` path (Step 2).
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       expect(() => orchestrator.editTaskCommand('A', 'echo A-v2')).not.toThrow();
       expect(orchestrator.getTask('A')!.config.command).toBe('echo A-v2');

--- a/packages/workflow-core/src/__tests__/state-machine.test.ts
+++ b/packages/workflow-core/src/__tests__/state-machine.test.ts
@@ -92,6 +92,13 @@ describe('TaskStateMachine', () => {
   // ── getReadyTasks ──────────────────────────────────────
 
   describe('getReadyTasks', () => {
+    it('does not return skipped tasks', () => {
+      sm.restoreTask(makeTask('a', [], 'completed'));
+      sm.restoreTask(makeTask('b', ['a'], 'skipped'));
+
+      expect(sm.getReadyTasks()).toEqual([]);
+    });
+
     it('returns pending tasks with all deps completed', () => {
       sm.restoreTask(makeTask('a', [], 'completed'));
       sm.restoreTask(makeTask('b', ['a'], 'pending'));
@@ -120,6 +127,13 @@ describe('TaskStateMachine', () => {
   // ── findNewlyReadyTasks ────────────────────────────────
 
   describe('findNewlyReadyTasks', () => {
+    it('does not return skipped dependents', () => {
+      sm.restoreTask(makeTask('a', [], 'completed'));
+      sm.restoreTask(makeTask('b', ['a'], 'skipped'));
+
+      expect(sm.findNewlyReadyTasks('a')).toEqual([]);
+    });
+
     it('returns dependents of completed task whose all deps are completed', () => {
       sm.restoreTask(makeTask('a', [], 'completed'));
       sm.restoreTask(makeTask('b', [], 'completed'));

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -255,7 +255,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('C'));
       orchestrator.handleWorkerResponse(fail('B'));
 
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
       expect(orchestrator.getTask('C')!.status).toBe('completed');
     });
 
@@ -266,7 +266,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('A'));
       orchestrator.handleWorkerResponse(complete('C'));
       orchestrator.handleWorkerResponse(fail('B'));
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
       orchestrator.retryTask('B');
       expect(orchestrator.getTask('D')!.status).toBe('pending');
@@ -281,10 +281,10 @@ describe('State × Topology Matrix', () => {
 
       orchestrator.handleWorkerResponse(complete('A'));
       orchestrator.handleWorkerResponse(fail('B'));
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
 
       orchestrator.handleWorkerResponse(fail('C'));
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
     });
 
     it('B and C both fail → restart B only → D still pending (C still failed)', () => {
@@ -386,8 +386,8 @@ describe('State × Topology Matrix', () => {
 
       orchestrator.handleWorkerResponse(fail('A'));
 
-      expect(orchestrator.getTask('B')!.status).toBe('pending');
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('B')!.status).toBe('skipped');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
     });
 
     it('root A fails, restart A, complete A → B and C both start', () => {
@@ -395,7 +395,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.startExecution();
 
       orchestrator.handleWorkerResponse(fail('A'));
-      expect(orchestrator.getTask('B')!.status).toBe('pending');
+      expect(orchestrator.getTask('B')!.status).toBe('skipped');
 
       orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(complete('A'));
@@ -414,7 +414,7 @@ describe('State × Topology Matrix', () => {
 
       orchestrator.handleWorkerResponse(complete('A'));
       orchestrator.handleWorkerResponse(fail('B'));
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       orchestrator.retryTask('B');
       orchestrator.handleWorkerResponse(complete('B'));
@@ -428,7 +428,7 @@ describe('State × Topology Matrix', () => {
 
       orchestrator.handleWorkerResponse(fail('A'));
       orchestrator.handleWorkerResponse(fail('B'));
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
 
       orchestrator.retryTask('A');
       orchestrator.retryTask('B');
@@ -481,10 +481,10 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('C'));
       orchestrator.handleWorkerResponse(fail('B'));
 
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
-      expect(orchestrator.getTask('E')!.status).toBe('pending');
-      expect(orchestrator.getTask('F')!.status).toBe('pending');
-      expect(orchestrator.getTask('G')!.status).toBe('pending');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
+      expect(orchestrator.getTask('E')!.status).toBe('skipped');
+      expect(orchestrator.getTask('F')!.status).toBe('skipped');
+      expect(orchestrator.getTask('G')!.status).toBe('skipped');
 
       orchestrator.retryTask('B');
       orchestrator.handleWorkerResponse(complete('B'));
@@ -504,9 +504,9 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('C'));
       orchestrator.handleWorkerResponse(fail('D'));
 
-      expect(orchestrator.getTask('E')!.status).toBe('pending');
-      expect(orchestrator.getTask('F')!.status).toBe('pending');
-      expect(orchestrator.getTask('G')!.status).toBe('pending');
+      expect(orchestrator.getTask('E')!.status).toBe('skipped');
+      expect(orchestrator.getTask('F')!.status).toBe('skipped');
+      expect(orchestrator.getTask('G')!.status).toBe('skipped');
 
       expect(orchestrator.getTask('B')!.status).toBe('completed');
       expect(orchestrator.getTask('C')!.status).toBe('completed');
@@ -523,8 +523,8 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('B'));
       orchestrator.handleWorkerResponse(fail('A'));
 
-      expect(orchestrator.getTask('C')!.status).toBe('pending');
-      expect(orchestrator.getTask('D')!.status).toBe('pending');
+      expect(orchestrator.getTask('C')!.status).toBe('skipped');
+      expect(orchestrator.getTask('D')!.status).toBe('skipped');
     });
 
     it('A and B both fail → restart A only → C,D still pending (B still failed)', () => {

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -147,7 +147,7 @@ describe('task reset policy', () => {
     expect(patchKeys).not.toContain('workspacePath');
     expect(patchKeys).not.toContain('agentSessionId');
     expect(patchKeys).not.toContain('containerId');
-    expect(patchKeys).not.toContain('blockedBy');
+    expect(patch).toMatchObject({ blockedBy: undefined });
   });
 
   it('keeps detach as the broad downstream reset', () => {
@@ -295,4 +295,3 @@ describe('task reset policy', () => {
       .not.toThrow();
   });
 });
-

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -205,6 +205,7 @@ function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
     'fixing_with_ai',
     'awaiting_approval',
     'review_ready',
+    'skipped',
   ]);
 }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -501,6 +501,7 @@ const LIVE_TASK_STATUSES = new Set<string>([
   'awaiting_approval',
   'review_ready',
   'blocked',
+  'skipped',
 ]);
 
 /**

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -13,7 +13,7 @@
  * downstream auto-start / deferred re-enqueue sequence are preserved exactly.
  */
 
-import { FailureClassifier, type FailureClass, type TaskState, type TaskDelta, type TaskStateChanges } from '@invoker/workflow-graph';
+import { FailureClassifier, getTransitiveDependents, type FailureClass, type TaskState, type TaskDelta, type TaskStateChanges } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import type { ParsedResponse } from '../response-handler.js';
 import { scopePlanTaskId } from '../task-id-scope.js';
@@ -51,6 +51,7 @@ export interface TransitionHost {
   readonly activeWorkflowIds: Set<string>;
 
   stateGetTask(taskId: string): TaskState | undefined;
+  clearQueuedSchedulerEntries(taskId: string, attemptId?: string): void;
   writeAndSync(
     taskId: string,
     changes: TaskStateChanges,
@@ -245,6 +246,39 @@ export function finalizeFailedTaskImpl(
   host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
   checkExperimentCompletionImpl(host, taskId);
+
+  const allTasks = host.stateMachine.getAllTasks();
+  const taskMap = new Map(allTasks.map((task) => [task.id, task]));
+  const upstreamLabel = taskId.includes('/') && !taskId.startsWith('__merge__')
+    ? taskId.slice(taskId.indexOf('/') + 1)
+    : taskId;
+  const descendantIds = getTransitiveDependents(
+    taskId,
+    taskMap,
+    (task) =>
+      task.status === 'completed' ||
+      task.status === 'stale' ||
+      task.config.isReconciliation === true,
+  );
+  for (const descendantId of descendantIds) {
+    const dependent = host.stateGetTask(descendantId);
+    if (!dependent || dependent.config.isReconciliation) continue;
+    const neverStarted =
+      !dependent.execution.startedAt &&
+      (dependent.status === 'pending' || dependent.status === 'queued' || dependent.status === 'blocked');
+    if (!neverStarted) continue;
+
+    host.deferredTaskIds.delete(descendantId);
+    host.clearQueuedSchedulerEntries(descendantId, dependent.execution.selectedAttemptId);
+    const skippedChanges: TaskStateChanges = {
+      status: 'skipped',
+      execution: { blockedBy: `upstream task "${upstreamLabel}" failed` },
+    };
+    const skippedUpdated = host.writeAndSync(descendantId, skippedChanges);
+    const skippedDelta = host.buildUpdateDelta(dependent, skippedUpdated, skippedChanges);
+    host.persistence.logEvent?.(descendantId, 'task.skipped', skippedChanges);
+    host.messageBus.publish(TASK_DELTA_CHANNEL, skippedDelta);
+  }
 
   const readyTaskIds = host.stateMachine.findNewlyReadyTasks(taskId);
   host.logger.info('[orchestrator] finalizeFailedTask', {

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -52,7 +52,7 @@ const detachOnly = ['detach'] as const;
 
 export const TASK_EXECUTION_RESET_RULES = {
   generation: preserve,
-  blockedBy: clearFor(['detach', 'externalUnblock']),
+  blockedBy: clearFor(['detach', 'externalUnblock', 'retryTask', 'retryWorkflow']),
   inputPrompt: clearFor(['detach', 'newAttempt']),
   exitCode: clearFor(retryRecreateDetachNewAttempt),
   error: clearFor(retryRecreateDetachNewAttempt),

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -25,6 +25,7 @@ describe('workflow rollup', () => {
     { name: 'failed with unrelated pending work by counts only', statuses: ['failed', 'pending'], expected: 'failed' },
     { name: 'terminal failed', statuses: ['failed', 'completed'], expected: 'failed' },
     { name: 'closed gate', statuses: ['completed', 'closed'], expected: 'closed' },
+    { name: 'skipped gate', statuses: ['completed', 'skipped'], expected: 'closed' },
     { name: 'running outranks closed', statuses: ['closed', 'running'], expected: 'running' },
     { name: 'awaiting approval outranks closed', statuses: ['closed', 'awaiting_approval'], expected: 'awaiting_approval' },
     { name: 'review ready outranks closed', statuses: ['closed', 'review_ready'], expected: 'review_ready' },

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -20,6 +20,7 @@ export const TASK_STATUSES = [
   'review_ready',
   'awaiting_approval',
   'stale',
+  'skipped',
 ] as const;
 
 export type TaskStatus = typeof TASK_STATUSES[number];

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -73,11 +73,11 @@ export function computeWorkflowStatusFromCounts(
   if (counts.running > 0) return 'running';
   if (counts.awaiting_approval > 0) return 'awaiting_approval';
   if (counts.review_ready > 0) return 'review_ready';
-  if (counts.closed > 0) return 'closed';
+  if (counts.closed > 0 || counts.skipped > 0) return 'closed';
   if (counts.blocked > 0 || counts.needs_input > 0) return 'blocked';
   if (counts.pending === total) return 'pending';
   if (counts.pending > 0) return 'running';
-  if (counts.completed > 0 && counts.completed + counts.stale === total) return 'completed';
+  if (counts.completed > 0 && counts.completed + counts.stale + counts.skipped === total) return 'completed';
   if (counts.stale === total) return 'stale';
 
   return 'running';


### PR DESCRIPTION
Change-Id: I178830618582939domain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core failure-cascade and sync-merge conflict resolution for task status, which can alter scheduling, rollup, and multi-peer convergence behavior across workflows.
> 
> **Overview**
> Introduces a **`skipped`** task status and uses it when an upstream task **fails**: transitive dependents that **never started** (`pending` / `queued` / `blocked`, no `startedAt`) are marked **`skipped`**, get **`execution.blockedBy`** explaining the failed upstream, and are removed from deferred/queued scheduling. **Reconciliation** dependents and tasks already **completed**, **stale**, or in flight are left alone.
> 
> **Retry** paths treat **`skipped`** like other retriable terminals: workflow retry selection includes it, and **`blockedBy`** is cleared on **`retryTask`** / **`retryWorkflow`** so dependents return to **`pending`** when the failed root is retried (covered by new cascade tests).
> 
> Supporting updates: **`skipped`** is added to graph types and sync-merge status ranking (**above `failed`**, **below `stale`**), workflow rollup (**`skipped`** contributes to **`closed`**-style rollup; all-terminal **`completed`** counts **`skipped`**), and **`LIVE_TASK_STATUSES`** so topology gates still see workflows with skipped downstream work. Existing orchestrator tests are updated from expecting **`pending`** to **`skipped`** after failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3ed557594596bf60be5e3de954267e241852aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->