### PR TITLE
fix(codex-session-audit): handle null info/rate_limits from no-credit sessions

### DIFF
--- a/scripts/codex-session-audit.py
+++ b/scripts/codex-session-audit.py
@@ -90,9 +90,9 @@ def summarize_session(path):
                     model = e.get("payload", {}).get("model", model)
                 if t == "event_msg" and e.get("payload", {}).get("type") == "token_count":
                     info = e["payload"]
-                    tu = info.get("info", {}).get("total_token_usage", {})
+                    tu = (info.get("info") or {}).get("total_token_usage") or {}
                     total_tokens = tu.get("total_tokens")
-                    rl = info.get("rate_limits", {})
+                    rl = info.get("rate_limits") or {}
                     primary = rl.get("primary") or {}
                     used_percent = primary.get("used_percent")
                     resets_at = primary.get("resets_at")

--- a/scripts/test-codex-session-audit.py
+++ b/scripts/test-codex-session-audit.py
@@ -102,6 +102,49 @@ class TestTokenAndQuotaExtraction(unittest.TestCase):
         self.assertEqual(row["resets_at"], 1787201973)
         self.assertEqual(row["plan_type"], "pro")
 
+    def test_null_info_from_no_credit_account_does_not_crash(self):
+        session_dir = tempfile.mkdtemp()
+        write_session(session_dir, "rollout-2026-09-03T12-48-23-repro.jsonl", [
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": None,
+                    "rate_limits": {
+                        "limit_id": "premium",
+                        "limit_name": None,
+                        "primary": None,
+                        "secondary": None,
+                        "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+                        "individual_limit": None,
+                        "spend_control_reached": None,
+                        "plan_type": None,
+                        "rate_limit_reached_type": None,
+                    },
+                },
+            },
+        ])
+        results = codex_session_audit.audit(session_dir)
+        row = results[0]
+        self.assertIsNone(row["total_tokens"])
+        self.assertIsNone(row["used_percent"])
+        self.assertIsNone(row["resets_at"])
+        self.assertIsNone(row["plan_type"])
+        self.assertIsNone(row["note"])
+
+    def test_null_rate_limits_does_not_crash(self):
+        session_dir = tempfile.mkdtemp()
+        write_session(session_dir, "rollout-2026-09-03T09-00-00-null-rl.jsonl", [
+            {
+                "type": "event_msg",
+                "payload": {"type": "token_count", "info": {"total_token_usage": {"total_tokens": 42}}, "rate_limits": None},
+            },
+        ])
+        results = codex_session_audit.audit(session_dir)
+        row = results[0]
+        self.assertEqual(row["total_tokens"], 42)
+        self.assertIsNone(row["used_percent"])
+
     def test_later_token_count_event_overwrites_earlier_one(self):
         session_dir = tempfile.mkdtemp()
         write_session(session_dir, "rollout-2026-08-15T09-00-00-xyz.jsonl", [


### PR DESCRIPTION
A codex account with zero credits still emits a token_count event, but with
info: null instead of a populated object. summarize_session crashed with
AttributeError instead of treating it as zero real usage. Two .get(key,
default) calls only used their default on a missing key, not an explicit
null value, unlike the existing rl.get("primary") or {} pattern one line
below. Extend that same idiom to both call sites.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014BP3ZTkVhEmfEVBzwqQ5Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in a local audit script’s JSON parsing; no auth, data writes, or production API behavior.
> 
> **Overview**
> Fixes **`summarize_session`** crashing with **`AttributeError`** when Codex **`token_count`** events include explicit JSON **`null`** for **`info`** or **`rate_limits`** (e.g. zero-credit accounts that still emit the event).
> 
> Parsing now uses **`(info.get("info") or {})`** and **`info.get("rate_limits") or {}`** so missing keys and **`null`** values both fall back to empty dicts, matching the existing **`primary`** handling. Token totals and quota fields degrade to **`None`** instead of aborting the audit row.
> 
> Adds fixture tests for **`info: null`** with a no-credit **`rate_limits`** payload and for **`rate_limits: null`** with valid token usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc29a1cab2e560d018355df75f1e239cbfcfcfc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->