### PR TITLE
[Daily Release Bump](5) Bump patch version for daily-20260902

### DIFF
--- a/scripts/open-daily-release-bump-pr.sh
+++ b/scripts/open-daily-release-bump-pr.sh
@@ -25,7 +25,7 @@ fi
 
 BRANCH="$(git branch --show-current)"
 
-mergify stack push
+mergify stack push --trunk origin/master
 
 pr_number="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
 if [ -z "$pr_number" ]; then


### PR DESCRIPTION
## Summary

#11882 installed the `mergify` CLI, but the next real run failed differently: `mergify: could not determine trunk branch` — `git symbolic-ref refs/remotes/origin/HEAD` isn't set because `actions/checkout` never sets it, so `mergify` can't guess which branch is trunk.

This passes `--trunk origin/master` explicitly instead of relying on that guess.

## Review Claim

Approve adding `--trunk origin/master` to the `mergify stack push` call in `scripts/open-daily-release-bump-pr.sh`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Confirmed by running the actual workflow (run 33698097038): it failed at exactly this line with `could not determine trunk branch`, which is the same error message the CLI's own help text says `--trunk REMOTE/BRANCH` resolves.

## Slice Rationale

Fourth small fix in this chain, kept separate so each CI-only failure and its correction stays independently reviewable and revertable.

## Non-goals

Does not change the version-bump logic, the build, or the publish steps.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-release-version-bump.mjs`
- [ ] Manually re-run `Daily release` via `workflow_dispatch` after merge and confirm it opens a bump PR, that PR merges, and a `daily-YYYYMMDD` prerelease gets published

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit; the nightly job goes back to failing at `could not determine trunk branch`, same as before #11885.

</details>
