### PR TITLE
[Stuck-Lease Load-Plan Staging](2) Stop staging plans loaded via standalone-owner invoker:load-plan

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1388,13 +1388,14 @@ function startHeadlessMode(): void {
       const loadGeneratedPlan = async (
         planText: string,
         repositoryBinding?: InAppPlanningRepoBinding,
+        staged = true,
       ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => (
         loadPlanSubmissionBundle(planText, {
           persistence,
           orchestrator,
           allowGraphMutation: invokerConfig.allowGraphMutation,
           logger,
-        }, { staged: true, repositoryBinding })
+        }, { staged, repositoryBinding })
       );
       submitAdminBypassE2eBabysitPlan = (planText) => loadGeneratedPlan(planText);
 
@@ -1599,7 +1600,7 @@ function startHeadlessMode(): void {
 
       registerStandaloneOwnerCapability('invoker:load-plan', async (payload) => {
         const planText = String(payload.args[0] ?? '');
-        await loadGeneratedPlan(planText);
+        await loadGeneratedPlan(planText, undefined, false);
         return undefined;
       });
 


### PR DESCRIPTION
## Summary

Sibling of #11845. The standalone-owner (daemon/remote-owner) `invoker:load-plan`
capability had the identical staging bug as the GUI-owner path: it always staged
the loaded workflow, so it never auto-launched.

Found via class-search while fixing #11845: `packages/app/src/main.ts`'s
`loadGeneratedPlan()` helper hardcoded the same `staged: true` into the one
function shared by its own `invoker:load-plan` capability and its own
planning-chat preview flow.

## Review Claim

Reviewer is asked to approve that the standalone-owner `invoker:load-plan`
capability no longer stages the loaded workflow, while its planning-chat preview
callers keep staging by default, unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`loadGeneratedPlan()` is called from three places: the standalone-owner
`invoker:load-plan` capability, `submitAdminBypassE2eBabysitPlan`, and
`in-app-planner.ts`'s planning-chat flow. It now takes an explicit `staged`
parameter that defaults to `true` (preserving today's behavior for the other
two callers), and only the `invoker:load-plan` capability passes `staged: false`.

## Slice Rationale

Same root cause as #11845 (staging a directly-loaded plan that was never meant
to be staged), in the parallel standalone-owner-mode wiring of the same
`invoker:load-plan` capability. Landed as its own PR because
`scripts/review-unit-rules.mjs` classifies `packages/app/src/main.ts` under a
different review unit than the `packages/app/src/ipc/*` file #11845 changed.

## Non-goals

Does not touch `submitAdminBypassE2eBabysitPlan` or the planning-chat preview
flow's staging behavior. Does not touch `executeStandaloneHeadlessRun`, the
headless CLI plan-load path, which never staged to begin with. No neither
originally-reported failing spec exercises standalone-owner mode (both run
`INVOKER_GUI_OWNER_MODE=gui`), so this PR is a preventive sibling fix, not
required for those two specs to pass.

## Visual Proof

This diff only changes `packages/app/src/main.ts`'s standalone-owner
`invoker:load-plan` capability, a code path not reachable from the normal
Electron GUI window shown below — `main.ts` is classified UI-impacting by this
repo's path-based rule regardless of which part of the file changes, so there is
no user-visible difference in the GUI's own rendering to show.

![App launches normally with this change applied](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260902-abe1a3/sibling-pr-app-launch.png)

Manually inspected: opened the captured screenshot myself — it shows the normal
Invoker "Planning" screen (sidebar icons, "What do you want to build?" prompt,
chat input) rendering with no errors or crash dialogs on a fresh app boot with
this change built in. This screenshot exists solely to satisfy the mechanical
UI-impact path check; the actual behavior change is process-level and has no
GUI rendering to demonstrate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build` — succeeds.
- [x] `pnpm --filter @invoker/app test -- plan-submission-loader` — `4 passed`, confirms the shared helper both call sites route through is unaffected.
- [x] No existing automated test exercises the standalone-owner `invoker:load-plan` capability specifically (`registerStandaloneOwnerCapability('invoker:load-plan', ...)` in `main.ts`) in either staged or unstaged form — a real coverage gap this PR does not add a regression test for, since standalone-owner mode is not exercised by any currently-failing spec. Flagging for a follow-up.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jfAqJY8rT8MbuDVUsxZCZ
