### PR TITLE
[Headless Set Model](3)[REFACTOR: Replace Conditional with Dispatch Table] set sub-command switch -> registry-keyed map

### DIFF
--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -67,7 +67,7 @@ describe('headless-command-classification', () => {
   });
 
   it('classifies every registered set subcommand as mutating', () => {
-    for (const subcommand of HEADLESS_SET_SUBCOMMANDS) {
+    for (const { name: subcommand } of HEADLESS_SET_SUBCOMMANDS) {
       expect(isHeadlessMutatingCommand(['set', subcommand])).toBe(true);
     }
 
@@ -90,7 +90,7 @@ describe('headless-command-classification', () => {
     await runHeadless(['--help'], {} as any);
 
     const help = write.mock.calls.map(([chunk]) => String(chunk)).join('');
-    for (const subcommand of HEADLESS_SET_SUBCOMMANDS) {
+    for (const { name: subcommand } of HEADLESS_SET_SUBCOMMANDS) {
       if (subcommand === 'executor') continue;
       expect(help).toContain(`set ${subcommand}`);
     }

--- a/packages/app/src/__tests__/headless-set-model.test.ts
+++ b/packages/app/src/__tests__/headless-set-model.test.ts
@@ -55,7 +55,7 @@ function makeContext(): GuiMutationTaskActionsContext {
   } as unknown as GuiMutationTaskActionsContext;
 }
 
-const WORKFLOW_SCOPED_SET_SUBCOMMANDS = new Set(['workflow', 'merge-mode']);
+const REGISTERED_SET_SUBCOMMAND_NAMES = HEADLESS_SET_SUBCOMMANDS.map((definition) => definition.name);
 
 describe('delegated edit-task-model (set model) classification', () => {
   it('resolves the task workflow for the translated invoker:edit-task-model payload', () => {
@@ -95,15 +95,35 @@ describe('delegated edit-task-model (set model) classification', () => {
   it('classifies every registered set subcommand to a workflow so no-track delegation can queue it', () => {
     const actions = createGuiMutationTaskActions(makeContext());
     const unresolved: string[] = [];
-    for (const subCommand of HEADLESS_SET_SUBCOMMANDS) {
-      const target = WORKFLOW_SCOPED_SET_SUBCOMMANDS.has(subCommand) ? 'wf-1' : 'wf-1/task-1';
+    for (const { name, scope } of HEADLESS_SET_SUBCOMMANDS) {
+      const target = scope === 'workflow' ? 'wf-1' : 'wf-1/task-1';
       const { workflowId } = actions.classifyHeadlessExecMutation({
-        args: ['set', subCommand, target, 'value'],
+        args: ['set', name, target, 'value'],
         noTrack: true,
       });
-      if (workflowId !== 'wf-1') unresolved.push(subCommand);
+      if (workflowId !== 'wf-1') unresolved.push(name);
     }
     expect(unresolved).toEqual([]);
+  });
+
+  it.each([
+    ['invoker:edit-task-command', ['wf-1/task-1', 'pnpm test']],
+    ['invoker:edit-task-prompt', ['wf-1/task-1', 'do the thing']],
+    ['invoker:edit-task-type', ['wf-1/task-1', 'docker']],
+    ['invoker:edit-task-agent', ['wf-1/task-1', 'codex']],
+    ['invoker:edit-task-model', ['wf-1/task-1', 'claude-sonnet-5']],
+    ['invoker:set-task-external-gate-policies', ['wf-1/task-1', [{ workflowId: 'wf-0', gatePolicy: 'completed' }]]],
+  ])('%s translates to a registered set sub-command that classifies to its workflow', (channel, args) => {
+    const actions = createGuiMutationTaskActions(makeContext());
+    const translated = actions.translateGuiMutationToHeadless({ channel, args } as never) as {
+      channel: string;
+      request: { args: string[]; noTrack: true };
+    } | null;
+    expect(translated?.channel).toBe('headless.exec');
+    const [command, subCommand] = translated!.request.args;
+    expect(command).toBe('set');
+    expect(REGISTERED_SET_SUBCOMMAND_NAMES).toContain(subCommand);
+    expect(actions.classifyHeadlessExecMutation(translated!.request).workflowId).toBe('wf-1');
   });
 });
 
@@ -145,7 +165,7 @@ describe('headless set model', () => {
   });
 
   it('registers model as a set subcommand', () => {
-    expect(HEADLESS_SET_SUBCOMMANDS).toContain('model');
+    expect(REGISTERED_SET_SUBCOMMAND_NAMES).toContain('model');
   });
 
   it('routes set model <taskId> <model> through commandService.editTaskModel', async () => {

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -5,24 +5,40 @@ export interface HeadlessCommandDefinition {
   readonly kind: HeadlessCommandKind;
 }
 
+export type HeadlessSetSubcommandScope = 'task' | 'workflow';
+
+export interface HeadlessSetSubcommandDefinition {
+  readonly name: string;
+  readonly scope: HeadlessSetSubcommandScope;
+}
+
 export const HEADLESS_SET_SUBCOMMANDS = [
-  'command',
-  'prompt',
-  'pool',
-  'executor',
-  'agent',
-  'model',
-  'task-pool',
-  'merge-mode',
-  'fix-prompt',
-  'fix-context',
-  'gate-policy',
-  'workflow',
-  'task',
-] as const;
+  { name: 'command', scope: 'task' },
+  { name: 'prompt', scope: 'task' },
+  { name: 'pool', scope: 'task' },
+  { name: 'executor', scope: 'task' },
+  { name: 'agent', scope: 'task' },
+  { name: 'model', scope: 'task' },
+  { name: 'task-pool', scope: 'task' },
+  { name: 'merge-mode', scope: 'workflow' },
+  { name: 'fix-prompt', scope: 'task' },
+  { name: 'fix-context', scope: 'task' },
+  { name: 'gate-policy', scope: 'task' },
+  { name: 'workflow', scope: 'workflow' },
+  { name: 'task', scope: 'task' },
+] as const satisfies readonly HeadlessSetSubcommandDefinition[];
+
+export type HeadlessSetSubcommand = (typeof HEADLESS_SET_SUBCOMMANDS)[number]['name'];
 
 export function formatHeadlessSetSubcommands(separator: string): string {
-  return HEADLESS_SET_SUBCOMMANDS.join(separator);
+  return HEADLESS_SET_SUBCOMMANDS.map((definition) => definition.name).join(separator);
+}
+
+export function findHeadlessSetSubcommandScope(
+  subcommand: string | undefined,
+): HeadlessSetSubcommandScope | undefined {
+  if (!subcommand) return undefined;
+  return HEADLESS_SET_SUBCOMMANDS.find((definition) => definition.name === subcommand)?.scope;
 }
 
 export const HEADLESS_COMMANDS = [

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -43,7 +43,9 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import {
+  findHeadlessSetSubcommandScope,
   formatHeadlessSetSubcommands,
+  type HeadlessSetSubcommand,
   isHeadlessHelpCommand,
 } from './headless-command-registry.js';
 import { printHeadlessUsage } from './headless-usage.js';
@@ -124,48 +126,29 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     throw new Error(`Missing set sub-command. Usage: --headless set <${formatHeadlessSetSubcommands('|')}>`);
   }
 
-  switch (subCommand) {
-    case 'command':
-      await headlessEdit(args[1], args.slice(2).join(' '), deps);
-      break;
-    case 'prompt':
-      await headlessEditPrompt(args[1], args.slice(2).join(' '), deps);
-      break;
-    case 'pool':
-    case 'executor':
-      await headlessEditExecutor(args[1], args[2], args[3], deps);
-      break;
-    case 'agent':
-      await headlessEditAgent(args[1], args[2], deps);
-      break;
-    case 'model':
-      await headlessEditModel(args[1], args[2], deps);
-      break;
-    case 'task-pool':
-      await headlessEditTaskPool(args[1], args[2], deps);
-      break;
-    case 'merge-mode':
-      await headlessSetMergeMode(args[1], args[2], deps);
-      break;
-    case 'fix-prompt':
-      await headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps);
-      break;
-    case 'fix-context':
-      await headlessSetFixContext(args[1], { fixContext: args.slice(2).join(' ') }, deps);
-      break;
-    case 'gate-policy':
-      await headlessSetGatePolicy(args.slice(1), deps);
-      break;
-    case 'workflow':
-      await headlessSetWorkflowMetadata(args[1], args[2], args.slice(3).join(' '), deps);
-      break;
-    case 'task':
-      await headlessSetTaskMetadata(args[1], args[2], args.slice(3).join(' '), deps);
-      break;
-    default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: ${formatHeadlessSetSubcommands(', ')}`);
+  if (findHeadlessSetSubcommandScope(subCommand) === undefined) {
+    throw new Error(`Unknown set sub-command: "${subCommand}". Use: ${formatHeadlessSetSubcommands(', ')}`);
   }
+  await HEADLESS_SET_HANDLERS[subCommand as HeadlessSetSubcommand](args, deps);
 }
+
+type HeadlessSetHandler = (args: string[], deps: HeadlessDeps) => Promise<void>;
+
+const HEADLESS_SET_HANDLERS: Record<HeadlessSetSubcommand, HeadlessSetHandler> = {
+  command: (args, deps) => headlessEdit(args[1], args.slice(2).join(' '), deps),
+  prompt: (args, deps) => headlessEditPrompt(args[1], args.slice(2).join(' '), deps),
+  pool: (args, deps) => headlessEditExecutor(args[1], args[2], args[3], deps),
+  executor: (args, deps) => headlessEditExecutor(args[1], args[2], args[3], deps),
+  agent: (args, deps) => headlessEditAgent(args[1], args[2], deps),
+  model: (args, deps) => headlessEditModel(args[1], args[2], deps),
+  'task-pool': (args, deps) => headlessEditTaskPool(args[1], args[2], deps),
+  'merge-mode': (args, deps) => headlessSetMergeMode(args[1], args[2], deps),
+  'fix-prompt': (args, deps) => headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps),
+  'fix-context': (args, deps) => headlessSetFixContext(args[1], { fixContext: args.slice(2).join(' ') }, deps),
+  'gate-policy': (args, deps) => headlessSetGatePolicy(args.slice(1), deps),
+  workflow: (args, deps) => headlessSetWorkflowMetadata(args[1], args[2], args.slice(3).join(' '), deps),
+  task: (args, deps) => headlessSetTaskMetadata(args[1], args[2], args.slice(3).join(' '), deps),
+};
 
 async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   const report = deps.persistence.runCompatibilityMigration();

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -55,6 +55,7 @@ import { runHeadless, resolveAgentSession } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
 import { publishForcedRefreshTaskGraphSnapshot, resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
 import { resolveHeadlessTarget, resolveHeadlessTargetWorkflowId } from '../headless-command-classification.js';
+import { findHeadlessSetSubcommandScope } from '../headless-command-registry.js';
 import {
   fixWithAgentAction,
   rebaseRecreate,
@@ -869,25 +870,14 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     switch (command) {
       case 'set': {
         const [, subCommand, targetArg] = payload.args;
-        switch (subCommand) {
-          case 'workflow':
-          case 'merge-mode':
-            return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
-          case 'command':
-          case 'prompt':
-          case 'pool':
-          case 'task-pool':
-          case 'executor':
-          case 'agent':
-          case 'model':
-          case 'fix-prompt':
-          case 'fix-context':
-          case 'gate-policy':
-          case 'task':
-            return { workflowId: workflowIdForTaskArg(targetArg), priority: 'high' };
-          default:
-            return { priority: 'normal' };
+        const scope = findHeadlessSetSubcommandScope(subCommand);
+        if (scope === 'workflow') {
+          return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
         }
+        if (scope === 'task') {
+          return { workflowId: workflowIdForTaskArg(targetArg), priority: 'high' };
+        }
+        return { priority: 'normal' };
       }
       case 'resume':
       case 'retry':


### PR DESCRIPTION
## Summary

The `set` sub-command names were hand-copied into the headless registry, the headless set router, and the owner's exec classifier. Nothing forced the copies to agree, which is how `model` went missing from two of them.

Each registry entry now carries a task or workflow scope. The classifier reads that scope instead of keeping its own case table.

The set router's switch becomes a handler map keyed by the registry names. A registry entry without a handler is now a compile error.

The drift check in `headless-set-model.test.ts` reads its expectations from the registry and also walks every GUI edit translation.

## Review Claim

Technique: Replace Conditional with Dispatch Table, the table-driven form of Replace Conditional with Polymorphism; the catalog has no exact name for it.

Every `set` name and its scope is declared once in `headless-command-registry.ts`, and the router and classifier derive from it with identical behavior to before.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

The handler map contains the same thirteen names with the same argument wiring as the old switch, and the classifier returns the same workflow id and priority for every name. The drift check covers all thirteen and every GUI edit translation.

## Slice Rationale

Slice 2 fixed the user-facing failure with the smallest change. This slice takes away the cause, so it is reviewed on its own as a pure structural change.

## Non-goals

- No behavior change.
- Does not touch the coordinator's copy of the task-scoped names; that is slice 4.
- Does not add or remove any `set` name.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-set-model.test.ts` (13 passed)
- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-delegation.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/headless-command-classification.test.ts src/__tests__/headless-install-skills.test.ts src/__tests__/acknowledge-no-track-start-ready.test.ts src/__tests__/headless-exec-ack-ok-precedence.test.ts` (127 passed)
- [x] `pnpm run check:types` (also fails with `Property 'model' is missing` when a handler is removed from the map)
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 707ce7baa0`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring with tests asserting parity; touches mutation classification and routing but claims no behavior change.
> 
> **Overview**
> **Headless `set` subcommands are now declared once** in `headless-command-registry.ts` as `{ name, scope: 'task' | 'workflow' }` entries instead of a plain name list, with `findHeadlessSetSubcommandScope()` for lookups.
> 
> The headless `set` router drops its large `switch` in favor of a **`HEADLESS_SET_HANDLERS` map** keyed by registry names (TypeScript requires every registered name to have a handler). GUI **`classifyHeadlessExecMutation`** for `set` reads scope from the registry instead of maintaining a parallel case table.
> 
> Tests iterate the new registry shape, derive workflow vs task targets from **`scope`**, and add coverage that common **`invoker:edit-task-*`** IPC paths translate to registered `set` subcommands and classify to the right workflow for no-track delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110fb4365e731fcd8f41ba0191296f92021feff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->