### PR TITLE
[Invoker-CLI Delete Command](1) Expose the existing 'delete' headless command as an invoker-cli subcommand

### DIFF
--- a/packages/cli/src/__tests__/cli-mutations.test.ts
+++ b/packages/cli/src/__tests__/cli-mutations.test.ts
@@ -73,6 +73,7 @@ describe('invoker-cli mutations', () => {
     ['retry-task', 'wf-1/task-1'],
     ['retry', 'wf-1'],
     ['resume', 'wf-1'],
+    ['delete', 'wf-1'],
   ])('sends %s over headless.exec with noTrack', async (command, targetId) => {
     const output = captureProcessOutput();
     const bus = new LocalBus();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -198,6 +198,7 @@ function usage(): string {
     '  invoker-cli retry <workflowId>',
     '  invoker-cli resume <workflowId>',
     '  invoker-cli retry-tasks --status <status> [--parallel N] [--dry-run]',
+    '  invoker-cli delete <workflowId>',
     '  invoker-cli delete-all',
     '  invoker-cli owner serve',
     '  invoker-cli doctor [--fix] [--json]',
@@ -718,7 +719,7 @@ async function sendHeadlessExec(bus: MessageBus, args: string[]): Promise<void> 
   );
 }
 
-async function runSimpleMutation(command: 'retry-task' | 'retry' | 'resume', targetId: string | undefined, deps: CliDeps): Promise<number> {
+async function runSimpleMutation(command: 'retry-task' | 'retry' | 'resume' | 'delete', targetId: string | undefined, deps: CliDeps): Promise<number> {
   if (!targetId) {
     const target = command === 'retry-task' ? 'taskId' : 'workflowId';
     throw new Error(`Missing ${target}. Usage: invoker-cli ${command} <${target}>`);
@@ -1310,7 +1311,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'wait') {
       return await runWait(parseWaitArgs(argv.slice(1)), deps);
     }
-    if (argv[0] === 'retry-task' || argv[0] === 'retry' || argv[0] === 'resume') {
+    if (argv[0] === 'retry-task' || argv[0] === 'retry' || argv[0] === 'resume' || argv[0] === 'delete') {
       if (argv.length > 2) {
         throw new Error(`Unexpected argument: ${argv[2]}`);
       }


### PR DESCRIPTION
## Summary

The live owner already knows how to take one named workflow down on request. That capability has its own test coverage and has worked for a long time.

Our own command-line tool never learned to ask for it by name. Someone at a terminal could only act on every workflow at once, or none.

This exposes the missing narrow request as a CLI command, sitting next to the two sibling commands that already work the same way.

## Review Claim

Approve widening the existing three-command dispatcher (already handling two workflow-scoped requests) to also expose this one, with no new logic beyond one more string.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The owner-side handler this calls is pre-existing, already covered by its own owner-delegation test suite, and completely unchanged here. This slice only widens a client-side dispatch table that already handles two commands in the identical shape, proven by extending the exact parametrized test those two commands already share.

## Slice Rationale

One dispatcher, one new branch, mirroring an established pattern exactly — no room to split further.

## Non-goals

Does not change the owner-side handler, its safety behavior, or the unconditional whole-database command that already exists alongside it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/cli-mutations.test.ts -t "sends delete over headless.exec"` (run from `packages/cli`) — fails with `expected 0 to be 1`-shaped mismatch before the fix, passes after
- [x] `bash node_modules/.bin/vitest run src/__tests__/cli-mutations.test.ts` (run from `packages/cli`) — 9/9 pass, no regressions
- [x] `pnpm --filter @invoker/cli build` — clean build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
