### PR TITLE
[Stuck-Lease Load-Plan Staging](1) Stop staging plans loaded via invoker:load-plan

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1302,6 +1302,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       preserveTaskHandles?: boolean;
       logLabel?: string;
       repositoryBinding?: InAppPlanningRepoBinding;
+      staged?: boolean;
     },
   ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
     return loadPlanSubmissionBundle(planText, {
@@ -1314,7 +1315,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       preserveTaskHandles: options?.preserveTaskHandles,
       repositoryBinding: options?.repositoryBinding,
       taskHandles,
-      staged: true,
+      staged: options?.staged ?? true,
     });
   }
 
@@ -1466,7 +1467,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
   registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
     const planText = String(planTextArg);
-    await loadGeneratedPlanPreview(planText, { logLabel: 'load-plan' });
+    await loadGeneratedPlanPreview(planText, { logLabel: 'load-plan', staged: false });
     publishOrchestratorSnapshotToRenderer();
   });
 


### PR DESCRIPTION
## Summary

Two stuck-lease e2e specs failed because a loaded plan's task never launched at
all — nothing for the reaper or a healthy task to observe.

Root cause: `invoker:load-plan` silently created every workflow as staged, and a
staged workflow never enters the ready-to-launch pool. PR #9907 meant to stage
only AI planning previews, but staged direct plan loads too.

The fix makes `staged` an explicit, per-caller flag: the planning-chat preview
stays staged, `invoker:load-plan` runs immediately again.

## Review Claim

Reviewer is asked to approve that the GUI's `invoker:load-plan` IPC handler no
longer stages the loaded workflow, while the in-app planning-chat preview flow
(`invoker:plan-from-goal`) keeps staging by default, unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`loadGeneratedPlanPreview()` is called from exactly two places: the direct
`invoker:load-plan` handler, and the planning-chat preview flow
(`invoker:plan-from-goal` / `restorePlanningChatSessions`'s `loadGeneratedPlan`
callback). It now takes an explicit `staged` option that defaults to `true`
(preserving today's behavior for every existing caller except one), and only the
`invoker:load-plan` handler passes `staged: false` explicitly. No other caller's
behavior changes.

## Slice Rationale

One behavior claim, one file: the GUI-owner-mode `invoker:load-plan` handler stops
staging plans it was never meant to stage. `packages/app/src/main.ts` classifies
under a separate review unit per `scripts/review-unit-rules.mjs`, and it has the
identical defect in its own `invoker:load-plan` capability (the parallel wiring
used when a GUI viewer delegates to a remote/daemon owner), which is not exercised
by either failing test — that sibling fix follows as its own PR to keep review
units single-concept per this repo's discipline.

## Non-goals

Does not touch the planning-chat preview flow's staging behavior. Does not touch
`invoker:start-ready` / `activateStagedWorkflows`. Does not touch the headless CLI
`owner-serve` run/resume paths, which never staged to begin with. Does not touch
`packages/app/src/main.ts`'s standalone-owner `invoker:load-plan` capability,
which has the identical bug — filed as a follow-up sibling PR per the class-search
finding above. Does not re-architect the shared `startPlan()` e2e fixture from
PR #11378 (that fixture-level fix stays valid for specs that explicitly call
`start()`/`startReady()`; this PR fixes the same root defect for specs — like
these two — that rely on fully automatic background dispatch with no explicit
start call at all, which #11378 could not reach).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `INVOKER_PLAYWRIGHT_WORKERS=1 npx playwright test e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts --reporter=line` — `2 passed (34.1s)`. Both failed before this change with the exact errors reported (empty generation-samples array; `initialAttemptId` undefined for a running task).
- [x] `INVOKER_PLAYWRIGHT_WORKERS=1 npx playwright test e2e/workflow-status-composition.spec.ts --reporter=line` — `1 passed (15.8s)`, regression check for another direct `loadPlan()` consumer.
- [x] `pnpm --filter @invoker/app test -- in-app-planner.test in-app-planner-monkey launch-dispatch-retry-budget-exhausted-repro launch-dispatch-stuck-lease-retry-storm-repro` — `89 passed`.
- [x] `pnpm --filter @invoker/app test -- plan-submission-loader` — `4 passed`.
- [x] `pnpm --filter @invoker/workflow-core test -- orchestrator` — `1006 passed, 1 pre-existing unrelated failure` (confirmed present on unmodified `origin/master` via `git stash`; an SSH failure-classification test unrelated to this diff).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jfAqJY8rT8MbuDVUsxZCZ
