### PR TITLE
[PR Authoring Agent](2) Use the declared execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1389,7 +1389,7 @@ describe('TaskRunner', () => {
       expect(result.artifacts).toHaveLength(1);
     });
 
-    it.fails('publishReviewStackWithMakePrSkill uses the workflow declared agent, not a fallback chain (documents pre-fix codex-only behavior)', async () => {
+    it('publishReviewStackWithMakePrSkill uses the workflow declared agent, not a fallback chain', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
       process.env.HOME = tempHome;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1563,8 +1563,9 @@ export class TaskRunner {
       throw new Error('make-pr skill is required to publish Invoker review stacks');
     }
 
-    const codex = this.executionAgentRegistry.get('codex');
-    const orderedAgents = codex ? [codex] : [];
+    const preferredAgentName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const preferredAgent = this.executionAgentRegistry.get(preferredAgentName);
+    const orderedAgents = preferredAgent ? [preferredAgent] : [];
     const logProgress = (
       level: 'debug' | 'info' | 'warn' | 'error',
       message: string,


### PR DESCRIPTION
## Summary

Every merge gate authors its GitHub PR through codex, no matter what agent a workflow's own tasks were configured to use.

That happened because the publish step picked codex by a hardcoded name, instead of asking the same resolver every other PR-authoring call site already asks.

This change makes it ask that resolver too, so publication follows the workflow's own configured agent.

## Review Claim

`publishReviewStackWithMakePrSkill` now picks its one publishing agent from the workflow's own configured agent (via the existing `resolvePrAuthoringAgentName` helper), instead of a hardcoded codex lookup.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Publication still goes through exactly one agent, never a multi-agent chain. PR #11629 removed a codex-then-claude-then-OMP chain after a malformed response cascaded into a 20-minute merge-gate timeout; this change keeps that same single-agent shape, it only changes which one name gets looked up.

## Slice Rationale

This is one isolated function change. The previous PR pinned the gap with an expected-failing test; this one flips it green. The follow-on change (letting a merge node's own agent field be edited) is a separate PR stacked on this one.

## Non-goals

Does not change `resolvePrAuthoringAgentName` itself, the fallback-order helper, or the generic per-task authoring call site that already used the resolver.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- task-runner-fix-publish-and-ssh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3428b39794`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gate PR publishing routing for workflows that use a non-Codex execution agent; behavior is intentional and scoped to one function with test coverage.
> 
> **Overview**
> Merge-gate **review stack publication** no longer always routes through Codex. **`publishReviewStackWithMakePrSkill`** now picks its single publishing agent via **`resolvePrAuthoringAgentName`** (same helper as other PR-authoring paths), so a workflow configured with e.g. Claude uses Claude for the make-pr stack—not a hardcoded Codex lookup.
> 
> Publication still uses **exactly one agent** (no multi-agent fallback chain). A previously expected-failing test is now a passing regression check: when tasks declare `executionAgent: 'claude'`, only Claude is invoked and Codex is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112c2cd97adc3bcb41694c9b427b936e14a985e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->