### PR TITLE
[UI-Impacting Path Gate](1) Widen the visual-proof allowlist

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -575,9 +575,11 @@ export function isUiImpactingPath(filePath) {
   const path = filePath.replace(/\\/g, '/');
   if (path.startsWith('packages/ui/')) return true;
   if (path.startsWith('packages/app/src/window/')) return true;
+  if (path.startsWith('packages/app/src/web/')) return true;
   if (path === 'packages/app/src/main.ts') return true;
   if (path === 'packages/app/src/preload.ts') return true;
   if (path === 'packages/app/src/app-menu.ts') return true;
+  if (path === 'packages/app/src/task-graph-event-publisher.ts') return true;
   return false;
 }
 

--- a/scripts/test-create-pr-visual-proof.mjs
+++ b/scripts/test-create-pr-visual-proof.mjs
@@ -13,6 +13,8 @@ assert(isUiImpactingPath('packages/app/src/window/window-lifecycle.ts'), 'Electr
 assert(isUiImpactingPath('packages/app/src/preload.ts'), 'preload bridge changes should require visual proof');
 assert(isUiImpactingPath('packages/app/src/main.ts'), 'main window wiring changes should require visual proof');
 assert(isUiImpactingPath('packages/app/src/app-menu.ts'), 'app menu changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/web/web-invoker-dispatch.ts'), 'web-surface changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/task-graph-event-publisher.ts'), 'task graph event publishing changes should require visual proof');
 assert(!isUiImpactingPath('packages/execution-engine/src/merge-runner.ts'), 'non-UI engine changes should not require visual proof');
 assert(!isUiImpactingPath('scripts/create-pr.mjs'), 'PR tooling changes should not require visual proof');
 


### PR DESCRIPTION
## Summary

The check that decides whether a PR needs a Visual Proof section only looked at a short list of paths.

It missed the web surface and the file that feeds live task state to the app's DAG and inspector.

A PR touching only those files could publish without proof, even though users would see the change.

## Review Claim

`isUiImpactingPath` now also flags `packages/app/src/web/` and `packages/app/src/task-graph-event-publisher.ts` as UI-impacting.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Purely additive to the allowlist. Every path that already required visual proof still does; no existing PR classification becomes less strict.

## Slice Rationale

One isolated widening of a single classifier function, discovered while auditing why a recent visual-proof-only PR wasn't flagged by this same check, plus its direct unit coverage.

## Non-goals

Does not move this check to an import-graph based approach (tracked separately in INV-286 as a bigger, more accurate but slower follow-up). Does not change the Review Unit classifier in `scripts/review-unit-rules.mjs`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-create-pr-visual-proof.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f69580abab`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R358DyrWKVKoZ6h4M8p3Ao


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated change detection so modifications to additional application components receive visual-proof handling.
  * Added validation coverage to confirm these components are correctly identified as UI-impacting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->