### PR TITLE
[auto: Plan submit traps](6) Report open plan-intake PRs in the class-search

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -415,6 +415,14 @@ must_contain "$PLAYBOOK" "Invoker is mandatory" "Playbook must warn when Invoker
 must_contain "$PLAYBOOK" "coverageItems" "Playbook must document row-level coverage for policy-matrix sources"
 must_contain "$PLAYBOOK" "assume no prior context" "Playbook must require zero-context prompt framing for implementation tasks"
 
+# Class-search — open plan-intake PRs must be reported regardless of relevance
+must_contain "$SKILL_MD" "**Open PRs touching plan intake / validation / freshness / preflight**" "SKILL class-search must require the open plan-intake PR heading"
+must_contain "$SKILL_MD" 'gh pr list --search "<freshness|preflight|validate-plan|plan-parser>" --state open' "SKILL class-search must name the open plan-intake PR query"
+must_contain "$SKILL_MD" '"zero relevant" is never a valid summary of them' "SKILL class-search must forbid collapsing plan-intake PRs to zero relevant"
+must_contain "$PLAYBOOK" "#### 0. Class-search and open plan-intake PRs" "Playbook Phase 1a must start with the class-search step"
+must_contain "$PLAYBOOK" "**Open PRs touching plan intake / validation / freshness / preflight**" "Playbook Phase 1a must require the open plan-intake PR heading"
+must_contain "$PLAYBOOK" 'Do not collapse this list to "zero relevant"' "Playbook Phase 1a must forbid collapsing plan-intake PRs to zero relevant"
+
 # Task patterns — traps that cost a resubmit (reflect session 4db2ca74)
 must_contain "$TASK_PATTERNS" "## Traps that cost a resubmit" "Task patterns must document the resubmit traps"
 must_contain "$TASK_PATTERNS" 'runs the whole package' "Task patterns must warn that test -- --run drops the vitest file filter"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -99,13 +99,17 @@ In both paths, the delegating agent chooses `poolId` best-effort per `references
    acknowledgment: confirm with the user whether the plan should use
    `scratch: true` (tasks run in a plain temp directory, no git involved,
    `onFinish: none` + `mergeMode: no_op` required) or a real `repoUrl`.
-2. Phase 1a static analysis.
+2. Phase 1a static analysis, including the class-search below.
 3. Runtime verification (Phase 1b): run the cheapest deterministic command that exercises the behavior, plus Invoker headless when applicable.
 4. Generate implementation YAML from verified facts — prefer rendering a matching formula (`skills/plan-to-invoker/formulas/`) and specializing its slots over authoring the shape from scratch.
 5. Validate with deterministic scripts.
 6. Present plan and submit on confirmation. That confirmation authorizes the reviewed `onFinish` outcome; implementation plans default to GitHub publication through `onFinish: pull_request` without a second approval prompt.
 
 Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b evidence.
+
+**Class-search (Phase 1a, required before any root-cause claim or premise):** run `git log --oneline --all --grep=<symptom>`, `git log --all -S <token>`, and `gh pr list --search <symptom> --state all` per the repo `CLAUDE.md` rule. Then, regardless of whether anything above looked relevant, report a separate heading:
+
+**Open PRs touching plan intake / validation / freshness / preflight** — the output of `gh pr list --search "<freshness|preflight|validate-plan|plan-parser>" --state open`, listed in full with one line each on what it means for this submission. These PRs change how the owner will process the plan, not whether the bug exists, so "zero relevant" is never a valid summary of them. Reflect session 4db2ca74 binned #11489 and the typed-freshness stack (#11557-#11561, #11579, #11594, #11631) as "zero relevant" and then spent 41 minutes rediscovering the prose freshness gate those PRs were replacing.
 
 **Deterministic validation gate:** Use `skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` as the primary deterministic proof surface, backed by `bash scripts/test-plan-to-invoker-skill.sh` for regression coverage. Schema-only validation or ad hoc individual script checks are not sufficient as the review gate, because they can miss strict atomicity, zero-context prompt, policy coverage, and final-gate failures. Individual validator scripts remain fallback diagnostics only; they are not submission proof unless `skill-doctor.sh` has already passed or a waiver is explicitly recorded.
 

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -18,6 +18,21 @@ Also use this playbook when the source is an architecture or policy document wit
 
 Fast checks: paths exist, `rg`/`grep` for patterns, read source. **Not sufficient alone** if the plan asserts runtime behavior (UI state, orchestrator output, persistence, headless CLI).
 
+#### 0. Class-search and open plan-intake PRs
+
+Before extracting assumptions, run the class-search from the repo `CLAUDE.md` (`git log --grep`, `git log -S`, `gh pr list --search <symptom> --state all`). Then report, under its own heading and regardless of relevance to the bug:
+
+**Open PRs touching plan intake / validation / freshness / preflight**
+
+```bash
+gh pr list --search "freshness" --state open
+gh pr list --search "preflight" --state open
+gh pr list --search "validate-plan" --state open
+gh pr list --search "plan-parser" --state open
+```
+
+List every hit with one line on what it means for this submission (for example "replaces the prose anchor gate the owner still runs; until it lands, `existing` on a create line blocks the task"). Do not collapse this list to "zero relevant".
+
 #### 1. Extract assumptions
 
 ```bash


### PR DESCRIPTION
## Summary

Phase 1a now carries a heading for open PRs that touch plan intake, freshness, or preflight, fed by a GitHub PR search.

That heading is reported regardless of whether anything in it looks related to the bug.

Those PRs change how the owner will process the plan, not whether the bug exists.

Reflect session 4db2ca74 binned #11489 and the typed-freshness stack as "zero relevant", then spent 41 minutes rediscovering the prose freshness gate those PRs replace.

## Review Claim

Phase 1a must report open plan-intake PRs under their own heading, even when they look unrelated to the bug.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Adds one paragraph to `skills/plan-to-invoker/SKILL.md` and one `#### 0.` subsection to `playbooks/verify-then-build.md`; the existing Phase 1a steps keep their numbers and text. The exact heading is `Open PRs touching plan intake / validation / freshness / preflight` and the exact query is `gh pr list --search "<freshness|preflight|validate-plan|plan-parser>" --state open`; both are pinned by new needles in `scripts/test-plan-to-invoker-skill.sh`. Evidence: session index [89] labelled `11489 [Freshness path intent](1)` and `11631 Typed task freshness (5)` as "10 results, zero relevant"; the diagnosis came at [491].

## Slice Rationale

This is a research-step rule, distinct from the authoring traps in slice 5 and the fan-out rule in slice 7, so it is reviewed alone.

## Non-goals

- Does not change the repo CLAUDE.md class-search rule; it points at it.
- Does not automate the search inside skill-doctor.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` → exit 0
- [x] `node scripts/check-added-comments.mjs --base origin/master` → `no disallowed comments found`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contract-test needles only; no runtime validation or owner pipeline behavior changes.
> 
> **Overview**
> **Phase 1a class-search** now mandates a separate section for **open PRs touching plan intake / validation / freshness / preflight**, using `gh pr list --search "<freshness|preflight|validate-plan|plan-parser>" --state open`, with a one-line impact note per PR—even when they look unrelated to the bug.
> 
> Agents must **not** dismiss that list as “zero relevant”; the rule is about how the owner will process the plan, not bug existence. The intended flow step 2 and `SKILL.md` class-search block document this (with a session 4db2ca74 cautionary example). The verify-then-build playbook adds **`#### 0. Class-search and open plan-intake PRs`** before assumption extraction.
> 
> `scripts/test-plan-to-invoker-skill.sh` pins the exact heading, query string, and anti-collapse wording in both `SKILL.md` and the playbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae21d3d5949719a35e726c51d5500f6c35aaa4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->