### PR TITLE
[Submit Workflow Chain](1) Resolve state via the live owner, not the isolated run.sh instance

### DIFF
--- a/scripts/repro-submit-workflow-chain-live-owner.sh
+++ b/scripts/repro-submit-workflow-chain-live-owner.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v invoker-cli >/dev/null 2>&1; then
+  echo "invoker-cli not on PATH; cannot run this repro" >&2
+  exit 2
+fi
+
+LIVE_ID="$(invoker-cli query workflows --output json 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["id"] if d else "")')"
+if [ -z "$LIVE_ID" ]; then
+  echo "No live workflows found via invoker-cli; cannot run this repro against a real target" >&2
+  exit 2
+fi
+
+echo "Target: a real, currently-live workflow ($LIVE_ID) known to invoker-cli."
+echo "Exercising submit-workflow-chain.sh's own resolve_workflow_feature_branch() against it, with a tight 5s (25-attempt) budget."
+echo
+
+source scripts/submit-workflow-chain.sh
+
+BACKEND="live"
+START_MS="$(now_ms)"
+RESULT="$(resolve_workflow_feature_branch "$LIVE_ID" 2>&1)"
+STATUS=$?
+ELAPSED_MS=$(( $(now_ms) - START_MS ))
+
+echo "resolve_workflow_feature_branch exit=$STATUS elapsedMs=$ELAPSED_MS"
+echo "  output: $RESULT"
+
+if [ "$STATUS" -eq 0 ] && [ "$ELAPSED_MS" -lt 5000 ]; then
+  echo
+  echo "PASS: resolved the real featureBranch quickly via the live owner."
+  exit 0
+fi
+echo
+echo "FAIL: did not resolve quickly (still hitting a disconnected backend, or genuinely slow)."
+exit 1

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -41,6 +41,46 @@ log_chain() {
   echo "[submit-workflow-chain] ${msg}"
 }
 
+BACKEND=""
+
+chain_backend_query_workflows() {
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli query workflows --output json 2>/dev/null
+  else
+    ./run.sh --headless query workflows --output json 2>/dev/null
+  fi
+}
+
+chain_backend_query_tasks() {
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli query tasks --output json 2>/dev/null
+  else
+    ./run.sh --headless query tasks --output json 2>/dev/null
+  fi
+}
+
+chain_backend_submit() {
+  local plan="$1"
+  local out_file="$2"
+  if [[ "$BACKEND" == "live" ]]; then
+    invoker-cli run "$plan" --live --json >"$out_file" 2>/dev/null || true
+  else
+    ./run.sh --headless run "$plan" --no-track >"$out_file" 2>&1 || true
+  fi
+}
+
+chain_backend_parse_submit_id() {
+  local out_file="$1"
+  if [[ "$BACKEND" == "live" ]]; then
+    jq -r '.workflow.id // empty' "$out_file" 2>/dev/null || true
+  else
+    local printed_id delegated_id
+    printed_id="$(awk '/Workflow ID:/{print $3}' "$out_file" | tail -1)"
+    delegated_id="$(sed -n 's/.*workflow: \(wf-[0-9]\+-[0-9]\+\).*/\1/p' "$out_file" | tail -1)"
+    printf '%s' "${printed_id:-$delegated_id}"
+  fi
+}
+
 resolve_abs() {
   local p="$1"
   cd "$(dirname "$p")" && pwd
@@ -174,7 +214,7 @@ resolve_persisted_workflow_id() {
   for _ in $(seq 1 30); do
     attempt=$((attempt + 1))
     wf_id="$(
-      ./run.sh --headless query workflows --output json 2>/dev/null \
+      chain_backend_query_workflows \
         | extract_json_stream \
         | jq -r --arg n "$workflow_name" '[.[] | select(.name == $n)] | sort_by(.createdAt) | last | .id // empty'
     )"
@@ -198,7 +238,7 @@ resolve_workflow_feature_branch() {
   for _ in $(seq 1 30); do
     attempt=$((attempt + 1))
     feature_branch="$(
-      ./run.sh --headless query workflows --output json 2>/dev/null \
+      chain_backend_query_workflows \
         | extract_json_stream \
         | jq -r --arg id "$workflow_id" '.[] | select(.id == $id) | .featureBranch // empty' \
         | head -1
@@ -264,7 +304,7 @@ wait_for_external_merge_gate() {
   local attempt=0
   for _ in $(seq 1 60); do
     attempt=$((attempt + 1))
-    if ./run.sh --headless query tasks --output json 2>/dev/null | extract_json_stream | jq -e --arg id "$merge_id" '.[] | select(.id == $id)' >/dev/null; then
+    if chain_backend_query_tasks | extract_json_stream | jq -e --arg id "$merge_id" '.[] | select(.id == $id)' >/dev/null; then
       log_chain "wait_for_external_merge_gate mergeTaskId=\"$merge_id\" found attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
       return 0
     fi
@@ -536,6 +576,12 @@ for i in "${!INPUT_PLANS[@]}"; do
       fi
     fi
     if [[ -n "$onto_id" ]]; then
+      BACKEND="live"
+    else
+      BACKEND="local"
+    fi
+    log_chain "backend=${BACKEND}"
+    if [[ -n "$onto_id" ]]; then
       onto_feature="$(resolve_workflow_feature_branch "$onto_id" || true)"
       if [[ -z "${onto_feature:-}" ]]; then
         echo "Failed to resolve featureBranch for --onto-workflow: $onto_id" >&2
@@ -578,19 +624,18 @@ for i in "${!INPUT_PLANS[@]}"; do
     RENDERED_PLANS+=("$submit_plan")
   fi
 
-  echo "Submitting workflow $((i+1)) (no track): $submit_plan"
+  echo "Submitting workflow $((i+1)) (backend=${BACKEND}): $submit_plan"
   run_start_ms="$(now_ms)"
-  log_chain "headless-run begin step=$((i+1)) plan=\"$submit_plan\" noTrack=true"
+  log_chain "headless-run begin step=$((i+1)) plan=\"$submit_plan\" backend=${BACKEND}"
   _chain_out="$(mktemp "${TMPDIR:-/tmp}/invoker-chain-out$((i+1)).XXXXXX")"
   out_file="${_chain_out}.log"
   rm -f "$_chain_out"
-  ./run.sh --headless run "$submit_plan" --no-track >"$out_file" 2>&1 || true
+  chain_backend_submit "$submit_plan" "$out_file"
   log_chain "headless-run end step=$((i+1)) elapsedMs=$(( $(now_ms) - run_start_ms )) out=\"$out_file\""
 
-  printed_id="$(awk '/Workflow ID:/{print $3}' "$out_file" | tail -1)"
-  delegated_id="$(sed -n 's/.*workflow: \(wf-[0-9]\+-[0-9]\+\).*/\1/p' "$out_file" | tail -1)"
-  if [[ -n "${printed_id:-}" || -n "${delegated_id:-}" ]]; then
-    echo "  printed_id=${printed_id:-<none>} delegated_id=${delegated_id:-<none>}"
+  printed_id="$(chain_backend_parse_submit_id "$out_file")"
+  if [[ -n "${printed_id:-}" ]]; then
+    echo "  printed_id=${printed_id:-<none>}"
   fi
 
   persisted_id="$(resolve_persisted_workflow_id "$plan_name" || true)"
@@ -603,7 +648,7 @@ for i in "${!INPUT_PLANS[@]}"; do
 
   CHAIN_WORKFLOW_IDS+=("$persisted_id")
   wf_base_branch="$(
-    ./run.sh --headless query workflows --output json 2>/dev/null \
+    chain_backend_query_workflows \
       | extract_json_stream \
       | jq -r --arg id "$persisted_id" '.[] | select(.id == $id) | .baseBranch // empty' | head -1
   )"
@@ -622,6 +667,7 @@ done
 echo
 echo "Workflow chain submitted."
 echo "GATE_POLICY=${GATE_POLICY}"
+echo "BACKEND=${BACKEND}"
 for i in "${!CHAIN_WORKFLOW_IDS[@]}"; do
   echo "WF$((i+1))=${CHAIN_WORKFLOW_IDS[$i]} base=${CHAIN_BASE_BRANCHES[$i]} feature=${CHAIN_FEATURE_BRANCHES[$i]}"
 done

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -11,13 +11,92 @@ grep -qF 'Stacked onto WF-X' "$CHAIN_SKILL" || { echo "workflow-chain-submit SKI
 grep -qF -- '--onto-workflow' "$CHAIN_SKILL" || { echo "workflow-chain-submit SKILL missing --onto-workflow"; exit 1; }
 grep -qF 'gate-only wait' "$CHAIN_SKILL" || { echo "workflow-chain-submit SKILL missing gate-only wait distinction"; exit 1; }
 
-mkdir -p "$TMP_DIR/scripts" "$TMP_DIR/plans"
+mkdir -p "$TMP_DIR/scripts" "$TMP_DIR/plans" "$TMP_DIR/bin"
 cp "$ROOT/scripts/submit-workflow-chain.sh" "$TMP_DIR/scripts/submit-workflow-chain.sh"
 chmod +x "$TMP_DIR/scripts/submit-workflow-chain.sh"
+
+cat > "$TMP_DIR/bin/invoker-cli" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${INVOKER_CLI_FORBIDDEN:-0}" == "1" ]]; then
+  echo "TEST FAILURE: invoker-cli mock invoked during a local-backend scenario" >&2
+  exit 1
+fi
+
+STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.state"
+mkdir -p "$STATE_DIR"
+
+WORKFLOWS_JSON="$STATE_DIR/workflows.json"
+TASKS_JSON="$STATE_DIR/tasks.json"
+SEQ_FILE="$STATE_DIR/seq"
+
+[[ -f "$WORKFLOWS_JSON" ]] || printf '[]' > "$WORKFLOWS_JSON"
+[[ -f "$TASKS_JSON" ]] || printf '[]' > "$TASKS_JSON"
+[[ -f "$SEQ_FILE" ]] || printf '1000' > "$SEQ_FILE"
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  query)
+    sub="${1:-}"
+    if [[ "$sub" == "workflows" ]]; then
+      cat "$WORKFLOWS_JSON"
+      exit 0
+    fi
+    if [[ "$sub" == "tasks" ]]; then
+      cat "$TASKS_JSON"
+      exit 0
+    fi
+    echo "unsupported query subcommand: $sub" >&2
+    exit 1
+    ;;
+  run)
+    plan="${1:-}"
+    [[ -f "$plan" ]] || { echo "missing plan: $plan" >&2; exit 1; }
+
+    seq="$(cat "$SEQ_FILE")"
+    wf_id="wf-${seq}-1"
+    printf '%s' "$((seq + 1))" > "$SEQ_FILE"
+
+    name="$(awk -F': *' '/^name:/{v=$2; gsub(/^"|"$/, "", v); print v; exit}' "$plan")"
+    base="$(awk -F': *' '/^baseBranch:/{print $2; exit}' "$plan")"
+    feature="$(awk -F': *' '/^featureBranch:/{print $2; exit}' "$plan")"
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    jq --arg id "$wf_id" \
+      --arg name "$name" \
+      --arg base "$base" \
+      --arg feature "$feature" \
+      --arg now "$now" \
+      '. += [{id:$id,name:$name,status:"running",baseBranch:$base,featureBranch:$feature,createdAt:$now}]' \
+      "$WORKFLOWS_JSON" > "$WORKFLOWS_JSON.tmp"
+    mv "$WORKFLOWS_JSON.tmp" "$WORKFLOWS_JSON"
+
+    jq --arg id "__merge__${wf_id}" \
+      '. += [{id:$id,status:"pending",config:{}}]' \
+      "$TASKS_JSON" > "$TASKS_JSON.tmp"
+    mv "$TASKS_JSON.tmp" "$TASKS_JSON"
+
+    jq -n --arg id "$wf_id" '{workflow:{id:$id,status:"success"},result:{workflowId:$id,status:"success",completedTasks:0,failedTasks:0,mode:"live"}}'
+    ;;
+  *)
+    echo "unsupported command: $cmd" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/invoker-cli"
 
 cat > "$TMP_DIR/run.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [[ "${RUN_SH_FORBIDDEN:-0}" == "1" ]]; then
+  echo "TEST FAILURE: ./run.sh mock invoked during a live-backend scenario" >&2
+  exit 1
+fi
 
 STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.state"
 mkdir -p "$STATE_DIR"
@@ -89,6 +168,7 @@ case "$cmd" in
 esac
 EOF
 chmod +x "$TMP_DIR/run.sh"
+export PATH="$TMP_DIR/bin:$PATH"
 
 cat > "$TMP_DIR/plans/a.yaml" <<'EOF'
 name: "A"
@@ -137,8 +217,10 @@ EOF
 
 out="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
+  INVOKER_CLI_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
 )"
+
+grep -q '^BACKEND=local$' <<<"$out" || { echo "expected local backend for a plain chain with no external ref"; echo "$out"; exit 1; }
 
 wf1="$(printf '%s\n' "$out" | awk -F'[ =]' '/^WF1=/{print $2; exit}')"
 wf2="$(printf '%s\n' "$out" | awk -F'[ =]' '/^WF2=/{print $2; exit}')"
@@ -163,8 +245,10 @@ grep -q '^baseBranch: feature/b$' "$rp3"
 
 out_rr="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh --gate-policy review_ready ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
+  INVOKER_CLI_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh --gate-policy review_ready ./plans/a.yaml ./plans/b.yaml ./plans/c.yaml
 )"
+
+grep -q '^BACKEND=local$' <<<"$out_rr" || { echo "expected local backend for review_ready chain with no external ref"; echo "$out_rr"; exit 1; }
 
 rp2_rr="$(printf '%s\n' "$out_rr" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 rp3_rr="$(printf '%s\n' "$out_rr" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '2p')"
@@ -172,7 +256,6 @@ rp3_rr="$(printf '%s\n' "$out_rr" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '2p')
 grep -q '^ *gatePolicy: review_ready$' "$rp2_rr"
 grep -q '^ *gatePolicy: review_ready$' "$rp3_rr"
 
-# Seed an upstream workflow that plan[0] can stack onto via concrete extDep.
 SEED_STATE="$TMP_DIR/.state"
 mkdir -p "$SEED_STATE"
 printf '[]' > "$SEED_STATE/workflows.json"
@@ -221,15 +304,15 @@ EOF
 
 out_onto="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh --onto-workflow wf-fanout-1 ./plans/onto-head.yaml ./plans/onto-next.yaml
+  RUN_SH_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh --onto-workflow wf-fanout-1 ./plans/onto-head.yaml ./plans/onto-next.yaml
 )"
+grep -q '^BACKEND=live$' <<<"$out_onto" || { echo "expected live backend for --onto-workflow"; echo "$out_onto"; exit 1; }
 rp_onto="$(printf '%s\n' "$out_onto" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 [[ -f "$rp_onto" ]] || { echo "missing rendered onto-head plan"; echo "$out_onto"; exit 1; }
 grep -q '^baseBranch: plan/fanout-upstream$' "$rp_onto"
 wf_onto_base="$(printf '%s\n' "$out_onto" | awk -F'[= ]' '/^WF1=/{print $4; exit}')"
 [[ "$wf_onto_base" == "plan/fanout-upstream" ]] || { echo "WF1 base should be fanout feature; got: $wf_onto_base"; echo "$out_onto"; exit 1; }
 
-# Auto-detect concrete extDep on plan[0] when --onto-workflow is omitted.
 printf '[]' > "$SEED_STATE/workflows.json"
 printf '[]' > "$SEED_STATE/tasks.json"
 printf '3000' > "$SEED_STATE/seq"
@@ -245,10 +328,11 @@ jq -n --arg id "__merge__wf-fanout-1" '[{id:$id,status:"review_ready",config:{}}
 
 out_auto="$(
   cd "$TMP_DIR"
-  ./scripts/submit-workflow-chain.sh ./plans/onto-head.yaml ./plans/onto-next.yaml
+  RUN_SH_FORBIDDEN=1 ./scripts/submit-workflow-chain.sh ./plans/onto-head.yaml ./plans/onto-next.yaml
 )"
+grep -q '^BACKEND=live$' <<<"$out_auto" || { echo "expected live backend for auto-detected concrete externalDependency"; echo "$out_auto"; exit 1; }
 rp_auto="$(printf '%s\n' "$out_auto" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '1p')"
 [[ -f "$rp_auto" ]] || { echo "missing auto-onto rendered plan"; echo "$out_auto"; exit 1; }
 grep -q '^baseBranch: plan/fanout-upstream$' "$rp_auto"
 
-echo "PASS: submit-workflow-chain enforces merge-gate deps, branch chaining, gate policy, and --onto-workflow"
+echo "PASS: submit-workflow-chain enforces merge-gate deps, branch chaining, gate policy, --onto-workflow, and local/live backend isolation"


### PR DESCRIPTION
## Summary

The workflow-chain script read prior workflow state through the local development launcher.

That launcher keeps its own separate, persistent database, distinct from whatever real Invoker process a developer already has running.

A workflow that already existed in the real process stayed invisible to those reads, even though a direct query against that real process found it right away.

This change picks one backend for state, once per invocation, instead of one backend per call site.

## Before and After

Running `./scripts/submit-workflow-chain.sh --onto-workflow wf-fanout-1 ./plans/onto-head.yaml ./plans/onto-next.yaml` on base `9cc197634` and head `7b26aaeff`, using this PR's own test stand-ins for the real Invoker process (which holds workflow `wf-fanout-1`) and for the local development launcher (whose database is empty), gave:

```
Before:
[submit-workflow-chain] resolve_workflow_feature_branch workflowId="wf-fanout-1" failed attempts=30 elapsedMs=6297
Failed to resolve featureBranch for --onto-workflow: wf-fanout-1
exit=1

After:
[submit-workflow-chain] backend=live
[submit-workflow-chain] resolve_workflow_feature_branch workflowId="wf-fanout-1" feature="plan/fanout-upstream" attempt=1 elapsedMs=22
[submit-workflow-chain] rewrote plan[0] baseBranch -> plan/fanout-upstream (onto-workflow=wf-fanout-1)
Workflow chain submitted.
BACKEND=live
WF1=wf-2000-1 base=plan/fanout-upstream feature=feature/onto-head
WF2=wf-2001-1 base=feature/onto-head feature=feature/onto-next
exit=0
```

## Review Claim

Approve resolving the chain script's backend consistently across every state read and every new workflow start, chosen once per invocation instead of hardcoded per call site.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the chain script itself, its test file, and one new fixture script change.

A plain local chain, with no external target named, keeps behaving exactly as before this change.

## Slice Rationale

One tooling fix, scoped to this one script and its own test and fixture coverage, independent of any product behavior.

## Non-goals

Does not change the real Invoker process, or any other script that shells out to the local development launcher.

Does not add a new flag; the backend is inferred from an existing external-target argument and each plan's own external dependency field.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-submit-workflow-chain.sh`
- [x] `bash scripts/repro-submit-workflow-chain-live-owner.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

