### PR TITLE
[Cancel keeps stack gated](1) Repro: cancelling an upstream slice releases its stack onto master

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1264,7 +1264,7 @@ describe('headless delegation enforcement', () => {
           return { preemptWorkflowExecution, preparePoolSpy };
         }
 
-        it('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
+        it.fails('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1280,7 +1280,7 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.cancelWorkflow).toHaveBeenCalledWith(
             'wf-1',
-            { detachDependents: false },
+            { cascadeDependents: false },
           );
           // Cancel-first remains inside applyInvalidation, before the retry primitive.
           const cancelOrder = (

--- a/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
+++ b/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
@@ -275,7 +275,7 @@ describe('restart-class workflow mutations preserve downstream gates', () => {
     expect(fixture.killActiveExecution).toHaveBeenCalledWith(fixture.upstreamTaskId);
   });
 
-  it('still detaches dependents for explicit Cancel Workflow', async () => {
+  it.fails('cancels dependents for explicit Cancel Workflow without detaching their gate', async () => {
     const fixture = createGatedWorkflowFixture();
 
     const result = await fixture.commandService.cancelWorkflow({
@@ -287,6 +287,14 @@ describe('restart-class workflow mutations preserve downstream gates', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(fixture.persistence.loadWorkflow(fixture.downstreamWorkflowId)?.externalDependencies).toBeUndefined();
+    expect(fixture.orchestrator.getTask(fixture.downstreamTaskId)?.status).toBe('failed');
+    expect(
+      fixture.persistence.loadWorkflow(fixture.downstreamWorkflowId)?.externalDependencies,
+    ).toContainEqual({
+      workflowId: fixture.upstreamWorkflowId,
+      taskId: '__merge__',
+      requiredStatus: 'completed',
+      gatePolicy: 'completed',
+    });
   });
 });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1758,7 +1758,7 @@ describe('buildCancelInFlight', () => {
     expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
 
-  it('cancels workflow before awaiting killActiveExecution per runningCancelled id', async () => {
+  it.fails('cancels workflow before awaiting killActiveExecution per runningCancelled id', async () => {
     const orchestrator = {
       cancelTask: vi.fn(),
       cancelWorkflow: vi.fn(() => ({
@@ -1776,7 +1776,7 @@ describe('buildCancelInFlight', () => {
     });
     await cancel('workflow', 'wf-1');
 
-    expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1', { detachDependents: false });
+    expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1', { cascadeDependents: false });
     expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(1, 'task-a');
     expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(2, 'task-b');
     expect(orchestrator.cancelTask).not.toHaveBeenCalled();

--- a/packages/workflow-core/src/__tests__/repro-cancel-upstream-keeps-stack-gated.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-cancel-upstream-keeps-stack-gated.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { Orchestrator } from '../orchestrator.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+interface Slice {
+  wfId: string;
+  rootId: string;
+  mergeId: string;
+}
+
+interface StackContext {
+  a: Slice;
+  b: Slice;
+  c: Slice;
+}
+
+function loadSlice(
+  orchestrator: Orchestrator,
+  name: string,
+  baseBranch: string,
+  upstreamWfId?: string,
+): Slice {
+  const before = new Set(orchestrator.getAllTasks().map((t) => t.config.workflowId));
+  orchestrator.loadPlan({
+    name,
+    baseBranch,
+    featureBranch: `plan/${name}`,
+    tasks: [
+      {
+        id: 'root',
+        description: `${name} root`,
+        ...(upstreamWfId
+          ? { externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'review_ready' as const }] }
+          : {}),
+      },
+      { id: 'verify', description: `${name} verify`, dependencies: ['root'] },
+    ],
+  });
+  const wfId = orchestrator.getAllTasks()
+    .map((t) => t.config.workflowId)
+    .find((id) => !before.has(id))!;
+  return { wfId, rootId: `${wfId}/root`, mergeId: `__merge__${wfId}` };
+}
+
+function setupStack(orchestrator: Orchestrator): StackContext {
+  const a = loadSlice(orchestrator, 'slice-1', 'master');
+  const b = loadSlice(orchestrator, 'slice-2', 'plan/slice-1', a.wfId);
+  const c = loadSlice(orchestrator, 'slice-3', 'plan/slice-2', b.wfId);
+  orchestrator.startExecution();
+  expect(orchestrator.getTask(a.rootId)!.status).toBe('running');
+  expect(orchestrator.getTask(b.rootId)!.status).toBe('pending');
+  expect(orchestrator.getTask(c.rootId)!.status).toBe('pending');
+  return { a, b, c };
+}
+
+function workflowTaskStatuses(orchestrator: Orchestrator, wfId: string): Record<string, string> {
+  return Object.fromEntries(
+    orchestrator.getAllTasks()
+      .filter((t) => t.config.workflowId === wfId)
+      .map((t) => [t.id, t.status]),
+  );
+}
+
+describe('REPRO 2026-09-01: cancelling slice 1 of a chained stack rewrote slices 2-4 onto master and launched them', () => {
+  it.fails('keeps downstream base branch and external dependency intact after upstream cancel', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const { a, b, c } = setupStack(orchestrator);
+
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: a.rootId, status: 'failed' }));
+    orchestrator.cancelWorkflow(a.wfId);
+
+    const bRecord = persistence.loadWorkflow(b.wfId)!;
+    expect(bRecord.baseBranch).toBe('plan/slice-1');
+    expect(bRecord.externalDependencies).toEqual([
+      { workflowId: a.wfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+    ]);
+    expect(bRecord.detachedExternalDependencies).toBeUndefined();
+
+    const cRecord = persistence.loadWorkflow(c.wfId)!;
+    expect(cRecord.baseBranch).toBe('plan/slice-2');
+    expect(cRecord.externalDependencies).toEqual([
+      { workflowId: b.wfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+    ]);
+    expect(cRecord.detachedExternalDependencies).toBeUndefined();
+
+    const ready = orchestrator.getExecutableReadyTasks().map((t) => t.id);
+    expect(ready).not.toContain(b.rootId);
+    expect(ready).not.toContain(c.rootId);
+  });
+
+  it.fails('cancels every never-started downstream task instead of leaving it pending forever', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const { a, b, c } = setupStack(orchestrator);
+
+    orchestrator.cancelWorkflow(a.wfId);
+
+    for (const wfId of [b.wfId, c.wfId]) {
+      const statuses = Object.values(workflowTaskStatuses(orchestrator, wfId));
+      expect(statuses, `all tasks of ${wfId} must be cancelled`).not.toContain('pending');
+      expect(statuses).not.toContain('running');
+    }
+    expect(orchestrator.getTask(b.rootId)!.execution.error).toContain(a.wfId);
+    expect(orchestrator.getTask(c.rootId)!.execution.error).toContain(a.wfId);
+  });
+
+  it.fails('does not resurrect a downstream slice that was already cancelled tail-first', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const { a, b, c } = setupStack(orchestrator);
+
+    orchestrator.cancelWorkflow(c.wfId);
+    orchestrator.cancelWorkflow(b.wfId);
+    const bAfterOwnCancel = workflowTaskStatuses(orchestrator, b.wfId);
+    expect(Object.values(bAfterOwnCancel)).not.toContain('pending');
+
+    orchestrator.cancelWorkflow(a.wfId);
+
+    expect(workflowTaskStatuses(orchestrator, b.wfId)).toEqual(bAfterOwnCancel);
+    expect(persistence.loadWorkflow(b.wfId)!.baseBranch).toBe('plan/slice-1');
+    expect(persistence.loadWorkflow(c.wfId)!.baseBranch).toBe('plan/slice-2');
+    expect(orchestrator.getExecutableReadyTasks().map((t) => t.id)).toEqual([]);
+  });
+});

--- a/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
@@ -55,7 +55,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
 // externalDependencies gate. The only thing that ever unblocked them was an
 // unrelated manual `detachWorkflow` call two days later.
 describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its downstream', () => {
-  it('detaches downstream from an invalidated upstream when that upstream is cancelled and abandoned', async () => {
+  it.fails('cancels the downstream chain when an invalidated upstream is cancelled and abandoned, keeping its gate intact', async () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const deps = buildOrchestratorDeps(orchestrator);
@@ -79,9 +79,23 @@ describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its
     // going to be retried to completion again).
     orchestrator.cancelWorkflow(ctx.upstreamWfId);
 
-    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toBeUndefined();
+    const downstream = persistence.loadWorkflow(ctx.downstreamWfId)!;
+    expect(downstream.externalDependencies).toEqual([
+      {
+        workflowId: ctx.upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
+    expect(downstream.baseBranch).toBe('feature/upstream');
+    expect(downstream.detachedExternalDependencies).toBeUndefined();
+    for (const taskId of [ctx.downstreamRootId, ctx.downstreamMidId, ctx.downstreamLastId, ctx.downstreamMergeId]) {
+      expect(orchestrator.getTask(taskId)!.status, `${taskId} must not sit pending forever`).toBe('failed');
+      expect(orchestrator.getTask(taskId)!.execution.error).toContain(ctx.upstreamWfId);
+    }
     expect(orchestrator.getExecutableReadyTasks().map((t) => t.id))
-      .toContain(ctx.downstreamRootId);
+      .not.toContain(ctx.downstreamRootId);
   });
 
   it('keeps a genuinely-still-invalid upstream gate blocking its downstream', async () => {

--- a/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
@@ -52,7 +52,7 @@ describe('REPRO: recreate preemption detaches a live downstream dependency', () 
     ]);
   });
 
-  it('CommandService.cancelWorkflow (the real standalone abandon action) must still detach downstream', async () => {
+  it.fails('CommandService.cancelWorkflow (the real standalone abandon action) cancels downstream but keeps its gate', async () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const commandService = new CommandService(orchestrator);
@@ -69,7 +69,17 @@ describe('REPRO: recreate preemption detaches a live downstream dependency', () 
 
     expect(
       persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies,
-      'a genuinely abandoned upstream must still detach its downstream dependents',
-    ).toBeUndefined();
+      'a cancelled upstream must not detach its downstream dependents onto the default branch',
+    ).toEqual([
+      {
+        workflowId: ctx.upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.baseBranch).toBe('feature/upstream');
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('failed');
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.execution.error).toContain(ctx.upstreamWfId);
   });
 });


### PR DESCRIPTION
## Summary

Adds a repro test for an incident on 2026-09-01. Cancelling slice one of a correctly chained four-slice stack rewrote slices two to four onto master and launched them there.

The test builds a three-slice chain, cancels the first slice, and asserts the downstream base branches and merge-gate dependencies stay as submitted and no downstream task becomes runnable.

A third case cancels the tail first and then the head, and asserts the tail is not reset back to pending.

Five existing cases that pinned the old detach behavior are rewritten to the new contract in the same way.

Those are the #8058 deadlock repro, the recreate-preemption cancel case, the app gate-preservation cancel case, and two preempt call-shape checks.

Every changed expectation is marked `it.fails` so this slice stays green. The next slice flips them to plain `it` together with the behavior change.

## Review Claim

Approve that this test encodes the intended contract for cancelling an upstream slice of a chained stack.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice touches test files only and changes no product code. Every new or changed expectation is marked `it.fails`, so it passes on current master and cannot break CI.

## Slice Rationale

The proof lands before the fix so a reviewer sees the bug demonstrated before approving the behavior change in the next slice.

## Non-goals

No product code changes. The behavior fix is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/repro-cancel-upstream-keeps-stack-gated.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
