### PR TITLE
[Merge Node Editing](1) Allow agent and model edits

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1389,7 +1389,7 @@ describe('TaskRunner', () => {
       expect(result.artifacts).toHaveLength(1);
     });
 
-    it.fails('publishReviewStackWithMakePrSkill uses the workflow declared agent, not a fallback chain (documents pre-fix codex-only behavior)', async () => {
+    it('publishReviewStackWithMakePrSkill uses the workflow declared agent, not a fallback chain', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
       process.env.HOME = tempHome;

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1389,7 +1389,7 @@ describe('TaskRunner', () => {
       expect(result.artifacts).toHaveLength(1);
     });
 
-    it('publishReviewStackWithMakePrSkill uses preferred agent then falls back to another make-pr agent', async () => {
+    it.fails('publishReviewStackWithMakePrSkill uses the workflow declared agent, not a fallback chain (documents pre-fix codex-only behavior)', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
       process.env.HOME = tempHome;
@@ -1407,7 +1407,11 @@ describe('TaskRunner', () => {
           bundledSkills: ['make-pr'],
           buildCommand: () => {
             attempts.push('claude');
-            return { cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'sess-claude' };
+            return {
+              cmd: 'node',
+              args: ['-e', 'var b=["## Summary","","Slice prose.","","## Review Claim","","c","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","s","","## Slice Rationale","","r","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
+              sessionId: 'sess-claude',
+            };
           },
           buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
         };
@@ -1418,11 +1422,7 @@ describe('TaskRunner', () => {
           bundledSkills: ['make-pr'],
           buildCommand: () => {
             attempts.push('codex');
-            return {
-              cmd: 'node',
-              args: ['-e', 'var b=["## Summary","","Slice prose.","","## Review Claim","","c","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","s","","## Slice Rationale","","r","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
-              sessionId: 'sess-codex',
-            };
+            throw new Error('codex must not be invoked when claude is the declared agent');
           },
           buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
         };
@@ -1454,8 +1454,8 @@ describe('TaskRunner', () => {
           expectedGeneration: 26,
         });
 
-        expect(attempts).toEqual(['claude', 'codex']);
-        expect(result.agentName).toBe('codex');
+        expect(attempts).toEqual(['claude']);
+        expect(result.agentName).toBe('claude');
         expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
         expect(result.artifacts.map((a: any) => a.generation)).toEqual([26, 26]);
         expect(logEvent).toHaveBeenCalledWith(
@@ -1464,15 +1464,7 @@ describe('TaskRunner', () => {
           expect.objectContaining({
             level: 'info',
             message: 'Preparing make-pr review stack publisher',
-            agentCount: 2,
-          }),
-        );
-        expect(logEvent).toHaveBeenCalledWith(
-          '__merge__wf-1',
-          'task.log',
-          expect.objectContaining({
-            level: 'warn',
-            message: 'claude make-pr agent failed',
+            agentCount: 1,
           }),
         );
         expect(logEvent).toHaveBeenCalledWith(
@@ -1489,6 +1481,66 @@ describe('TaskRunner', () => {
         else process.env.HOME = originalHome;
       }
     });
+
+    it('publishReviewStackWithMakePrSkill falls back to the fleet default agent when the workflow declares none', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const attempts: string[] = [];
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('codex');
+            return {
+              cmd: 'node',
+              args: ['-e', 'var b=["## Summary","","x","","## Review Claim","","x","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","x","","## Slice Rationale","","x","","## Non-goals","- none","","## Test Plan","- [x] x","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))'],
+              sessionId: 'sess-codex',
+            };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-no-agent' } })],
+          } as any,
+          persistence: { logEvent: vi.fn() } as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => (name === 'codex' ? codexAgent : undefined),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([codexAgent]),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-no-agent',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+          mergeNodeTaskId: '__merge__wf-no-agent',
+          expectedGeneration: 1,
+        });
+
+        expect(attempts).toEqual(['codex']);
+        expect(result.agentName).toBe('codex');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
 
     it('publishReviewStackWithMakePrSkill writes skill=invoker-make-pr onto merge task output', async () => {
       const tempHome = createTempWorkspace();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1563,8 +1563,9 @@ export class TaskRunner {
       throw new Error('make-pr skill is required to publish Invoker review stacks');
     }
 
-    const codex = this.executionAgentRegistry.get('codex');
-    const orderedAgents = codex ? [codex] : [];
+    const preferredAgentName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const preferredAgent = this.executionAgentRegistry.get(preferredAgentName);
+    const orderedAgents = preferredAgent ? [preferredAgent] : [];
     const logProgress = (
       level: 'debug' | 'info' | 'warn' | 'error',
       message: string,

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4435,6 +4435,28 @@ describe('Orchestrator', () => {
       expect(() => orchestrator.editTaskPool(mergeTask.id, 'mixed-local-ssh')).toThrow('Cannot change executor pool');
     });
 
+    it('allows agent and model edits for merge nodes', () => {
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        availablePoolIds: ['mixed-local-ssh'],
+      });
+      orchestrator.loadPlan({
+        name: 'edit-agent-model-merge',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello' }],
+      });
+      const mergeTask = orchestrator.getAllTasks().find((candidate) => candidate.config.isMergeNode)!;
+
+      orchestrator.editTaskAgent(mergeTask.id, 'claude');
+      orchestrator.editTaskModel(mergeTask.id, 'claude-sonnet-5');
+
+      const updated = orchestrator.getTask(mergeTask.id)!;
+      expect(updated.config.executionAgent).toBe('claude');
+      expect(updated.config.executionModel).toBe('claude-sonnet-5');
+    });
+
     it('cancels active work before retrying for a pool edit', () => {
       orchestrator = new Orchestrator({
         persistence,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2507,7 +2507,6 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    if (task.config.isMergeNode) throw new Error(`Cannot change execution model of merge node ${taskId}`);
 
     if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);

--- a/packages/workflow-core/src/orchestrator/task-edits.ts
+++ b/packages/workflow-core/src/orchestrator/task-edits.ts
@@ -206,7 +206,6 @@ export function editTaskAgentImpl(host: TaskEditHost, taskId: string, agentName:
   host.refreshFromDb();
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  if (task.config.isMergeNode) throw new Error(`Cannot change execution agent of merge node ${taskId}`);
 
   if (isActiveForInvalidation(task.status)) {
     host.cancelTask(taskId);


### PR DESCRIPTION
## Summary

A merge/PR node's agent and model were permanently locked once a workflow began running, unlike every regular task.

Both fields now accept the same edit a regular task already supports.

A merge node's pool stays locked, for a real structural reason explained below, not an oversight.

## Review Claim

`editTaskAgentImpl` and `editTaskModel` accept a merge node the same way they already accept a regular task.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Pool edits on a merge node stay rejected. A merge node's `runnerKind` is structurally always `'merge'`, and `workflow-graph`'s persisted config guard rejects any config that pairs `runnerKind='merge'` with a concrete `poolId` -- confirmed directly: adding a passing pool-edit path here broke that guard's own check in a real test run, which is why pool is left alone. A merge node genuinely has no pool concept.

## Slice Rationale

One behavior slice: the two field-level guard removals and their direct unit coverage. Surfacing the matching UI controls, and making the PR-authoring resolver honor a merge node's own agent value, are separate, dependent PRs.

## Non-goals

Does not touch `editTaskCommandImpl`, `editTaskPromptImpl`, `editTaskTypeImpl`, a merge node's pool, or any UI file.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- orchestrator`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 59e5d9d48a`
- Post-revert steps: None
- Data migration? No

</details>
