### PR TITLE
[Fix MCP submit-plan](1) Stop SEA binary argv prepend bug

### DIFF
--- a/packages/cli/src/__tests__/mcp-server-cli-invocation-sea.test.ts
+++ b/packages/cli/src/__tests__/mcp-server-cli-invocation-sea.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:sea', () => ({ isSea: vi.fn(() => false) }));
+
+const spawnCalls: unknown[][] = [];
+const spawnMock = vi.fn((...args: unknown[]) => {
+  spawnCalls.push(args);
+  return {
+    stdout: { setEncoding: () => {}, on: () => {} },
+    stderr: { setEncoding: () => {}, on: () => {} },
+    once: (event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0);
+    },
+  } as never;
+});
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
+afterEach(() => {
+  spawnCalls.length = 0;
+  spawnMock.mockClear();
+});
+
+describe('createProcessRunner SEA-aware default cliPath', () => {
+  it('defaults to execPath (no extra prepend) when running as a packaged SEA binary', async () => {
+    const sea = await import('node:sea');
+    vi.mocked(sea.isSea).mockReturnValue(true);
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = 'invoker-cli';
+    vi.resetModules();
+    const { createProcessRunner } = await import('../mcp-server.js');
+    const runner = createProcessRunner();
+    await runner.run(['run', '/tmp/plan.yaml', '--live', '--json']);
+    expect(spawnCalls.length).toBe(1);
+    const [command, args] = spawnCalls[0] as [string, string[]];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['run', '/tmp/plan.yaml', '--live', '--json']);
+    process.argv[1] = originalArgv1;
+  });
+
+  it('keeps prepending the real script path in dev mode (non-SEA)', async () => {
+    const sea = await import('node:sea');
+    vi.mocked(sea.isSea).mockReturnValue(false);
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = '/repo/dist/index.js';
+    vi.resetModules();
+    const { createProcessRunner } = await import('../mcp-server.js');
+    const runner = createProcessRunner();
+    await runner.run(['run', '/tmp/plan.yaml', '--json']);
+    expect(spawnCalls.length).toBe(1);
+    const [command, args] = spawnCalls[0] as [string, string[]];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/repo/dist/index.js', 'run', '/tmp/plan.yaml', '--json']);
+    process.argv[1] = originalArgv1;
+  });
+});

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
+import { isSea } from 'node:sea';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -173,7 +174,9 @@ export function resolveCliInvocation(
   return { command: execPath, args: [cliPath, ...args] };
 }
 
-export function createProcessRunner(cliPath = process.argv[1] ?? ''): McpCliRunner {
+export function createProcessRunner(
+  cliPath = isSea() ? process.execPath : process.argv[1] ?? '',
+): McpCliRunner {
   return {
     run(args, options) {
       const complete = Promise.withResolvers<{ exitCode: number; stdout: string; stderr: string }>();


### PR DESCRIPTION
## Summary

The MCP tool for running a plan against the live owner failed every call with an "Unknown command" error naming the CLI itself.

The subprocess re-spawn logic wrongly prepended `process.argv[1]` for the packaged binary, shifting every downstream argument by one position.

## Review Claim

`createProcessRunner`'s default `cliPath` now uses `node:sea`'s `isSea()` to detect the packaged binary and defaults to `process.execPath` (no extra token) in that case, matching the already-correct compiled-binary branch of `resolveCliInvocation`. Dev-mode behavior (a real script path from `process.argv[1]`) is unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only `createProcessRunner`'s default-parameter computation changes. `resolveCliInvocation` itself, its existing exported signature, and its existing passing unit tests are untouched. Dev-mode (non-SEA) callers keep prepending `process.argv[1]` exactly as before.

## Slice Rationale

One root-cause fix in the one function that mis-detects packaged vs dev-mode, plus its regression test. No unrelated refactor.

## Non-goals

- No change to `resolveCliInvocation`'s exported contract.
- No change to any other MCP tool or CLI command.
- Does not touch the 9 pre-existing, unrelated `--standalone`/merge-gate-workspace test timeouts in `cli.test.ts` — confirmed pre-existing on the same suite against the pre-fix baseline (identical timeout, same test).

## Test Plan

<details>
<summary>Test Plan</summary>

Real production binary, before the code change: spawning the packaged CLI with the buggy argument shape (an extra token ahead of the real subcommand) reproduces the exact "unknown command" text byte for byte; the corrected shape (no extra token) reaches real argument parsing and fails only on a missing downstream file instead.

New regression test, fail-before / pass-after against the actual TypeScript source:

```
$ npx vitest run --reporter=verbose src/__tests__/mcp-server-cli-invocation-sea.test.ts
# before fix:
 × ... defaults to execPath (no extra prepend) when running as a packaged SEA binary
   → expected [ 'invoker-cli', 'run', …(3) ] to deeply equal [ 'run', '/tmp/plan.yaml', …(2) ]
 ✓ ... keeps prepending the real script path in dev mode (non-SEA)

# after fix:
 ✓ ... defaults to execPath (no extra prepend) when running as a packaged SEA binary
 ✓ ... keeps prepending the real script path in dev mode (non-SEA)
```

Full package suite: `pnpm --filter @invoker/cli test` — 198 pass, 2 not run, 9 fail. The 9 failures reproduce identically against the pre-fix baseline (`--standalone`/merge-gate-workspace timeouts, unrelated to this change) — confirmed by stashing this fix and re-running the same failing test, same 60s timeout, same test name.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: none
- Data migration? No

</details>
