### PR TITLE
[Sandbox Slack Work](1) Default Slack-originated tasks to Docker isolation

### DIFF
--- a/packages/app/src/slack-bug-scan-planner.ts
+++ b/packages/app/src/slack-bug-scan-planner.ts
@@ -33,8 +33,14 @@ function buildDraftPrompt(input: { repoUrl: string; problemStatement: string; th
 
 export function createSlackBugScanPlanner(deps: SlackBugScanPlannerDeps): SlackBugScanPlanSubmitter {
   return async (input) => {
-    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver, BUILTIN_HARNESS_PRESETS, DEFAULT_HARNESS_PRESET }
-      = await import('@invoker/surfaces');
+    const {
+      PlanConversation,
+      applySlackDockerIsolationDefault,
+      extractYamlPlan,
+      selectHarnessSessionDriver,
+      BUILTIN_HARNESS_PRESETS,
+      DEFAULT_HARNESS_PRESET,
+    } = await import('@invoker/surfaces');
     const presets = { ...BUILTIN_HARNESS_PRESETS, ...(deps.config.slackHarnessPresets ?? {}) };
     const presetKey = deps.config.defaultSlackHarnessPreset ?? DEFAULT_HARNESS_PRESET;
     const preset = presets[presetKey];
@@ -73,8 +79,9 @@ export function createSlackBugScanPlanner(deps: SlackBugScanPlannerDeps): SlackB
       });
 
       const plannerOutput = await conversation.sendMessage(buildDraftPrompt(input));
-      const planText = extractYamlPlan(plannerOutput);
-      if (!planText) throw new Error('Planner did not return a valid YAML plan.');
+      const draftedPlanText = extractYamlPlan(plannerOutput);
+      if (!draftedPlanText) throw new Error('Planner did not return a valid YAML plan.');
+      const planText = applySlackDockerIsolationDefault(draftedPlanText);
 
       const loaded = await loadPlanSubmissionBundle(planText, {
         persistence: deps.persistence,

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PlanConversation, buildPlanSystemPrompt, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation, redactEmbeddedPlanFence } from '../slack/plan-conversation.js';
+import { PlanConversation, applySlackDockerIsolationDefault, buildPlanSystemPrompt, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation, redactEmbeddedPlanFence } from '../slack/plan-conversation.js';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -388,6 +388,117 @@ Does this look better?`;
         expect.stringContaining('task missing id or description'),
       );
     });
+  });
+});
+
+describe('applySlackDockerIsolationDefault', () => {
+  it('stamps dockerImage on every task that has no explicit routing', () => {
+    const planText = `name: "Slack Plan"
+onFinish: none
+tasks:
+  - id: task-1
+    description: "First task"
+    command: "npm test"
+  - id: task-2
+    description: "Second task"
+    command: "npm build"
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.tasks[0].dockerImage).toBe('invoker/agent-base:latest');
+    expect(result.tasks[1].dockerImage).toBe('invoker/agent-base:latest');
+  });
+
+  it('does not clobber a task that already declares dockerImage', () => {
+    const planText = `name: "Slack Plan"
+tasks:
+  - id: task-1
+    description: "First task"
+    command: "npm test"
+    dockerImage: custom/image:v1
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.tasks[0].dockerImage).toBe('custom/image:v1');
+  });
+
+  it('does not clobber a task that already declares poolId', () => {
+    const planText = `name: "Slack Plan"
+tasks:
+  - id: task-1
+    description: "First task"
+    command: "npm test"
+    poolId: my-pool
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.tasks[0].dockerImage).toBeUndefined();
+    expect(result.tasks[0].poolId).toBe('my-pool');
+  });
+
+  it('leaves a plan-level poolId untouched and does not stamp any task', () => {
+    const planText = `name: "Slack Plan"
+poolId: my-pool
+tasks:
+  - id: task-1
+    description: "First task"
+    command: "npm test"
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.tasks[0].dockerImage).toBeUndefined();
+  });
+
+  it('leaves a scratch plan untouched', () => {
+    const planText = `name: "Slack Plan"
+scratch: true
+tasks:
+  - id: task-1
+    description: "First task"
+    command: "npm test"
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.tasks[0].dockerImage).toBeUndefined();
+  });
+
+  it('stamps tasks inside each workflow of a stacked plan', () => {
+    const planText = `name: "Stack"
+workflows:
+  - name: "Workflow 1"
+    tasks:
+      - id: task-1
+        description: "First task"
+        command: "npm test"
+  - name: "Workflow 2"
+    tasks:
+      - id: task-2
+        description: "Second task"
+        command: "npm build"
+        poolId: my-pool
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.workflows[0].tasks[0].dockerImage).toBe('invoker/agent-base:latest');
+    expect(result.workflows[1].tasks[0].dockerImage).toBeUndefined();
+  });
+
+  it('respects a stack-level scratch default inherited by a workflow', () => {
+    const planText = `name: "Stack"
+scratch: true
+workflows:
+  - name: "Workflow 1"
+    tasks:
+      - id: task-1
+        description: "First task"
+        command: "npm test"
+`;
+    const result = parsePlanText(applySlackDockerIsolationDefault(planText));
+    expect(result.workflows[0].tasks[0].dockerImage).toBeUndefined();
+  });
+
+  it('returns the input unchanged for invalid YAML', () => {
+    const planText = 'not: [valid: yaml: here';
+    expect(applySlackDockerIsolationDefault(planText)).toBe(planText);
+  });
+
+  it('returns the input unchanged when the plan has no tasks array', () => {
+    const planText = 'name: "Empty"\n';
+    expect(applySlackDockerIsolationDefault(planText)).toBe(planText);
   });
 });
 

--- a/packages/surfaces/src/__tests__/slack-plan-turn-reminder-approve-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-turn-reminder-approve-repro.e2e.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SlackSurface } from '../slack/slack-surface.js';
+import { applySlackDockerIsolationDefault } from '../slack/plan-conversation.js';
 import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 
@@ -207,6 +208,9 @@ describe('replaying the stuck Slack plan-staging thread end to end', () => {
       respond: vi.fn().mockResolvedValue(undefined),
     });
 
-    expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ type: 'start_plan', planText: draft!.planText }));
+    expect(onCommand).toHaveBeenCalledTimes(1);
+    const submittedCommand = onCommand.mock.calls[0]![0] as { type: string; planText: string };
+    expect(submittedCommand.type).toBe('start_plan');
+    expect(submittedCommand.planText).toBe(applySlackDockerIsolationDefault(draft!.planText));
   });
 });

--- a/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { SlackSurface } from '../slack/slack-surface.js';
+import { applySlackDockerIsolationDefault } from '../slack/plan-conversation.js';
 import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
 
 interface MockHandler {
@@ -184,11 +185,11 @@ describe('slack planning session happy path', () => {
       respond: vi.fn().mockResolvedValue(undefined),
     });
 
-    expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'start_plan',
-      planText: draft!.planText,
-      repoUrl: 'https://github.com/example/repo.git',
-    }));
+    expect(onCommand).toHaveBeenCalledTimes(1);
+    const submittedCommand = onCommand.mock.calls[0]![0] as { type: string; planText: string; repoUrl: string };
+    expect(submittedCommand.type).toBe('start_plan');
+    expect(submittedCommand.repoUrl).toBe('https://github.com/example/repo.git');
+    expect(submittedCommand.planText).toBe(applySlackDockerIsolationDefault(draft!.planText));
     expect(parseYaml(draft!.planText)).toMatchObject({
       name: 'CodeRabbit Audit',
       repoUrl: 'https://github.com/example/repo.git',
@@ -271,11 +272,10 @@ workflows:
         respond: vi.fn().mockResolvedValue(undefined),
       });
 
-      expect(onCommand).toHaveBeenLastCalledWith(expect.objectContaining({
-        type: 'start_plan',
-        repoUrl,
-        planText: draft!.planText,
-      }));
+      const lastSubmittedCommand = onCommand.mock.calls.at(-1)![0] as { type: string; planText: string; repoUrl: string };
+      expect(lastSubmittedCommand.type).toBe('start_plan');
+      expect(lastSubmittedCommand.repoUrl).toBe(repoUrl);
+      expect(lastSubmittedCommand.planText).toBe(applySlackDockerIsolationDefault(draft!.planText));
     }
 
     expect(onCommand.mock.calls.map(([command]) => (command as any).repoUrl)).toEqual([

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -1407,6 +1407,57 @@ export function extractYamlPlan(text: string): string | null {
   }
 }
 
+const SLACK_DEFAULT_DOCKER_IMAGE = 'invoker/agent-base:latest';
+
+function stampDockerImageOnTasks(
+  plan: Record<string, unknown>,
+  inheritedScratch: boolean,
+  inheritedPoolId: string | undefined,
+): boolean {
+  const effectiveScratch = plan.scratch === true || (plan.scratch === undefined && inheritedScratch);
+  if (effectiveScratch) return false;
+  const effectivePoolId = typeof plan.poolId === 'string' ? plan.poolId : inheritedPoolId;
+  if (typeof effectivePoolId === 'string' && effectivePoolId.trim() !== '') return false;
+  if (!Array.isArray(plan.tasks)) return false;
+
+  let changed = false;
+  for (const task of plan.tasks) {
+    if (!task || typeof task !== 'object' || Array.isArray(task)) continue;
+    const t = task as Record<string, unknown>;
+    if (typeof t.dockerImage === 'string' && t.dockerImage.trim() !== '') continue;
+    if (typeof t.poolId === 'string' && t.poolId.trim() !== '') continue;
+    t.dockerImage = SLACK_DEFAULT_DOCKER_IMAGE;
+    changed = true;
+  }
+  return changed;
+}
+
+export function applySlackDockerIsolationDefault(planText: string): string {
+  let raw: unknown;
+  try {
+    raw = parseYaml(planText);
+  } catch {
+    return planText;
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return planText;
+
+  const plan = raw as Record<string, unknown>;
+  let changed: boolean;
+  if (Array.isArray(plan.workflows)) {
+    const stackScratch = plan.scratch === true;
+    const stackPoolId = typeof plan.poolId === 'string' ? plan.poolId : undefined;
+    changed = false;
+    for (const workflow of plan.workflows) {
+      if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) continue;
+      changed = stampDockerImageOnTasks(workflow as Record<string, unknown>, stackScratch, stackPoolId) || changed;
+    }
+  } else {
+    changed = stampDockerImageOnTasks(plan, false, undefined);
+  }
+
+  return changed ? stringifyYaml(plan) : planText;
+}
+
 const PLAN_DRAFT_PLACEHOLDER = '_(Plan drafted — see the review card for the full plan.)_';
 
 /**

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_PLANNER_RETRY_BASE_DELAY_MS,
   DEFAULT_PLANNER_RETRY_LIMIT,
   PlanConversation,
+  applySlackDockerIsolationDefault,
   buildEmptyPlannerOutputError,
   defaultPlanningCommand,
   isConfirmation,
@@ -1660,7 +1661,7 @@ export class SlackSurface implements Surface {
     }
     const planTextForSubmit = draft.planningDraftId
       ? approvedPlanText
-      : this.normalizeDraftedPlanRepoUrl(approvedPlanText, draft.repoUrl);
+      : applySlackDockerIsolationDefault(this.normalizeDraftedPlanRepoUrl(approvedPlanText, draft.repoUrl));
     const executionKey = this.slackPlanDraftRepo?.claim(draft);
     if (!executionKey) {
       throw new Error('This plan is already being submitted.');


### PR DESCRIPTION
## Summary

Slack-originated plans now default every task to a Docker sandbox instead of the shared worktree executor.

Before this change, a Slack `/plan` draft or an auto-filed bug-report plan ran the same as an operator plan, sharing the local worktree pool with no isolation.

This adds a small YAML transform that stamps `dockerImage` onto each unrouted task, right before the plan text leaves the Slack surface. Every other plan-authoring surface is untouched.

## Review Claim

Every task built by the two Slack plan-construction call sites this change touches (the interactive `/plan` review-and-approve flow, and the automatic bug-report plan drafter) now defaults to `dockerImage: invoker/agent-base:latest` unless the plan or task already declares its own routing (`dockerImage`, `poolId`, or `scratch`).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`applySlackDockerIsolationDefault` (new export in `packages/surfaces/src/slack/plan-conversation.ts`) is called from exactly two call sites: `SlackSurface.submitSlackPlanDraft` (only on the non-doctor-approved branch) and `createSlackBugScanPlanner`. Neither call site is reachable from an operator, CLI, or GUI plan submission — `loadPlanSubmissionBundle`, `parsePlanSubmissionBundle`, and every other plan-parsing call site are untouched, verified by grep and by full package test runs showing zero new failures.

## Slice Rationale

This is a corrected, smaller first slice of a larger Slack-sandboxing plan. A prior pass correctly stopped short of inventing a new pool-member schema for Docker; this slice instead uses the existing per-task `dockerImage` → `runnerKind: 'docker'` routing (`packages/workflow-core/src/orchestrator.ts:1542`), which already exists and needs no schema change.

## Non-goals

Does not touch `executionPools` or add a poolable Docker member type.

Does not touch `slack-bug-scan`'s own off-by-default enable/disable gate.

Does not change `runnerKind`/routing for operator-submitted, CLI-submitted, or in-app-planner-submitted plans.

Does not stamp the doctor-approved immutable-draft path (`draft.planningDraftId` set, i.e. `conversation.draftDoctorEnabled` true — the default in production `main.ts`). That path's immutable bytes are shared with the in-app operator planning UI (`packages/app/src/in-app-planner.ts` also builds `PlanConversation` with `planDoctorScriptPath` set), and a dedicated regression test (`slack-doctor-draft-stringify-clash.e2e.test.ts`) exists specifically to catch a re-stringify corrupting those approved bytes — my first attempt at stamping there tripped exactly that test by dropping a blank line on re-serialize. Closing this gap needs a config flag threaded through `PlanConversationConfig`/`PlanConversation` to distinguish Slack-origin conversations from operator ones before the doctor-approved snapshot is captured; that is more than this slice should do. Flagging this precisely rather than forcing an unsafe fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `packages/surfaces/node_modules/.bin/vitest run --root packages/surfaces` (614 tests total; 16 fail identically on origin/master before this change — 0 new failures, 9 new passing tests added by this PR)
- [ ] `packages/slack-manager/node_modules/.bin/vitest run --root packages/slack-manager` (74 passed, 1 skipped)
- [ ] `node scripts/check-added-comments.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slack plan submissions now apply Docker isolation by default to eligible tasks using the standard agent environment.
  - The default is also applied within stacked workflows, including inherited workflow settings.

- **Bug Fixes**
  - Existing Docker image, pool, and scratch execution settings are preserved.
  - Plans with explicit routing, unsupported structures, or invalid YAML remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->