### PR TITLE
[Retry-Task Ack Timeout](1) Give retry-task the extended 60s delegation ack timeout

### DIFF
--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -85,6 +85,10 @@ describe('headless→owner delegation', () => {
       expect(delegationTimeoutMs(['rebase-retry', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
 
+    it('uses 60s timeout for retry-task even though its target is a bare taskId', async () => {
+      await expect(resolveDelegationTimeoutMs(['retry-task', 'task-abc123'])).resolves.toBe(60_000);
+    });
+
     it('keeps non-matching workflow ids at the default timeout', () => {
       expect(delegationTimeoutMs(['restart', 'not-a-workflow-id'], targetLookup)).toBe(5_000);
     });

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -94,6 +94,7 @@ export async function tryDelegateResume(
 function usesExtendedDelegationTimeout(command: string): boolean {
   return command === 'rebase-retry'
     || command === 'rebase-recreate'
+    || command === 'retry-task'
     || command === 'restart'
     || command === 'start-ready';
 }
@@ -132,9 +133,11 @@ export async function resolveDelegationTimeoutMs(args: string[]): Promise<number
   if (!usesExtendedDelegationTimeout(command)) {
     return DEFAULT_DELEGATION_TIMEOUT_MS;
   }
-  // start-ready is global (no workflow arg) but recreates/starts many workflows.
   if (command === 'start-ready') {
     return startReadyDelegationTimeoutMs(args);
+  }
+  if (command === 'retry-task') {
+    return WORKFLOW_DELEGATION_TIMEOUT_MS;
   }
   return looksLikeWorkflowId(args[1])
     ? WORKFLOW_DELEGATION_TIMEOUT_MS


### PR DESCRIPTION
## Summary

A headless mutation that resets a stuck task waited only five seconds for the owner to confirm it, even though the owner's own work behind that command takes longer.

Two sibling commands already got sixty seconds because their target argument looks like a workflow identifier. This command's target never does, so it always fell through to the short default.

The client gave up and reported failure while the owner was still finishing the work, which had in fact already succeeded.

## Review Claim

Approve adding this one command to the existing extended-timeout allowlist, bypassing the workflow-id shape check for it specifically since its target is structurally never shaped that way.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only one command's own path through one existing timeout function changes. Every other command covered by that function keeps its exact prior behavior, proven by the full pre-existing suite for that file passing unchanged alongside the one new case.

## Slice Rationale

One function, one command, one line of new branching logic — the smallest unit that fixes the observed client-side timeout without touching the sibling commands that already worked correctly.

## Non-goals

Does not change the owner-side handling of this command, the underlying task-reset logic itself, or any other headless command's timeout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/owner-delegation.test.ts -t "uses 60s timeout for retry-task even though its target is a bare taskId"` (run from `packages/app`) — fails with `expected 5000 to be 60000` before the fix, passes after
- [x] `bash node_modules/.bin/vitest run src/__tests__/owner-delegation.test.ts` (run from `packages/app`) — 53/53 pass, no regressions

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the delegation timeout for `retry-task` commands to 60 seconds, including when targeting a task directly.
  * Preserved existing timeout behavior for other commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->