### PR TITLE
Task filter (3) expose it on headless query, invoker-cli, and the api

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -405,6 +405,22 @@ describe('GET /api/search task filters', () => {
     expect(mocks.persistence.searchWorkflowsAndTasks).toHaveBeenCalledWith('test', { type: 'tasks', limit: 20, offset: 0 });
     expect(mocks.persistence.queryTasksByFilter).not.toHaveBeenCalled();
   });
+
+  it('rejects a non-numeric limit before reading tasks', async () => {
+    const filter = encodeURIComponent(JSON.stringify({ op: 'eq', key: 'status', value: 'running' }));
+    const res = await request(port, 'GET', `/api/search?type=tasks&filter=${filter}&limit=abc`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('limit');
+    expect(mocks.persistence.queryTasksByFilter).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric offset before reading tasks', async () => {
+    const filter = encodeURIComponent(JSON.stringify({ op: 'eq', key: 'status', value: 'running' }));
+    const res = await request(port, 'GET', `/api/search?type=tasks&filter=${filter}&offset=abc`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('offset');
+    expect(mocks.persistence.queryTasksByFilter).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/workflows/:id/review-gate', () => {

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -137,6 +137,7 @@ function createMocks() {
       logEvent: vi.fn(),
       getEvents: vi.fn(() => [{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]),
       getTaskOutput: vi.fn(() => 'hello world output'),
+      queryTasksByFilter: vi.fn(() => [makeTask()]),
     },
     executorRegistry: {},
     commandService: {
@@ -377,6 +378,32 @@ describe('GET /api/workflows', () => {
     expect(res.body).toHaveLength(1);
     expect(res.body[0].id).toBe('wf-1');
     expect(mocks.persistence.listWorkflows).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/search task filters', () => {
+  it('returns filtered task summaries with pagination', async () => {
+    const filter = encodeURIComponent(JSON.stringify({ op: 'eq', key: 'status', value: 'running' }));
+    const res = await request(port, 'GET', `/api/search?type=tasks&filter=${filter}&limit=7&offset=2`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([expect.objectContaining({ kind: 'task', id: 'task-1', title: 'test task' })]);
+    expect(mocks.persistence.queryTasksByFilter).toHaveBeenCalledWith({ op: 'eq', key: 'status', value: 'running' }, { limit: 7, offset: 2 });
+  });
+
+  it('rejects an invalid filter before reading tasks', async () => {
+    const filter = encodeURIComponent(JSON.stringify({ op: 'eq', key: 'nope', value: 'x' }));
+    const res = await request(port, 'GET', `/api/search?type=tasks&filter=${filter}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('filter');
+    expect(mocks.persistence.queryTasksByFilter).not.toHaveBeenCalled();
+  });
+
+  it('keeps plain q search on the existing path', async () => {
+    mocks.persistence.searchWorkflowsAndTasks = vi.fn(() => []);
+    const res = await request(port, 'GET', '/api/search?type=tasks&q=test');
+    expect(res.status).toBe(200);
+    expect(mocks.persistence.searchWorkflowsAndTasks).toHaveBeenCalledWith('test', { type: 'tasks', limit: 20, offset: 0 });
+    expect(mocks.persistence.queryTasksByFilter).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { WorkerActionRecord } from '@invoker/data-store';
 import {
   runReadOnlyHeadlessQueryToString,
@@ -199,6 +199,42 @@ function makeTaskQueryDeps(overrides: {
     resetUiPerfStats: () => {},
   };
 }
+
+describe('headless query task filters', () => {
+  it('validates and delegates a filter while composing legacy task flags', async () => {
+    const task = {
+      id: 'wf-1/task-1', description: 'filtered task', status: 'failed', dependencies: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'), config: { workflowId: 'wf-1', isMergeNode: false },
+      execution: {}, taskStateVersion: 1,
+    } as any;
+    const queryTasksByFilter = vi.fn(() => [task]);
+    const deps = {
+      ...makeTaskQueryDeps({}),
+      persistence: { queryTasksByFilter } as any,
+      orchestrator: { getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 1, running: 0, pending: 0 }) } as any,
+    };
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'tasks', '--filter', JSON.stringify({ op: 'eq', key: 'description', value: 'filtered task' }), '--workflow', 'wf-1', '--status', 'failed', '--no-merge', '--output', 'json'],
+      deps,
+    );
+    expect(JSON.parse(output)).toEqual([expect.objectContaining({ id: task.id })]);
+    expect(queryTasksByFilter).toHaveBeenCalledWith({ op: 'and', filters: [
+      { op: 'eq', key: 'description', value: 'filtered task' },
+      { op: 'eq', key: 'workflow_id', value: 'wf-1' },
+      { op: 'eq', key: 'status', value: 'failed' },
+      { op: 'eq', key: 'is_merge_node', value: false },
+    ] });
+  });
+
+  it('rejects an invalid filter before reading persistence', async () => {
+    const queryTasksByFilter = vi.fn();
+    const deps = { ...makeTaskQueryDeps({}), persistence: { queryTasksByFilter } as any };
+    await expect(runReadOnlyHeadlessQueryToString(
+      ['query', 'tasks', '--filter', JSON.stringify({ op: 'eq', key: 'not_a_column', value: 'x' })], deps,
+    )).rejects.toThrow('taskFilter.key');
+    expect(queryTasksByFilter).not.toHaveBeenCalled();
+  });
+});
 
 describe('headless query task-output', () => {
   it('prints the task output for a short task id', async () => {

--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -223,7 +223,55 @@ describe('headless query task filters', () => {
       { op: 'eq', key: 'workflow_id', value: 'wf-1' },
       { op: 'eq', key: 'status', value: 'failed' },
       { op: 'eq', key: 'is_merge_node', value: false },
-    ] });
+    ] }, { limit: 500, offset: 0 });
+  });
+
+  it('prefers the positional workflow id over the flag default when composing a filter', async () => {
+    const task = {
+      id: 'wf-1/task-1', description: 'filtered task', status: 'failed', dependencies: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'), config: { workflowId: 'wf-1', isMergeNode: false },
+      execution: {}, taskStateVersion: 1,
+    } as any;
+    const queryTasksByFilter = vi.fn(() => [task]);
+    const deps = {
+      ...makeTaskQueryDeps({}),
+      persistence: { queryTasksByFilter } as any,
+      orchestrator: { getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 1, running: 0, pending: 0 }) } as any,
+    };
+    await runReadOnlyHeadlessQueryToString(
+      ['query', 'tasks', 'wf-1', '--filter', JSON.stringify({ op: 'eq', key: 'description', value: 'filtered task' })],
+      deps,
+    );
+    expect(queryTasksByFilter).toHaveBeenCalledWith({ op: 'and', filters: [
+      { op: 'eq', key: 'description', value: 'filtered task' },
+      { op: 'eq', key: 'workflow_id', value: 'wf-1' },
+    ] }, { limit: 500, offset: 0 });
+  });
+
+  it('pages through filtered results past the persistence default page size', async () => {
+    const makeTask = (id: string) => ({
+      id: `wf-1/${id}`, description: id, status: 'failed', dependencies: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'), config: { workflowId: 'wf-1', isMergeNode: false },
+      execution: {}, taskStateVersion: 1,
+    } as any);
+    const firstPage = Array.from({ length: 500 }, (_, i) => makeTask(`task-${i}`));
+    const secondPage = [makeTask('task-500')];
+    const queryTasksByFilter = vi.fn()
+      .mockReturnValueOnce(firstPage)
+      .mockReturnValueOnce(secondPage);
+    const deps = {
+      ...makeTaskQueryDeps({}),
+      persistence: { queryTasksByFilter } as any,
+      orchestrator: { getWorkflowStatus: () => ({ total: 501, completed: 0, failed: 501, running: 0, pending: 0 }) } as any,
+    };
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'tasks', '--filter', JSON.stringify({ op: 'eq', key: 'status', value: 'failed' }), '--output', 'json'],
+      deps,
+    );
+    expect(JSON.parse(output)).toHaveLength(501);
+    expect(queryTasksByFilter).toHaveBeenCalledTimes(2);
+    expect(queryTasksByFilter).toHaveBeenNthCalledWith(1, { op: 'eq', key: 'status', value: 'failed' }, { limit: 500, offset: 0 });
+    expect(queryTasksByFilter).toHaveBeenNthCalledWith(2, { op: 'eq', key: 'status', value: 'failed' }, { limit: 500, offset: 500 });
   });
 
   it('rejects an invalid filter before reading persistence', async () => {
@@ -232,6 +280,15 @@ describe('headless query task filters', () => {
     await expect(runReadOnlyHeadlessQueryToString(
       ['query', 'tasks', '--filter', JSON.stringify({ op: 'eq', key: 'not_a_column', value: 'x' })], deps,
     )).rejects.toThrow('taskFilter.key');
+    expect(queryTasksByFilter).not.toHaveBeenCalled();
+  });
+
+  it('rejects --filter on a non-task query subcommand', async () => {
+    const queryTasksByFilter = vi.fn();
+    const deps = { ...makeTaskQueryDeps({}), persistence: { queryTasksByFilter } as any };
+    await expect(runReadOnlyHeadlessQueryToString(
+      ['query', 'workflows', '--filter', JSON.stringify({ op: 'eq', key: 'status', value: 'x' })], deps,
+    )).rejects.toThrow('--filter is only supported for `query tasks`');
     expect(queryTasksByFilter).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -44,7 +44,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { Logger } from '@invoker/contracts';
-import { resolveInvokerInstanceProfile } from '@invoker/contracts';
+import { resolveInvokerInstanceProfile, validateTaskFilter, type TaskFilterNode } from '@invoker/contracts';
 import {
   OrchestratorError,
   OrchestratorErrorCode,
@@ -435,6 +435,37 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const type = query.type === 'workflows' || query.type === 'tasks' ? query.type : 'all';
         const limit = query.limit ? Math.min(parseInt(query.limit, 10), 50) : 20;
         const offset = query.offset ? parseInt(query.offset, 10) : 0;
+        if (type === 'tasks' && query.filter !== undefined) {
+          let parsedFilter: unknown;
+          try {
+            parsedFilter = JSON.parse(query.filter);
+          } catch (error) {
+            json(res, 400, { error: `filter: invalid JSON (${error instanceof Error ? error.message : String(error)})` });
+            return;
+          }
+          const validation = validateTaskFilter(parsedFilter);
+          if (!validation.valid) {
+            json(res, 400, { error: `filter: ${validation.error}` });
+            return;
+          }
+          const tasks = persistence.queryTasksByFilter(parsedFilter as TaskFilterNode, { limit, offset });
+          const results = tasks.map((task) => {
+            const workflowId = task.config.workflowId;
+            const workflow = workflowId ? persistence.loadWorkflow(workflowId) : undefined;
+            const workflowName = workflow?.name || 'Unnamed workflow';
+            return {
+              kind: 'task' as const,
+              id: task.id,
+              workflowId: workflowId || undefined,
+              title: task.description || 'Unnamed task',
+              subtitle: `Task · ${workflowName}`,
+              status: task.status,
+              createdAt: task.createdAt instanceof Date ? task.createdAt.toISOString() : task.createdAt,
+            };
+          });
+          json(res, 200, results);
+          return;
+        }
         const results = persistence.searchWorkflowsAndTasks(q, { type, limit, offset });
         json(res, 200, results);
         return;

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -436,6 +436,10 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const limit = query.limit ? Math.min(parseInt(query.limit, 10), 50) : 20;
         const offset = query.offset ? parseInt(query.offset, 10) : 0;
         if (type === 'tasks' && query.filter !== undefined) {
+          if (!Number.isFinite(limit) || limit < 0 || !Number.isFinite(offset) || offset < 0) {
+            json(res, 400, { error: 'limit and offset must be non-negative integers' });
+            return;
+          }
           let parsedFilter: unknown;
           try {
             parsedFilter = JSON.parse(query.filter);

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -17,6 +17,8 @@ import {
   type NormalizedCostEvent,
   type WorkerActionSummary,
   type WorkerStatusSnapshot,
+  type TaskFilterNode,
+  validateTaskFilter,
 } from '@invoker/contracts';
 import { AUTO_FIX_WORKER_KIND, createWorkerRegistry, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import type { CostAttributionAttempt, WorkerActionRecord } from '@invoker/data-store';
@@ -139,6 +141,40 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
     }
     case 'tasks': {
       const { orchestrator, persistence } = deps;
+      let filteredTasks: TaskState[] | undefined;
+      if (flags.filter !== undefined) {
+        let parsedFilter: unknown;
+        try {
+          parsedFilter = JSON.parse(flags.filter);
+        } catch (error) {
+          throw new Error(`Invalid --filter JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        const validation = validateTaskFilter(parsedFilter);
+        if (!validation.valid) throw new Error(validation.error);
+        const filters: TaskFilterNode[] = [parsedFilter as TaskFilterNode];
+        if (flags.workflow) filters.push({ op: 'eq', key: 'workflow_id', value: flags.workflow });
+        if (flags.status) filters.push({ op: 'eq', key: 'status', value: flags.status });
+        if (flags.noMerge) filters.push({ op: 'eq', key: 'is_merge_node', value: false });
+        const filter: TaskFilterNode = filters.length === 1 ? filters[0] : { op: 'and', filters };
+        filteredTasks = persistence.queryTasksByFilter(filter);
+      }
+
+      if (filteredTasks) {
+        const allTasks = filteredTasks;
+        switch (flags.output) {
+          case 'label': writeOut(formatAsLabel(allTasks) + '\n'); break;
+          case 'json':  writeOut(formatAsJson(allTasks.map(serializeTask)) + '\n'); break;
+          case 'jsonl': writeOut(formatAsJsonl(allTasks.map(serializeTask)) + '\n'); break;
+          default: {
+            for (const task of allTasks) writeOut(formatTaskStatus(task) + '\n');
+            const status = orchestrator.getWorkflowStatus();
+            writeOut(`\n${formatWorkflowStatus(status)}\n`);
+            break;
+          }
+        }
+        break;
+      }
+
       const workflows = persistence.listWorkflows();
       if (workflows.length === 0) {
         writeOut('No workflows found. Run a plan first.\n');

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -78,6 +78,23 @@ function hasStringProp(value: unknown, key: string): boolean {
   return Boolean(value && typeof value === 'object' && typeof (value as Record<string, unknown>)[key] === 'string');
 }
 
+const TASK_FILTER_PAGE_SIZE = 500;
+
+function queryAllTasksByFilter(
+  persistence: Pick<HeadlessQueryDeps['persistence'], 'queryTasksByFilter'>,
+  filter: TaskFilterNode,
+): TaskState[] {
+  const all: TaskState[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = persistence.queryTasksByFilter(filter, { limit: TASK_FILTER_PAGE_SIZE, offset });
+    all.push(...page);
+    if (page.length < TASK_FILTER_PAGE_SIZE) break;
+    offset += TASK_FILTER_PAGE_SIZE;
+  }
+  return all;
+}
+
 function isAlertWorkerAction(action: WorkerActionRecord): boolean {
   const searchable = [
     action.actionType,
@@ -104,6 +121,9 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
     throw new Error(`Missing query sub-command. Usage: --headless query <${QUERY_SUBCOMMAND_USAGE}>`);
   }
   const flags = parseQueryFlags(args.slice(1));
+  if (flags.filter !== undefined && subCommand !== 'tasks') {
+    throw new Error('--filter is only supported for `query tasks`');
+  }
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
@@ -152,11 +172,12 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         const validation = validateTaskFilter(parsedFilter);
         if (!validation.valid) throw new Error(validation.error);
         const filters: TaskFilterNode[] = [parsedFilter as TaskFilterNode];
-        if (flags.workflow) filters.push({ op: 'eq', key: 'workflow_id', value: flags.workflow });
+        const workflowFilterId = flags.workflow ?? flags.positional[0];
+        if (workflowFilterId) filters.push({ op: 'eq', key: 'workflow_id', value: workflowFilterId });
         if (flags.status) filters.push({ op: 'eq', key: 'status', value: flags.status });
         if (flags.noMerge) filters.push({ op: 'eq', key: 'is_merge_node', value: false });
         const filter: TaskFilterNode = filters.length === 1 ? filters[0] : { op: 'and', filters };
-        filteredTasks = persistence.queryTasksByFilter(filter);
+        filteredTasks = queryAllTasksByFilter(persistence, filter);
       }
 
       if (filteredTasks) {

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -262,6 +262,7 @@ export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): voi
 
 export interface QueryFlags {
   output: 'text' | 'label' | 'json' | 'jsonl';
+  filter?: string;
   status?: string;
   workflow?: string;
   noMerge?: boolean;
@@ -286,6 +287,10 @@ export function parseQueryFlags(args: string[]): QueryFlags {
       i += 2;
     } else if (arg === '--status' && i + 1 < args.length) {
       flags.status = args[i + 1];
+      i += 2;
+    } else if (arg === '--filter') {
+      if (i + 1 >= args.length) throw new Error('Missing value for --filter');
+      flags.filter = args[i + 1];
       i += 2;
     } else if (arg === '--workflow' && i + 1 < args.length) {
       flags.workflow = args[i + 1];

--- a/packages/cli/src/__tests__/cli-query.test.ts
+++ b/packages/cli/src/__tests__/cli-query.test.ts
@@ -117,6 +117,28 @@ describe('invoker-cli query', () => {
     output.restore();
   });
 
+  it('forwards --filter to a live owner', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const filter = JSON.stringify({ op: 'eq', key: 'status', value: 'failed' });
+    const queryHandler = vi.fn(async (request: unknown) => {
+      expect(request).toEqual({ kind: 'cli-query', args: ['query', 'tasks', '--filter', filter] });
+      return { output: '[]\n' };
+    });
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', queryHandler);
+    expect(await main(['query', 'tasks', '--filter', filter], { createMessageBus: () => bus })).toBe(0);
+    expect(queryHandler).toHaveBeenCalledTimes(1);
+    output.restore();
+  });
+
+  it('rejects a bare --filter', async () => {
+    const output = captureProcessOutput();
+    expect(await main(['query', 'tasks', '--filter'], { createMessageBus: () => new LocalBus() })).toBe(1);
+    expect(output.stderr).toContain('Missing value for --filter');
+    output.restore();
+  });
+
   it('uses INVOKER_DB_DIR for standalone read-only workflow queries', async () => {
     const dbDir = makeTempDir('invoker-cli-query-env-');
     await seedDb(dbDir);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -488,6 +488,23 @@ function renderWorkflowText(workflows: Workflow[]): string {
   )).join('\n')}\n`;
 }
 
+const TASK_FILTER_PAGE_SIZE = 500;
+
+function queryAllTasksByFilter(
+  persistence: Pick<SQLiteAdapter, 'queryTasksByFilter'>,
+  filter: import('@invoker/contracts').TaskFilterNode,
+): TaskState[] {
+  const all: TaskState[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = persistence.queryTasksByFilter(filter, { limit: TASK_FILTER_PAGE_SIZE, offset });
+    all.push(...page);
+    if (page.length < TASK_FILTER_PAGE_SIZE) break;
+    offset += TASK_FILTER_PAGE_SIZE;
+  }
+  return all;
+}
+
 function renderTaskText(tasks: TaskState[]): string {
   if (tasks.length === 0) return 'No tasks found.\n';
   return `${tasks.map((task) => (
@@ -532,7 +549,7 @@ async function queryStandaloneDatabase(options: QueryOptions): Promise<string> {
 
     let tasks = snapshot.tasks;
     if (parsedFilter) {
-      tasks = persistence.queryTasksByFilter(parsedFilter);
+      tasks = queryAllTasksByFilter(persistence, parsedFilter);
     }
     if (options.workflowId) {
       tasks = tasks.filter((task) => task.config.workflowId === options.workflowId);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import {
   resolveHeadlessOwnerLaunchSpec,
   resolveInvokerHomeRoot,
   resolveRepoRoot,
+  validateTaskFilter,
   updateInvokerConfigFile,
   type HeadlessOwnerLaunchSpec,
   type Logger,
@@ -158,6 +159,7 @@ type QueryOptions = {
   resource: QueryResource;
   workflowId?: string;
   status?: string;
+  filter?: string;
   output: QueryOutput;
   forwardedFlags: string[];
 };
@@ -315,6 +317,12 @@ function parseQueryArgs(argv: string[]): QueryOptions {
       const value = argv[++i];
       if (!value) throw new Error('Missing value for --status');
       options.status = value;
+      options.forwardedFlags.push(arg, value);
+    } else if (arg === '--filter') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --filter');
+      if (resource !== 'tasks') throw new Error('--filter is only supported for `query tasks`');
+      options.filter = value;
       options.forwardedFlags.push(arg, value);
     } else if (arg === '--output') {
       const value = argv[++i];
@@ -488,6 +496,18 @@ function renderTaskText(tasks: TaskState[]): string {
 }
 
 async function queryStandaloneDatabase(options: QueryOptions): Promise<string> {
+  let parsedFilter: import('@invoker/contracts').TaskFilterNode | undefined;
+  if (options.filter !== undefined) {
+    let rawFilter: unknown;
+    try {
+      rawFilter = JSON.parse(options.filter);
+    } catch (error) {
+      throw new Error(`Invalid --filter JSON: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    const validation = validateTaskFilter(rawFilter);
+    if (!validation.valid) throw new Error(validation.error);
+    parsedFilter = rawFilter as import('@invoker/contracts').TaskFilterNode;
+  }
   const dbDir = resolveQueryDbDir();
   const dbPath = join(dbDir, 'invoker.db');
   if (!existsSync(dbPath)) {
@@ -511,6 +531,9 @@ async function queryStandaloneDatabase(options: QueryOptions): Promise<string> {
     }
 
     let tasks = snapshot.tasks;
+    if (parsedFilter) {
+      tasks = persistence.queryTasksByFilter(parsedFilter);
+    }
     if (options.workflowId) {
       tasks = tasks.filter((task) => task.config.workflowId === options.workflowId);
     }


### PR DESCRIPTION
## Summary

Add one JSON filter surface across headless task queries, invoker-cli, and the task API search endpoint.

Requests without a filter retain their existing behavior, while filtered reads delegate to the persistence query path.

## Review Claim

The three read surfaces check task-filter trees before reading, delegate accepted filters to `queryTasksByFilter`, and preserve unfiltered behavior.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Absent the new flag or parameter, each path remains unchanged; invalid input fails before database access with cli exit 1 or HTTP 400.

## Slice Rationale

This activates one persistence-backed capability across its three entry points, keeping the filter definition and SQL read path in earlier slices.

## Non-goals

No UI search box change, workflow-level filter, documentation update, or change to the existing `q` substring path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test --run src/__tests__/headless-query-list.test.ts src/__tests__/api-server.test.ts`
- [ ] `pnpm --filter @invoker/cli test --run src/__tests__/cli.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only query additions with validation before DB access; existing unfiltered search and task listing paths are preserved.
> 
> **Overview**
> Adds a shared **JSON task filter** surface on three read paths, all wired through `validateTaskFilter` and `persistence.queryTasksByFilter`. Unfiltered behavior is unchanged.
> 
> **HTTP:** `GET /api/search?type=tasks&filter=<json>` validates the filter and `limit`/`offset`, then returns paginated task search summaries. Invalid JSON, schema, or pagination returns **400** without calling persistence. Requests that still use `q` keep the existing `searchWorkflowsAndTasks` path.
> 
> **Headless:** `query tasks` accepts `--filter` (JSON only on this subcommand). The filter is AND-composed with existing `--workflow` / positional workflow id, `--status`, and `--no-merge`. Results are loaded in **500-row pages** until exhausted. Invalid filters error before any DB read.
> 
> **CLI:** `invoker-cli query tasks --filter …` parses and restricts the flag to task queries, forwards it to a live owner when present, and uses the same paged `queryTasksByFilter` path for standalone read-only DB access (legacy `--workflow` / `--status` still apply after the filter when no `--filter`).
> 
> Tests cover happy paths, validation gates, pagination, and delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6082aea02cd4f363aee056e11d78dd5d0409cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->