### PR TITLE
[Self-deploy worker](1) Add selfDeploy config surface

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1015,6 +1015,43 @@ describe('catstackDeploy config', () => {
   });
 });
 
+describe('selfDeploy config', () => {
+  it('accepts omitted selfDeploy block', () => {
+    expect(validateInvokerConfig({})).toEqual({});
+  });
+
+  it('accepts a valid intervalMinutes and paths', () => {
+    const config = validateInvokerConfig({
+      selfDeploy: {
+        intervalMinutes: 30,
+        repoPath: '~/Invoker',
+        remoteName: 'upstream',
+        branchName: 'master',
+        deployScriptPath: 'scripts/deploy-do1.sh',
+      },
+    });
+    expect(config.selfDeploy?.intervalMinutes).toBe(30);
+  });
+
+  it('rejects intervalMinutes of 0', () => {
+    expect(() => validateInvokerConfig({
+      selfDeploy: { intervalMinutes: 0 },
+    })).toThrow(/selfDeploy.intervalMinutes must be an integer > 0/);
+  });
+
+  it('rejects non-integer intervalMinutes', () => {
+    expect(() => validateInvokerConfig({
+      selfDeploy: { intervalMinutes: 1.5 },
+    })).toThrow(/selfDeploy.intervalMinutes must be an integer > 0/);
+  });
+
+  it('rejects an empty repoPath', () => {
+    expect(() => validateInvokerConfig({
+      selfDeploy: { repoPath: '' },
+    })).toThrow(/selfDeploy.repoPath must be a non-empty string/);
+  });
+});
+
 describe('dbReaper config', () => {
   it('accepts omitted dbReaper block', () => {
     expect(validateInvokerConfig({})).toEqual({});

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -9,6 +9,7 @@ import {
   type InvokerConfig,
   type MergifyQueueResearchConfig,
   type MergifyQueueResearchSource,
+  type SelfDeployConfig,
   DEFAULT_CROSS_REPO_RESEARCH_LOOKBACK_DAYS,
   DEFAULT_MERGIFY_QUEUE_RESEARCH_LOOKBACK_DAYS,
 } from './config.js';
@@ -257,6 +258,44 @@ function validateCatstackDeployConfig(config: InvokerConfig): void {
   }
 }
 
+function validateSelfDeployConfig(config: InvokerConfig): void {
+  const selfDeploy = config.selfDeploy;
+  if (selfDeploy === undefined) return;
+  if (typeof selfDeploy !== 'object' || selfDeploy === null || Array.isArray(selfDeploy)) {
+    throw new Error('selfDeploy must be an object');
+  }
+  const typed = selfDeploy as SelfDeployConfig;
+  if (typed.intervalMinutes !== undefined) {
+    if (
+      typeof typed.intervalMinutes !== 'number'
+      || !Number.isInteger(typed.intervalMinutes)
+      || typed.intervalMinutes <= 0
+    ) {
+      throw new Error('selfDeploy.intervalMinutes must be an integer > 0');
+    }
+  }
+  if (typed.repoPath !== undefined) {
+    if (typeof typed.repoPath !== 'string' || typed.repoPath.trim().length === 0) {
+      throw new Error('selfDeploy.repoPath must be a non-empty string when set');
+    }
+  }
+  if (typed.remoteName !== undefined) {
+    if (typeof typed.remoteName !== 'string' || typed.remoteName.trim().length === 0) {
+      throw new Error('selfDeploy.remoteName must be a non-empty string when set');
+    }
+  }
+  if (typed.branchName !== undefined) {
+    if (typeof typed.branchName !== 'string' || typed.branchName.trim().length === 0) {
+      throw new Error('selfDeploy.branchName must be a non-empty string when set');
+    }
+  }
+  if (typed.deployScriptPath !== undefined) {
+    if (typeof typed.deployScriptPath !== 'string' || typed.deployScriptPath.trim().length === 0) {
+      throw new Error('selfDeploy.deployScriptPath must be a non-empty string when set');
+    }
+  }
+}
+
 function validateDbReaperConfig(config: InvokerConfig): void {
   const dbReaper = config.dbReaper;
   if (dbReaper === undefined) return;
@@ -365,6 +404,7 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
   validateCrossRepoResearchConfig(config);
   validateMergifyQueueResearchConfig(config);
   validateCatstackDeployConfig(config);
+  validateSelfDeployConfig(config);
   validateDbReaperConfig(config);
   validateAdminBypassE2eBabysitConfig(config);
   return config;

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -230,6 +230,16 @@ export interface CatstackDeployConfig {
 /** Default poll cadence when catstackDeploy.intervalMinutes is unset. */
 export const DEFAULT_CATSTACK_DEPLOY_INTERVAL_MINUTES = 15;
 
+export interface SelfDeployConfig {
+  intervalMinutes?: number;
+  repoPath?: string;
+  remoteName?: string;
+  branchName?: string;
+  deployScriptPath?: string;
+}
+
+export const DEFAULT_SELF_DEPLOY_INTERVAL_MINUTES = 30;
+
 export interface DbReaperConfig {
   intervalMinutes?: number;
   eventsRetentionDays?: number;
@@ -607,6 +617,7 @@ export interface InvokerConfig {
    * Remotes always come from top-level `remoteTargets`.
    */
   catstackDeploy?: CatstackDeployConfig;
+  selfDeploy?: SelfDeployConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
   dbReaper?: DbReaperConfig;
 }


### PR DESCRIPTION
## Summary

Adds an `InvokerConfig.selfDeploy` block (`intervalMinutes`, `repoPath`, `remoteName`, `branchName`, `deployScriptPath`) and its validation.

This mirrors the existing `catstackDeploy` config shape exactly, one field name at a time.

Nothing reads this config yet. The next slice in this stack adds the worker that consumes it.

## Review Claim

Approve the new `selfDeploy` config block and its validation, matching `catstackDeploy`'s existing shape and defaults.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

This slice only adds an optional config field and its validator function. No worker, registry, or runtime code reads `config.selfDeploy` in this PR, so an existing deployment with no `selfDeploy` block in its config.json is unaffected.

## Slice Rationale

Config shape and validation is the foundation the following slices in this stack both depend on. Landing it first keeps each later slice focused on a single kind of review concern instead of one PR mixing several.

## Non-goals

Does not add the self-deploy worker itself, does not register it in the builtin worker registry, and does not wire it into `main.ts`, `worker-control.ts`, or the headless CLI. Those are the next two PRs in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx vitest run src/__tests__/config.test.ts -t "selfDeploy"`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit SHA>`
- Post-revert steps: None
- Data migration? No

</details>
