### PR TITLE
Drop removed log parser import from regression-watch repro

### DIFF
--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -12,7 +12,6 @@ import {
   buildPlanVars,
   claimRepairFiling,
   classifyJobConclusion,
-  extractFailureIdentitiesFromLog,
   failureStorageKey,
   fileBugfixPlan,
   getActionableFailures,
@@ -510,12 +509,6 @@ function testLiveGithubSmokeIfRequested() {
 
 function testDistinctIdentitiesUnderOneJob() {
   const jobName = 'required-fast / Mergify Admin Requeue';
-  const log = "rm: cannot remove '/tmp/repro-babysit-pr-body-human-split.ERdycn/seed/.git/objects': Directory not empty";
-  const extracted = extractFailureIdentitiesFromLog(log);
-  if (!extracted.some((entry) => entry.failureId.includes('repro-babysit-pr-body-human-split'))) {
-    fail('log parser must identify the babysit human-split repro');
-  }
-
   const state = loadEmptyState();
   reconcileCiRun(state, fakeRun(32534741079, '22891618af26fc7e3e19227ccc56ed183c0e7e26', [{
     ...fakeJob(jobName, 'failure', 96936670245),


### PR DESCRIPTION
## Summary

The nightly hermetic regression-watch repro crashed at startup on master. It still imported `extractFailureIdentitiesFromLog`, which #11593 deleted from `scripts/e2e-regression-watch.mjs`.

The repro now stops importing that parser and drops its one log-parsing assertion. The rest of that scenario already feeds explicit `failureIdentities`, so its coverage is unchanged.

## Review Claim

`node scripts/repro/repro-e2e-regression-watch.mjs` loads and passes again on top of current master.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the repro script changes; `scripts/e2e-regression-watch.mjs` and its unit tests are untouched, and every remaining repro scenario asserts the same thing it did before.

## Slice Rationale

#11593 landed the parser removal without this repro, so the repro is its own follow-up under the `scripts/repro/` lane rather than a change to the watcher itself.

## Non-goals

- Does not change the regression watcher or its unit tests.
- Does not add a replacement assertion for log parsing; log text is no longer an identity source.
- Does not remove the three-line explanatory comment #11593 added at `scripts/e2e-regression-watch.mjs:286`; that is a separate tooling change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-e2e-regression-watch.mjs` fails on master with `SyntaxError: The requested module '../e2e-regression-watch.mjs' does not provide an export named 'extractFailureIdentitiesFromLog'`
- [x] `INVOKER_AUTO_FIX_PAUSE_FILE=/nonexistent/none.json node scripts/repro/repro-e2e-regression-watch.mjs` prints `all checks passed` with this change (the env override bypasses the local `~/.invoker/auto-fix-pause.json` usage-limit circuit breaker, which otherwise short-circuits the filing sweep on this machine)
- [x] `node scripts/check-added-comments.mjs --base origin/master`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but the repro goes back to crashing at import.
- Revert command: `git revert 4eecda1fca`.
- Post-revert steps: None.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repro-only cleanup with no changes to the regression watcher or production paths.
> 
> **Overview**
> Fixes the **hermetic `repro-e2e-regression-watch.mjs` script** so it loads again after #11593 removed log-based failure identity parsing from `e2e-regression-watch.mjs`.
> 
> The repro **drops the `extractFailureIdentitiesFromLog` import** and **removes the log-line assertion** in `testDistinctIdentitiesUnderOneJob`. That scenario still reconciles a fake job with explicit `failureIdentities` and asserts two actionable failures and separate filings—**coverage for multiple identities under one job is unchanged**; only log-parsing coverage is gone, matching the watcher’s new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eecda1fca2edaa32c71a1c6054d7fa1da2dc82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->