### PR TITLE
[auto: Plan submit traps](8) Contract-test the invoker-ops needs_input, wait, and chain-cancel rules

### DIFF
--- a/scripts/test-invoker-ops-skill.sh
+++ b/scripts/test-invoker-ops-skill.sh
@@ -42,4 +42,15 @@ must_contain "$SKILL_MD" "Never report a workflow/task count, CI status, merge s
 must_contain "$SKILL_MD" "Run the query command again in the same turn" "skill must require a fresh query before reporting state"
 must_contain "$SKILL_MD" "skills/prove-it/SKILL.md" "skill must reference the shared prove-it evidence rule"
 
+must_contain "$SKILL_MD" "The stop reason is stored in \`execution.inputPrompt\`, and no headless query projection emits that field" "skill must name where the needs_input reason lives and that queries do not project it"
+must_contain "$SKILL_MD" 'say "not projected", not "empty"' "skill must distinguish an unprojected field from an empty one"
+must_contain "$SKILL_MD" "/Applications/Invoker.app/Contents/Resources/app.asar" "skill must point at the greppable owner bundle"
+must_contain "$SKILL_MD" "/Applications/Invoker.app/Contents/MacOS/Invoker --headless query task" "skill must call the app binary directly on macOS instead of the open -a wrapper"
+must_contain "$SKILL_MD" "before any \`retry-task\`, agent switch (\`set agent\`), or resubmit" "skill must order reason-reading before retry, agent switch, or resubmit"
+must_contain "$SKILL_MD" "do not also poll it with foreground \`sleep\`/\`seq\` loops" "skill must forbid foreground polling beside an armed invoker-cli wait"
+must_contain "$SKILL_MD" "delegate the digging" "skill must delegate stuck-workflow digging to a subagent when context is large"
+must_contain "$SKILL_MD" "Cancel downstream workflows first, then the head" "skill must cancel chained downstream workflows before the head"
+must_contain "$SKILL_MD" "until every task shows \`failed\`" "skill must re-query after cancel until every task is failed"
+must_contain "$SKILL_MD" "the app-binary cancel exit code is unreliable" "skill must not trust the app-binary cancel exit code"
+
 echo "OK: invoker-ops skill contract checks passed"


### PR DESCRIPTION
## Summary

scripts/test-invoker-ops-skill.sh now pins the three operator rules added in slice 1: read the needs_input reason before acting, one waiter per workflow, and stop chained downstream workflows before the head.

It lands apart from slice 1 because the PR checker files the invoker-ops skill file under docs and scripts/ under tooling-policy.

## Review Claim

Dropping any of the three slice-1 sentences makes the invoker-ops skill test fail.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Ten `must_contain` needles appended before the final OK line; no existing needle changes, and the script's `--self-test` of the retry wrapper still runs first. Each needle quotes a sentence that exists verbatim in slice 1.

## Slice Rationale

Test lines and skill prose sit in different review units, so the pin lands after the prose it pins.

## Non-goals

- Does not change `scripts/retry-tasks-by-status.sh` or any wrapper the test exercises.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-invoker-ops-skill.sh` → `OK: invoker-ops skill contract checks passed` (exit 0)
- [x] `node scripts/check-added-comments.mjs --base origin/master` → `no disallowed comments found`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only contract strings in a shell script; no runtime or skill prose changes in this diff.
> 
> **Overview**
> Extends **`scripts/test-invoker-ops-skill.sh`** with ten new **`must_contain`** checks so **`skills/invoker-ops/SKILL.md`** cannot drift on operator rules added in slice 1 without breaking CI.
> 
> The new needles lock in: where **`needs_input`** reasons live (**`execution.inputPrompt`**) and that headless queries do not project them (wording must say **"not projected"**, not **"empty"**); reading that reason from the greppable app bundle via the macOS **Invoker** binary **before** retry, agent switch, or resubmit; **one armed waiter** per workflow (no foreground **`sleep`**/**`seq`** polling alongside **`invoker-cli wait`**); delegating heavy stuck-workflow digging to a subagent; and **chain cancel** order (downstream first, re-query until every task is **`failed`**, do not trust the app-binary cancel exit code).
> 
> Existing checks and the retry wrapper **`--self-test`** run unchanged before these assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1264d415fe277f5d4bd43e6f52a45a57c2147dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->