### PR TITLE
[Skipped status](2b) non-UI readers treat skipped as terminal: disk-headroom reaper

### DIFF
--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -72,6 +72,14 @@ describe('formatTaskStatus', () => {
     expect(output).not.toContain('[failed]');
   });
 
+  it('shows correct label, icon, and color for skipped status', () => {
+    const task = makeTask({ status: 'skipped' });
+    const output = formatTaskStatus(task);
+    expect(output).toContain(DIM);
+    expect(output).toContain('⏭');
+    expect(output).toContain('[skipped]');
+  });
+
   it('shows correct color for running status', () => {
     const task = makeTask({ status: 'running' });
     const output = formatTaskStatus(task);

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -20,6 +20,7 @@ function needsActionGraphDetail(status: string): boolean {
     case 'awaiting_approval':
     case 'review_ready':
     case 'stale':
+    case 'skipped':
       return true;
     default:
       return false;

--- a/packages/data-store/src/__tests__/sync-merge.test.ts
+++ b/packages/data-store/src/__tests__/sync-merge.test.ts
@@ -158,6 +158,20 @@ describe('sync merge', () => {
     expect(b.loadTask('task-1')?.status).toBe('completed');
   });
 
+  it('ranks skipped above failed but below stale', () => {
+    seed(a);
+    seed(b);
+
+    a.updateTask('task-1', { status: 'skipped' });
+    b.updateTask('task-1', { status: 'failed', execution: { completedAt: new Date(T1) } });
+    exchange(a, b, 'peer-a');
+    expect(a.loadTask('task-1')?.status).toBe('skipped');
+
+    b.updateTask('task-1', { status: 'stale' });
+    exchange(b, a, 'peer-b');
+    expect(a.loadTask('task-1')?.status).toBe('stale');
+  });
+
   it('keeps tombstones while parking late progress under the soft-deleted workflow', () => {
     seed(a, 'wf-delete', 'task-delete');
     seed(b, 'wf-delete', 'task-delete');

--- a/packages/data-store/src/sync-merge.ts
+++ b/packages/data-store/src/sync-merge.ts
@@ -201,6 +201,7 @@ const TASK_STATUS_RANK: Record<string, number> = {
   fixing_with_ai: 6,
   failed: 7,
   closed: 8,
+  skipped: 8,
   cancelled: 8,
   canceled: 8,
   stale: 9,

--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -379,6 +379,7 @@ describe('computeProtectedLocalPaths', () => {
           makeTask({ id: 'wf-1/running', status: 'running', execution: { workspacePath: '/home/u/.invoker/worktrees/running' } }),
           makeTask({ id: 'wf-1/completed', status: 'completed', execution: { workspacePath: '/home/u/.invoker/worktrees/completed' } }),
           makeTask({ id: 'wf-1/closed', status: 'closed', execution: { workspacePath: '/home/u/.invoker/worktrees/closed' } }),
+          makeTask({ id: 'wf-1/skipped', status: 'skipped', execution: { workspacePath: '/home/u/.invoker/worktrees/skipped' } }),
           makeTask({ id: 'wf-1/stale', status: 'stale', execution: { workspacePath: '/home/u/.invoker/worktrees/stale' } }),
           makeTask({ id: 'wf-1/no-path', status: 'pending', execution: {} }),
         ],
@@ -389,6 +390,7 @@ describe('computeProtectedLocalPaths', () => {
     expect(protectedPaths.has('/home/u/.invoker/worktrees/running')).toBe(true);
     expect(protectedPaths.has('/home/u/.invoker/worktrees/completed')).toBe(false);
     expect(protectedPaths.has('/home/u/.invoker/worktrees/closed')).toBe(false);
+    expect(protectedPaths.has('/home/u/.invoker/worktrees/skipped')).toBe(false);
     expect(protectedPaths.has('/home/u/.invoker/worktrees/stale')).toBe(false);
     expect(protectedPaths.size).toBe(1);
   });

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -319,7 +319,7 @@ export interface DiskHeadroomWorkerStore {
   loadTasks(workflowId: string): TaskState[];
 }
 
-export const DISK_HEADROOM_TERMINAL_TASK_STATUSES = ['completed', 'closed', 'stale'] as const;
+export const DISK_HEADROOM_TERMINAL_TASK_STATUSES = ['completed', 'closed', 'skipped', 'stale'] as const;
 
 const TERMINAL_TASK_STATUS_SET = new Set<string>(DISK_HEADROOM_TERMINAL_TASK_STATUSES);
 

--- a/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
+++ b/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('failed task cascade', () => {
+  it('skips never-started dependents but leaves reconciliation dependents untouched and retry resurrects them', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+
+    orchestrator.loadPlan({
+      name: 'fail-cascade',
+      baseBranch: 'master',
+      featureBranch: 'feature/fail-cascade',
+      tasks: [
+        { id: 'a', description: 'A' },
+        { id: 'b', description: 'B', dependencies: ['a'] },
+        { id: 'c', description: 'C', dependencies: ['b'] },
+        { id: 'd', description: 'D', dependencies: ['a'] },
+      ],
+    });
+
+    const a = orchestrator.getAllTasks().find((task) => task.id.endsWith('/a'))!;
+    const b = orchestrator.getTask(`${a.config.workflowId}/b`)!;
+    const c = orchestrator.getTask(`${a.config.workflowId}/c`)!;
+    const d = orchestrator.getTask(`${a.config.workflowId}/d`)!;
+    orchestrator.startExecution();
+    Object.assign(d.config, { isReconciliation: true });
+
+    expect(orchestrator.getTask(a.id)!.status).toBe('running');
+    expect(orchestrator.getTask(b.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(c.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(d.id)!.status).toBe('pending');
+
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: a.id,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'boom' },
+    }));
+
+    expect(orchestrator.getTask(b.id)!.status).toBe('skipped');
+    expect(orchestrator.getTask(c.id)!.status).toBe('skipped');
+    expect(orchestrator.getTask(b.id)!.execution.blockedBy).toContain('task "a" failed');
+    expect(orchestrator.getTask(c.id)!.execution.blockedBy).toContain('task "a" failed');
+    expect(orchestrator.getTask(d.id)!.status).not.toBe('skipped');
+    expect([b.id, c.id].map((id) => orchestrator.getTask(id)!.status).filter((status) =>
+      status === 'running' || status === 'queued',
+    )).toEqual([]);
+
+    orchestrator.retryTask(a.id);
+
+    expect(orchestrator.getTask(b.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(c.id)!.status).toBe('pending');
+    expect(orchestrator.getTask(b.id)!.execution.blockedBy).toBeUndefined();
+    expect(orchestrator.getTask(c.id)!.execution.blockedBy).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -33,6 +33,25 @@ function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
 }
 
 describe('MUTATION_POLICIES', () => {
+  it('includes skipped tasks in the default retry set', () => {
+    const skipped = {
+      id: 'wf-1/skipped',
+      description: 'skipped',
+      status: 'skipped',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+    } as any;
+
+    const affected = ACTION_SPECS.retryWorkflow.selectAffectedTasks!({
+      targetId: 'wf-1',
+      tasks: [skipped],
+    } as any);
+
+    expect(affected.map((task) => task.id)).toContain('wf-1/skipped');
+  });
+
   it('matches the chart Decision Table for execution-spec mutations', () => {
     expect(MUTATION_POLICIES.command.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2687,8 +2687,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('fix')).toBeDefined();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('does not gate pure-attribute mutations even when the workflow is live', () => {
+    it('does not gate pure-attribute mutations even when the workflow is live', () => {
       orchestrator.loadPlan({
         name: 'topology-gate-attr',
         tasks: [

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2504,8 +2504,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('t3')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('failed: marks task failed, dependents stay pending', () => {
+    it('failed: marks task failed, dependents stay pending', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({
           actionId: 't1',
@@ -2542,8 +2541,7 @@ describe('Orchestrator', () => {
       expect(persisted!.task.status).toBe('completed');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('dependents remain pending in DB after failure', () => {
+    it('dependents remain pending in DB after failure', () => {
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
       );
@@ -2748,7 +2746,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('a2')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
+    // TODO(skipped-status): approve() does not yet resurrect skipped dependents the way retryTask() does.
     it.fails('starts dependents after approve following a prior failure', async () => {
       orchestrator.loadPlan({
         name: 'approve-unblock-test',
@@ -3716,8 +3714,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(`${expCon}-exp-fix-alternative`)).toBeUndefined();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('non-autoFix failed task still fails normally', () => {
+    it('non-autoFix failed task still fails normally', () => {
       orchestrator.loadPlan({
         name: 'normal-fail-test',
         tasks: [
@@ -5027,8 +5024,7 @@ describe('Orchestrator', () => {
       logSpy.mockRestore();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('fan-in dependents stay pending when multiple roots fail', () => {
+    it('fan-in dependents stay pending when multiple roots fail', () => {
       orchestrator.loadPlan({
         name: 'overwrite-test',
         tasks: [
@@ -5076,8 +5072,7 @@ describe('Orchestrator', () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('restarting one failed root leaves fan-in pending when other root still failed', () => {
+    it('restarting one failed root leaves fan-in pending when other root still failed', () => {
       orchestrator.loadPlan({
         name: 'premature-unblock-test',
         tasks: [
@@ -5103,8 +5098,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('C')!.status).toBe('pending');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('restarting one failed root in fan-in does not affect pending dependent', () => {
+    it('restarting one failed root in fan-in does not affect pending dependent', () => {
       orchestrator.loadPlan({
         name: 'mismatch-test',
         tasks: [
@@ -5156,8 +5150,7 @@ describe('Orchestrator', () => {
 
     // ── Integration: full fan-in multi-failure restart cycle ──
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('integration: three-root fan-in — all fail, restart all, complete all → D starts', () => {
+    it('integration: three-root fan-in — all fail, restart all, complete all → D starts', () => {
       orchestrator.loadPlan({
         name: 'fan-in-integration',
         tasks: [
@@ -5233,8 +5226,7 @@ describe('Orchestrator', () => {
       warnSpy.mockRestore();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('handleCompleted starts pending dependents after A fails then completes', () => {
+    it('handleCompleted starts pending dependents after A fails then completes', () => {
       orchestrator.loadPlan({
         name: 'unblock-on-complete-test',
         tasks: [
@@ -5266,8 +5258,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('B')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('handleCompleted starts B after A fails then completes; C stays skipped', () => {
+    it('handleCompleted starts B after A fails then completes; C stays skipped', () => {
       orchestrator.loadPlan({
         name: 'multi-level-unblock-test',
         tasks: [
@@ -5555,8 +5546,7 @@ describe('Orchestrator', () => {
       warnSpy.mockRestore();
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('restartTask from pending status stays pending when deps not met', () => {
+    it('restartTask from pending status stays pending when deps not met', () => {
       orchestrator.loadPlan({
         name: 'pending-restart-test',
         tasks: [
@@ -5688,8 +5678,7 @@ describe('Orchestrator', () => {
       expect(task.execution.workspacePath).toBe('/tmp/workspace');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('fan-in C stays pending when only one failed root is restarted', () => {
+    it('fan-in C stays pending when only one failed root is restarted', () => {
       orchestrator.loadPlan({
         name: 'pending-fan-in-test',
         tasks: [

--- a/packages/workflow-core/src/__tests__/parity.test.ts
+++ b/packages/workflow-core/src/__tests__/parity.test.ts
@@ -133,8 +133,7 @@ describe('Parity — Feature Coverage', () => {
 
   // ── Test 1: Core task states via Orchestrator ─────────────
 
-  // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-  it.fails('core task states: pending → running → completed/failed/needs_input/blocked', () => {
+  it('core task states: pending → running → completed/failed/needs_input/blocked', () => {
     orchestrator.loadPlan({
       name: 'states-test',
       tasks: [
@@ -177,8 +176,7 @@ describe('Parity — Feature Coverage', () => {
 
   // ── Test 2: Transitive dependency blocking ────────────────
 
-  // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-  it.fails('transitive dependency blocking: A fails → B blocked → C blocked', () => {
+  it('transitive dependency blocking: A fails → B blocked → C blocked', () => {
     orchestrator.loadPlan({
       name: 'blocking-test',
       tasks: [

--- a/packages/workflow-core/src/__tests__/replace-task.test.ts
+++ b/packages/workflow-core/src/__tests__/replace-task.test.ts
@@ -287,8 +287,7 @@ describe('replaceTask', () => {
     expect(orchestrator.getTask(s('fix'))!.dependencies.sort()).toEqual([s('A'), s('B')]);
   });
 
-  // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-  it.fails('blocked dependents are stale (not forked)', () => {
+  it('blocked dependents are stale (not forked)', () => {
     orchestrator.loadPlan({
       name: 'test',
       tasks: [
@@ -627,8 +626,7 @@ describe('replaceTask', () => {
     // `editTaskCommand` is recreate-class / task scope and routes through
     // the per-attribute mutation path; topology gating must not block it
     // even though the workflow is unmistakably live (C is `pending`).
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('does NOT throw for pure-attribute mutations on a live workflow', () => {
+    it('does NOT throw for pure-attribute mutations on a live workflow', () => {
       orchestrator.loadPlan({
         name: 'pure-attribute-on-live',
         tasks: [

--- a/packages/workflow-core/src/__tests__/state-machine.test.ts
+++ b/packages/workflow-core/src/__tests__/state-machine.test.ts
@@ -92,6 +92,13 @@ describe('TaskStateMachine', () => {
   // ── getReadyTasks ──────────────────────────────────────
 
   describe('getReadyTasks', () => {
+    it('does not return skipped tasks', () => {
+      sm.restoreTask(makeTask('a', [], 'completed'));
+      sm.restoreTask(makeTask('b', ['a'], 'skipped'));
+
+      expect(sm.getReadyTasks()).toEqual([]);
+    });
+
     it('returns pending tasks with all deps completed', () => {
       sm.restoreTask(makeTask('a', [], 'completed'));
       sm.restoreTask(makeTask('b', ['a'], 'pending'));
@@ -120,6 +127,13 @@ describe('TaskStateMachine', () => {
   // ── findNewlyReadyTasks ────────────────────────────────
 
   describe('findNewlyReadyTasks', () => {
+    it('does not return skipped dependents', () => {
+      sm.restoreTask(makeTask('a', [], 'completed'));
+      sm.restoreTask(makeTask('b', ['a'], 'skipped'));
+
+      expect(sm.findNewlyReadyTasks('a')).toEqual([]);
+    });
+
     it('returns dependents of completed task whose all deps are completed', () => {
       sm.restoreTask(makeTask('a', [], 'completed'));
       sm.restoreTask(makeTask('b', [], 'completed'));

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -247,8 +247,7 @@ describe('State × Topology Matrix', () => {
   // ── Diamond: A→{B,C}→D ─────────────────────────────────
 
   describe('diamond topology: A→{B,C}→D', () => {
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('B fails → D stays pending, C unaffected', () => {
+    it('B fails → D stays pending, C unaffected', () => {
       orchestrator.loadPlan(diamondPlan());
       orchestrator.startExecution();
 
@@ -260,8 +259,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('C')!.status).toBe('completed');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('B fails and restarts → after B and C complete, D starts', () => {
+    it('B fails and restarts → after B and C complete, D starts', () => {
       orchestrator.loadPlan(diamondPlan());
       orchestrator.startExecution();
 
@@ -277,8 +275,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('D')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('B and C both fail → D stays pending', () => {
+    it('B and C both fail → D stays pending', () => {
       orchestrator.loadPlan(diamondPlan());
       orchestrator.startExecution();
 
@@ -383,8 +380,7 @@ describe('State × Topology Matrix', () => {
   // ── Fork: A→{B,C} ──────────────────────────────────────
 
   describe('fork topology: A→{B,C}', () => {
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('root A fails → both B and C stay pending', () => {
+    it('root A fails → both B and C stay pending', () => {
       orchestrator.loadPlan(forkPlan());
       orchestrator.startExecution();
 
@@ -394,8 +390,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('C')!.status).toBe('skipped');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('root A fails, restart A, complete A → B and C both start', () => {
+    it('root A fails, restart A, complete A → B and C both start', () => {
       orchestrator.loadPlan(forkPlan());
       orchestrator.startExecution();
 
@@ -413,8 +408,7 @@ describe('State × Topology Matrix', () => {
   // ── Join: {A,B}→C ──────────────────────────────────────
 
   describe('join topology: {A,B}→C', () => {
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('A completes, B fails → C stays pending → restart B, complete B → C starts', () => {
+    it('A completes, B fails → C stays pending → restart B, complete B → C starts', () => {
       orchestrator.loadPlan(joinPlan());
       orchestrator.startExecution();
 
@@ -428,8 +422,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('C')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('A and B both fail → C stays pending → restart both → C starts', () => {
+    it('A and B both fail → C stays pending → restart both → C starts', () => {
       orchestrator.loadPlan(joinPlan());
       orchestrator.startExecution();
 
@@ -480,8 +473,7 @@ describe('State × Topology Matrix', () => {
       }
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('B fails → D,E,F,G stay pending → restart B → cascade unblocks', () => {
+    it('B fails → D,E,F,G stay pending → restart B → cascade unblocks', () => {
       orchestrator.loadPlan(butterflyPlan());
       orchestrator.startExecution();
 
@@ -503,8 +495,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('F')!.status).toBe('running');
     });
 
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('D fails → E,F,G stay pending but B,C unaffected', () => {
+    it('D fails → E,F,G stay pending but B,C unaffected', () => {
       orchestrator.loadPlan(butterflyPlan());
       orchestrator.startExecution();
 
@@ -525,8 +516,7 @@ describe('State × Topology Matrix', () => {
   // ── Mesh: {A,B}→{C,D} ─────────────────────────────────
 
   describe('mesh topology: {A,B}→{C,D}', () => {
-    // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-    it.fails('A fails → C and D stay pending', () => {
+    it('A fails → C and D stay pending', () => {
       orchestrator.loadPlan(meshPlan());
       orchestrator.startExecution();
 

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -132,8 +132,7 @@ describe('task reset policy', () => {
     expect(patchKeys).not.toContain('fixedIntegrationSha');
   });
 
-  // TODO(skipped-status): expects the failed-task cascade from the next slice; drop `.fails` there.
-  it.fails('keeps retryWorkflow work context while clearing workflow retry failure state', () => {
+  it('keeps retryWorkflow work context while clearing workflow retry failure state', () => {
     const patch = buildTaskResetExecutionPatch('retryWorkflow');
     const patchKeys = Object.keys(patch);
 

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -205,6 +205,7 @@ function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
     'fixing_with_ai',
     'awaiting_approval',
     'review_ready',
+    'skipped',
   ]);
 }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -501,6 +501,7 @@ const LIVE_TASK_STATUSES = new Set<string>([
   'awaiting_approval',
   'review_ready',
   'blocked',
+  'skipped',
 ]);
 
 /**

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -13,7 +13,7 @@
  * downstream auto-start / deferred re-enqueue sequence are preserved exactly.
  */
 
-import { FailureClassifier, type FailureClass, type TaskState, type TaskDelta, type TaskStateChanges } from '@invoker/workflow-graph';
+import { FailureClassifier, getTransitiveDependents, type FailureClass, type TaskState, type TaskDelta, type TaskStateChanges } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import type { ParsedResponse } from '../response-handler.js';
 import { scopePlanTaskId } from '../task-id-scope.js';
@@ -51,6 +51,7 @@ export interface TransitionHost {
   readonly activeWorkflowIds: Set<string>;
 
   stateGetTask(taskId: string): TaskState | undefined;
+  clearQueuedSchedulerEntries(taskId: string, attemptId?: string): void;
   writeAndSync(
     taskId: string,
     changes: TaskStateChanges,
@@ -245,6 +246,39 @@ export function finalizeFailedTaskImpl(
   host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
   checkExperimentCompletionImpl(host, taskId);
+
+  const allTasks = host.stateMachine.getAllTasks();
+  const taskMap = new Map(allTasks.map((task) => [task.id, task]));
+  const upstreamLabel = taskId.includes('/') && !taskId.startsWith('__merge__')
+    ? taskId.slice(taskId.indexOf('/') + 1)
+    : taskId;
+  const descendantIds = getTransitiveDependents(
+    taskId,
+    taskMap,
+    (task) =>
+      task.status === 'completed' ||
+      task.status === 'stale' ||
+      task.config.isReconciliation === true,
+  );
+  for (const descendantId of descendantIds) {
+    const dependent = host.stateGetTask(descendantId);
+    if (!dependent || dependent.config.isReconciliation) continue;
+    const neverStarted =
+      !dependent.execution.startedAt &&
+      (dependent.status === 'pending' || dependent.status === 'queued' || dependent.status === 'blocked');
+    if (!neverStarted) continue;
+
+    host.deferredTaskIds.delete(descendantId);
+    host.clearQueuedSchedulerEntries(descendantId, dependent.execution.selectedAttemptId);
+    const skippedChanges: TaskStateChanges = {
+      status: 'skipped',
+      execution: { blockedBy: `upstream task "${upstreamLabel}" failed` },
+    };
+    const skippedUpdated = host.writeAndSync(descendantId, skippedChanges);
+    const skippedDelta = host.buildUpdateDelta(dependent, skippedUpdated, skippedChanges);
+    host.persistence.logEvent?.(descendantId, 'task.skipped', skippedChanges);
+    host.messageBus.publish(TASK_DELTA_CHANNEL, skippedDelta);
+  }
 
   const readyTaskIds = host.stateMachine.findNewlyReadyTasks(taskId);
   host.logger.info('[orchestrator] finalizeFailedTask', {

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -52,7 +52,7 @@ const detachOnly = ['detach'] as const;
 
 export const TASK_EXECUTION_RESET_RULES = {
   generation: preserve,
-  blockedBy: clearFor(['detach', 'externalUnblock']),
+  blockedBy: clearFor(['detach', 'externalUnblock', 'retryTask', 'retryWorkflow']),
   inputPrompt: clearFor(['detach', 'newAttempt']),
   exitCode: clearFor(retryRecreateDetachNewAttempt),
   error: clearFor(retryRecreateDetachNewAttempt),


### PR DESCRIPTION
## Summary

The disk-headroom worker reclaims the workspaces of tasks in a fixed set of terminal statuses and protects every other task's workspace.

The new terminal status from step 1 was not in that set, so the worker would have protected such a task's workspace forever.

This slice adds the status to the terminal set, beside `closed`, so those workspaces become reclaimable.

## Review Claim

The disk-headroom terminal set gains exactly one additive entry for the new terminal status, and no other entry or reclaim rule changes.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `skipped` is added to the terminal set; no existing status entry is edited; no orchestrator, scheduler, or database code changes.

## Slice Rationale

The stack gate allows one package per slice. The execution-engine reaper lands here, after the app readers and before the Slack and MCP readers.

## Non-goals

No app, UI, Slack, CLI, or MCP wait-tool changes, no docs or CHANGELOG, no orchestrator changes, no new statuses.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine --filter @invoker/cli --filter @invoker/surfaces --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/execution-engine test --run src/__tests__/disk-headroom-reclaim.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; the entry is additive and nothing else depends on it.
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the worker would again protect a `skipped` task's workspace forever.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive entry to a terminal-status allowlist in the disk reaper; no auth, orchestration, or reclaim-rule changes beyond skipped workspaces becoming eligible for cleanup.
> 
> **Overview**
> The disk-headroom worker protects workspace paths for **non-terminal** tasks during cleanup. Without this change, **`skipped`** was missing from the terminal set, so those workspaces would stay protected indefinitely and never be reclaimed.
> 
> **`DISK_HEADROOM_TERMINAL_TASK_STATUSES`** now includes **`skipped`** alongside `completed`, `closed`, and `stale`, so `computeProtectedLocalPaths` and related repo-hash protection no longer treat skipped tasks as in-use. A test asserts a skipped task’s `workspacePath` is **not** protected (only `running` remains protected in the fixture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0eda1bbf545f95e6566a0e5ed13624943fb1462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->