### PR TITLE
[Headless Set Model](2) Register set model and classify it to its task workflow

### DIFF
--- a/packages/app/src/__tests__/headless-set-model.test.ts
+++ b/packages/app/src/__tests__/headless-set-model.test.ts
@@ -58,7 +58,7 @@ function makeContext(): GuiMutationTaskActionsContext {
 const WORKFLOW_SCOPED_SET_SUBCOMMANDS = new Set(['workflow', 'merge-mode']);
 
 describe('delegated edit-task-model (set model) classification', () => {
-  it.fails('resolves the task workflow for the translated invoker:edit-task-model payload', () => {
+  it('resolves the task workflow for the translated invoker:edit-task-model payload', () => {
     const actions = createGuiMutationTaskActions(makeContext());
     const translated = actions.translateGuiMutationToHeadless({
       channel: 'invoker:edit-task-model',
@@ -75,7 +75,7 @@ describe('delegated edit-task-model (set model) classification', () => {
     expect(classified).toEqual({ workflowId: 'wf-1', priority: 'high' });
   });
 
-  it.fails('queues the no-track set model mutation instead of rejecting it as workflow-not-resolved', () => {
+  it('queues the no-track set model mutation instead of rejecting it as workflow-not-resolved', () => {
     const actions = createGuiMutationTaskActions(makeContext());
     const payload = { args: ['set', 'model', 'wf-1/task-1', 'claude-sonnet-5'], noTrack: true as const };
     const { workflowId, priority } = actions.classifyHeadlessExecMutation(payload);
@@ -92,7 +92,7 @@ describe('delegated edit-task-model (set model) classification', () => {
     expect(submit).toHaveBeenCalledWith('wf-1', 'high', 'headless.exec', [payload], expect.anything());
   });
 
-  it.fails('classifies every registered set subcommand to a workflow so no-track delegation can queue it', () => {
+  it('classifies every registered set subcommand to a workflow so no-track delegation can queue it', () => {
     const actions = createGuiMutationTaskActions(makeContext());
     const unresolved: string[] = [];
     for (const subCommand of HEADLESS_SET_SUBCOMMANDS) {
@@ -144,11 +144,11 @@ describe('headless set model', () => {
     };
   });
 
-  it.fails('registers model as a set subcommand', () => {
+  it('registers model as a set subcommand', () => {
     expect(HEADLESS_SET_SUBCOMMANDS).toContain('model');
   });
 
-  it.fails('routes set model <taskId> <model> through commandService.editTaskModel', async () => {
+  it('routes set model <taskId> <model> through commandService.editTaskModel', async () => {
     await runHeadless(['set', 'model', 'wf-1/task-1', 'claude-sonnet-5'], deps);
 
     expect(deps.commandService.editTaskModel).toHaveBeenCalledTimes(1);
@@ -158,7 +158,7 @@ describe('headless set model', () => {
     expect(envelope.payload).toEqual({ taskId: 'wf-1/task-1', executionModel: 'claude-sonnet-5' });
   });
 
-  it.fails('clears the model when the value is empty, matching the GUI reset payload', async () => {
+  it('clears the model when the value is empty, matching the GUI reset payload', async () => {
     await runHeadless(['set', 'model', 'wf-1/task-1', ''], deps);
 
     const envelope = vi.mocked(deps.commandService.editTaskModel).mock.calls[0]?.[0] as {
@@ -167,7 +167,7 @@ describe('headless set model', () => {
     expect(envelope.payload).toEqual({ taskId: 'wf-1/task-1', executionModel: null });
   });
 
-  it.fails('rejects a missing task id', async () => {
+  it('rejects a missing task id', async () => {
     await expect(runHeadless(['set', 'model'], deps)).rejects.toThrow('Usage: --headless set model');
   });
 });

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -11,6 +11,7 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'pool',
   'executor',
   'agent',
+  'model',
   'task-pool',
   'merge-mode',
   'fix-prompt',

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -63,6 +63,7 @@ ${BOLD}Configure:${RESET}
   set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
   set task-pool <taskId> <poolId>                     Change execution pool by poolId (from executionPools config)
   set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
+  set model <taskId> <model|"">                       Change execution model (empty string clears the override)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
   set fix-context <taskId> <text>                     Update fix-session context and retry

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -138,6 +138,9 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'agent':
       await headlessEditAgent(args[1], args[2], deps);
       break;
+    case 'model':
+      await headlessEditModel(args[1], args[2], deps);
+      break;
     case 'task-pool':
       await headlessEditTaskPool(args[1], args[2], deps);
       break;
@@ -810,6 +813,35 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set agent accepted; exiting without tracking.\n');
+    return;
+  }
+  if (runnable.length === 0) {
+    return;
+  }
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+}
+
+async function headlessEditModel(taskId: string, modelArg: string | undefined, deps: HeadlessDeps): Promise<void> {
+  if (!taskId || modelArg === undefined) throw new Error('Missing arguments. Usage: --headless set model <taskId> <model|"">');
+  const executionModel = modelArg.trim() === '' ? null : modelArg;
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set model');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  const taskExecutor = createHeadlessExecutor(deps);
+
+  const envelope = makeEnvelope('edit-task-model', 'headless', 'task', { taskId, executionModel });
+  const result = await deps.commandService.editTaskModel(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const runnable = result.data.filter(isDispatchableLaunch);
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-model');
+  process.stdout.write(`Edited task "${taskId}" model → "${executionModel ?? ''}"\n`);
+
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: set model accepted; exiting without tracking.\n');
     return;
   }
   if (runnable.length === 0) {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -875,8 +875,11 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
             return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
           case 'command':
           case 'prompt':
+          case 'pool':
+          case 'task-pool':
           case 'executor':
           case 'agent':
+          case 'model':
           case 'fix-prompt':
           case 'fix-context':
           case 'gate-policy':


### PR DESCRIPTION
## Summary

Changing a task's model from the GUI now works. Before, the owner answered with `workflow-not-resolved` and nothing changed.

The GUI turns the model edit into a headless `set model` request. The headless registry had no such name, the headless set handler had no branch for it, and the owner's exec classifier could not map it to a workflow.

This slice adds `model` to the registry, implements the headless handler (an empty value clears the override, matching what the GUI sends on reset), documents it in usage, and makes the classifier resolve every registered task-scoped name, including `pool` and `task-pool`.

The pending expectations from slice 1 now pass.

## Review Claim

A headless `set model <taskId> <model>` request is accepted, applied through `commandService.editTaskModel`, and queued against the task's workflow like `set agent` already is.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the `set` family gains a new name. Existing `set` names keep their handlers and classification, and `set agent` coverage in `headless-delegation.test.ts` still passes unchanged.

## Slice Rationale

This is the smallest change that makes the GUI action work. Making the registry the single source for these names is a separate structural change and lands in slice 3.

## Non-goals

- Does not change how the coordinator scopes set intents; that is slice 4.
- Does not restructure the registry or the set router; that is slice 3.
- Does not change the GUI or web dispatch translation, which already emitted `set model`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-set-model.test.ts` (7 passed)
- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-delegation.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/headless-command-classification.test.ts src/__tests__/headless-install-skills.test.ts src/__tests__/acknowledge-no-track-start-ready.test.ts src/__tests__/headless-exec-ack-ok-precedence.test.ts` (121 passed)
- [x] `pnpm run check:types`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 65dfce240c`
- Post-revert steps: None; the GUI model edit goes back to failing with `workflow-not-resolved`
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task execution configuration and workflow mutation classification for delegated GUI edits; behavior mirrors existing `set agent` but touches mutation routing.
> 
> **Overview**
> **GUI task model edits** now succeed when delegated as no-track `headless.exec set model …` instead of failing with `workflow-not-resolved`.
> 
> This PR registers **`model`** in the headless `set` subcommand list, documents it in CLI usage, and routes **`set model <taskId> <model>`** through a new **`headlessEditModel`** path that calls **`commandService.editTaskModel`** (empty string clears the override, matching GUI reset). **`classifyHeadlessExecMutation`** also treats **`model`**, **`pool`**, and **`task-pool`** as task-scoped so every registered `set` name maps to a workflow for queuing.
> 
> Previously failing tests in **`headless-set-model.test.ts`** are enabled as normal expectations now that the wiring is in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21bf3e4158b88188a5ae170ccbd1b29742dc89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->