### PR TITLE
[Headless Delegation] Register reset-autofix-budget for owner delegation

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -434,6 +434,30 @@ describe('headless-client', () => {
     }));
   });
 
+  it('delegates reset-autofix-budget as a mutating command through headless.exec, honoring --no-track', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-rab', mode: 'standalone' }));
+
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['reset-autofix-budget', '--exhausted', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['reset-autofix-budget', '--exhausted'],
+      noTrack: true,
+      waitForApproval: false,
+    }));
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('accepts a stale-owner FK failure for no-track recreate-task of an explicitly scoped task', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => {

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -56,6 +56,7 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['check-pr-status'])).toBe(true);
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);
     expect(isHeadlessMutatingCommand(['close-task'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['reset-autofix-budget'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'prompt'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'fix-context'])).toBe(true);

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -60,6 +60,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'close-task', kind: 'write' },
   { name: 'delete', kind: 'write' },
   { name: 'delete-all', kind: 'write' },
+  { name: 'reset-autofix-budget', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },
   { name: 'query-select', kind: 'read' },
   { name: 'worker', kind: 'read' },


### PR DESCRIPTION
## Summary

`reset-autofix-budget --exhausted` now checks for a running Invoker owner process before touching the database, the same way `recreate-task` already does.

Previously it went straight to opening its own standalone database connection every time, even with an owner process already running, instead of reaching that owner first.

On a live production instance this made it see a partial, out-of-date view of workflows and report a false zero-reset result while the real owner process held the current state.

## Review Claim

Approve adding `reset-autofix-budget` to the registered write-commands table so it takes the same owner-first path every other mutating headless command already takes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Proposed — please confirm or correct: `HEADLESS_COMMANDS` is a flat, order-independent name-to-kind lookup consulted by name (`findHeadlessCommandDefinition`). Adding one new entry (`reset-autofix-budget`) only changes classification for that exact command name; every other entry's name, kind, and position is unchanged, so no other command's owner-first path is affected.

## Slice Rationale

This is a single addition to the command classification table plus matching assertions in the two files that already cover this classification, kept separate from any change to `recreate-task` or the shared owner-delegation machinery mutating commands already exercise.

## Non-goals

Does not change how the owner process executes `reset-autofix-budget` once a request reaches it — `runHeadless` on the owner side already handles this command correctly; only the client-side decision to attempt owner delegation first was missing.

Does not touch `delete`, `recreate-task`, or any other already-working command's classification or delegation path.

Does not add a new owner-side IPC channel or handler; `reset-autofix-budget` reuses the existing generic `headless.exec` channel the same way `delete-all` and other bulk write commands do.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && npx vitest run src/__tests__/headless-command-classification.test.ts` — confirms `isHeadlessMutatingCommand(['reset-autofix-budget'])` is now `true`
- [ ] `cd packages/app && npx vitest run src/__tests__/headless-client.test.ts` — confirms `reset-autofix-budget --exhausted` now delegates through `headless.exec` to a live owner instead of running standalone

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
