### PR TITLE
[Required executor pool (2)](4) Fixture: repair the SSH startup-failure metadata repro

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -25,13 +25,16 @@ function makeTask(overrides: {
   config?: Partial<TaskState['config']>;
   execution?: Partial<TaskState['execution']>;
 } = {}): TaskState {
+  const config = overrides.config?.runnerKind === 'ssh' && !overrides.config.poolId
+    ? { ...overrides.config, poolId: 'ssh-fixture' }
+    : overrides.config;
   return {
     id: overrides.id ?? 'wf-1/test-execution-engine',
     description: 'repro task',
     status: overrides.status ?? 'pending',
     dependencies: [],
     createdAt: new Date(),
-    config: { ...overrides.config },
+    config: { ...config },
     execution: { ...overrides.execution },
   } as TaskState;
 }
@@ -126,12 +129,15 @@ describe('SSH worktree metadata repro', () => {
         getAll: () => [failingExecutor],
       } as any,
       cwd: '/tmp',
+      executionPoolsProvider: () => ({
+        'ssh-fixture': { members: [{ type: 'ssh' as const, id: 'remote-1' }] },
+      }),
     });
 
     await runner.executeTask(task);
 
     expect(updateSpy).toHaveBeenCalledWith('wf-1/test-execution-engine', {
-      config: { runnerKind: 'ssh' },
+      config: { runnerKind: 'ssh', poolMemberId: 'remote-1' },
       execution: {
         workspacePath: ownerPath,
         branch,
@@ -216,6 +222,9 @@ describe('SSH worktree metadata repro', () => {
       } as any,
       cwd: '/tmp',
       callbacks: { onLaunchFailed },
+      executionPoolsProvider: () => ({
+        'ssh-fixture': { members: [{ type: 'ssh' as const, id: 'remote-1' }] },
+      }),
     });
 
     await runner.executeTask(staleLaunchTask);


### PR DESCRIPTION
## Summary

An SSH startup-failure repro test built its task by hand and never gave it a pool. Selecting an executor for that task threw, so the test never reached the code it meant to exercise.

The fixture now gives the task a real pool with one SSH member, matching how the rest of this test suite already builds SSH tasks.

With a real member selected, the run now legitimately records which pool member ran the task. The test's own expectation is updated to match.

## Review Claim

Approve that this repro's task fixture is now complete enough to reach the code it tests, and that its expectation matches what a real run actually persists.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product file changes. All four tests in this file pass against today's code; nothing here depends on the routing slice that follows.

## Slice Rationale

This fixture gap surfaced during a full-suite run while completing the pool-routing slice, but fixing it does not require any product change, so it stands on its own ahead of that slice.

## Non-goals

No product code. No other test files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine test -- ssh-worktree-metadata-repro`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
