### PR TITLE
[Daily Release Bump](2) Bump patch version for daily-20260902

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   CI: true
@@ -34,14 +35,36 @@ jobs:
         id: decide
         run: bash scripts/daily-release-decide.sh --tip HEAD --out "$GITHUB_OUTPUT"
 
+      - name: Install pnpm
+        if: steps.decide.outputs.should_run == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        if: steps.decide.outputs.should_run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies for the bump PR helper
+        if: steps.decide.outputs.should_run == 'true'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Bump nightly patch version
         if: steps.decide.outputs.should_run == 'true'
+        env:
+          MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           node scripts/bump-release-version.mjs --type patch
+          git checkout -b "daily-version-bump-${{ steps.decide.outputs.tag }}"
           git config user.name "invoker-release-bot"
           git config user.email "invoker-release-bot@users.noreply.github.com"
           git commit -am "chore(release): bump patch version for ${{ steps.decide.outputs.tag }}"
-          git push origin HEAD:master
+          bash scripts/open-daily-release-bump-pr.sh --tag "${{ steps.decide.outputs.tag }}"
 
       - name: Resolve build sha
         id: bump

--- a/scripts/daily-release-bump-pr-body-template.txt
+++ b/scripts/daily-release-bump-pr-body-template.txt
@@ -1,0 +1,48 @@
+## Summary
+
+The nightly release job cannot push its version bump straight to master anymore — branch protection requires every change to land through a PR.
+
+This PR is that mechanical bump for {{TAG}}: patch-version-only, opened and merged automatically by the daily-release workflow.
+
+## Review Claim
+
+Approve a mechanical patch-version bump across all package.json/const version targets, with no other code changes.
+
+## Review Lane
+
+behavior
+
+## Review Unit
+
+activation-surface
+
+## Safety Invariant
+
+Diff is limited to version-string fields already covered by `scripts/bump-release-version.mjs`'s own mismatch check; no runtime logic changes.
+
+## Slice Rationale
+
+One bump per daily cut, isolated from product changes so it can auto-merge via the `admin-bypass` queue without a human review.
+
+## Non-goals
+
+No behavior change. Does not touch the build, tag, or publish steps.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [ ] `node scripts/bump-release-version.mjs --type patch --dry-run` matches the committed version
+- [ ] `git diff --stat` shows only version-string fields changed
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+Revert this commit; no data migrations or feature flags involved.
+
+</details>

--- a/scripts/open-daily-release-bump-pr.sh
+++ b/scripts/open-daily-release-bump-pr.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+TAG=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag)
+      TAG="${2:?missing tag}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  echo "--tag is required" >&2
+  exit 64
+fi
+
+BRANCH="$(git branch --show-current)"
+
+mergify stack push
+
+pr_number="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+if [ -z "$pr_number" ]; then
+  echo "Could not resolve PR number for branch $BRANCH after mergify stack push" >&2
+  exit 1
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+sed "s/{{TAG}}/${TAG}/g" scripts/daily-release-bump-pr-body-template.txt > "$body_file"
+
+node scripts/create-pr.mjs \
+  --title "[Daily Release Bump](1) Bump patch version for ${TAG}" \
+  --base master \
+  --body-file "$body_file" \
+  --update-existing
+
+gh pr edit "$pr_number" --add-label admin-bypass
+node scripts/land-stack.mjs "$pr_number" --execute


### PR DESCRIPTION
## Summary

`daily-release.yml` bumped the patch version, then ran `git push origin HEAD:master` to land it.

Master now requires every change to go through a PR, so that push has been rejected (`GH013`) on every scheduled run since Aug 28. No daily prerelease has shipped since.

This sends the bump through a stacked, `admin-bypass`-labeled PR instead, so it lands the same way every other master change does.

## Review Claim

Approve replacing the nightly `git push origin HEAD:master` with `mergify stack push` + an auto-queued `admin-bypass` PR, using the existing `MERGIFY_TOKEN` secret so the bump still triggers required CI checks (a default `GITHUB_TOKEN`-authored push would not).

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The bump still runs `scripts/bump-release-version.mjs --type patch` unchanged — only how the result reaches master changes. `scripts/test-ci-workflow-release-version-bump.mjs` still asserts the step is gated on `should_run` and invokes `--type patch`.

## Slice Rationale

Kept separate from the one-off catch-up bump (#11873) so that mechanical, no-review PR could land on its own while this workflow change gets a real review.

## Non-goals

Does not change `release.yml`'s minor-bump guard for real `v*` releases — that guard is intentional (see `scripts/test-ci-workflow-release-version-bump.mjs`).

Does not change build, tag, or publish steps.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-release-version-bump.mjs`
- [ ] `bash scripts/test-daily-release-workflow.sh` (pre-existing `invoker-watcher` asset-list failure is unrelated, unchanged by this PR)
- [ ] Manually re-run `Daily release` via `workflow_dispatch` after merge and confirm it opens/merges a bump PR and publishes a `daily-YYYYMMDD` prerelease

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit to restore the direct push (it will keep failing under branch protection, but that is the pre-existing state).

</details>
