### PR TITLE
[Fix submit-workflow-chain](2) Restore local dev-chain backend

### DIFF
--- a/scripts/repro-submit-workflow-chain-live-owner.sh
+++ b/scripts/repro-submit-workflow-chain-live-owner.sh
@@ -21,6 +21,7 @@ echo
 
 source scripts/submit-workflow-chain.sh
 
+BACKEND="live"
 START_MS="$(now_ms)"
 RESULT="$(resolve_workflow_feature_branch "$LIVE_ID" 2>&1)"
 STATUS=$?

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -41,6 +41,46 @@ log_chain() {
   echo "[submit-workflow-chain] ${msg}"
 }
 
+BACKEND=""
+
+chain_backend_query_workflows() {
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli query workflows --output json 2>/dev/null
+  else
+    ./run.sh --headless query workflows --output json 2>/dev/null
+  fi
+}
+
+chain_backend_query_tasks() {
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli query tasks --output json 2>/dev/null
+  else
+    ./run.sh --headless query tasks --output json 2>/dev/null
+  fi
+}
+
+chain_backend_submit() {
+  local plan="$1"
+  local out_file="$2"
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli run "$plan" --live --json >"$out_file" 2>/dev/null || true
+  else
+    ./run.sh --headless run "$plan" --no-track >"$out_file" 2>&1 || true
+  fi
+}
+
+chain_backend_parse_submit_id() {
+  local out_file="$1"
+  if [[ "$BACKEND" == "live" ]]; then
+    jq -r '.workflow.id // empty' "$out_file" 2>/dev/null || true
+  else
+    local printed_id delegated_id
+    printed_id="$(awk '/Workflow ID:/{print $3}' "$out_file" | tail -1)"
+    delegated_id="$(sed -n 's/.*workflow: \(wf-[0-9]\+-[0-9]\+\).*/\1/p' "$out_file" | tail -1)"
+    printf '%s' "${printed_id:-$delegated_id}"
+  fi
+}
+
 resolve_abs() {
   local p="$1"
   cd "$(dirname "$p")" && pwd
@@ -174,7 +214,7 @@ resolve_persisted_workflow_id() {
   for _ in $(seq 1 30); do
     attempt=$((attempt + 1))
     wf_id="$(
-      invoker-cli query workflows --output json 2>/dev/null \
+      chain_backend_query_workflows \
         | extract_json_stream \
         | jq -r --arg n "$workflow_name" '[.[] | select(.name == $n)] | sort_by(.createdAt) | last | .id // empty'
     )"
@@ -198,7 +238,7 @@ resolve_workflow_feature_branch() {
   for _ in $(seq 1 30); do
     attempt=$((attempt + 1))
     feature_branch="$(
-      invoker-cli query workflows --output json 2>/dev/null \
+      chain_backend_query_workflows \
         | extract_json_stream \
         | jq -r --arg id "$workflow_id" '.[] | select(.id == $id) | .featureBranch // empty' \
         | head -1
@@ -264,7 +304,7 @@ wait_for_external_merge_gate() {
   local attempt=0
   for _ in $(seq 1 60); do
     attempt=$((attempt + 1))
-    if invoker-cli query tasks --output json 2>/dev/null | extract_json_stream | jq -e --arg id "$merge_id" '.[] | select(.id == $id)' >/dev/null; then
+    if chain_backend_query_tasks | extract_json_stream | jq -e --arg id "$merge_id" '.[] | select(.id == $id)' >/dev/null; then
       log_chain "wait_for_external_merge_gate mergeTaskId=\"$merge_id\" found attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
       return 0
     fi
@@ -536,6 +576,12 @@ for i in "${!INPUT_PLANS[@]}"; do
       fi
     fi
     if [[ -n "$onto_id" ]]; then
+      BACKEND="live"
+    else
+      BACKEND="local"
+    fi
+    log_chain "backend=${BACKEND}"
+    if [[ -n "$onto_id" ]]; then
       onto_feature="$(resolve_workflow_feature_branch "$onto_id" || true)"
       if [[ -z "${onto_feature:-}" ]]; then
         echo "Failed to resolve featureBranch for --onto-workflow: $onto_id" >&2
@@ -578,16 +624,16 @@ for i in "${!INPUT_PLANS[@]}"; do
     RENDERED_PLANS+=("$submit_plan")
   fi
 
-  echo "Submitting workflow $((i+1)) (no track): $submit_plan"
+  echo "Submitting workflow $((i+1)) (backend=${BACKEND}): $submit_plan"
   run_start_ms="$(now_ms)"
-  log_chain "headless-run begin step=$((i+1)) plan=\"$submit_plan\" noTrack=true"
+  log_chain "headless-run begin step=$((i+1)) plan=\"$submit_plan\" backend=${BACKEND}"
   _chain_out="$(mktemp "${TMPDIR:-/tmp}/invoker-chain-out$((i+1)).XXXXXX")"
   out_file="${_chain_out}.log"
   rm -f "$_chain_out"
-  invoker-cli run "$submit_plan" --live --json >"$out_file" 2>/dev/null || true
+  chain_backend_submit "$submit_plan" "$out_file"
   log_chain "headless-run end step=$((i+1)) elapsedMs=$(( $(now_ms) - run_start_ms )) out=\"$out_file\""
 
-  printed_id="$(jq -r '.workflow.id // empty' "$out_file" 2>/dev/null || true)"
+  printed_id="$(chain_backend_parse_submit_id "$out_file")"
   if [[ -n "${printed_id:-}" ]]; then
     echo "  printed_id=${printed_id:-<none>}"
   fi
@@ -602,7 +648,7 @@ for i in "${!INPUT_PLANS[@]}"; do
 
   CHAIN_WORKFLOW_IDS+=("$persisted_id")
   wf_base_branch="$(
-    invoker-cli query workflows --output json 2>/dev/null \
+    chain_backend_query_workflows \
       | extract_json_stream \
       | jq -r --arg id "$persisted_id" '.[] | select(.id == $id) | .baseBranch // empty' | head -1
   )"
@@ -621,6 +667,7 @@ done
 echo
 echo "Workflow chain submitted."
 echo "GATE_POLICY=${GATE_POLICY}"
+echo "BACKEND=${BACKEND}"
 for i in "${!CHAIN_WORKFLOW_IDS[@]}"; do
   echo "WF$((i+1))=${CHAIN_WORKFLOW_IDS[$i]} base=${CHAIN_BASE_BRANCHES[$i]} feature=${CHAIN_FEATURE_BRANCHES[$i]}"
 done

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -19,6 +19,11 @@ cat > "$TMP_DIR/bin/invoker-cli" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${INVOKER_CLI_FORBIDDEN:-0}" == "1" ]]; then
+  echo "TEST FAILURE: invoker-cli mock invoked during a local-backend scenario" >&2
+  exit 1
+fi
+
 STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.state"
 mkdir -p "$STATE_DIR"
 
@@ -83,6 +88,86 @@ case "$cmd" in
 esac
 EOF
 chmod +x "$TMP_DIR/bin/invoker-cli"
+
+cat > "$TMP_DIR/run.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${RUN_SH_FORBIDDEN:-0}" == "1" ]]; then
+  echo "TEST FAILURE: ./run.sh mock invoked during a live-backend scenario" >&2
+  exit 1
+fi
+
+STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.state"
+mkdir -p "$STATE_DIR"
+
+WORKFLOWS_JSON="$STATE_DIR/workflows.json"
+TASKS_JSON="$STATE_DIR/tasks.json"
+SEQ_FILE="$STATE_DIR/seq"
+
+[[ -f "$WORKFLOWS_JSON" ]] || printf '[]' > "$WORKFLOWS_JSON"
+[[ -f "$TASKS_JSON" ]] || printf '[]' > "$TASKS_JSON"
+[[ -f "$SEQ_FILE" ]] || printf '1000' > "$SEQ_FILE"
+
+if [[ "${1:-}" != "--headless" ]]; then
+  echo "mock run.sh expects --headless" >&2
+  exit 1
+fi
+shift
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  query)
+    sub="${1:-}"
+    if [[ "$sub" == "workflows" ]]; then
+      cat "$WORKFLOWS_JSON"
+      exit 0
+    fi
+    if [[ "$sub" == "tasks" ]]; then
+      cat "$TASKS_JSON"
+      exit 0
+    fi
+    echo "unsupported query subcommand: $sub" >&2
+    exit 1
+    ;;
+  run)
+    plan="${1:-}"
+    [[ -f "$plan" ]] || { echo "missing plan: $plan" >&2; exit 1; }
+
+    seq="$(cat "$SEQ_FILE")"
+    wf_id="wf-${seq}-1"
+    printf '%s' "$((seq + 1))" > "$SEQ_FILE"
+
+    name="$(awk -F': *' '/^name:/{v=$2; gsub(/^"|"$/, "", v); print v; exit}' "$plan")"
+    base="$(awk -F': *' '/^baseBranch:/{print $2; exit}' "$plan")"
+    feature="$(awk -F': *' '/^featureBranch:/{print $2; exit}' "$plan")"
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    jq --arg id "$wf_id" \
+      --arg name "$name" \
+      --arg base "$base" \
+      --arg feature "$feature" \
+      --arg now "$now" \
+      '. += [{id:$id,name:$name,status:"running",baseBranch:$base,featureBranch:$feature,createdAt:$now}]' \
+      "$WORKFLOWS_JSON" > "$WORKFLOWS_JSON.tmp"
+    mv "$WORKFLOWS_JSON.tmp" "$WORKFLOWS_JSON"
+
+    jq --arg id "__merge__${wf_id}" \
+      '. += [{id:$id,status:"pending",config:{}}]' \
+      "$TASKS_JSON" > "$TASKS_JSON.tmp"
+    mv "$TASKS_JSON.tmp" "$TASKS_JSON"
+
+    echo "Workflow ID: $wf_id"
+    ;;
+  *)
+    echo "unsupported command: $cmd" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$TMP_DIR/run.sh"
 export PATH="$TMP_DIR/bin:$PATH"
 
 cat > "$TMP_DIR/plans/a.yaml" <<'EOF'
@@ -132,8 +217,10 @@ EOF
 
 out="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
+  INVOKER_CLI_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
 )"
+
+grep -q '^BACKEND=local$' <<<"$out" || { echo "expected local backend for a plain chain with no external ref"; echo "$out"; exit 1; }
 
 wf1="$(printf '%s\n' "$out" | awk -F'[ =]' '/^WF1=/{print $2; exit}')"
 wf2="$(printf '%s\n' "$out" | awk -F'[ =]' '/^WF2=/{print $2; exit}')"
@@ -158,8 +245,10 @@ grep -q '^baseBranch: feature/b$' "$rp3"
 
 out_rr="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh --gate-policy review_ready ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
+  INVOKER_CLI_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh --gate-policy review_ready ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
 )"
+
+grep -q '^BACKEND=local$' <<<"$out_rr" || { echo "expected local backend for review_ready chain with no external ref"; echo "$out_rr"; exit 1; }
 
 rp2_rr="$(printf '%s\n' "$out_rr" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 rp3_rr="$(printf '%s\n' "$out_rr" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '2p')"
@@ -215,8 +304,9 @@ EOF
 
 out_onto="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh --onto-workflow wf-fanout-1 ./plans/onto-head.yaml ./plans/onto-next.yaml
+  RUN_SH_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh --onto-workflow wf-fanout-1 ./plans/onto-head.yaml ./plans/onto-next.yaml
 )"
+grep -q '^BACKEND=live$' <<<"$out_onto" || { echo "expected live backend for --onto-workflow"; echo "$out_onto"; exit 1; }
 rp_onto="$(printf '%s\n' "$out_onto" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 [[ -f "$rp_onto" ]] || { echo "missing rendered onto-head plan"; echo "$out_onto"; exit 1; }
 grep -q '^baseBranch: plan/fanout-upstream$' "$rp_onto"
@@ -238,10 +328,11 @@ jq -n --arg id "__merge__wf-fanout-1" '[{id:$id,status:"review_ready",config:{}}
 
 out_auto="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh ./plans/onto-head.yaml ./plans/onto-next.yaml
+  RUN_SH_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh ./plans/onto-head.yaml ./plans/onto-next.yaml
 )"
+grep -q '^BACKEND=live$' <<<"$out_auto" || { echo "expected live backend for auto-detected concrete externalDependency"; echo "$out_auto"; exit 1; }
 rp_auto="$(printf '%s\n' "$out_auto" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 [[ -f "$rp_auto" ]] || { echo "missing auto-onto rendered plan"; echo "$out_auto"; exit 1; }
 grep -q '^baseBranch: plan/fanout-upstream$' "$rp_auto"
 
-echo "PASS: submit-workflow-chain enforces merge-gate deps, branch chaining, gate policy, and --onto-workflow"
+echo "PASS: submit-workflow-chain enforces merge-gate deps, branch chaining, gate policy, --onto-workflow, and local/live backend isolation"


### PR DESCRIPTION
## Summary

The prior commit on this branch (fd1b776e15, PR #11912) fixed a real lookup mismatch, but went further than needed.

It changed every call, including new-workflow creation, to always go through the live owner -- erasing the plain local chain test path.

## Review Claim

The script now picks one backend per invocation -- local or live -- once, up front. Live is chosen only when `--onto-workflow` names a real external workflow, or plan[0] carries a concrete external reference to one. Every call in that invocation, new or lookup, goes through that same choice. A plain chain with no external reference never reaches the live owner at all.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The prior local-only path was never a no-op: it always performed real, tracked work locally, just without blocking on status. Bringing it back does not reintroduce a dead or silent code path.

## Slice Rationale

One script, stacked directly on the commit it narrows, so the two diffs read together as one story.

## Non-goals

No change to gate-policy enforcement or template rendering already covered by the tests added in PR #11912.

## Test Plan

<details>
<summary>Test Plan</summary>

Real output, `bash scripts/test-submit-workflow-chain.sh`:

```
PASS: submit-workflow-chain enforces merge-gate deps, branch chaining, gate policy, --onto-workflow, and local/live backend isolation
```

The suite now checks a plain chain picks the local backend while the live-owner double exits loudly if reached at all, and checks a chain naming a real external workflow picks the live backend while the local double exits loudly if reached at all -- proving the two paths never cross.

Real output, `bash scripts/repro-submit-workflow-chain-live-owner.sh`, against an actual already-existing workflow:

```
resolve_workflow_feature_branch exit=0 elapsedMs=337
plan/invoker-optimizations-push-not-poll-skill

PASS: resolved the real featureBranch quickly via the live owner.
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Safe to revert. Reverting this one commit returns to the all-live behavior from PR #11912 alone -- mechanically safe, though it drops the restored local-chain path. No data migration.

</details>
