### PR TITLE
[Cascade-skip resurrection](1) Un-skip a fixed task's descendants on approve

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2099,6 +2099,8 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     mergeTrace('APPROVE_DONE', { taskId });
 
+    this.unskipDescendants(taskId);
+
     const workflowId = task.config.workflowId;
     if (workflowId) {
       const mergeNode = this.getMergeNode(workflowId);
@@ -2123,6 +2125,29 @@ export class Orchestrator {
     mergeTrace('APPROVE_STARTED', { taskId: task.id, startedIds: started.map(t => t.id), startedStatuses: started.map(t => t.status) });
     this.checkWorkflowCompletion(task.config.workflowId);
     return started;
+  }
+
+  private unskipDescendants(taskId: string): void {
+    const allTasks = this.stateMachine.getAllTasks();
+    const taskMap = new Map(allTasks.map((t) => [t.id, t]));
+    const descendantIds = getTransitiveDependents(
+      taskId,
+      taskMap,
+      (t) => t.status === 'completed' || t.status === 'stale' || t.config.isReconciliation === true,
+    );
+    for (const descendantId of descendantIds) {
+      const dependent = this.stateGetTask(descendantId);
+      if (!dependent || dependent.status !== 'skipped') continue;
+      const changes: TaskStateChanges = {
+        status: 'pending',
+        execution: { blockedBy: undefined },
+      };
+      const updated = this.writeAndSync(descendantId, changes);
+      const delta: TaskDelta = this.buildUpdateDelta(dependent, updated, changes);
+      this.persistence.logEvent?.(descendantId, 'task.pending', changes);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.replaceSelectedAttempt(dependent);
+    }
   }
 
   async resumeTaskAfterFixApproval(taskId: string): Promise<TaskState[]> {


### PR DESCRIPTION
## Summary

CI has been failing several e2e cases since 2026-09-01: a task that gets fixed and approved leaves a further downstream task stuck forever, instead of running.

That downstream task carries a terminal, never-ran state. PR #11672's fail-cascade puts a failed task's never-started descendants into that state.

`approve()` only looks at tasks currently in `pending`. A descendant already in the terminal state stays invisible to `approve()`'s follow-up check, even once the cause is fixed.

## Review Claim

Reviewer is asked to approve that `approve()` returns a completed task's never-started, terminally-marked descendants to `pending` using the same graph walk the original terminal-marking pass uses, so it can only ever touch a task currently carrying that terminal marking.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`unskipDescendants` only writes a task whose current status is exactly `skipped` (checked per-task before the write); it walks `getTransitiveDependents` with the identical completed/stale/reconciliation prune predicate the fail-cascade in `transitions.ts` already uses to compute the same set, so it can't reach past a completed task or into a reconciliation branch. It cannot fire on any status other than `skipped`, so a pending, running, or already-terminal task is never touched.

## Slice Rationale

This is the domain half of the fix: it makes `approve()` correctly restore descendant state, independent of whether anything downstream actually goes and runs the restored task. The next PR in this stack adds the piece that actually runs it; the PR after that updates the e2e assertions that surfaced both gaps.

## Non-goals

Does not change the fail-cascade itself, `cancelTaskImpl`, or any other completion path. Does not touch the headless CLI (see the next PR in this stack).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test` — 1006 passed, 1 pre-existing unrelated failure (`orchestrator.test.ts > does not classify a non-ssh task with the same error text`; confirmed failing identically on an unmodified checkout via `git stash`)
- [x] `bash scripts/e2e-dry-run/cases/case-2.7-fan-in-fix.sh` — end-to-end proof this slice plus the next slice in this stack resurrects and completes a skipped fan-in descendant

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 697dfc0`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jfAqJY8rT8MbuDVUsxZCZ
