### PR TITLE
fix(e2e): allow skipped status in stop-fails-running-tasks assertion

### DIFF
--- a/packages/app/e2e/workflow-lifecycle.spec.ts
+++ b/packages/app/e2e/workflow-lifecycle.spec.ts
@@ -89,7 +89,11 @@ test.describe('Workflow lifecycle', () => {
     const result = await page.evaluate(() => window.invoker.getTasks());
     const tasks = Array.isArray(result) ? result : result.tasks;
     const allSettled = tasks.every(
-      (t: any) => t.status === 'failed' || t.status === 'completed' || t.status === 'pending',
+      (t: any) =>
+        t.status === 'failed' ||
+        t.status === 'completed' ||
+        t.status === 'pending' ||
+        t.status === 'skipped',
     );
     expect(allSettled).toBe(true);
   });


### PR DESCRIPTION
## Summary

The Playwright e2e spec "stop fails running tasks" asserted every task
lands on failed/completed/pending after a stop.

The already-merged "Skipped status" work (PRs #11672, #11691-#11694,
#11722, #11723, 2026-09-01) changed never-started descendants of a
failed task to land on "skipped" instead of "pending".

Stop fails the in-flight task via the same finalizeFailedTask()
cascade, so its never-started downstream tasks now land on "skipped"
too, and the stale assertion failed on every run.

## Review Claim

The "stop fails running tasks" e2e assertion should accept "skipped" as
a settled terminal status, matching the current cascade-skip behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change to one Playwright assertion in
`packages/app/e2e/workflow-lifecycle.spec.ts`; no product code changed.

## Slice Rationale

Single-file, single-assertion fix scoped to the one spec broken by the
"Skipped status" change; no other e2e spec in this repo uses the same
failed/completed/pending status-set check.

## Non-goals

- Does not touch `packages/workflow-core/src/orchestrator/transitions.ts`
  or any other cascade-skip product code — that contract is already
  merged and working as intended.
- Does not touch the separate "Cascade-skip resurrection" PR stack
  (#11833/#11834/#11835), which is still open and covers the
  `scripts/e2e-dry-run` / `scripts/e2e-ssh` shell-case assertions, not
  this Playwright spec.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm run test:e2e -- e2e/workflow-lifecycle.spec.ts -g "stop fails running tasks"` — failed before this change (`Expected: true / Received: false` at line 94, with task-beta/task-gamma landing on "Skipped" per the failure's error-context.md), passed after (`1 passed`)
- [x] `cd packages/app && pnpm run test:e2e -- e2e/workflow-lifecycle.spec.ts` — full spec file, `5 passed (55.9s)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4ec0a0e0c7`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jfAqJY8rT8MbuDVUsxZCZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to one e2e assertion; no product or runtime behavior is modified.
> 
> **Overview**
> Updates the **stop fails running tasks** Playwright check so tasks are considered settled when their status is `failed`, `completed`, `pending`, or **`skipped`**.
> 
> After cascade-skip behavior, stopping a run can leave never-started downstream tasks on `skipped` instead of `pending`, which was causing this assertion to fail even though stop behaved correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec0a0e0c7071c8c8d6e8eab85555061008d29c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->