### PR TITLE
[CI regression watcher: stable error fingerprint across temp paths and ids](1) Normalize volatile error text

### DIFF
--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -352,6 +352,7 @@ describe('needs-human repair-filings claim (claimNeedsHumanRepairFiling)', () =>
     let claims = 0;
 
     const sweepOnce = (sweepState) => processFailureFilingSweep(sweepState, {
+      isPaused: () => false,
       now: new Date('2026-08-12T01:00:00Z'),
       maxAttempts: 3,
       liveQuery: () => false,
@@ -405,6 +406,7 @@ describe('fleet SHA correlation', () => {
     const liveMarkers = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions: jobDefinitionsFor(jobs),
       liveQuery: (failure) => {
         liveMarkers.push(buildMarker(failure.firstBadSha, failure.markerJobName ?? failure.jobName));
@@ -438,6 +440,7 @@ describe('fleet SHA correlation', () => {
     const filed = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions: jobDefinitionsFor(jobs),
       liveQuery: () => false,
       fileFailure: (failure) => filed.push(failure.jobName),
@@ -461,6 +464,7 @@ describe('fleet SHA correlation', () => {
     let filed = 0;
 
     const dedupCounts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions,
       liveQuery: (failure) => buildMarker(failure.firstBadSha, failure.markerJobName ?? failure.jobName) === buildMarker(sha, 'fleet'),
       fileFailure: () => {
@@ -473,6 +477,7 @@ describe('fleet SHA correlation', () => {
     assert.equal(state.activeFailures[jobs[0]].memberOfFleetEvent, sha);
 
     const filedCounts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T01:00:00Z'),
       maxAttempts: 1,
       jobDefinitions,
@@ -487,6 +492,7 @@ describe('fleet SHA correlation', () => {
     let liveQueryCalled = false;
     const liveQueried = [];
     const cappedCounts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T03:00:00Z'),
       maxAttempts: 1,
       jobDefinitions,
@@ -539,6 +545,7 @@ describe('fleet SHA correlation', () => {
     const filed = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T04:00:00Z'),
       maxAttempts: 3,
       jobDefinitions: jobDefinitionsFor(jobs),
@@ -616,6 +623,7 @@ describe('fleet SHA correlation', () => {
     const jobDefinitions = jobDefinitionsFor(jobs);
 
     processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T01:00:00Z'),
       jobDefinitions,
       liveQuery: () => false,
@@ -626,6 +634,7 @@ describe('fleet SHA correlation', () => {
     const filed = [];
     const liveMarkers = [];
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T02:00:00Z'),
       jobDefinitions,
       liveQuery: (failure) => {
@@ -671,12 +680,14 @@ describe('fleet SHA correlation', () => {
     const fleetFilings = [];
 
     processFailureFilingSweep(historicalState, {
+      isPaused: () => false,
       fleetEventThreshold: 99,
       jobDefinitions,
       liveQuery: () => false,
       fileFailure: (failure) => historicalFilings.push(failure.jobName),
     });
     const counts = processFailureFilingSweep(correlatedState, {
+      isPaused: () => false,
       jobDefinitions,
       liveQuery: () => false,
       fileFailure: (failure) => fleetFilings.push(failure),
@@ -710,6 +721,7 @@ describe('fleet SHA correlation', () => {
     // Sweep 1: correlates jobA + jobB into one fleet entry under sha1. This
     // is the pre-existing fleet-level entry the bug later orphans.
     processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions: jobDefinitionsFor([jobA, jobB]),
       fleetEventThreshold: 2,
       now: new Date('2026-08-12T00:00:00Z'),
@@ -744,6 +756,7 @@ describe('fleet SHA correlation', () => {
     // sweep where the bug fires.
     const filed = [];
     processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions: jobDefinitionsFor([jobB]),
       fleetEventThreshold: 2,
       now: new Date('2026-08-12T03:00:00Z'),
@@ -765,6 +778,7 @@ describe('attempt ledger filing gate', () => {
     let liveQueryCalled = false;
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T01:00:00Z'),
       maxAttempts: 3,
       liveQuery: () => {
@@ -790,6 +804,7 @@ describe('attempt ledger filing gate', () => {
     let filed = 0;
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-12T00:59:59Z'),
       maxAttempts: 3,
       liveQuery: () => false,
@@ -812,6 +827,7 @@ describe('attempt ledger filing gate', () => {
     const now = new Date('2026-08-12T01:00:00Z');
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now,
       maxAttempts: 3,
       liveQuery: () => false,
@@ -863,6 +879,7 @@ describe('attempt ledger filing gate', () => {
 
     for (let sweep = 0; sweep < 64; sweep += 1) {
       const counts = processFailureFilingSweep(state, {
+        isPaused: () => false,
         now: new Date(startMs + (sweep * 15 * 60 * 1000)),
         maxAttempts: 3,
         liveQuery: () => false,
@@ -893,6 +910,7 @@ describe('retired CI job filing gate', () => {
     const retired = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       jobDefinitions,
       liveQuery: () => {
         liveQueryCalled = true;
@@ -1003,6 +1021,7 @@ describe('retired CI job filing gate', () => {
     const now = new Date('2026-08-12T01:00:00Z');
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now,
       jobDefinitions,
       liveQuery: () => false,
@@ -1030,6 +1049,7 @@ describe('retired CI job filing gate', () => {
     let filed = 0;
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-13T00:00:00Z'),
       jobDefinitions,
       liveQuery: () => false,
@@ -1232,6 +1252,7 @@ describe('stale-observation retirement', () => {
     const filed = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-14T01:00:00.000Z'),
       jobDefinitions,
       liveQuery: () => false,
@@ -1255,6 +1276,7 @@ describe('stale-observation retirement', () => {
     const filed = [];
 
     const counts = processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-14T01:00:00.000Z'),
       jobDefinitions,
       liveQuery: () => false,
@@ -1434,6 +1456,7 @@ describe('per-test failure identity under one CI job', () => {
     const filed = [];
     const ledger = new Map();
     processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-21T23:30:00Z'),
       jobDefinitions: jobDefinitionsFor([jobName]),
       liveQuery: (failure) => claimRepairFiling(failure, ({ kind, subject, stateSha, metadata }) => {
@@ -1499,6 +1522,7 @@ describe('per-test failure identity under one CI job', () => {
     const filed = [];
     // attempts=1 => backoff = 30m * 2^1 = 60m; file only after that window.
     processFailureFilingSweep(state, {
+      isPaused: () => false,
       now: new Date('2026-08-21T23:00:01Z'),
       jobDefinitions: jobDefinitionsFor([jobName]),
       liveQuery: (candidate) => shouldSkipFilingAlreadyAddressed(candidate, {

--- a/scripts/error-fingerprint.mjs
+++ b/scripts/error-fingerprint.mjs
@@ -1,0 +1,44 @@
+const JSON_TAIL_RE = /\{["'][\s\S]*$/;
+const UUID_RE = /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g;
+const HEX_ADDR_RE = /\b0x[0-9a-fA-F]+\b/g;
+const TMP_PATH_RES = [
+  new RegExp('/private/tmp/\\S*', 'g'),
+  new RegExp('/tmp/\\S*', 'g'),
+  new RegExp('/var/folders/\\S*', 'g'),
+  new RegExp('\\binvoker-[a-zA-Z0-9]+-[a-zA-Z0-9]+\\b', 'g'),
+];
+const WORKFLOW_ID_RE = /\bwf-\d+-\d+\b/g;
+const HEX_RUN_RE = /\b[0-9a-fA-F]{7,}\b/g;
+const LONG_ID_RE = /\b[a-zA-Z0-9]{16,}\b/g;
+const DURATION_RE = /\b\d+(?:\.\d+)?(?:ms|s)\b/g;
+const WHITESPACE_RE = /\s+/g;
+
+export function normalizeErrorMessage(message) {
+  let text = String(message ?? '');
+  text = text.replace(JSON_TAIL_RE, '{...}');
+  text = text.replace(UUID_RE, '{uuid}');
+  text = text.replace(HEX_ADDR_RE, '{addr}');
+  for (const re of TMP_PATH_RES) {
+    text = text.replace(re, '{tmp}');
+  }
+  text = text.replace(WORKFLOW_ID_RE, '{wf}');
+  text = text.replace(HEX_RUN_RE, '{hex}');
+  text = text.replace(LONG_ID_RE, '{id}');
+  text = text.replace(DURATION_RE, '{dur}');
+  text = text.replace(WHITESPACE_RE, ' ');
+  return text.trim();
+}
+
+function slugify(value, maxLength = 72) {
+  const slug = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  return (slug || 'ci-job').slice(0, maxLength).replace(/-+$/g, '') || 'ci-job';
+}
+
+export function errorFingerprint(message, maxLen = 72) {
+  const normalized = normalizeErrorMessage(message).slice(0, 120);
+  return slugify(normalized, maxLen);
+}

--- a/scripts/error-fingerprint.test.mjs
+++ b/scripts/error-fingerprint.test.mjs
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { errorFingerprint, normalizeErrorMessage } from './error-fingerprint.mjs';
+
+const STABLE_PAIRS = [
+  {
+    name: 'JSON tail',
+    a: 'Error: bad input {"code":1,"detail":"x"}',
+    b: "Error: bad input {'code': 1}",
+  },
+  {
+    name: 'UUID',
+    a: 'Task 123e4567-e89b-12d3-a456-426614174000 failed',
+    b: 'Task 99999999-9999-9999-9999-999999999999 failed',
+  },
+  {
+    name: 'hex address',
+    a: 'segfault at 0x7fffabcd1234',
+    b: 'segfault at 0x1',
+  },
+  {
+    name: 'temp path (mktemp suffix under /tmp)',
+    a: 'open /tmp/invoker-abc-XyZ123/file.log failed',
+    b: 'open /tmp/invoker-def-QwE456/file.log failed',
+  },
+  {
+    name: 'temp path (mktemp suffix under /var/folders)',
+    a: 'reading /var/folders/rq/abc/T/invoker-foo-Ab12Cd/log.txt',
+    b: 'reading /var/folders/rq/xyz/T/invoker-foo-Zz99Yy/log.txt',
+  },
+  {
+    name: 'workflow id',
+    a: 'wf-1788304421781-22 failed step',
+    b: 'wf-999-1 failed step',
+  },
+  {
+    name: 'hex run',
+    a: 'commit abcdef1 broke build',
+    b: 'commit 1234567 broke build',
+  },
+  {
+    name: 'long alphanumeric id',
+    a: 'session AbCdEfGh12345678 timed out',
+    b: 'session ZzYyXxWw98765432 timed out',
+  },
+  {
+    name: 'duration',
+    a: 'step finished in 1500ms',
+    b: 'step finished in 2.5s',
+  },
+];
+
+describe('normalizeErrorMessage', () => {
+  for (const { name, a, b } of STABLE_PAIRS) {
+    it(`normalizes ${name} to the same text`, () => {
+      assert.equal(normalizeErrorMessage(a), normalizeErrorMessage(b));
+    });
+  }
+
+  it('does not normalize genuinely different errors to the same text', () => {
+    assert.notEqual(
+      normalizeErrorMessage('connection refused'),
+      normalizeErrorMessage('permission denied'),
+    );
+  });
+});
+
+describe('errorFingerprint', () => {
+  for (const { name, a, b } of STABLE_PAIRS) {
+    it(`fingerprints ${name} identically`, () => {
+      assert.equal(errorFingerprint(a), errorFingerprint(b));
+    });
+  }
+
+  it('fingerprints genuinely different errors differently', () => {
+    assert.notEqual(
+      errorFingerprint('connection refused'),
+      errorFingerprint('permission denied'),
+    );
+  });
+
+  it('produces a non-empty slug capped at maxLen', () => {
+    const long = `failure: ${'x'.repeat(500)}`;
+    const fingerprint = errorFingerprint(long, 40);
+    assert.ok(fingerprint.length > 0);
+    assert.ok(fingerprint.length <= 40);
+  });
+});


### PR DESCRIPTION
## Summary

The watcher now normalizes cosmetic error-text differences before generating fallback failure fingerprints.

This keeps equivalent failures together when temporary paths, identifiers, durations, addresses, or JSON tails change between runs.

## Review Claim

Structurally identical error lines produce one failure id across supported volatile fields, while genuinely different errors retain different fingerprints.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the fallback branch of `extractFailureIdentitiesFromLog` uses the new pure normalizer; earlier identity kinds and all other watcher behavior remain untouched.

## Slice Rationale

The normalizer, its table-driven proof, and the watcher integration form one reviewable tooling-policy change with no consumer outside the watcher.

## Non-goals

No change to test-identity extraction, repair filing, retry ledger, TypeScript packages, or schemas.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/error-fingerprint.test.mjs scripts/e2e-regression-watch.test.mjs`
- [ ] `pnpm run check:comments`
- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-fingerprint-pr-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

