### PR TITLE
[auto: Plan submit traps](3) Land freshness-check and unit-triggers pre-submit checks

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -211,7 +211,7 @@ must_contain "$SKILL_MD" "skill://review-compression/SKILL.md" "SKILL handoff mo
 must_contain "$SKILL_MD" "before writing workflow YAML" "SKILL handoff mode must require review compression before workflow YAML"
 must_contain "$SKILL_MD" 'Present plan and submit on confirmation. That confirmation authorizes the reviewed `onFinish` outcome; implementation plans default to GitHub publication through `onFinish: pull_request` without a second approval prompt.' "SKILL intended flow must authorize the reviewed publication outcome"
 must_contain "$SKILL_MD" "approved implementation plans use **Mergify Stacks** for their declared GitHub publication outcome" "SKILL dogfooding rule must use Mergify for the reviewed Invoker publication outcome"
-must_contain "$SKILL_MD" "then publish/update the resulting commit stack with \`mergify stack push\`." "SKILL dogfooding rule must document the later PR publication command"
+must_contain "$SKILL_MD" "then publish/update the resulting commit stack with \`mergify stack push\` after the work is ready without asking again." "SKILL dogfooding rule must document the later PR publication command"
 must_contain "$SKILL_MD" "Do **not** generalize this to unrelated target repos" "SKILL dogfooding rule must keep Invoker-only PR publication scoped"
 must_not_contain "$SKILL_MD" "workflow handoff only" "SKILL must not preserve the obsolete no-publication approval boundary"
 must_not_contain "$SKILL_MD" "PR publication still requires a separate explicit request" "SKILL must not require redundant publication approval"

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -494,3 +494,67 @@ if [[ -f "$POLICY_TEST_SCRIPT" ]]; then
 else
   fail "Policy coverage test script not found: $POLICY_TEST_SCRIPT"
 fi
+
+# Pre-submit trap checks: freshness-check reproduces the owner's prose
+# freshness gate; unit-triggers names the line behind a review-unit lint hit.
+FRESHNESS_CHECK="$SKILL_DIR/scripts/freshness-check.mjs"
+UNIT_TRIGGERS="$SKILL_DIR/scripts/unit-triggers.mjs"
+[[ -f "$FRESHNESS_CHECK" ]] || fail "expected $FRESHNESS_CHECK"
+[[ -f "$UNIT_TRIGGERS" ]] || fail "expected $UNIT_TRIGGERS"
+TRAP_FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$TRAP_FIXTURE_DIR"' EXIT
+TRAP_MISSING_SYMBOL="missingSymbol_$(date +%s)_$$"
+cat > "$TRAP_FIXTURE_DIR/stale.yaml" <<'YAML'
+name: stale-anchor-fixture
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+tasks:
+  - id: implement-stale-anchor
+    description: |
+      Review claim: Add a helper.
+      Implementation details:
+      - Extend the existing `__TRAP_MISSING_SYMBOL__` and validate the routing.
+    prompt: |
+      Create packages/nope/src/missing.ts; the existing packages/execution-engine/src/task-runner.ts stays.
+    dependencies: []
+YAML
+sed -i.bak "s/__TRAP_MISSING_SYMBOL__/$TRAP_MISSING_SYMBOL/" "$TRAP_FIXTURE_DIR/stale.yaml" && rm -f "$TRAP_FIXTURE_DIR/stale.yaml.bak"
+FRESHNESS_OUTPUT="$(node "$FRESHNESS_CHECK" "$REPO_ROOT" "$TRAP_FIXTURE_DIR/stale.yaml" 2>&1 || true)"
+must_output_contain "$FRESHNESS_OUTPUT" "STALE -> needs_input  stale.yaml :: implement-stale-anchor" "freshness-check must predict the owner's needs_input stop for an anchor clause naming a missing path"
+must_output_contain "$FRESHNESS_OUTPUT" "missing path:packages/nope/src/missing.ts" "freshness-check must name the missing path anchor"
+must_output_contain "$FRESHNESS_OUTPUT" "missing symbol:$TRAP_MISSING_SYMBOL" "freshness-check must name the missing symbol anchor"
+if node "$FRESHNESS_CHECK" "$REPO_ROOT" "$TRAP_FIXTURE_DIR/stale.yaml" >/dev/null 2>&1; then
+  fail "freshness-check must exit non-zero when any anchor is missing"
+fi
+cat > "$TRAP_FIXTURE_DIR/current.yaml" <<'YAML'
+name: current-anchor-fixture
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+tasks:
+  - id: implement-current-anchor
+    description: |
+      Review claim: Add a helper.
+      Implementation details:
+      - Reuse the existing `detectReviewUnits` export in scripts/review-unit-rules.mjs.
+    prompt: |
+      Create packages/nope/src/new-helper.ts.
+      Import from the existing scripts/review-unit-rules.mjs.
+    dependencies: []
+YAML
+FRESHNESS_CURRENT_OUTPUT="$(node "$FRESHNESS_CHECK" "$REPO_ROOT" "$TRAP_FIXTURE_DIR/current.yaml" 2>&1)" \
+  || fail "freshness-check must exit 0 for a plan whose anchors all exist: $FRESHNESS_CURRENT_OUTPUT"
+must_output_contain "$FRESHNESS_CURRENT_OUTPUT" "current  current.yaml :: implement-current-anchor" "freshness-check must print current for a plan whose anchors all exist"
+UNIT_TRIGGERS_OUTPUT="$(node "$UNIT_TRIGGERS" "$TRAP_FIXTURE_DIR/stale.yaml" 2>&1 || true)"
+must_output_contain "$UNIT_TRIGGERS_OUTPUT" "description mentions multiple review units (validation-policy, routing)" "unit-triggers must report the same verdict as lint-review-units"
+must_output_contain "$UNIT_TRIGGERS_OUTPUT" "Implementation details: - Extend the existing \`$TRAP_MISSING_SYMBOL\` and validate the routing." "unit-triggers must print the scanned line that tripped each review unit"
+must_output_contain "$UNIT_TRIGGERS_OUTPUT" "[routing]" "unit-triggers must label the tripped unit"
+if node "$UNIT_TRIGGERS" "$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml" >/dev/null 2>&1; then
+  :
+else
+  fail "unit-triggers must exit 0 when no task mixes review units"
+fi
+rm -rf "$TRAP_FIXTURE_DIR"
+trap - EXIT
+echo "OK: freshness-check and unit-triggers pre-submit trap checks behave"

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -108,3 +108,28 @@ Report the missing command surface and add/fix the command if the user asked for
 ## State claims must be fresh
 
 Never report a workflow/task count, CI status, merge status, or "it's running"/"it's fixed"/"autofix kicked in" from memory of an earlier check in this conversation. Run the query command again in the same turn and report what it actually returns now. State drifts between when you last checked and when you answer — a count from five minutes ago is not current state. See `skills/prove-it/SKILL.md`.
+
+## `needs_input` with empty task output is a read-the-reason problem
+
+A task that goes `needs_input` seconds after submit, with empty task output and no agent session, was stopped by the owner before launch. The stop reason is stored in `execution.inputPrompt`, and no headless query projection emits that field (`query task`, `query tasks`, `invoker_list_tasks`, and `/api/tasks` all go through the same serializer).
+
+Do this, in order, before any `retry-task`, agent switch (`set agent`), or resubmit:
+
+1. Print the returned key set of the task record, not just truthy values. If `inputPrompt` is not among the keys, say "not projected", not "empty". Absence of a field is not absence of state.
+2. Read the emitter in the running owner. The installed app bundle is greppable: `grep -n "ANCHOR_CLAUSE_PATTERN\|inputPrompt" /Applications/Invoker.app/Contents/Resources/app.asar`. Read the owner's copy, not the checkout's — a checkout can carry an untracked or unmerged rewrite of the same file.
+3. On macOS, `invoker-ui --headless ...` goes through `open -a` and discards stdout and the exit code, so an empty result proves nothing. Call the binary directly: `/Applications/Invoker.app/Contents/MacOS/Invoker --headless query task <taskId> --output json`.
+4. Only after the reason is in hand, reword the task or choose the operator action. A retry against the same task text reproduces the same stop.
+
+Do not hand the lookup back to the user ("open the task in the app and paste the text") until steps 1-3 have been tried and shown.
+
+## Waiting on a workflow
+
+Once a background `invoker-cli wait <workflowId>` is armed on a workflow, do not also poll it with foreground `sleep`/`seq` loops around `invoker-cli query`. One waiter per workflow; the wake-up is the signal.
+
+When the session context is already large and a workflow is stuck, delegate the digging (owner log reads, bundle greps, key-set dumps) to a subagent and keep only its conclusion in the main context.
+
+## Cancelling a chain
+
+Cancelling a chain head releases its chained downstream workflows: their merge-gate dependency detaches and their implement tasks launch on plain master seconds later. Cancel downstream workflows first, then the head.
+
+After each cancel, re-query with `query tasks --workflow <workflowId>` until every task shows `failed`. A cancel of a still-pending workflow may not stick on the first call, and the app-binary cancel exit code is unreliable, so the query result is the only proof that the cancel took.

--- a/skills/plan-to-invoker/scripts/freshness-check.mjs
+++ b/skills/plan-to-invoker/scripts/freshness-check.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REPO_PATH_PATTERN = /(?:^|[\s`'"(])((?:\.github|corpus|docs|engine|packages|scripts|tests)\/[A-Za-z0-9_@./-]+)/g;
+const BACKTICK_TOKEN_PATTERN = /`([^`]+)`/g;
+const ANCHOR_CLAUSE_PATTERN = /\b(?:already exists?|existing|do not create|must not create|without creating)\b/i;
+
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+  const localRepoRoot = resolve(scriptDir, '../../..');
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: scriptDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    const repoRoot = resolveInvokerRepoRoot(scriptDir);
+    for (const candidate of ['packages/app/node_modules/yaml/dist/index.js', 'node_modules/yaml/dist/index.js']) {
+      const yamlPath = repoRoot ? resolve(repoRoot, candidate) : null;
+      if (yamlPath && existsSync(yamlPath)) return import(yamlPath);
+    }
+    throw new Error('Unable to resolve yaml runtime. Set INVOKER_REPO_ROOT to an Invoker checkout with installed dependencies.');
+  }
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function normalizedRepoPaths(text) {
+  const paths = [];
+  for (const match of text.matchAll(REPO_PATH_PATTERN)) {
+    const value = match[1]?.replace(/[),.;:]+$/, '');
+    if (value && !value.split('/').includes('..')) paths.push(value);
+  }
+  return uniqueSorted(paths);
+}
+
+function anchorsOf(text) {
+  const anchors = new Map();
+  for (const raw of text.split(/\r?\n/)) {
+    const clause = raw.trim();
+    if (!clause || !ANCHOR_CLAUSE_PATTERN.test(clause)) continue;
+    const paths = normalizedRepoPaths(clause);
+    for (const value of paths) anchors.set(`path:${value}`, { kind: 'path', value, clause });
+    for (const match of clause.matchAll(BACKTICK_TOKEN_PATTERN)) {
+      const value = match[1]?.trim();
+      if (!value || paths.includes(value) || !/^[A-Za-z_$][\w$]*$/.test(value)) continue;
+      anchors.set(`symbol:${value}`, { kind: 'symbol', value, clause });
+    }
+  }
+  return [...anchors.values()];
+}
+
+function usage() {
+  console.error('Usage: node freshness-check.mjs [--ref <git-ref>] <repo-checkout> <plan.yaml...>');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  let ref = 'HEAD';
+  const positional = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--ref') {
+      ref = argv[index + 1] ?? '';
+      index += 1;
+    } else {
+      positional.push(argv[index]);
+    }
+  }
+  if (!ref || positional.length < 2) usage();
+  const [repo, ...files] = positional;
+  return { ref, repo, files };
+}
+
+const { ref, repo, files } = parseArgs(process.argv.slice(2));
+const { parse } = await importYaml(__dirname);
+
+function gitOk(args) {
+  try {
+    execFileSync('git', ['-C', repo, ...args], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const resolvedRef = execFileSync('git', ['-C', repo, 'rev-parse', '--short', ref]).toString().trim();
+const pathExists = (value) => gitOk(['cat-file', '-e', `${ref}:${value}`]);
+const symbolExists = (value) => gitOk(['grep', '-F', '-q', '-e', value, ref, '--']);
+
+let anyStale = false;
+for (const file of files) {
+  const plan = parse(readFileSync(file, 'utf8'));
+  for (const task of plan?.tasks ?? []) {
+    if (!task?.prompt) continue;
+    const text = [task.description, task.prompt].filter(Boolean).join('\n');
+    const missing = anchorsOf(text).filter((anchor) => (
+      anchor.kind === 'path' ? !pathExists(anchor.value) : !symbolExists(anchor.value)
+    ));
+    const verdict = missing.length ? 'STALE -> needs_input' : 'current';
+    if (missing.length) anyStale = true;
+    console.log(`${verdict}  ${basename(file)} :: ${task.id}`);
+    for (const anchor of missing) {
+      console.log(`    missing ${anchor.kind}:${anchor.value}`);
+      console.log(`      clause: ${anchor.clause.slice(0, 110)}`);
+    }
+  }
+}
+console.log(`(checked against ${repo} @ ${ref} = ${resolvedRef})`);
+process.exit(anyStale ? 1 : 0);

--- a/skills/plan-to-invoker/scripts/unit-triggers.mjs
+++ b/skills/plan-to-invoker/scripts/unit-triggers.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const EXCLUDED_LINE_PATTERN = /\b(separate|non-goals?|do not|does not|without|no\s+)\b/i;
+const SCANNED_SECTIONS = ['Review claim', 'Slice rationale', 'Implementation details', 'Implementation'];
+
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+  const localRepoRoot = resolve(scriptDir, '../../..');
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: scriptDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    const repoRoot = resolveInvokerRepoRoot(scriptDir);
+    for (const candidate of ['packages/app/node_modules/yaml/dist/index.js', 'node_modules/yaml/dist/index.js']) {
+      const yamlPath = repoRoot ? resolve(repoRoot, candidate) : null;
+      if (yamlPath && existsSync(yamlPath)) return import(yamlPath);
+    }
+    throw new Error('Unable to resolve yaml runtime. Set INVOKER_REPO_ROOT to an Invoker checkout with installed dependencies.');
+  }
+}
+
+function resolveReviewUnitRulesModulePath(scriptDir) {
+  const vendoredPath = resolve(scriptDir, 'vendor', 'review-unit-rules.mjs');
+  if (existsSync(vendoredPath)) return vendoredPath;
+  const repoRoot = resolveInvokerRepoRoot(scriptDir);
+  const repoRulesPath = repoRoot ? resolve(repoRoot, 'scripts/review-unit-rules.mjs') : null;
+  if (repoRulesPath && existsSync(repoRulesPath)) return repoRulesPath;
+  throw new Error('Unable to resolve review-unit-rules.mjs (run bash scripts/vendor-plan-doctor-deps.sh).');
+}
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('Usage: node unit-triggers.mjs <plan.yaml...>');
+  process.exit(2);
+}
+
+const { parse } = await importYaml(__dirname);
+const { detectReviewUnits, getLabelSection, validateSingleReviewUnitFocus } = await import(resolveReviewUnitRulesModulePath(__dirname));
+
+function scannedTexts(text) {
+  return SCANNED_SECTIONS.map((label) => [label, getLabelSection(text, label)]).filter(([, section]) => section);
+}
+
+function triggerLines(text) {
+  const hits = new Map();
+  for (const [label, section] of scannedTexts(text)) {
+    for (const line of section.split('\n')) {
+      if (!line.trim() || EXCLUDED_LINE_PATTERN.test(line)) continue;
+      for (const unit of detectReviewUnits(line)) {
+        if (!hits.has(unit)) hits.set(unit, []);
+        hits.get(unit).push(`${label}: ${line.trim().slice(0, 120)}`);
+      }
+    }
+  }
+  return hits;
+}
+
+let anyFailure = false;
+for (const file of files) {
+  const plan = parse(readFileSync(file, 'utf8'));
+  for (const task of plan?.tasks ?? []) {
+    for (const field of ['description', 'prompt']) {
+      const text = String(task[field] ?? '');
+      if (!text) continue;
+      const errors = validateSingleReviewUnitFocus({
+        context: `${field}`,
+        texts: scannedTexts(text).map(([, section]) => section),
+      });
+      if (errors.length === 0) continue;
+      anyFailure = true;
+      console.log(`== ${file} :: ${task.id} (${field})`);
+      for (const error of errors) console.log(`  ${error}`);
+      for (const [unit, lines] of triggerLines(text)) {
+        console.log(`  [${unit}]`);
+        for (const line of lines.slice(0, 3)) console.log(`     ${line}`);
+      }
+    }
+  }
+}
+process.exit(anyFailure ? 1 : 0);


### PR DESCRIPTION
## Summary

Two pre-send checks join skills/plan-to-invoker/scripts. freshness-check.mjs reproduces the owner's launch-time prose freshness gate against a git ref, so a task the owner would block as needs_input fails locally first.

unit-triggers.mjs gives the same verdict as lint-review-units and prints the section line behind each tripped review unit, so a reword targets the line instead of guessing synonyms.

Both were hand-built and left untracked during reflect session 4db2ca74. The skill test now covers a blocked plan, a clean plan, and the printed trigger line.

## Review Claim

freshness-check.mjs predicts the owner's needs_input stop and unit-triggers.mjs names the line behind a review-unit lint hit, both before anything is sent to Invoker.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Both scripts are read-only advisors: they read a plan file and `git cat-file` / `git grep` a ref, never write, never call the owner, and are not yet wired into `skill-doctor.sh`. `freshness-check.mjs` copies `ANCHOR_CLAUSE_PATTERN`, `REPO_PATH_PATTERN`, and the backtick-symbol rule from `packages/execution-engine/src/task-specification-preflight.ts` on origin/master (lines 32 and 64); `unit-triggers.mjs` takes its verdict from the exported `validateSingleReviewUnitFocus` in `scripts/review-unit-rules.mjs` (vendored copy preferred, repo copy as fallback), so it cannot disagree with `lint-review-units.mjs`. Live check on the three untracked idle-cleanup seed plans printed `current` for every task; a synthetic plan with `existing` next to a create path printed `STALE -> needs_input` and exit 1.

## Slice Rationale

The scripts are the lever the later prose slices point at, so they land first with their own test coverage; the prose that references them is slice 5.

## Non-goals

- Does not add either script to `skill-doctor.sh`; that is a follow-up once the typed-freshness stack (#11557-#11631) settles what the owner will parse.
- Does not import the preflight module directly; the regex copy is the same drift risk as the existing vendored `review-unit-rules.mjs` and is called out here so a later PR can replace it with a shared import.
- Does not change `lint-review-units.mjs` output.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` → `OK: freshness-check and unit-triggers pre-submit trap checks behave` (exit 0)
- [x] `node skills/plan-to-invoker/scripts/freshness-check.mjs . <seed plan>` → `current  idle-cleanup-age-authority.yaml :: fix-idle-cleanup-age-authority`
- [x] `node skills/plan-to-invoker/scripts/unit-triggers.mjs skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml` → exit 0
- [x] `node scripts/check-added-comments.mjs --base origin/master` → `no disallowed comments found`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; slice 5's step-map text would then reference missing scripts, so revert 5 with it.
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
