### PR TITLE
[Skill category](1a) Core selection function

### DIFF
--- a/packages/shell/src/bundled-skills-selection.test.ts
+++ b/packages/shell/src/bundled-skills-selection.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { listBundledSkillNames } from './bundled-skills.js';
+
+const tempRoots: string[] = [];
+
+function makeSourceRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-skill-selection-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeSkill(sourceRoot: string, name: string, category?: string): void {
+  const skillDir = join(sourceRoot, name);
+  mkdirSync(skillDir, { recursive: true });
+  const categoryLine = category ? `category: ${category}\n` : '';
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\n${categoryLine}description: test skill\n---\n\n# ${name}\n`,
+  );
+}
+
+function makeFixtureRoot(): string {
+  const sourceRoot = makeSourceRoot();
+  writeSkill(sourceRoot, 'alpha-core', 'core');
+  writeSkill(sourceRoot, 'beta-optimization', 'optimization');
+  writeSkill(sourceRoot, 'delta-core', 'core');
+  writeSkill(sourceRoot, 'gamma-untagged');
+  return sourceRoot;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('listBundledSkillNames category selection', () => {
+  it('returns every bundled skill when no category is supplied', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual([
+      'alpha-core',
+      'beta-optimization',
+      'delta-core',
+      'gamma-untagged',
+    ]);
+  });
+
+  it('returns the same full set when the default category is passed explicitly', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'all')).toEqual(listBundledSkillNames(sourceRoot));
+  });
+
+  it('returns only core skills for the core category', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual(['alpha-core', 'delta-core']);
+  });
+
+  it('returns only optimization skills for the optimization category', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'optimization')).toEqual(['beta-optimization']);
+  });
+
+  it('excludes an untagged skill from both named categories but keeps it in the default', () => {
+    const sourceRoot = makeSourceRoot();
+    writeSkill(sourceRoot, 'untagged-only');
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual(['untagged-only']);
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual([]);
+    expect(listBundledSkillNames(sourceRoot, 'optimization')).toEqual([]);
+  });
+
+  it('ignores a category key that appears below the frontmatter block', () => {
+    const sourceRoot = makeSourceRoot();
+    const skillDir = join(sourceRoot, 'body-mention');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: body-mention\n---\n\ncategory: core\n');
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual(['body-mention']);
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual([]);
+  });
+
+  it('skips directories without a SKILL.md regardless of category', () => {
+    const sourceRoot = makeFixtureRoot();
+    mkdirSync(join(sourceRoot, 'not-a-skill'), { recursive: true });
+
+    expect(listBundledSkillNames(sourceRoot)).not.toContain('not-a-skill');
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual(['alpha-core', 'delta-core']);
+  });
+});

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -77,11 +77,29 @@ function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string |
   return existsSync(repoSkills) ? repoSkills : null;
 }
 
-function listBundledSkillNames(sourceRoot: string): string[] {
-  return readdirSync(sourceRoot, { withFileTypes: true })
+export type BundledSkillCategory = 'all' | 'core' | 'optimization';
+
+function readBundledSkillCategory(sourceDir: string): string | null {
+  const lines = readFileSync(path.join(sourceDir, 'SKILL.md'), 'utf8').split('\n');
+  if (lines[0]?.trim() !== '---') return null;
+  for (const line of lines.slice(1)) {
+    const trimmed = line.trim();
+    if (trimmed === '---') return null;
+    const match = /^category:\s*(.*)$/.exec(trimmed);
+    if (!match) continue;
+    const value = match[1].trim().replace(/^['"]|['"]$/g, '').trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+export function listBundledSkillNames(sourceRoot: string, category: BundledSkillCategory = 'all'): string[] {
+  const names = readdirSync(sourceRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory() && existsSync(path.join(sourceRoot, entry.name, 'SKILL.md')))
     .map((entry) => entry.name)
     .sort();
+  if (category === 'all') return names;
+  return names.filter((name) => readBundledSkillCategory(path.join(sourceRoot, name)) === category);
 }
 
 /** A SKILL.md must open with a YAML frontmatter block (`---` … `---`); the agent
@@ -951,18 +969,19 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
 export function installBundledSkills(
   context: BundledSkillsContext,
   mode: BundledSkillsInstallMode = 'install',
+  category: BundledSkillCategory = 'all',
 ): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
   if (mode === 'uninstall') {
-    return uninstallBundledSkills(context);
+    return uninstallBundledSkills(context, category);
   }
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
   if (!sourceRoot) {
     throw new Error('Bundled skills are not available in this app build.');
   }
 
-  const bundledSkillNames = listBundledSkillNames(sourceRoot);
+  const bundledSkillNames = listBundledSkillNames(sourceRoot, category);
   for (const skillName of bundledSkillNames) {
     assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
   }
@@ -1065,12 +1084,15 @@ function managedCommandFilesFromManifestOrPrefix(manifest: BundledSkillsManifest
   return readdirSync(targetPath).filter((name) => name.startsWith(MANAGED_PREFIX) && name.endsWith('.md'));
 }
 
-function uninstallBundledSkills(context: BundledSkillsContext): BundledSkillsStatus {
+function uninstallBundledSkills(
+  context: BundledSkillsContext,
+  category: BundledSkillCategory = 'all',
+): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
   const manifest = readManifest(invokerHomeRoot);
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
-  const expectedNames = sourceRoot ? prefixedSkillNames(listBundledSkillNames(sourceRoot)) : [];
+  const expectedNames = sourceRoot ? prefixedSkillNames(listBundledSkillNames(sourceRoot, category)) : [];
   const commandFiles = sourceRoot ? listCommandNames(sourceRoot) : [];
 
   for (const target of resolveManagedTargets()) {


### PR DESCRIPTION
## Summary

The bundled-skill installer's selection function always returns every skill in one undifferentiated group today.

This PR adds an optional third argument so a future caller can ask for a named subset instead of everything.

The change is additive only. Every caller that omits the new argument keeps getting the exact same result as before.

A helper reads one metadata line from the top of a bundled skill's markdown file to decide which subset it belongs to.

## Review Claim

`listBundledSkillNames` and `installBundledSkills` in `packages/shell/src/bundled-skills.ts` accept a new optional third argument with three variants (a default/unfiltered one and two named subsets: `core` and `optimization`), defaulting to unfiltered selection when omitted.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Every existing caller that omits the new argument must keep selecting the exact same set it selects today, in the exact same order. This is proven by a dedicated spec file that snapshots the default (unfiltered) result and compares it against the current bundled contents.

## Slice Rationale

This is one product-code slice — the selection function itself — independent of its outer entry point (the next PR in this stack, which forwards the value from the headless CLI) and the shell-script forwarding (a later, separate stack). Splitting here keeps the reviewable diff to one function and its direct spec.

## Non-goals

No entry-point or shell-wiring change (next PR in this stack). No shell-script change. No existing bundled skill's metadata is edited. No new bundled skill is added (a later, separate stack).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/shell test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
