### PR TITLE
[Required executor pool (2)](2) TaskRunner always exposes the built-in local pool

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -12,6 +12,9 @@ import { resolveInvokerConfigPath } from '@invoker/contracts';
 import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 import type { E2eAutoFixWorkerConfig, PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
+
+export { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
 
 const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
@@ -609,8 +612,6 @@ export interface InvokerConfig {
 }
 
 export const BUILT_IN_LOCAL_WORKTREE_TARGET_ID = 'local-worktree';
-
-export const BUILT_IN_LOCAL_EXECUTION_POOL_ID = 'local-worktree';
 
 function isBuiltInLocalWorktreeTarget(
   target: NonNullable<InvokerConfig['worktreeTargets']>[string],

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -11,7 +11,7 @@ import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
-import { scopePlanTaskId } from '@invoker/workflow-core';
+import { BUILT_IN_LOCAL_EXECUTION_POOL_ID, scopePlanTaskId } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState, ExperimentVariant, Attempt } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
@@ -374,9 +374,19 @@ export class TaskRunner {
     this.reviewGateCiFailurePublisher = config.reviewGateCiFailurePublisher;
     this.reviewGateMergeConflictPublisher = config.reviewGateMergeConflictPublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
-    this.getWorktreeTargets = config.worktreeTargetsProvider ?? (() => ({}));
+    const configuredWorktreeTargets = config.worktreeTargetsProvider ?? (() => ({}));
+    this.getWorktreeTargets = () => ({
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {},
+      ...configuredWorktreeTargets(),
+    });
     this.getRepoProvisionCommands = config.repoProvisionCommandsProvider ?? (() => ({}));
-    this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
+    const configuredExecutionPools = config.executionPoolsProvider ?? (() => ({}));
+    this.getExecutionPools = () => ({
+      [BUILT_IN_LOCAL_EXECUTION_POOL_ID]: {
+        members: [{ type: 'worktree', id: BUILT_IN_LOCAL_EXECUTION_POOL_ID }],
+      },
+      ...configuredExecutionPools(),
+    });
     this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -35,6 +35,8 @@ export interface TaskFreshnessSpec {
   readonly guardedBehaviorIds?: readonly string[];
 }
 
+export const BUILT_IN_LOCAL_EXECUTION_POOL_ID = 'local-worktree';
+
 export interface BaseTaskConfig {
   readonly workflowId?: string;
   readonly parentTask?: string;


### PR DESCRIPTION
## Summary

`TaskRunner` used to know only the execution pools and worktree targets its host handed it. A host that passed none had no local pool at all.

The runner now always includes the built-in `local-worktree` pool with one worktree member, plus a matching worktree target. Host-provided entries still win when they use the same id.

## Review Claim

Approve that every `TaskRunner` can route a task to the built-in local pool even when the host configures no pools.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Configured pools and worktree targets are spread after the built-in entry, so an explicit host definition of `local-worktree` still overrides it. No other pool id is added or altered.

## Slice Rationale

The persisted-invariant slice makes every ordinary task carry a pool id. The runner must be able to resolve the built-in one before that lands, so this small routing default goes first.

## Non-goals

No pool selection strategy changes. No merge gate changes. No changes to how the app builds its pool config.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/execution-engine test -- task-runner`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing-default change in TaskRunner config wiring; host overrides preserve existing pool definitions and no auth or persistence logic is touched.
> 
> **Overview**
> **TaskRunner** no longer relies on the host to supply execution pools and worktree targets for local work. When `worktreeTargetsProvider` or `executionPoolsProvider` are missing or empty, the runner still advertises the built-in **`local-worktree`** pool (`BUILT_IN_LOCAL_EXECUTION_POOL_ID`) with a single worktree member and a matching worktree target entry.
> 
> Host-provided maps are merged **after** these defaults, so an explicit `local-worktree` entry from config still overrides the built-in definition. Pool selection strategy and merge-gate behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f103b021ce47bb87d962f2ad61c5d72a6e6b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Depends-On: #11725