### PR TITLE
[Transient transport failures](3b) stall reaper keeps definitive infra faults

### DIFF
--- a/packages/app/src/__tests__/headless-executing-stall-tail-classification.test.ts
+++ b/packages/app/src/__tests__/headless-executing-stall-tail-classification.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { createRendererTaskFeed } from '../window/renderer-task-feed.js';
+
+describe('headless db-poll executing stall tail classification', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fails a stalled task with the definitive infra class found in its output tail', async () => {
+    const now = new Date('2026-08-23T08:00:00.000Z');
+    vi.setSystemTime(now);
+
+    const diskFullTask = {
+      id: 'wf-headless/disk-full-tail',
+      status: 'running',
+      config: {
+        workflowId: 'wf-headless',
+        runnerKind: 'worktree',
+      },
+      execution: {
+        phase: 'executing',
+        generation: 0,
+        selectedAttemptId: 'attempt-stale',
+        startedAt: new Date(now.getTime() - 30 * 60_000).toISOString(),
+        lastHeartbeatAt: new Date(now.getTime() - 20 * 60_000).toISOString(),
+      },
+    } as unknown as TaskState;
+    const plainTask = {
+      ...diskFullTask,
+      id: 'wf-headless/plain-stall',
+    } as unknown as TaskState;
+    const tasks = [diskFullTask, plainTask];
+
+    const handleWorkerResponse = vi.fn();
+    const publishDelta = vi.fn();
+    const requestWorkflowMetadataPublish = vi.fn();
+    const pollLaunchDispatcher = vi.fn();
+
+    const feed = createRendererTaskFeed({
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+      persistence: {
+        listWorkflows: () => [{ id: 'wf-headless', status: 'running' } as never],
+        loadTasks: () => tasks,
+        loadTasksForWorkflows: () => tasks,
+        loadTask: (taskId: string) => tasks.find((task) => task.id === taskId),
+        loadAttempt: () => ({
+          status: 'running',
+          leaseExpiresAt: new Date(now.getTime() - 5 * 60_000).toISOString(),
+          lastHeartbeatAt: new Date(now.getTime() - 20 * 60_000).toISOString(),
+        }),
+        writeActivityLog: vi.fn(),
+        appendOutputChunk: vi.fn(),
+        getOutputTail: (taskId: string) => taskId === diskFullTask.id
+          ? [{ data: 'write failed: No space left on device\n' }]
+          : [],
+        appendTaskOutput: vi.fn(),
+      },
+      messageBus: { publish: vi.fn() },
+      getOrchestrator: () => ({
+        getAllTasks: () => tasks,
+        getMergeNode: () => undefined,
+        syncAllFromDb: vi.fn(),
+        handleWorkerResponse,
+        reclaimStalledFixSession: vi.fn(),
+      }),
+      taskHandles: { has: () => false },
+      taskGraphEventPublisher: { publishDelta },
+      getMainWindow: () => null,
+      setStartupWorkflowId: vi.fn(),
+      requestWorkflowMetadataPublish,
+      scheduleAutoFix: vi.fn(),
+      logAutoFixDebug: vi.fn(),
+      uiPerfStats: {
+        mainDeltaToUi: 0,
+        dbPollCreated: 0,
+        dbPollUpdatedAsCreated: 0,
+        workflowMetadataPublishes: 0,
+        workflowMetadataCoalescedRequests: 0,
+      },
+      traceUiDeltaFlow: false,
+      traceDbPollPerTask: false,
+      traceTaskOutput: false,
+      executingStallTimeoutMs: 120_000,
+      pollLaunchDispatcher,
+    });
+
+    const handle = feed.startDbPolling();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(handleWorkerResponse).toHaveBeenCalledTimes(2);
+    const responseFor = (actionId: string) =>
+      handleWorkerResponse.mock.calls.map((call) => call[0]).find((response) => response.actionId === actionId);
+
+    expect(responseFor(diskFullTask.id)).toMatchObject({
+      status: 'failed',
+      outputs: {
+        error: 'write failed: No space left on device',
+        failureClass: 'ssh-disk-full',
+      },
+    });
+
+    const plainResponse = responseFor(plainTask.id);
+    expect(plainResponse).toMatchObject({
+      status: 'failed',
+      outputs: { failureClass: 'liveness_stall' },
+    });
+    expect(String(plainResponse.outputs.error)).toContain('Execution stalled');
+    expect(String(plainResponse.outputs.error)).toContain('attempt lease expired');
+    expect(publishDelta).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
+});

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -2,9 +2,10 @@ import type { BrowserWindow } from 'electron';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
-import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskDelta, type TaskState } from '@invoker/workflow-core';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
+import { deriveOrphanReason } from '../reconcile-orphaned-running-tasks.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
 import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
 import type { TaskOutputData } from '../types.js';
@@ -279,6 +280,10 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
                 const executingError =
                   `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
                   `without a live execution handle and no completion signal from executor (${staleReason}).`;
+                const effectiveError = deriveOrphanReason(task.id, deps.persistence, executingError);
+                const failureClass = effectiveError === executingError
+                  ? 'liveness_stall'
+                  : FailureClassifier.classifyError(effectiveError);
                 deps.logger.info(
                   `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
                     `handlePresent=${deps.taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
@@ -298,8 +303,8 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
                   status: 'failed',
                   outputs: {
                     exitCode: 1,
-                    error: executingError,
-                    failureClass: 'liveness_stall',
+                    error: effectiveError,
+                    failureClass,
                   },
                 };
                 deps.logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });


### PR DESCRIPTION
## Summary

Stalled tasks now preserve a definitive infrastructure error from saved output instead of replacing it with a generic stall message.

Stalls without a recognized tail error keep the existing liveness-stall class and message.

## Review Claim

When a running task stalls, the watchdog uses the shared tail helper to persist the last definitive infrastructure error and class; otherwise the existing fallback is unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The tail helper is read-only and keeps the boot reconciler's guarded behavior. If it returns the fallback, the watchdog keeps the same `liveness_stall` class, error text, and diagnostic.

## Slice Rationale

This slice changes only the app watchdog's failure response after the export-only foundation. It does not alter engine requeue policy or failure matchers.

## Non-goals

No changes to stall timeout math, requeue budget, infrastructure repair, classifier patterns, task status rules, or documentation.

## Architecture

### Before

```mermaid
graph TD
    A["executing-stall watchdog"] --> B["generic stall error"]
    B --> C["liveness_stall"]
```

### After

```mermaid
graph TD
    A["executing-stall watchdog"] --> B["shared output-tail helper"]
    B -->|"definitive line"| C["preserved error and classified fault"]
    B -->|"no definitive line"| D["unchanged generic error and liveness_stall"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test --run src/__tests__/headless-executing-stall-tail-classification.test.ts src/__tests__/headless-executing-stall-reap.test.ts src/__tests__/reconcile-orphaned-running-tasks.test.ts`
- [x] `STALL_PROOF_LABEL=before STALL_PROOF_OUT_DIR=/tmp/invoker-pr-11690-proof-20260901/before pnpm --filter @invoker/app exec playwright test e2e/stall-tail-visual-proof.spec.ts --reporter=line`
- [x] `STALL_PROOF_LABEL=after STALL_PROOF_OUT_DIR=/tmp/invoker-pr-11690-proof-20260901/after pnpm --filter @invoker/app exec playwright test e2e/stall-tail-visual-proof.spec.ts --reporter=line`

</details>

## Visual Proof

[Disk-full stall inspector before and after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260902-9b4ac6/stall-tail-classification-before-after.mp4)

[Plain-stall fallback inspector before and after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260902-9b4ac6/stall-tail-control-before-after.mp4)

Manually inspected: The disk-full task changes from the generic `Execution stalled` text to `fatal: No space left on device`. The plain-stall control keeps the generic stall text in both frames.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 82e06200d6211e3289f21a7bc73c42232c05ce28`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stalled in-flight tasks are failed and classified in the app watchdog, but only enriches errors when tail output already indicates an infra fault; otherwise the prior liveness_stall path is preserved.
> 
> **Overview**
> When the **db-poll executing-stall watchdog** forces a failure, it no longer always emits the generic “Execution stalled…” message and `liveness_stall`. It first runs the same **output-tail helper** (`deriveOrphanReason`) used at boot orphan reconcile: if the persisted tail contains a line that classifies as a definitive infrastructure fault, that line becomes the failure **error** and `FailureClassifier` sets **failureClass** (e.g. disk-full → `ssh-disk-full`).
> 
> If the tail has no such line, behavior is unchanged: generic stall text and `liveness_stall`. Shutdown diagnostics still record the original stall message.
> 
> Adds a **headless vitest** that exercises db-poll stall reaping for a disk-full tail vs. a plain stall control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1afbc0d83775146e2be724c90030c8d34d74fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->