### PR TITLE
[Transient transport failures](3a)[REFACTOR: Export Function] stall reaper keeps definitive infra faults

### DIFF
--- a/packages/app/src/reconcile-orphaned-running-tasks.ts
+++ b/packages/app/src/reconcile-orphaned-running-tasks.ts
@@ -32,7 +32,7 @@ export type ReconcileOrphanedInFlightTasksOptions = {
 
 export const OWNER_RESTART_REASON = 'Owner restart';
 
-function deriveOrphanReason(
+export function deriveOrphanReason(
   taskId: string,
   persistence: ShutdownDiagnosticDb | null | undefined,
   fallbackReason: string,

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -10,6 +10,7 @@ import type { TaskState } from '@invoker/workflow-core';
 import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from './fixtures/pr-6976-oauth-session-expired.js';
 import {
   buildRepoMirrorRepairScript,
+  classifyGenericSshInfraFailure,
   createInfraRepairTick,
   deriveCorruptWorktreeAdminPathFromWorkspace,
   extractCorruptMirrorPath,
@@ -747,6 +748,14 @@ describe('infra-repair worker', () => {
         }),
       }),
     ]));
+  });
+});
+
+describe('classifyGenericSshInfraFailure', () => {
+  it('returns infra classes and ignores the transient transport class', () => {
+    expect(classifyGenericSshInfraFailure('No space left on device')).toBe('ssh-disk-full');
+    expect(classifyGenericSshInfraFailure('ssh transport failed exit=255')).toBeUndefined();
+    expect(classifyGenericSshInfraFailure(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/execution-engine/src/__tests__/requeue-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-worker.test.ts
@@ -131,8 +131,31 @@ describe('requeue worker tick', () => {
     expect(parsed.prompt).toMatch(/stalled/i);
   });
 
+  it('requeues a transient SSH transport failure under budget then escalates at budget', async () => {
+    const h = harness(makeTask({
+      execution: {
+        failureClass: 'ssh-transport-transient',
+        error: 'SSH transport failed (exit 255): connection timed out.',
+        generation: 2,
+      },
+    }), { budget: 1, backoffMs: 120_000 });
+
+    await h.tick(POLL_CTX);
+    expect(h.submit.mock.calls.filter((c) => c[2] === REQUEUE_COMMAND_CHANNEL)).toHaveLength(1);
+
+    h.setNow(120_000);
+    await h.tick(POLL_CTX);
+    expect(h.submit.mock.calls.filter((c) => c[2] === REQUEUE_ESCALATE_CHANNEL)).toHaveLength(1);
+  });
+
   it('ignores a failed task that is not a liveness stall', async () => {
     const h = harness(makeTask({ execution: { failureClass: undefined, error: 'real bug', generation: 2 } }));
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('ignores a failed SSH disk-full task', async () => {
+    const h = harness(makeTask({ execution: { failureClass: 'ssh-disk-full', error: 'No space left on device', generation: 2 } }));
     await h.tick(POLL_CTX);
     expect(h.submit).not.toHaveBeenCalled();
   });

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -662,6 +662,71 @@ describe('execution-pool member circuit breaker', () => {
     expect(getPendingSelection(runner, nextTask.id).member.id).toBe('remote-a');
   });
 
+  it('quarantines the member when mid-run response handling fails with a transient SSH transport error', async () => {
+    const failingTask = makeTask('wf-1/task-a');
+    const tasks = new Map([[failingTask.id, failingTask]]);
+    const completeByTaskId = new Map<string, (response: any) => void>();
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(async (request: any) => ({
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+      })),
+      onComplete: vi.fn((handle: any, cb: any) => {
+        completeByTaskId.set(handle.taskId, cb);
+      }),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const runner = makeRunner({
+      members: [
+        { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+        { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+      ],
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => tasks.get(id) ?? null,
+        getAllTasks: () => [...tasks.values()],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: vi.fn((response: any) => {
+          if (response.status === 'completed') {
+            failingTask.execution = {
+              ...failingTask.execution,
+              failureClass: 'ssh-transport-transient',
+            };
+            throw new Error('SSH transport failed (exit 255): connection timed out.');
+          }
+          return [];
+        }),
+        deferTask: vi.fn(),
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        updateTask: vi.fn(),
+        updateAttempt: vi.fn(),
+        appendTaskOutput: vi.fn(),
+      },
+    });
+
+    const run = runner.executeTask(failingTask);
+    await vi.waitFor(() => expect(completeByTaskId.has(failingTask.id)).toBe(true));
+    completeByTaskId.get(failingTask.id)?.({
+      requestId: `complete-${failingTask.id}`,
+      actionId: failingTask.id,
+      attemptId: failingTask.execution.selectedAttemptId,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await run;
+
+    expect(runner.getPoolMemberHealthSnapshot()).toEqual([
+      expect.objectContaining({ memberKey: 'ssh:remote-a', consecutiveFailures: 1 }),
+    ]);
+  });
+
   it('re-admits a member automatically once its cooldown expires', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-09T00:00:00Z'));

--- a/packages/execution-engine/src/__tests__/task-runner-launch-support.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-support.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isRetryableSshStartupTransportError } from '../task-runner-launch-support.js';
+
+describe('isRetryableSshStartupTransportError', () => {
+  it.each([
+    ['exit=255', true],
+    ['exit 255', true],
+    ['ssh transport failed', true],
+    ['connection timed out', true],
+    ['operation timed out', true],
+    ['connection reset', true],
+    ['broken pipe', true],
+    ['banner exchange', true],
+    ['kex_exchange_identification', true],
+    ['remote session terminated unexpectedly', true],
+    ['exit=1', false],
+    ['ordinary task failure', false],
+  ])('%s => %s', (message, expected) => {
+    expect(isRetryableSshStartupTransportError(message)).toBe(expected);
+  });
+});

--- a/packages/execution-engine/src/task-runner-finalize.ts
+++ b/packages/execution-engine/src/task-runner-finalize.ts
@@ -50,6 +50,23 @@ export function wireCompletion(
             `executionId=${handle.executionId} activeExecutions=${host.activeExecutions.size}`,
         );
         let newlyStarted: TaskState[] = [];
+        const quarantinePoolMemberForFailure = (failureResponse: WorkResponse): void => {
+          if (failureResponse.status !== 'failed' || !activeExecution?.poolMemberKey) return;
+          try {
+            const finalized = host.orchestrator.getTask(task.id);
+            if (
+              finalized?.execution.failureClass === 'ssh-oauth-session-expired'
+              || finalized?.execution.failureClass === 'ssh-transport-transient'
+            ) {
+              host.recordPoolMemberTransportFailure(
+                activeExecution.poolMemberKey,
+                new Error(failureResponse.outputs.error ?? finalized.execution.failureClass),
+              );
+            }
+          } catch (err) {
+            host.logger.error(`[TaskRunner] pool member quarantine failed for task=${task.id}`, { err });
+          }
+        };
         try {
           try {
             traceExecution(
@@ -95,22 +112,11 @@ export function wireCompletion(
             } catch (callbackErr) {
               host.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err: callbackErr });
             }
+            quarantinePoolMemberForFailure(errResponse);
             return;
           }
 
-          if (normalizedResponse.status === 'failed' && activeExecution?.poolMemberKey) {
-            try {
-              const finalized = host.orchestrator.getTask(task.id);
-              if (finalized?.execution.failureClass === 'ssh-oauth-session-expired') {
-                host.recordPoolMemberTransportFailure(
-                  activeExecution.poolMemberKey,
-                  new Error(normalizedResponse.outputs.error ?? 'ssh-oauth-session-expired'),
-                );
-              }
-            } catch (err) {
-              host.logger.error(`[TaskRunner] oauth-expiry pool member quarantine failed for task=${task.id}`, { err });
-            }
-          }
+          quarantinePoolMemberForFailure(normalizedResponse);
 
           try {
             host.callbacks.onComplete?.(task.id, normalizedResponse);

--- a/packages/execution-engine/src/task-runner-launch-support.ts
+++ b/packages/execution-engine/src/task-runner-launch-support.ts
@@ -7,7 +7,7 @@
  */
 
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
 /** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 export const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -83,14 +83,5 @@ export function computePoolMemberCooldownMs(consecutiveFailures: number): number
 
 export function isRetryableSshStartupTransportError(err: unknown): boolean {
   const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
-  const lower = message.toLowerCase();
-  return lower.includes('exit=255')
-    || lower.includes('ssh transport failed')
-    || lower.includes('connection timed out')
-    || lower.includes('operation timed out')
-    || lower.includes('connection reset')
-    || lower.includes('broken pipe')
-    || lower.includes('banner exchange')
-    || lower.includes('kex_exchange_identification')
-    || lower.includes('remote session terminated unexpectedly');
+  return FailureClassifier.isTransientTransportError(message);
 }

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -367,7 +367,8 @@ export function listInfraRepairScanCandidates(
 }
 
 export function classifyGenericSshInfraFailure(errorText: unknown): InfraRepairReason | undefined {
-  return FailureClassifier.classifyError(typeof errorText === 'string' ? errorText : undefined);
+  const failureClass = FailureClassifier.classifyError(typeof errorText === 'string' ? errorText : undefined);
+  return FailureClassifier.isSshInfra(failureClass) ? failureClass : undefined;
 }
 
 function resolveRemoteTargetId(

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -1,10 +1,9 @@
 import type { Logger } from '@invoker/contracts';
 import type { WorkflowMutationPriority } from '@invoker/data-store';
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
-import type { TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
 import type { AutoFixRecoveryStore } from '../auto-fix-recovery.js';
-import { isLivenessFailureTask } from '../auto-fix-gating.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
 import {
   createRequeueAttemptLedger,
@@ -114,7 +113,7 @@ export function listRequeueScanCandidates(store: AutoFixRecoveryStore): RequeueC
   const candidates: RequeueCandidate[] = [];
   for (const workflow of store.listWorkflows()) {
     for (const task of store.loadTasks(workflow.id)) {
-      if (task.status !== 'failed' || !isLivenessFailureTask(task)) continue;
+      if (task.status !== 'failed' || !FailureClassifier.isRequeueableFailureTask(task)) continue;
       const workflowId = workflowIdForTask(task);
       if (workflowId) candidates.push({ taskId: task.id, workflowId });
     }
@@ -148,10 +147,7 @@ export function createRequeueRecoveryTick(options: RequeueWorkerPolicyOptions): 
     for (const candidate of candidates) {
       if (handled.has(candidate.taskId)) continue;
       const latest = loadLatestTask(candidate, options.store);
-      // Re-check authoritative state: only a task still parked as a liveness
-      // stall is actionable (a requeue/escalation already applied would have
-      // cleared the class or moved it out of `failed`).
-      if (!latest || latest.status !== 'failed' || !isLivenessFailureTask(latest)) continue;
+      if (!latest || latest.status !== 'failed' || !FailureClassifier.isRequeueableFailureTask(latest)) continue;
       const workflowId = workflowIdForTask(latest);
       if (!workflowId) continue;
       handled.add(candidate.taskId);

--- a/packages/workflow-core/src/__tests__/finalize-failed-task-classification.test.ts
+++ b/packages/workflow-core/src/__tests__/finalize-failed-task-classification.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'vitest';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('finalize failed task classification', () => {
+  it('persists classifications for docker and local runner kinds', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    orchestrator.loadPlan({
+      name: 'finalize-classification',
+      onFinish: 'none',
+      tasks: [
+        { id: 'docker-task', description: 'docker', command: 'x', runnerKind: 'docker' },
+        { id: 'local-task', description: 'local', command: 'x', runnerKind: 'worktree' },
+      ],
+    });
+    const tasks = orchestrator.getAllTasks().filter((task) => !task.config.isMergeNode);
+    const dockerTask = tasks.find((task) => task.id.endsWith('/docker-task'))!;
+    const localTask = tasks.find((task) => task.id.endsWith('/local-task'))!;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: dockerTask.id,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'No space left on device' },
+    }));
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: localTask.id,
+      status: 'failed',
+      outputs: { exitCode: 255, error: 'SSH transport failed (exit 255): connection reset by peer.' },
+    }));
+
+    expect(persistence.getTaskEntry(dockerTask.id)?.task.execution.failureClass).toBe('ssh-disk-full');
+    expect(persistence.getTaskEntry(localTask.id)?.task.execution.failureClass).toBe('ssh-transport-transient');
+  });
+});

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -209,10 +209,7 @@ export function finalizeFailedTaskImpl(
     throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
   }
 
-  const failureClass = executionFields.failureClass
-    ?? (existing.config.runnerKind === 'ssh'
-      ? FailureClassifier.classifyError(executionFields.error)
-      : undefined);
+  const failureClass = executionFields.failureClass ?? FailureClassifier.classifyError(executionFields.error);
 
   const changes: TaskStateChanges = {
     status: 'failed',

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -77,6 +77,13 @@ describe('FailureClassifier.classifyError', () => {
     )).toBeUndefined();
   });
 
+  it('classifies transport failures after definitive infrastructure checks miss', () => {
+    expect(FailureClassifier.classifyError('SSH transport failed (exit 255): connection reset by peer.'))
+      .toBe('ssh-transport-transient');
+    expect(FailureClassifier.classifyError('SSH remote script failed (exit=1, phase=run_task)'))
+      .toBeUndefined();
+  });
+
   it('returns undefined for ordinary code failures and non-strings', () => {
     expect(FailureClassifier.classifyError('AssertionError: expected 1 to be 2')).toBeUndefined();
     expect(FailureClassifier.classifyError(undefined)).toBeUndefined();

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -31,7 +31,7 @@ export class FailureClassifier {
    * Matches are narrow and exact by design — an unknown failure is a code
    * failure, not an infra failure.
    */
-  static classifyError(errorText: string | undefined): SshInfraFailureClass | undefined {
+  static classifyError(errorText: string | undefined): FailureClass | undefined {
     if (typeof errorText !== 'string') return undefined;
     if (errorText.includes('.invoker/env.sh') && errorText.includes('not a valid identifier')) {
       return 'ssh-env-invalid-export';
@@ -66,7 +66,25 @@ export class FailureClassifier {
     if (errorText.includes('No space left on device')) {
       return 'ssh-disk-full';
     }
+    if (this.isTransientTransportError(errorText)) {
+      return 'ssh-transport-transient';
+    }
     return undefined;
+  }
+
+  static isTransientTransportError(text: unknown): boolean {
+    if (typeof text !== 'string') return false;
+    const lower = text.toLowerCase();
+    return lower.includes('exit=255')
+      || lower.includes('exit 255')
+      || lower.includes('ssh transport failed')
+      || lower.includes('connection timed out')
+      || lower.includes('operation timed out')
+      || lower.includes('connection reset')
+      || lower.includes('broken pipe')
+      || lower.includes('banner exchange')
+      || lower.includes('kex_exchange_identification')
+      || lower.includes('remote session terminated unexpectedly');
   }
 
   /** True when the failure was a liveness stall (owned by the requeue worker). */

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -92,6 +92,11 @@ export class FailureClassifier {
     return failureClass === 'liveness_stall';
   }
 
+  static isRequeueableFailureTask(task: { execution: { failureClass?: FailureClass } }): boolean {
+    return task.execution.failureClass === 'liveness_stall'
+      || task.execution.failureClass === 'ssh-transport-transient';
+  }
+
   /** True when the failure is a machine-owned SSH infra bucket (owned by infra-repair). */
   static isSshInfra(failureClass: FailureClass | undefined): failureClass is SshInfraFailureClass {
     return failureClass !== undefined

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -215,10 +215,16 @@ export type SshInfraFailureClass =
   | 'ssh-oauth-session-expired'
   | 'ssh-disk-full';
 
-export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
+export type TransientFailureClass = 'ssh-transport-transient';
+
+export type FailureClass = 'liveness_stall' | SshInfraFailureClass | TransientFailureClass;
 
 export function isLivenessFailureClass(failureClass: FailureClass | undefined): boolean {
   return failureClass === 'liveness_stall';
+}
+
+export function isTransientFailureClass(failureClass: FailureClass | undefined): boolean {
+  return failureClass === 'ssh-transport-transient';
 }
 
 export interface TaskExecution {


### PR DESCRIPTION
## Summary

The boot-time helper that reads a task's saved output tail for a known infrastructure error is now exported from its module.

Nothing calls it differently yet. The next slice makes the executing-stall watchdog reuse it instead of copying the same tail walk.

## Review Claim

`deriveOrphanReason` in reconcile-orphaned-running-tasks is exported with an identical body so a second caller can reuse the same output-tail walk. No catalog technique fits exactly: this is a visibility widening (adding `export`) of an existing function, with no behavior change.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The only change is the `export` keyword on an existing function; its body, signature, and the boot reconciler that calls it are untouched, so runtime behavior is byte-identical.

## Slice Rationale

The helper and the watchdog that needs it live in files assigned to different review units, and CI allows one unit per PR. The export therefore lands first as its own foundation slice.

## Non-goals

No behavior change. No change to the boot reconciler, the watchdog, the classifier matchers, tests, UI, or docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test --run src/__tests__/reconcile-orphaned-running-tasks.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c0ef231792bc6a95f2676591d22f9542e8660ce3`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only change with identical runtime behavior for existing callers.
> 
> **Overview**
> **Exports** `deriveOrphanReason` from `reconcile-orphaned-running-tasks.ts` so other modules can reuse the same output-tail walk and `FailureClassifier` lookup when choosing a failure reason.
> 
> Boot orphan reconciliation still calls it the same way; there is **no** logic or signature change—only the `export` keyword.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee2c6e4a8cc9cc9694b3de278a6ceeffc9e7d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->