### PR TITLE
[Web/Desktop Capability Parity](3c)[REFACTOR: Remove Parameter] HTTP activation — drop legacy GUI-mutation bridge

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -354,16 +354,6 @@ describe('buildWebInvokerDispatch', () => {
     await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
   });
 
-  it('bridges a known channel through the legacy guiMutations callback when no owner registry is wired', async () => {
-    const guiMutations = vi.fn(async (channel: string) => ({ ok: true, channel }));
-    const { dispatch } = makeDispatch({ guiMutations });
-    await expect(dispatch('invoker:planning-chat-list', [])).resolves.toEqual({
-      ok: true,
-      channel: 'invoker:planning-chat-list',
-    });
-    expect(guiMutations).toHaveBeenCalledExactlyOnceWith('invoker:planning-chat-list', []);
-  });
-
   it('allows Codex and forbids Claude by deployment policy without restricting HTTP itself', async () => {
     const ownerCapabilities = new OwnerCapabilityRegistry();
     const fixWithAgent = vi.fn(async (_taskId: unknown, agentName: unknown) => ({ agentName }));

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -85,12 +85,6 @@ export interface WebInvokerDispatchDeps {
   getWorkers?: () => WorkerStatusSnapshot;
   taskTerminals?: TaskTerminalAdapter;
   ownerCapabilities?: Pick<OwnerCapabilityRegistry, 'has' | 'invoke'>;
-  /**
-   * Routes planning-chat channels (and plan-from-goal) to the owner's shared
-   * GUI-mutation handlers. Wired by both the desktop-owned and headless web
-   * surfaces; absent means the historical web downgrades stay in effect.
-   */
-  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
   planningTerminals?: WebPlanningTerminals;
   logger?: Logger;
 }
@@ -448,13 +442,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         if (deps.planningTerminals) return deps.planningTerminals.close(String(args[0]));
         return { ok: false, reason: 'unsupported' };
       default:
-        if (Object.hasOwn(IpcChannels, channel)) {
-          if (deps.guiMutations) {
-            assertOwnerCapabilityAccess(deps, channel, args);
-            return deps.guiMutations(channel, args);
-          }
-          return providerMissing(channel);
-        }
+        if (Object.hasOwn(IpcChannels, channel)) return providerMissing(channel);
         throw new WebDispatchError('unknown_channel', channel, `Unknown channel "${channel}"`);
     }
   };


### PR DESCRIPTION
## Summary

Authenticated HTTP dispatch no longer accepts the legacy GUI-mutation callback.

Both startup paths already hand the shared owner registry to the web surface, so the fallback bridge is unreachable.

## Review Claim

Drop the legacy GUI-mutation callback dependency from the HTTP dispatcher now that every host supplies the shared owner registry.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Desktop IPC behavior is unchanged; HTTP invokes only already-registered owner handlers, and unauthorized execution agents are rejected before handler execution.

## Slice Rationale

This slice follows the owner-wiring slice so the transitional bridge lands and leaves in separately reviewable steps.

## Non-goals

No behavior change. No startup wiring, dispatcher policy changes, UI redesign, hard-coded demo credentials, desktop agent restriction, or real agent execution in tests.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
  - `check:types exit=0`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/web-invoker-dispatch.test.ts src/__tests__/web-bridge-server.test.ts src/__tests__/surface-capability-parity.test.ts src/__tests__/start-web-surface.test.ts src/__tests__/invoker-surface-access.test.ts src/__tests__/owner-capability-registry.test.ts`
  - `Test Files  6 passed (6)`
  - `Tests  59 passed (59)`
- [x] `node scripts/check-added-comments.mjs --base <owner-wiring branch>`
  - `[comments] Checked added source lines; no disallowed comments found.`
- Full suite not run; this slice's acceptance gate names the six focused app test files above.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cb896d1b508c7e97b358cdfe2be9a0b7ffa5b841`
- Post-revert steps: Rerun the six focused app test files.
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that removes dead fallback wiring; behavior only shifts for HTTP callers that relied on `guiMutations` without an owner registry, which the PR states is no longer a supported startup path.
> 
> **Overview**
> **Removes the transitional `guiMutations` callback** from authenticated HTTP/web invoker dispatch now that hosts wire the shared **owner capability registry** instead.
> 
> For IPC channels that are known in `IpcChannels` but not handled in the explicit `switch` and not registered on `ownerCapabilities`, dispatch **always** rejects with `capability_provider_missing`—it no longer forwards those calls through an optional GUI-mutation handler. Planning and other owner-only channels are expected to be registered on the registry at startup.
> 
> The **`guiMutations` dependency option** and its JSDoc are deleted from `WebInvokerDispatchDeps`, and the test that asserted the legacy bridge for `invoker:planning-chat-list` is removed. Explicit routes (mutations facade, terminals, reads) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7512e2bb4368a1f496bcf0d508c625c12f83c224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Requests for recognized but unsupported channels no longer fall back to legacy handlers.
  - These requests now immediately report that the required capability provider is unavailable.

- **Reliability**
  - Capability routing now provides clearer, more consistent handling when no provider is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->