### PR TITLE
[Skill category](1b) Headless entry point wiring

### DIFF
--- a/packages/app/src/__tests__/headless-install-skills.test.ts
+++ b/packages/app/src/__tests__/headless-install-skills.test.ts
@@ -66,6 +66,40 @@ describe('headless install-skills', () => {
     );
   });
 
+  it('forwards a named category value to the dependency call', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const installBundledSkills = vi.fn(() => makeStatus());
+
+    await runHeadless(['install-skills', 'install', 'core'], {
+      installBundledSkills,
+    } as unknown as HeadlessDeps);
+
+    expect(installBundledSkills).toHaveBeenCalledWith('install', 'core');
+  });
+
+  it('forwards the other named category value to the dependency call', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const installBundledSkills = vi.fn(() => makeStatus());
+
+    await runHeadless(['install-skills', 'reinstall', 'optimization'], {
+      installBundledSkills,
+    } as unknown as HeadlessDeps);
+
+    expect(installBundledSkills).toHaveBeenCalledWith('reinstall', 'optimization');
+  });
+
+  it('omits the category argument when none is supplied, keeping prior call shape', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const installBundledSkills = vi.fn(() => makeStatus());
+
+    await runHeadless(['install-skills', 'install'], {
+      installBundledSkills,
+    } as unknown as HeadlessDeps);
+
+    expect(installBundledSkills).toHaveBeenCalledWith('install');
+    expect(installBundledSkills.mock.calls[0]).toHaveLength(1);
+  });
+
   it('documents helper installation and OMP agent selection in help output', async () => {
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -11,6 +11,7 @@
  */
 
 import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
+import type { BundledSkillCategory } from '@invoker/shell/bundled-skills';
 import { makeEnvelope } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, CommandService, TaskState } from '@invoker/workflow-core';
@@ -70,7 +71,7 @@ export interface HeadlessDeps {
   noTrack?: boolean;
   isStandaloneOwnerIdle?: () => boolean;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
-  installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  installBundledSkills?: (mode?: BundledSkillsInstallMode, category?: BundledSkillCategory) => BundledSkillsStatus;
   repairReviewGateCi?: (prArg: string) => Promise<ReviewGateCiRepairCommandResult>;
   /** Abort signal from the workflow mutation coordinator, if running inside a coordinated mutation. */
   signal?: AbortSignal;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,6 +11,7 @@
 
 import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
+import type { BundledSkillCategory } from '@invoker/shell/bundled-skills';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import {
   AUTO_FIX_WORKER_KIND,
@@ -246,6 +247,7 @@ async function headlessRepairFiling(args: string[], deps: HeadlessDeps): Promise
 
 async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
+  category: BundledSkillCategory | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
 ): Promise<void> {
   process.stderr.write(
@@ -254,7 +256,9 @@ async function headlessInstallSkills(
   if (!deps.installBundledSkills) {
     throw new Error('Bundled AI helper installation is not available in this runtime.');
   }
-  const status = deps.installBundledSkills(mode ?? 'install');
+  const status = category === undefined
+    ? deps.installBundledSkills(mode ?? 'install')
+    : deps.installBundledSkills(mode ?? 'install', category);
   const verb = mode === 'uninstall' ? 'Uninstalled' : 'Installed';
   process.stdout.write(`${verb} ${status.bundledSkillNames.length} bundled AI helpers with prefix "${status.managedPrefix}".\n`);
   for (const target of status.targets) {
@@ -303,6 +307,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<u
     case 'install-skills':
       await headlessInstallSkills(
         args[1] === 'reinstall' || args[1] === 'update' || args[1] === 'uninstall' ? args[1] : 'install',
+        args[2] === 'core' || args[2] === 'optimization' || args[2] === 'all' ? args[2] : undefined,
         deps,
       );
       break;

--- a/packages/shell/src/bundled-skills-selection.test.ts
+++ b/packages/shell/src/bundled-skills-selection.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { listBundledSkillNames } from './bundled-skills.js';
+
+const tempRoots: string[] = [];
+
+function makeSourceRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-skill-selection-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeSkill(sourceRoot: string, name: string, category?: string): void {
+  const skillDir = join(sourceRoot, name);
+  mkdirSync(skillDir, { recursive: true });
+  const categoryLine = category ? `category: ${category}\n` : '';
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\n${categoryLine}description: test skill\n---\n\n# ${name}\n`,
+  );
+}
+
+function makeFixtureRoot(): string {
+  const sourceRoot = makeSourceRoot();
+  writeSkill(sourceRoot, 'alpha-core', 'core');
+  writeSkill(sourceRoot, 'beta-optimization', 'optimization');
+  writeSkill(sourceRoot, 'delta-core', 'core');
+  writeSkill(sourceRoot, 'gamma-untagged');
+  return sourceRoot;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('listBundledSkillNames category selection', () => {
+  it('returns every bundled skill when no category is supplied', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual([
+      'alpha-core',
+      'beta-optimization',
+      'delta-core',
+      'gamma-untagged',
+    ]);
+  });
+
+  it('returns the same full set when the default category is passed explicitly', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'all')).toEqual(listBundledSkillNames(sourceRoot));
+  });
+
+  it('returns only core skills for the core category', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual(['alpha-core', 'delta-core']);
+  });
+
+  it('returns only optimization skills for the optimization category', () => {
+    const sourceRoot = makeFixtureRoot();
+
+    expect(listBundledSkillNames(sourceRoot, 'optimization')).toEqual(['beta-optimization']);
+  });
+
+  it('excludes an untagged skill from both named categories but keeps it in the default', () => {
+    const sourceRoot = makeSourceRoot();
+    writeSkill(sourceRoot, 'untagged-only');
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual(['untagged-only']);
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual([]);
+    expect(listBundledSkillNames(sourceRoot, 'optimization')).toEqual([]);
+  });
+
+  it('ignores a category key that appears below the frontmatter block', () => {
+    const sourceRoot = makeSourceRoot();
+    const skillDir = join(sourceRoot, 'body-mention');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: body-mention\n---\n\ncategory: core\n');
+
+    expect(listBundledSkillNames(sourceRoot)).toEqual(['body-mention']);
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual([]);
+  });
+
+  it('skips directories without a SKILL.md regardless of category', () => {
+    const sourceRoot = makeFixtureRoot();
+    mkdirSync(join(sourceRoot, 'not-a-skill'), { recursive: true });
+
+    expect(listBundledSkillNames(sourceRoot)).not.toContain('not-a-skill');
+    expect(listBundledSkillNames(sourceRoot, 'core')).toEqual(['alpha-core', 'delta-core']);
+  });
+});

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -77,11 +77,29 @@ function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string |
   return existsSync(repoSkills) ? repoSkills : null;
 }
 
-function listBundledSkillNames(sourceRoot: string): string[] {
-  return readdirSync(sourceRoot, { withFileTypes: true })
+export type BundledSkillCategory = 'all' | 'core' | 'optimization';
+
+function readBundledSkillCategory(sourceDir: string): string | null {
+  const lines = readFileSync(path.join(sourceDir, 'SKILL.md'), 'utf8').split('\n');
+  if (lines[0]?.trim() !== '---') return null;
+  for (const line of lines.slice(1)) {
+    const trimmed = line.trim();
+    if (trimmed === '---') return null;
+    const match = /^category:\s*(.*)$/.exec(trimmed);
+    if (!match) continue;
+    const value = match[1].trim().replace(/^['"]|['"]$/g, '').trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+export function listBundledSkillNames(sourceRoot: string, category: BundledSkillCategory = 'all'): string[] {
+  const names = readdirSync(sourceRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory() && existsSync(path.join(sourceRoot, entry.name, 'SKILL.md')))
     .map((entry) => entry.name)
     .sort();
+  if (category === 'all') return names;
+  return names.filter((name) => readBundledSkillCategory(path.join(sourceRoot, name)) === category);
 }
 
 /** A SKILL.md must open with a YAML frontmatter block (`---` … `---`); the agent
@@ -951,18 +969,19 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
 export function installBundledSkills(
   context: BundledSkillsContext,
   mode: BundledSkillsInstallMode = 'install',
+  category: BundledSkillCategory = 'all',
 ): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
   if (mode === 'uninstall') {
-    return uninstallBundledSkills(context);
+    return uninstallBundledSkills(context, category);
   }
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
   if (!sourceRoot) {
     throw new Error('Bundled skills are not available in this app build.');
   }
 
-  const bundledSkillNames = listBundledSkillNames(sourceRoot);
+  const bundledSkillNames = listBundledSkillNames(sourceRoot, category);
   for (const skillName of bundledSkillNames) {
     assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
   }
@@ -1065,12 +1084,15 @@ function managedCommandFilesFromManifestOrPrefix(manifest: BundledSkillsManifest
   return readdirSync(targetPath).filter((name) => name.startsWith(MANAGED_PREFIX) && name.endsWith('.md'));
 }
 
-function uninstallBundledSkills(context: BundledSkillsContext): BundledSkillsStatus {
+function uninstallBundledSkills(
+  context: BundledSkillsContext,
+  category: BundledSkillCategory = 'all',
+): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const isInstalled = context.isInstalled ?? commandExists;
   const manifest = readManifest(invokerHomeRoot);
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
-  const expectedNames = sourceRoot ? prefixedSkillNames(listBundledSkillNames(sourceRoot)) : [];
+  const expectedNames = sourceRoot ? prefixedSkillNames(listBundledSkillNames(sourceRoot, category)) : [];
   const commandFiles = sourceRoot ? listCommandNames(sourceRoot) : [];
 
   for (const target of resolveManagedTargets()) {


### PR DESCRIPTION
## Summary

The previous PR in this stack added an optional subset argument to the bundled-skill installer's core function.

Nothing outside that package could set it yet. This PR reaches the headless CLI entry point that end users actually invoke.

The `install-skills` headless command reads one more positional argument and forwards it unchanged. When the argument is absent, behavior is unchanged.

## Review Claim

The `install-skills` branch in `packages/app/src/headless.ts`, and the shared `HeadlessDeps.installBundledSkills` signature in `packages/app/src/headless-shared.ts`, accept and forward the same optional subset value added to the installer's core function in the previous PR, defaulting the same way when absent.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Invoking the existing `install-skills` command with no new argument, from every current call path, must keep behaving exactly as it does today. Three new spec cases cover: each named subset value reaching the dependency call, and the no-argument case keeping the prior one-argument call shape.

## Slice Rationale

This is one activation-surface slice — the headless CLI entry point and its shared dependency shape — independent of the core function it calls into (previous PR) and the `packages/app/src/main.ts` installer wiring (next PR in this stack). Those two files fall under different review units in this repo's classifier, so a single PR cannot ship both.

## Non-goals

No change to the core function itself (previous PR). No `packages/app/src/main.ts` change (next PR in this stack). No shell-script forwarding. No existing bundled skill's metadata is edited.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-install-skills.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
