### PR TITLE
[Required executor pool (2)](2)[REFACTOR: Move Field] Define the built-in local pool id in workflow-graph

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -12,6 +12,9 @@ import { resolveInvokerConfigPath } from '@invoker/contracts';
 import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 import type { E2eAutoFixWorkerConfig, PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
+
+export { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
 
 const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
@@ -609,8 +612,6 @@ export interface InvokerConfig {
 }
 
 export const BUILT_IN_LOCAL_WORKTREE_TARGET_ID = 'local-worktree';
-
-export const BUILT_IN_LOCAL_EXECUTION_POOL_ID = 'local-worktree';
 
 function isBuiltInLocalWorktreeTarget(
   target: NonNullable<InvokerConfig['worktreeTargets']>[string],

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -35,6 +35,8 @@ export interface TaskFreshnessSpec {
   readonly guardedBehaviorIds?: readonly string[];
 }
 
+export const BUILT_IN_LOCAL_EXECUTION_POOL_ID = 'local-worktree';
+
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;


### PR DESCRIPTION
## Summary

The built-in local pool id `local-worktree` used to live only in the app config module. Lower packages could not name it without importing the app.

It is now defined in `@invoker/workflow-graph` and re-exported through `@invoker/workflow-core`. The app config module re-exports the same constant, so every existing import keeps working.

## Review Claim

Approve that `BUILT_IN_LOCAL_EXECUTION_POOL_ID` keeps the same value and the same app export while becoming importable from the graph package.

## Review Lane

refactor

## Review Unit

validation-policy

## Safety Invariant

The constant value is unchanged (`local-worktree`) and `packages/app/src/config.ts` still exports it under the same name, so no caller changes and no config semantics change.

## Slice Rationale

The next slices make the orchestrator, runner, and SQLite layer default to this pool id. They need the constant below the app package before any of them can reference it.

## Non-goals

No behavior change. No reserved-pool handling changes in the app config. No callers are updated here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/app test -- config`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure constant relocation with unchanged value and app re-export; no runtime behavior or caller updates in this PR.
> 
> **Overview**
> Moves **`BUILT_IN_LOCAL_EXECUTION_POOL_ID`** (`local-worktree`) out of the app config module into **`@invoker/workflow-graph`**, so orchestrator/runner/SQLite layers can reference the reserved pool id without depending on `@invoker/app`.
> 
> **`packages/app/src/config.ts`** no longer defines the constant locally; it **imports and re-exports** the same symbol from **`@invoker/workflow-core`**, so existing app imports and reserved-pool validation in `materializeResolvedConfig` stay unchanged. No config semantics or constant value changes in this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc55d98e3828697383cd593ba26a635540b9d8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->