### PR TITLE
[Nonssh Failure Classification](1) Fix orchestrator test to match runner-kind-independent classification

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8838,7 +8838,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)!.execution.failureClass).toBe('ssh-env-invalid-export');
     });
 
-    it('does not classify a non-ssh task with the same error text', () => {
+    it('classifies a non-ssh task with the same error text the same way', () => {
       const { taskId } = loadSingleTask('infra-nonssh');
       orchestrator.startExecution();
 
@@ -8851,7 +8851,7 @@ describe('Orchestrator', () => {
         },
       }));
 
-      expect(orchestrator.getTask(taskId)!.execution.failureClass).toBeUndefined();
+      expect(orchestrator.getTask(taskId)!.execution.failureClass).toBe('ssh-env-invalid-export');
     });
   });
 


### PR DESCRIPTION
## Summary

`orchestrator.test.ts` asserted that a non-SSH task's failure never gets an SSH-named `failureClass`, even when the error text matches one of the seven infra signatures.

Yesterday's #11667 deliberately dropped that runner-kind gate, so classification now applies to every runner kind on purpose.

The old test was never touched by that change, so it now expects the opposite of what the shipped code does, and fails on master's real diff.

The fix flips that one assertion to match the shipped behavior: a non-SSH task with the same error text now gets classified the same way.

## Review Claim

The reviewer is asked to approve updating one outdated test assertion so it matches the runner-kind-independent classification behavior #11667 already shipped in production code.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

Only a test file changes; no production code is touched. The full `packages/workflow-core` orchestrator suite (291 tests) and the repo's `required-fast / Vitest Workspace` suite both pass locally against this branch.

## Slice Rationale

This is a single, isolated one-line test fix with no dependency on other in-flight work; it stands alone as its own reviewable unit.

## Non-goals

No production code changes. No changes to `FailureClassifier` or `finalizeFailedTaskImpl`. Does not revisit whether #11667's runner-kind-independent classification is the right design; it only aligns the test with what already shipped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && npx vitest run src/__tests__/orchestrator.test.ts`
- [x] `bash scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>
