### PR TITLE
[Task filter](2) read path: compile the tree to parameterized SQL

### DIFF
--- a/packages/data-store/src/__tests__/task-filter-sql.test.ts
+++ b/packages/data-store/src/__tests__/task-filter-sql.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { TaskFilterNode } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import { compileTaskFilter } from '../task-filter-sql.js';
+
+describe('task filter SQL read path', () => {
+  let adapter: SQLiteAdapter;
+
+  afterEach(() => adapter?.close());
+
+  function workflow(id: string, deletedAt?: number): Workflow {
+    return {
+      id,
+      name: id,
+      status: 'running',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...(deletedAt === undefined ? {} : { deletedAt }),
+    };
+  }
+
+  function task(id: string, workflowId: string, createdAt: string, overrides: Partial<TaskState> = {}): TaskState {
+    return {
+      id,
+      description: `description ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date(createdAt),
+      config: { workflowId },
+      execution: {},
+      taskStateVersion: 1,
+      ...overrides,
+    };
+  }
+
+  async function seededAdapter(): Promise<SQLiteAdapter> {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(workflow('live-a'));
+    adapter.saveWorkflow(workflow('live-b'));
+    adapter.saveWorkflow(workflow('deleted', 1));
+    adapter.saveTask('live-a', task('first', 'live-a', '2026-01-01T00:00:01.000Z', {
+      description: 'Alpha worker',
+      status: 'running',
+      config: { workflowId: 'live-a', executionAgent: 'codex', isMergeNode: true, poolMemberId: 'pool-1' },
+      execution: { startedAt: new Date('2026-01-01T00:00:02.000Z'), failureClass: 'timeout', branch: 'feature/alpha' },
+    }));
+    adapter.saveTask('live-b', task('second', 'live-b', '2026-01-01T00:00:03.000Z', {
+      description: 'Beta worker',
+      status: 'completed',
+      config: { workflowId: 'live-b', executionModel: 'model-b', repoUrl: 'https://example.test/repo' },
+      execution: { completedAt: new Date('2026-01-01T00:00:04.000Z'), error: 'finished' },
+    }));
+    adapter.saveTask('deleted', task('deleted-task', 'deleted', '2026-01-01T00:00:02.000Z', {
+      description: 'Alpha deleted',
+    }));
+    return adapter;
+  }
+
+  it('compiles identifiers, values, logical nodes, contains escaping, and time ranges', async () => {
+    await seededAdapter();
+    const filter: TaskFilterNode = {
+      op: 'and',
+      filters: [
+        { op: 'or', filters: [{ op: 'eq', key: 'status', value: 'running' }, { op: 'in', key: 'status', values: ['completed'] }] },
+        { op: 'not', filter: { op: 'eq', key: 'id', value: 'nope' } },
+        { op: 'exists', key: 'description' },
+        { op: 'contains', key: 'description', value: 'Alpha' },
+        { op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:00.000Z', end: '2026-01-01T00:00:03.000Z' },
+      ],
+    };
+    const compiled = compileTaskFilter(filter);
+    expect(compiled.where).toContain("ESCAPE '\\'");
+    expect(compiled.params).toEqual(['running', 'completed', 'nope', '%Alpha%', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:03.000Z']);
+    expect(adapter.queryTasksByFilter(filter).map((row) => row.id)).toEqual(['first']);
+  });
+
+  it('binds boolean values as SQLite integers and matches every leaf operation', async () => {
+    await seededAdapter();
+    expect(adapter.queryTasksByFilter({ op: 'eq', key: 'is_merge_node', value: true }).map((row) => row.id)).toEqual(['first']);
+    expect(adapter.queryTasksByFilter({ op: 'eq', key: 'execution_agent', value: 'codex' }).map((row) => row.id)).toEqual(['first']);
+    expect(adapter.queryTasksByFilter({ op: 'in', key: 'status', values: ['completed', 'running'] }).map((row) => row.id)).toEqual(['first', 'second']);
+    expect(adapter.queryTasksByFilter({ op: 'contains', key: 'description', value: '%' }).map((row) => row.id)).toEqual([]);
+    expect(adapter.queryTasksByFilter({ op: 'time_range', key: 'created_at', start: '2026-01-01T00:00:03.000Z' }).map((row) => row.id)).toEqual(['second']);
+  });
+
+  it('does not treat values as SQL and rejects unknown identifiers', async () => {
+    await seededAdapter();
+    expect(adapter.queryTasksByFilter({ op: 'eq', key: 'description', value: "' OR 1=1 --" })).toEqual([]);
+    expect(() => compileTaskFilter({ op: 'eq', key: 'description; DROP TABLE tasks' as never, value: 'x' })).toThrow('Unknown task filter key');
+  });
+
+  it('excludes deleted workflows and caps results at 500 in creation order', async () => {
+    await seededAdapter();
+    const deletedOnly = adapter.queryTasksByFilter({ op: 'contains', key: 'description', value: 'deleted' });
+    expect(deletedOnly).toEqual([]);
+    for (let index = 0; index < 501; index += 1) {
+      adapter.saveTask('live-a', task(`cap-${index}`, 'live-a', new Date(Date.parse('2026-02-01T00:00:00.000Z') + index * 1000).toISOString()));
+    }
+    const rows = adapter.queryTasksByFilter({ op: 'eq', key: 'workflow_id', value: 'live-a' }, { limit: 999 });
+    expect(rows).toHaveLength(500);
+    expect(rows[0].id).toBe('first');
+    expect(rows.at(-1)?.id).toBe('cap-498');
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, InAppPlanningTurnStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, InAppPlanningTurnStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions, TaskFilterNode } from '@invoker/contracts';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
@@ -419,6 +419,7 @@ export interface PersistenceAdapter {
   findReviewGateByPr(pr: string, repo?: string): ReviewGateLookup | undefined;
 
   // Tasks
+  queryTasksByFilter(filter: TaskFilterNode, opts?: { limit?: number; offset?: number }): TaskState[];
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges, opts?: { skipWorkflowStatusSync?: boolean }): void;
   updateTaskFromKnownState?(

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -36,7 +36,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions, TaskFilterNode } from '@invoker/contracts';
 import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
@@ -73,11 +73,13 @@ import type {
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
 import {
+  mapRowToTask,
   mapRowToTaskLaunchDispatch,
   mapRowToWorkflowMutationIntent,
   mapRowToWorkflowMutationLease,
   mapRowToWorkerAction,
 } from './sqlite-row-mappers.js';
+import { compileTaskFilter } from './task-filter-sql.js';
 import {
   taskOutputFilePath,
   taskSpoolFilePath,
@@ -1245,6 +1247,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   // ── Tasks ─────────────────────────────────────────────
+
+  queryTasksByFilter(filter: TaskFilterNode, opts: { limit?: number; offset?: number } = {}): TaskState[] {
+    const compiled = compileTaskFilter(filter);
+    const limit = Math.min(500, Math.max(0, Math.floor(opts.limit ?? 100)));
+    const offset = Math.max(0, Math.floor(opts.offset ?? 0));
+    const rows = this.queryAll(
+      `SELECT t.* FROM tasks t
+       JOIN workflows w ON w.id = t.workflow_id
+       WHERE w.deleted_at IS NULL AND (${compiled.where})
+       ORDER BY t.created_at ASC
+       LIMIT ? OFFSET ?`,
+      [...compiled.params, limit, offset],
+    );
+    return rows.map(mapRowToTask);
+  }
 
   saveTask(workflowId: string, task: TaskState): void {
     this.taskAttemptRepo.saveTask(workflowId, task);

--- a/packages/data-store/src/task-filter-sql.ts
+++ b/packages/data-store/src/task-filter-sql.ts
@@ -1,0 +1,85 @@
+import type { TaskFilterKey, TaskFilterNode, TaskFilterValue } from '@invoker/contracts';
+
+export interface CompiledTaskFilter {
+  where: string;
+  params: unknown[];
+}
+
+const TASK_FILTER_COLUMNS: Record<TaskFilterKey, string> = {
+  id: 't.id',
+  workflow_id: 't.workflow_id',
+  status: 't.status',
+  failure_class: 't.failure_class',
+  execution_agent: 't.execution_agent',
+  execution_model: 't.execution_model',
+  pool_member_id: 't.pool_member_id',
+  repo_url: 't.repo_url',
+  branch: 't.branch',
+  description: 't.description',
+  error: 't.error',
+  is_merge_node: 't.is_merge_node',
+  created_at: 't.created_at',
+  started_at: 't.started_at',
+  completed_at: 't.completed_at',
+  last_heartbeat_at: 't.last_heartbeat_at',
+};
+
+function columnFor(key: string): string {
+  if (!Object.hasOwn(TASK_FILTER_COLUMNS, key)) throw new Error(`Unknown task filter key: ${key}`);
+  return TASK_FILTER_COLUMNS[key as TaskFilterKey];
+}
+
+function bindValue(value: TaskFilterValue): unknown {
+  return typeof value === 'boolean' ? (value ? 1 : 0) : value;
+}
+
+function escapeLikeValue(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
+}
+
+function compileNode(node: TaskFilterNode, params: unknown[]): string {
+  switch (node.op) {
+    case 'and':
+    case 'or':
+      return `(${node.filters.map((child) => compileNode(child, params)).join(node.op === 'and' ? ' AND ' : ' OR ')})`;
+    case 'not':
+      return `(NOT ${compileNode(node.filter, params)})`;
+    case 'exists': {
+      const column = columnFor(node.key);
+      return `(${column} IS NOT NULL AND ${column} != '')`;
+    }
+    case 'eq': {
+      const column = columnFor(node.key);
+      params.push(bindValue(node.value));
+      return `${column} = ?`;
+    }
+    case 'in': {
+      const column = columnFor(node.key);
+      params.push(...node.values.map(bindValue));
+      return `${column} IN (${node.values.map(() => '?').join(', ')})`;
+    }
+    case 'contains': {
+      const column = columnFor(node.key);
+      params.push(`%${escapeLikeValue(node.value)}%`);
+      return `${column} LIKE ? ESCAPE '\\'`;
+    }
+    case 'time_range': {
+      const column = columnFor(node.key);
+      const clauses: string[] = [];
+      if (node.start !== undefined) {
+        clauses.push(`${column} >= ?`);
+        params.push(node.start);
+      }
+      if (node.end !== undefined) {
+        clauses.push(`${column} <= ?`);
+        params.push(node.end);
+      }
+      return clauses.length === 1 ? clauses[0] : `(${clauses.join(' AND ')})`;
+    }
+  }
+}
+
+export function compileTaskFilter(filter: TaskFilterNode): CompiledTaskFilter {
+  const params: unknown[] = [];
+  return { where: compileNode(filter, params), params };
+}


### PR DESCRIPTION
## Summary

Add a compiler that turns a task filter tree into a SQLite WHERE clause with bound parameters.

Add `queryTasksByFilter` to the persistence adapter so filtered task reads run inside SQLite instead of loading every task into memory.

Column names come from a fixed allowlist map. Values are always bound parameters, so user input never becomes SQL text.

The existing search method is untouched. Nothing outside the in-memory SQLite spec calls the new method yet.

## Review Claim

`compileTaskFilter` maps every filter node to SQL using only fixed identifiers and bound parameters, and `queryTasksByFilter` returns matching tasks of live workflows in creation order.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Identifiers come from a fixed allowlist-to-column map and an unknown key throws; every value is a bound parameter; `contains` escapes `%`, `_`, and `\` with an explicit ESCAPE clause; `limit` is capped at 500; `searchWorkflowsAndTasks` is not edited; the method is dormant until a later slice wires a caller.

## Slice Rationale

The filter tree shape landed in the previous slice. The compiler and the adapter method are one read-path claim, so they are reviewed together before any user-facing surface uses them.

## Non-goals

No user-facing surface wiring. No change to `searchWorkflowsAndTasks`. No workflow-level filter. No new indexes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test --run src/__tests__/task-filter-sql.test.ts`
- [x] `pnpm -w run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/task-filter-2.md --base stack/EdbertChan/plan/task-filter-1-contract-filter-tree-types-and-validator/task-filter-1-contract-filter-tree-types-validator--981d4a96`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only persistence path with parameterized SQL and allowlisted keys; not wired to user-facing APIs yet.
> 
> **Overview**
> Adds **`compileTaskFilter`** in `task-filter-sql.ts`, which turns a `TaskFilterNode` tree into a parameterized SQLite `WHERE` clause: allowlisted column keys, bound values (booleans as 0/1), `and`/`or`/`not`, `exists`, `eq`, `in`, `contains` with `LIKE` escaping, and optional `time_range` bounds.
> 
> Extends **`PersistenceAdapter`** with **`queryTasksByFilter`**. **`SQLiteAdapter`** runs the compiled filter against `tasks` joined to non-deleted workflows, orders by `created_at`, and applies **limit** (default 100, max 500) and **offset**.
> 
> New integration tests cover compilation, end-to-end queries, injection-style values, unknown keys, excluding deleted workflows, and the result cap. No callers outside tests yet; **`searchWorkflowsAndTasks`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d4b0ea47c0e0565cc83517ff2e2fa730eddbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->