### PR TITLE
[Planning PATH diagnostics](2) skill docs

### DIFF
--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
@@ -101,8 +103,9 @@ describe('checkDefaultPresetTool', () => {
   it('errors when the default preset tool is not on PATH', () => {
     const c = checkDefaultPresetTool(presets, 'cursor+claude', installed('omp'));
     expect(c.status).toBe('error');
-    expect(c.detail).toContain('cursor');
-    expect(c.remediation).toContain('defaultSlackHarnessPreset');
+    expect(c.detail).toBe('Default preset "cursor+claude" needs "cursor", which is not on Invoker\'s PATH');
+    expect(c.remediation).toBe("Make cursor available on Invoker's PATH (restart Invoker if it already works in a terminal), or set defaultSlackHarnessPreset to a preset whose tool is available");
+    expect(c.remediation).not.toMatch(/^Install /);
   });
 
   it('errors and lists valid keys when the default preset is undefined', () => {
@@ -114,13 +117,27 @@ describe('checkDefaultPresetTool', () => {
 
 describe('checkPlanningToolsPresent', () => {
   it('passes when any preset tool is installed', () => {
-    expect(checkPlanningToolsPresent(presets, installed('codex')).status).toBe('ok');
+    const c = checkPlanningToolsPresent(presets, installed('codex'));
+    expect(c.status).toBe('ok');
+    expect(c.detail).toBe("Available on Invoker's PATH: codex");
   });
 
-  it('errors when no planning tool is installed', () => {
+  it("reports PATH availability without claiming configured planning tools are uninstalled", () => {
     const c = checkPlanningToolsPresent(presets, installed('git'));
     expect(c.status).toBe('error');
-    expect(c.remediation).toContain('cursor');
+    expect(c.detail).toBe("Planning unavailable: none of the configured planner commands are on Invoker's PATH (cursor, omp, codex)");
+    expect(c.remediation).toBe("Make one of these commands available on Invoker's PATH: cursor, omp, codex. If it already works in a terminal, restart Invoker to refresh its shell environment; otherwise install it or configure another planning preset.");
+    expect(c.detail).not.toContain('installed');
+    expect(c.remediation).not.toMatch(/^Install /);
+  });
+});
+
+describe('invoker-setup planning availability guidance', () => {
+  it('distinguishes PATH visibility from installation state', () => {
+    const skill = readFileSync(new URL('../../../../skills/invoker-setup/SKILL.md', import.meta.url), 'utf8').replace(/\s+/g, ' ');
+    expect(skill).toContain("not available on Invoker's own `PATH`");
+    expect(skill).toContain('Do not report that command as uninstalled based on this probe alone');
+    expect(skill).toContain('restart Invoker to refresh its shell environment');
   });
 });
 
@@ -143,7 +160,8 @@ describe('buildReport / formatReport', () => {
   it('emits machine-readable JSON and shows remediation in text mode', () => {
     const report = buildReport([checkPlanningToolsPresent(presets, installed())]);
     expect(JSON.parse(formatReport(report, { json: true }))).toEqual(report);
-    expect(formatReport(report)).toContain('-> Install at least one');
+    const text = formatReport(report);
+    expect(text).toContain("-> Make one of these commands available on Invoker's PATH");
   });
 });
 

--- a/packages/contracts/src/prerequisites.ts
+++ b/packages/contracts/src/prerequisites.ts
@@ -111,8 +111,8 @@ export function checkDefaultPresetTool(
       id: 'default-preset',
       name: 'Default planning preset',
       status: 'error',
-      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on PATH`,
-      remediation: `Install ${preset.tool}, or set defaultSlackHarnessPreset to a preset whose tool is installed`,
+      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on Invoker's PATH`,
+      remediation: `Make ${preset.tool} available on Invoker's PATH (restart Invoker if it already works in a terminal), or set defaultSlackHarnessPreset to a preset whose tool is available`,
     };
   }
   return {
@@ -131,15 +131,15 @@ export function checkPlanningToolsPresent(
   const tools = [...new Set(Object.values(presets).map((p) => p.tool))];
   const installed = tools.filter(isInstalled);
   if (installed.length > 0) {
-    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Installed: ${installed.join(', ')}` };
+    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Available on Invoker's PATH: ${installed.join(', ')}` };
   }
   const wanted = tools.length ? tools.join(', ') : 'cursor, omp, codex';
   return {
     id: 'planning-tools',
     name: 'Planning tools',
     status: 'error',
-    detail: `No planning tool installed (need one of: ${wanted})`,
-    remediation: `Install at least one of: ${wanted}`,
+    detail: `Planning unavailable: none of the configured planner commands are on Invoker's PATH (${wanted})`,
+    remediation: `Make one of these commands available on Invoker's PATH: ${wanted}. If it already works in a terminal, restart Invoker to refresh its shell environment; otherwise install it or configure another planning preset.`,
   };
 }
 

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -24,9 +24,12 @@ the config check, planning tools, and the default preset check.
 
 - `error` blocks "good to go" — surface the `remediation` verbatim.
 - `warn` is advisory (an optional tool / preset not installed) — mention it, don't block.
-- The `default-preset` and `planning-tools` checks are config-aware: an `error` there means the
-  configured `defaultSlackHarnessPreset` points at a CLI that is not installed. This is the most
-  common Slack failure ("spawn cursor ENOENT") — fix it before going further.
+- The `default-preset` and `planning-tools` checks are config-aware and PATH-based: an `error`
+  means the configured planner command is not available on Invoker's own `PATH`. Do not report
+  that command as uninstalled based on this probe alone. If it already works in a terminal,
+  restart Invoker to refresh its shell environment; otherwise install it or configure a preset
+  whose command is available. This is the most common Slack failure ("spawn cursor ENOENT") —
+  fix it before going further.
 
 Offer to auto-install missing installable tools:
 


### PR DESCRIPTION
## Summary

The setup skill now tells the agent that a planning-tool `error` means the command is missing from Invoker's own `PATH`, not that it is uninstalled.

It adds the restart-versus-install remediation that matches the readiness copy shipped in the parent slice.

## Review Claim

The setup skill's planning-tool guidance matches the PATH-scoped readiness copy without changing any other setup step.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only `skills/invoker-setup/SKILL.md` prose changes; no product code, scripts, or tests change.

## Slice Rationale

The guidance is separated from the parent slice so the readiness copy and its focused assertions ship as product-only, and this wording ships on its own.

## Non-goals

- No product, script, or test changes.
- No changes to other setup checks or their remediation text.
- No PATH mutation or environment refresh.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/check-added-comments.mjs --base origin/stack/EdbertChan/fix/planning-path-diagnostic-copy/clarify-planning-tool-path-diagnostics--8c6c59ff`
- [x] `git diff --check`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
