### PR TITLE
[Headless Delete Hang](1) Skip task tracking so the CLI client stops hanging

### DIFF
--- a/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
+++ b/packages/app/src/__tests__/headless-exec-ack-ok-precedence.test.ts
@@ -115,3 +115,23 @@ describe('executeHeadlessExec no-workflow acknowledgment', () => {
     });
   });
 });
+
+describe('executeHeadlessExec delete acknowledgment', () => {
+  it('acknowledges a workflow delete without a tasks array to track', async () => {
+    vi.mocked(runHeadless).mockResolvedValue(undefined);
+    const actions = createGuiMutationTaskActions(makeContext());
+
+    const result = await actions.executeHeadlessExec({ args: ['delete', 'wf-123'], noTrack: false } as never);
+
+    expect(result).toEqual({ ok: true, workflowId: 'wf-123' });
+  });
+
+  it('acknowledges a delete-workflow alias without a tasks array to track', async () => {
+    vi.mocked(runHeadless).mockResolvedValue(undefined);
+    const actions = createGuiMutationTaskActions(makeContext());
+
+    const result = await actions.executeHeadlessExec({ args: ['delete-workflow', 'wf-456'], noTrack: false } as never);
+
+    expect(result).toEqual({ ok: true, workflowId: 'wf-456' });
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -746,6 +746,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     return { workflowId, tasks };
   }
 
+  const HEADLESS_COMMANDS_WITHOUT_TASK_TRACKING = new Set(['delete', 'delete-workflow']);
+
   async function executeHeadlessExec(payload: HeadlessExecMutationPayload): Promise<unknown> {
     logger.info(`executeHeadlessExec begin args="${payload.args.join(' ')}" noTrack=${payload.noTrack ? 'true' : 'false'}`, {
       module: 'ipc-delegate',
@@ -802,10 +804,11 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {
       module: 'ipc-delegate',
     });
-    if (!workflowId) {
+    if (!workflowId || HEADLESS_COMMANDS_WITHOUT_TASK_TRACKING.has(headlessCommand)) {
       return {
         ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
         ok: true,
+        ...(workflowId ? { workflowId } : {}),
       };
     }
     orchestrator.syncFromDb(workflowId);


### PR DESCRIPTION
## Summary

Two `invoker-ui --headless` workflow-teardown commands never returned to the shell.

The owner's response to a delegated teardown looked identical to a `recreate` response: `{workflowId, tasks}`. The client saw that shape and waited for the workflow to reach a terminal state.

But the workflow was already gone by then. Nothing was left to reach a terminal state, so the client waited forever, leaking a process until something force-killed it.

This fix makes the two commands return a plain acknowledgment instead, so the client stops waiting. See Non-goals below for the exact command names.

## Review Claim

`executeHeadlessExec` returns `{ok: true, workflowId}` (no `tasks`) for the two workflow-teardown commands named in Non-goals, so the delegating client never enters its workflow-tracking wait for them.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every other headless mutation command (`recreate`, `retry`, `cancel-workflow`, etc.) is untouched — only `delete` and `delete-workflow` skip the `{workflowId, tasks}` shape, and only after the underlying delete already succeeded via the existing `runHeadless` call. No change to what gets deleted or how.

## Slice Rationale

One root cause, one fix, one regression test. Nothing else in this diff.

## Non-goals

The two fixed commands are `delete <workflowId>` and `delete-workflow <workflowId>`.

Does not address `delete-task`, which resolves a `workflowId` through the same classifier but targets a still-existing workflow, so it is not proven to hang the same way. Does not change the client-side `tryDelegate`/`trackWorkflow` logic, which is already correct — it only tracks when the response includes a `tasks` array.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/headless-exec-ack-ok-precedence.test.ts` — 5/5 passing
- [x] Reverted the fix locally and re-ran the same test: 2 new cases fail with `orchestrator.syncFromDb is not a function` (proves the test catches the regression)
- [x] End-to-end repro: built `dist/main.js`, created a scratch workflow, ran `electron dist/main.js --headless delete <id>` — before the fix: prints "Delegated to owner" then hangs past a 20s timeout (`exit 124`), reproduced twice; workflow deletion itself always succeeded instantly, only the client hung

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9c665314e3`
- Post-revert steps: None
- Data migration? No

</details>
