### PR TITLE
[Workers pr-status Autostart](1) Fix pr-status not auto-starting under Playwright e2e

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -31,6 +31,7 @@ const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.includes('--install-skills')
   || process.argv.slice(2).includes('install-skills');
 const sourceDevelopmentProfile = process.env.INVOKER_DEVELOPMENT_PROFILE === '1';
+const suppressWorkerAutoStart = sourceDevelopmentProfile && process.env.NODE_ENV !== 'test';
 
 configureEarlyElectronApp({
   app,
@@ -2216,7 +2217,7 @@ function startHeadlessMode(): void {
               },
             },
           ),
-          autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+          autoStartKinds: suppressWorkerAutoStart ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -2280,7 +2281,7 @@ function startHeadlessMode(): void {
             logger.info('Web surface ready, proceeding with workers/dispatcher/recovery', { module: 'headless' });
           }
         }
-        if (!sourceDevelopmentProfile) workerRuntimeController.startAutoStartedWorkers();
+        if (!suppressWorkerAutoStart) workerRuntimeController.startAutoStartedWorkers();
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
           standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
@@ -2850,7 +2851,7 @@ startMainProcessBootstrap({
     recordStartupMark('deferred-startup.begin');
     if (ownerMode && workerRuntimeController) {
       setTimeout(() => {
-        if (!sourceDevelopmentProfile) workerRuntimeController?.startAutoStartedWorkers();
+        if (!suppressWorkerAutoStart) workerRuntimeController?.startAutoStartedWorkers();
         recordStartupMark('workers.auto-started');
       }, 0);
     }
@@ -3526,7 +3527,7 @@ startMainProcessBootstrap({
             },
           },
         ),
-        autoStartKinds: sourceDevelopmentProfile ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+        autoStartKinds: suppressWorkerAutoStart ? [] : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,


### PR DESCRIPTION
## Summary

Two Playwright e2e tests in `workers-surface.spec.ts` expect the pr-status
worker to start running by default, but it always showed stopped instead.

PR #10736 added a dev-profile flag that keeps worker auto-start off for
real source-development launches. The e2e fixture sets that same flag
for path isolation, so e2e launches also kept pr-status off.

## Review Claim

`packages/app/src/main.ts` now only keeps worker auto-start off under a
real source-development launch, not under Playwright's e2e launches,
restoring the pre-#10736 default where pr-status and the other always-on
workers auto-start under test.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`NODE_ENV` is only `'test'` for Playwright/Vitest launches — the same
marker this file already uses for `hideE2eWindow` and other e2e-only
branches. Packaged launches and real interactive source-development
launches never set it, so their startup behavior is unchanged.

Assumptions: this PR is opened autonomously as part of an assigned
CI-regression fix; the Safety Invariant above is proposed but not
interactively confirmed by a human reviewer before publishing.

## Slice Rationale

One file, one gating expression, reused at its four existing call sites.
No unrelated cleanup.

## Non-goals

Does not touch the launch-dispatcher top-up gate or the orchestrator
auto-run-on-startup gate (`topUpReadyLaunchesEnabled`,
`orchestrator.startExecution()`) — both stay suppressed under
source-development and e2e as before, since no failing test needs them
changed and widening the fix there would touch behavior far outside this
bug's scope.

Does not change which worker kinds are always-on, and does not change
packaged/production launch behavior.

## Visual Proof

Captured via `bash scripts/ui-visual-proof.sh --spec e2e/workers-surface.spec.ts`, driving the real Workers details panel in Electron with the pr-status row selected, on `origin/master` and on this branch.

**On `origin/master` — pr-status shown in a stopped state.** Selecting the PR status row shows `State: Stopped`, an `Enable worker` button, and `Runtime: Not running`, even though pr-status is one of Invoker's always-on workers.

![pr-status shown in a stopped state with an Enable worker button](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260902-60ab97/workers-pr-status-stopped-state.png)

**On this branch — pr-status shown in a running state.** Same selection, same test, now shows `State: Running`, a `Disable worker` button, and `Runtime: pr-status`, matching the worker's actual auto-started state.

![pr-status shown in a running state with a Disable worker button](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260902-60ab97/workers-pr-status-running-state.png)

Manually inspected: opened both PNGs directly. The `origin/master` image shows the PR status detail panel with the "Enable worker" button, `State: Stopped` chip, and "Runtime: Not running"; this branch's image shows the same panel with "Disable worker", `State: Running`, and "Runtime: pr-status" — confirming the fix changes exactly the state this PR claims to fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Reproduced on `origin/master`: `cd packages/app && INVOKER_PLAYWRIGHT_WORKERS=1 npx playwright test workers-surface.spec.ts --reporter=line` — 2 failed (`worker-detail-start-stop`'s `data-action` stayed `"start"` instead of `"stop"` after selecting the pr-status row), 3 passed
- [x] After the fix, same command: 5 passed
- [x] `cd packages/app && INVOKER_PLAYWRIGHT_WORKERS=1 npx playwright test worker-tab-scroll.spec.ts autofix-worker-ui.spec.ts start-ready-daemon-owner.spec.ts --reporter=line` — 3 passed (spot-check for regressions on other worker/owner-boot e2e specs)
- [x] `cd packages/app && pnpm test` — 16 files / 45 tests fail; verified via `git stash` that the identical 16 files fail the same way with this diff fully removed, and confirmed none of the 16 failing files import `main.ts` — pre-existing/environment failures (ambient `INVOKER_GITHUB_TARGET_REPO*` env vars leaking into the sandbox), unrelated to this change
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build` — clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7e4bf51a57`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jfAqJY8rT8MbuDVUsxZCZ
