### PR TITLE
[Cancel keeps stack gated](2) Cascade cancel to downstream workflows instead of detaching them

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1264,7 +1264,7 @@ describe('headless delegation enforcement', () => {
           return { preemptWorkflowExecution, preparePoolSpy };
         }
 
-        it.fails('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
+        it('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {

--- a/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
+++ b/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
@@ -275,7 +275,7 @@ describe('restart-class workflow mutations preserve downstream gates', () => {
     expect(fixture.killActiveExecution).toHaveBeenCalledWith(fixture.upstreamTaskId);
   });
 
-  it.fails('cancels dependents for explicit Cancel Workflow without detaching their gate', async () => {
+  it('cancels dependents for explicit Cancel Workflow without detaching their gate', async () => {
     const fixture = createGatedWorkflowFixture();
 
     const result = await fixture.commandService.cancelWorkflow({

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1758,7 +1758,7 @@ describe('buildCancelInFlight', () => {
     expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
 
-  it.fails('cancels workflow before awaiting killActiveExecution per runningCancelled id', async () => {
+  it('cancels workflow before awaiting killActiveExecution per runningCancelled id', async () => {
     const orchestrator = {
       cancelTask: vi.fn(),
       cancelWorkflow: vi.fn(() => ({

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
@@ -21,7 +21,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id, { detachDependents: false });
+        orchestrator.cancelWorkflow(id, { cascadeDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
@@ -21,7 +21,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id, { detachDependents: false });
+        orchestrator.cancelWorkflow(id, { cascadeDependents: false });
       } catch (e) {
         // Already-terminal targets have nothing to cancel; the rest
         // of the pipeline still runs.

--- a/packages/workflow-core/src/__tests__/repro-cancel-upstream-keeps-stack-gated.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-cancel-upstream-keeps-stack-gated.test.ts
@@ -66,7 +66,7 @@ function workflowTaskStatuses(orchestrator: Orchestrator, wfId: string): Record<
 }
 
 describe('REPRO 2026-09-01: cancelling slice 1 of a chained stack rewrote slices 2-4 onto master and launched them', () => {
-  it.fails('keeps downstream base branch and external dependency intact after upstream cancel', () => {
+  it('keeps downstream base branch and external dependency intact after upstream cancel', () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const { a, b, c } = setupStack(orchestrator);
@@ -93,7 +93,7 @@ describe('REPRO 2026-09-01: cancelling slice 1 of a chained stack rewrote slices
     expect(ready).not.toContain(c.rootId);
   });
 
-  it.fails('cancels every never-started downstream task instead of leaving it pending forever', () => {
+  it('cancels every never-started downstream task instead of leaving it pending forever', () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const { a, b, c } = setupStack(orchestrator);
@@ -109,7 +109,7 @@ describe('REPRO 2026-09-01: cancelling slice 1 of a chained stack rewrote slices
     expect(orchestrator.getTask(c.rootId)!.execution.error).toContain(a.wfId);
   });
 
-  it.fails('does not resurrect a downstream slice that was already cancelled tail-first', () => {
+  it('does not resurrect a downstream slice that was already cancelled tail-first', () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const { a, b, c } = setupStack(orchestrator);

--- a/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
@@ -20,7 +20,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id, { detachDependents: false });
+        orchestrator.cancelWorkflow(id, { cascadeDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
@@ -55,7 +55,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
 // externalDependencies gate. The only thing that ever unblocked them was an
 // unrelated manual `detachWorkflow` call two days later.
 describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its downstream', () => {
-  it.fails('cancels the downstream chain when an invalidated upstream is cancelled and abandoned, keeping its gate intact', async () => {
+  it('cancels the downstream chain when an invalidated upstream is cancelled and abandoned, keeping its gate intact', async () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const deps = buildOrchestratorDeps(orchestrator);

--- a/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
@@ -52,7 +52,7 @@ describe('REPRO: recreate preemption detaches a live downstream dependency', () 
     ]);
   });
 
-  it.fails('CommandService.cancelWorkflow (the real standalone abandon action) cancels downstream but keeps its gate', async () => {
+  it('CommandService.cancelWorkflow (the real standalone abandon action) cancels downstream but keeps its gate', async () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const commandService = new CommandService(orchestrator);

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -454,7 +454,7 @@ export class CommandService {
   ): Promise<CommandResult<CancelResult>> {
     return this.executeCommand<CancelResult>(
       'PREEMPT_WORKFLOW_FAILED',
-      () => this.orchestrator.cancelWorkflow(envelope.payload.workflowId, { detachDependents: false }),
+      () => this.orchestrator.cancelWorkflow(envelope.payload.workflowId, { cascadeDependents: false }),
       envelope.payload.workflowId,
     );
   }

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -446,10 +446,10 @@ export async function applyInvalidation(
 // `Orchestrator` class (which imports `applyInvalidation` from here).
 export interface InvalidationDepsOrchestrator {
   cancelTask(taskId: string): { runningCancelled: string[] };
-  cancelWorkflow(workflowId: string, opts?: { detachDependents?: boolean }): { runningCancelled: string[] };
+  cancelWorkflow(workflowId: string, opts?: { cascadeDependents?: boolean }): { runningCancelled: string[] };
   /** Deferred-invalidation variant of cancelTask: skips releasing resource leases/abandoning dispatch rows so the caller can kill the real process first. */
   cancelTaskAwaitingKill?(taskId: string): { runningCancelled: string[]; toCancelIds: string[] };
-  cancelWorkflowAwaitingKill?(workflowId: string, opts?: { detachDependents?: boolean }): { runningCancelled: string[]; toCancelIds: string[] };
+  cancelWorkflowAwaitingKill?(workflowId: string, opts?: { cascadeDependents?: boolean }): { runningCancelled: string[]; toCancelIds: string[] };
   /** Performs the deferred invalidation skipped above, once every running task has been killed. */
   finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void;
   retryTask(taskId: string): TaskState[];
@@ -586,7 +586,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
       try {
         result = scope === 'task'
           ? deps.orchestrator.cancelTaskAwaitingKill!(id)
-          : deps.orchestrator.cancelWorkflowAwaitingKill!(id, { detachDependents: false });
+          : deps.orchestrator.cancelWorkflowAwaitingKill!(id, { cascadeDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
@@ -606,7 +606,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
     try {
       result = scope === 'task'
         ? deps.orchestrator.cancelTask(id)
-        : deps.orchestrator.cancelWorkflow(id, { detachDependents: false });
+        : deps.orchestrator.cancelWorkflow(id, { cascadeDependents: false });
     } catch (e) {
       const code = (e as { code?: string })?.code;
       if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2629,7 +2629,7 @@ export class Orchestrator {
       throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `forkWorkflow: workflow ${workflowId} not found (no tasks)`);
     }
 
-    this.cancelWorkflow(workflowId, { detachDependents: false });
+    this.cancelWorkflow(workflowId, { cascadeDependents: false });
 
     this.refreshWorkflowFromDb(workflowId);
     const settledSourceTasks = this.stateMachine
@@ -3545,38 +3545,40 @@ export class Orchestrator {
   }
 
   /**
-   * Cancel all active tasks in a workflow.
-   * Terminal tasks (completed/stale) are preserved as-is.
+   * Cancel all active tasks in a workflow and, unless `cascadeDependents` is
+   * false, in every workflow gated on it via `externalDependencies`.
+   * Downstream gates and base branches are left untouched so a retry of the
+   * upstream can revive the chain. Terminal tasks (completed/stale) are
+   * preserved as-is.
    */
   cancelWorkflow(
     workflowId: string,
-    opts: { detachDependents?: boolean } = {},
+    opts: { cascadeDependents?: boolean } = {},
   ): { cancelled: string[]; runningCancelled: string[] } {
-    const detachDependents = opts.detachDependents ?? true;
-    if (!detachDependents) {
-      return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+    const { cancelled, runningCancelled } = this.cancelWorkflowWithDependents(workflowId, opts);
+    return { cancelled, runningCancelled };
+  }
+
+  private cancelWorkflowWithDependents(
+    workflowId: string,
+    opts: { cascadeDependents?: boolean; deferInvalidation?: boolean },
+  ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    const cancelOpts = { deferInvalidation: opts.deferInvalidation };
+    if (opts.cascadeDependents === false) {
+      return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, cancelOpts);
     }
 
     this.syncAllFromDb();
-    const directDependents = this.collectDirectDependentWorkflowIds(workflowId);
-    const workflowMetadata = this.persistence.listWorkflows();
-    const directDependentBaseBranches = new Map<string, string>();
-    for (const dependentWorkflowId of directDependents) {
-      const dependentWorkflow = this.persistence.loadWorkflow?.(dependentWorkflowId)
-        ?? workflowMetadata.find((candidate) => candidate.id === dependentWorkflowId);
-      directDependentBaseBranches.set(
-        dependentWorkflowId,
-        this.resolveDetachDefaultBranch(dependentWorkflowId, dependentWorkflow),
-      );
-    }
-
-    const result = cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
-    for (const dependentWorkflowId of directDependents) {
-      this.detachWorkflowInternal(
-        dependentWorkflowId,
-        workflowId,
-        directDependentBaseBranches.get(dependentWorkflowId)!,
-      );
+    const downstreamWorkflowIds = this.collectDownstreamWorkflowIds(workflowId);
+    const result = cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, cancelOpts);
+    for (const downstreamWorkflowId of downstreamWorkflowIds) {
+      const downstream = cancelWorkflowImpl(this as unknown as CancellationHost, downstreamWorkflowId, {
+        ...cancelOpts,
+        reason: `Cancelled: upstream workflow ${workflowId} was cancelled`,
+      });
+      result.cancelled.push(...downstream.cancelled);
+      result.runningCancelled.push(...downstream.runningCancelled);
+      result.toCancelIds.push(...downstream.toCancelIds);
     }
     return result;
   }
@@ -3595,10 +3597,9 @@ export class Orchestrator {
   /** Deferred-invalidation counterpart to `cancelWorkflow` -- see `cancelTaskAwaitingKill`. */
   cancelWorkflowAwaitingKill(
     workflowId: string,
-    opts: { detachDependents?: boolean } = {},
+    opts: { cascadeDependents?: boolean } = {},
   ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
-    void opts;
-    return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, { deferInvalidation: true });
+    return this.cancelWorkflowWithDependents(workflowId, { ...opts, deferInvalidation: true });
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -352,9 +352,10 @@ export function closeIdleTaskImpl(host: CancellationHost, taskId: string): TaskS
 export function cancelWorkflowImpl(
   host: CancellationHost,
   workflowId: string,
-  opts?: { deferInvalidation?: boolean },
+  opts?: { deferInvalidation?: boolean; reason?: string },
 ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
   host.refreshWorkflowFromDb(workflowId);
+  const reason = opts?.reason ?? 'Cancelled by user (workflow)';
 
   const allTasks = host.stateMachine.getAllTasks().filter(
     (t) => t.config.workflowId === workflowId,
@@ -396,14 +397,14 @@ export function cancelWorkflowImpl(
     const changes: TaskStateChanges = {
       status: 'failed',
       execution: {
-        error: 'Cancelled by user (workflow)',
+        error: reason,
         completedAt: new Date(),
       },
     };
     const wfCancelUpdated = host.writeAndSync(id, changes);
     host.updateSelectedAttempt(id, {
       status: 'failed',
-      error: 'Cancelled by user (workflow)',
+      error: reason,
       completedAt: changes.execution?.completedAt,
     });
     host.persistence.logEvent?.(id, 'task.cancelled', changes);


### PR DESCRIPTION
## Summary

Cancelling a workflow used to detach every workflow stacked on it. Those downstream slices were rewritten to the repo default branch, reset to pending, and launched there.

On 2026-09-01 this turned a correctly chained four-slice stack into three unrelated runs on master within thirty seconds of cancelling slice one.

Now cancel cascades instead. Every workflow gated on the cancelled one is cancelled too, and its base branch and merge-gate dependency stay exactly as the plan specified.

Rerunning the upstream can therefore revive the chain, and a slice that was already cancelled tail-first is never reset back to pending.

Cascaded tasks record the upstream workflow id in their error text so the reason is visible in the UI and the query output.

## Review Claim

Approve that cancelling a workflow cancels its downstream chain and never rewrites downstream base branches or external dependencies.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `cancelWorkflow` and `cancelWorkflowAwaitingKill` with `cascadeDependents` unset change behavior. Every preemption path (recreate, rerun, rebase, fork) passes `cascadeDependents: false` and makes the same call it made before under the old option name, so downstream gates stay attached while an upstream reruns. `deleteWorkflow` and `detachWorkflow` are untouched. Cancel never writes a downstream workflow record.

## Slice Rationale

One behavior change in workflow-core plus the tests that pinned the old detach behavior. The repro landed as the previous slice; UI copy is deferred so this slice stays single-layer.

## Non-goals

`deleteWorkflow` still detaches its direct dependents onto the default branch. The manual Detach Upstream Workflow action is unchanged. The Cancel Workflow confirmation text in the UI is not updated here. No changelog entry.

## Architecture

### Before

```mermaid
graph TD
    A["cancelWorkflow(upstream)"] --> B["cancel upstream tasks"]
    B --> C["detachWorkflowInternal(dependent)"]
    C --> D["baseBranch := repo default branch"]
    C --> E["externalDependencies := none"]
    C --> F["resetSubgraphToPending(all dependent tasks)"]
    F --> G["dependent launches on master"]
```

### After

```mermaid
graph TD
    A["cancelWorkflow(upstream)"] --> B["cancel upstream tasks"]
    B --> C["collectDownstreamWorkflowIds (transitive)"]
    C --> D["cancelWorkflowImpl(dependent, reason: upstream cancelled)"]
    D --> E["baseBranch and externalDependencies unchanged"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/workflow-core test`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/recreate-preserves-downstream-gates.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/api-server.test.ts src/__tests__/parity-regression.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default cancel semantics for multi-workflow stacks—a core orchestration path that previously detached dependents; regressions could strand or incorrectly launch downstream work.
> 
> **Overview**
> **Cancel Workflow** no longer detaches stacked dependents onto the repo default branch and relaunches them. It **cascades cancellation** transitively to every workflow gated on the cancelled one via `externalDependencies`, while leaving each downstream **base branch** and **merge gate** unchanged so an upstream retry can revive the chain.
> 
> The cancel option is renamed from `detachDependents` to **`cascadeDependents`** (default: cascade). Preemption and invalidation paths (`preemptWorkflow`, `forkWorkflow`, `buildCancelInFlight`, etc.) pass **`cascadeDependents: false`** so recreate/retry/rebase behavior stays local to the upstream workflow. `cancelWorkflowAwaitingKill` now shares the same cascade helper instead of only cancelling the target workflow.
> 
> Cascaded tasks get a configurable failure reason (including upstream workflow id in the message). Previously failing repro and integration tests are enabled (`it.fails` → `it`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359247ce653f3d4f7d7164fbf1b487e57d272fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->