### PR TITLE
[Merge Node Editing](3) Honor a merge node's own agent

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1542,6 +1542,85 @@ describe('TaskRunner', () => {
     });
 
 
+    it('publishReviewStackWithMakePrSkill prefers the merge node\'s own declared agent over its upstream tasks\'', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const attempts: string[] = [];
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('claude');
+            return {
+              cmd: 'node',
+              args: ['-e', 'var b=["## Summary","","x","","## Review Claim","","x","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","x","","## Slice Rationale","","x","","## Non-goals","- none","","## Test Plan","- [x] x","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))'],
+              sessionId: 'sess-claude',
+            };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('codex');
+            throw new Error('codex must not be invoked when the merge node itself declares claude');
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const mergeTaskId = '__merge__wf-own-agent';
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [
+              makeTask({ id: 't1', config: { workflowId: 'wf-own-agent', executionAgent: 'codex' } }),
+              makeTask({
+                id: mergeTaskId,
+                config: { workflowId: 'wf-own-agent', isMergeNode: true, executionAgent: 'claude' },
+              }),
+            ],
+          } as any,
+          persistence: { logEvent: vi.fn() } as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-own-agent',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+          mergeNodeTaskId: mergeTaskId,
+          expectedGeneration: 1,
+        });
+
+        expect(attempts).toEqual(['claude']);
+        expect(result.agentName).toBe('claude');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
     it('publishReviewStackWithMakePrSkill writes skill=invoker-make-pr onto merge task output', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1756,6 +1756,13 @@ export class TaskRunner {
 
   private resolvePrAuthoringAgentName(workflowId?: string, mergeNodeTaskId?: string): string {
     const allTasks = this.orchestrator.getAllTasks();
+    if (mergeNodeTaskId) {
+      const ownMergeTask = allTasks.find((task) => task.id === mergeNodeTaskId && task.config.isMergeNode);
+      const ownAgent = ownMergeTask?.config.executionAgent?.trim();
+      if (ownAgent) {
+        return ownAgent;
+      }
+    }
     let candidateTasks = allTasks.filter((task) => !task.config.isMergeNode);
     if (workflowId) {
       candidateTasks = candidateTasks.filter((task) => task.config.workflowId === workflowId);


### PR DESCRIPTION
## Summary

The previous change let a merge node's own agent field be edited.

But the resolver PR authoring calls only ever looked at a merge node's upstream tasks for a declared agent, never at the merge node's own field.

An override set directly on the merge node was silently ignored. It no longer is.

## Review Claim

`resolvePrAuthoringAgentName` checks the merge node's own declared agent first, before falling back to its existing upstream-task check.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The existing upstream-tasks scan and fleet-default fallback are unchanged for a merge node with no agent of its own set; only a merge node that HAS its own agent set takes the new path, and it did not have that field editable before this stack's first PR.

## Slice Rationale

One isolated resolver change plus its direct unit coverage, stacked last since it depends on the earlier PRs making a merge node's agent field editable in the first place.

## Non-goals

Does not change `buildAgentFallbackOrder`, `resolveSkillPathViaAgent`, or the generic per-task PR-authoring path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- task-runner-fix-publish-and-ssh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 646d09f934`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R358DyrWKVKoZ6h4M8p3Ao

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped routing change in PR authoring agent resolution with regression test; upstream fallback unchanged when the merge node has no agent.
> 
> **Overview**
> Merge nodes can now set their own **execution agent**, but PR stack publishing (`publishReviewStackWithMakePrSkill`) and related authoring still picked the agent only from **upstream non-merge tasks**, so a merge-level override was ignored.
> 
> **`resolvePrAuthoringAgentName`** now returns the merge task’s own `executionAgent` when `mergeNodeTaskId` is set and that field is non-empty, **before** the existing upstream-task scan and fleet-default fallback. Behavior is unchanged when the merge node has no agent set.
> 
> A unit test asserts that with upstream `codex` and merge node `claude`, only **claude** runs for `publishReviewStackWithMakePrSkill`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75f3b22e3ceb29802345ca41091862104956d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->