### PR TITLE
[Daily Release Catch-up](1) Bump patch version for daily-20260902

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,7 +76,7 @@ import {
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
 
-const VERSION = '0.0.18';
+const VERSION = '0.0.19';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-watcher",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Invoker standalone owner-restart watcher installer",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -30,7 +30,7 @@ import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
 import { startLocalSmokeInject } from './local-smoke-inject.js';
-const VERSION = '0.0.18';
+const VERSION = '0.0.19';
 let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/watcher",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

The nightly release bot has been unable to bump `package.json`'s version since branch protection started requiring PRs on master.

Every daily-release run since Aug 28 failed at the push step, so master has been stuck at 0.0.18 with no new daily prerelease.

This is a manual, one-off catch-up bump to unblock today's daily cut while the workflow itself gets fixed separately.

## Review Claim

Approve a mechanical patch-version bump (0.0.18 → 0.0.19) across all package.json/const version targets, with no other code changes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Diff is limited to version-string fields already covered by `scripts/bump-release-version.mjs`'s own mismatch check; no runtime logic changes.

## Slice Rationale

Isolated from the workflow-level fix (routing future bumps through a PR) so this catch-up bump can land immediately without waiting on that redesign.

## Non-goals

No behavior change. Does not fix the daily-release.yml push mechanism itself — that is a separate follow-up PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/bump-release-version.mjs --type patch --dry-run --from 0.0.18` prints `0.0.19`
- [ ] `git diff --stat` shows only version-string fields changed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit; no data migrations or feature flags involved.

</details>
