### PR TITLE
Add Rescan button and invoker.tickWorker UI

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -548,6 +548,10 @@ export function App() {
     await invoker.stopWorker(kind);
     void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
+  const handleTickWorker = useCallback(async (kind: string) => {
+    await invoker.tickWorker(kind);
+    void refreshWorkerStatus();
+  }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
@@ -4367,6 +4371,7 @@ export function App() {
                 readOnly={runtimeStatus?.readOnly === true}
                 onStartWorker={handleStartWorker}
                 onStopWorker={handleStopWorker}
+                onTickWorker={handleTickWorker}
               />
               <button
                 type="button"

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -456,6 +456,10 @@ export function createMockInvoker(
       const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
       return row;
     }),
+    tickWorker: vi.fn(async (kind: string) => {
+      const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
+      return row;
+    }),
     getActionGraph: vi.fn(async () => actionGraphSnapshot),
     getClaudeSession: vi.fn(async () => null),
     getAgentSession: vi.fn(async () => null),

--- a/packages/ui/src/__tests__/worker-detail-control.test.tsx
+++ b/packages/ui/src/__tests__/worker-detail-control.test.tsx
@@ -140,4 +140,36 @@ describe('WorkerDetailControl', () => {
 
     expect(screen.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'stop');
   });
+
+  it('rescans a running worker when onTickWorker is provided', async () => {
+    const onTickWorker = vi.fn(async () => {});
+    render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+        onTickWorker={onTickWorker}
+      />,
+    );
+
+    const rescan = screen.getByTestId('worker-detail-rescan');
+    expect(rescan).toHaveTextContent('Rescan');
+
+    fireEvent.click(rescan);
+
+    await waitFor(() => expect(onTickWorker).toHaveBeenCalledWith('pr-status'));
+  });
+
+  it('hides the rescan button for stopped workers', () => {
+    render(
+      <WorkerDetailControl
+        worker={makeWorker({ lifecycle: 'stopped', startable: true, stoppable: false })}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+        onTickWorker={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('worker-detail-rescan')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/WorkerDetailControl.tsx
+++ b/packages/ui/src/components/WorkerDetailControl.tsx
@@ -6,6 +6,7 @@ interface WorkerDetailControlProps {
   readOnly?: boolean;
   onStartWorker: (kind: string) => Promise<void> | void;
   onStopWorker: (kind: string) => Promise<void> | void;
+  onTickWorker?: (kind: string) => Promise<void> | void;
 }
 
 type OptimisticLifecycle = 'running' | 'stopped';
@@ -15,9 +16,11 @@ export function WorkerDetailControl({
   readOnly = false,
   onStartWorker,
   onStopWorker,
+  onTickWorker,
 }: WorkerDetailControlProps) {
   const [optimistic, setOptimistic] = useState<OptimisticLifecycle | null>(null);
   const [pending, setPending] = useState(false);
+  const [tickPending, setTickPending] = useState(false);
 
   useEffect(() => {
     setOptimistic(null);
@@ -36,28 +39,50 @@ export function WorkerDetailControl({
   const showStart = lifecycle !== 'running';
   const disabledReason = readOnly ? 'Read-only window' : worker.controlDisabledReason;
   const disabled = Boolean(disabledReason) || pending;
+  const canRescan = !showStart && onTickWorker !== undefined && !readOnly;
 
   return (
-    <button
-      type="button"
-      data-testid="worker-detail-start-stop"
-      data-action={showStart ? 'start' : 'stop'}
-      title={disabledReason}
-      disabled={disabled}
-      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
-      onClick={() => {
-        if (disabled) return;
-        setOptimistic(showStart ? 'running' : 'stopped');
-        setPending(true);
-        void Promise.resolve(showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind))
-          .catch((error: unknown) => {
-            setOptimistic(null);
-            console.error(`Failed to ${showStart ? 'enable' : 'disable'} worker ${worker.kind}`, error);
-          })
-          .finally(() => setPending(false));
-      }}
-    >
-      {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        data-testid="worker-detail-start-stop"
+        data-action={showStart ? 'start' : 'stop'}
+        title={disabledReason}
+        disabled={disabled}
+        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+        onClick={() => {
+          if (disabled) return;
+          setOptimistic(showStart ? 'running' : 'stopped');
+          setPending(true);
+          void Promise.resolve(showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind))
+            .catch((error: unknown) => {
+              setOptimistic(null);
+              console.error(`Failed to ${showStart ? 'enable' : 'disable'} worker ${worker.kind}`, error);
+            })
+            .finally(() => setPending(false));
+        }}
+      >
+        {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
+      </button>
+      {canRescan ? (
+        <button
+          type="button"
+          data-testid="worker-detail-rescan"
+          disabled={tickPending}
+          className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+          onClick={() => {
+            if (tickPending) return;
+            setTickPending(true);
+            void Promise.resolve(onTickWorker!(worker.kind))
+              .catch((error: unknown) => {
+                console.error(`Failed to rescan worker ${worker.kind}`, error);
+              })
+              .finally(() => setTickPending(false));
+          }}
+        >
+          {tickPending ? 'Rescanning…' : 'Rescan'}
+        </button>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION


Depends-On: #11939

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only manual trigger for an existing invoker API (depends on #11939); no auth or data-model changes in this diff.
> 
> **Overview**
> Adds a **Rescan** control on the worker detail header so users can trigger an immediate worker tick without stopping and restarting the process.
> 
> `WorkerDetailControl` now accepts an optional `onTickWorker` callback and shows **Rescan** next to enable/disable when the worker is running, read-only mode is off, and the callback is provided; the button shows **Rescanning…** while the request is in flight. **App** wires this through `handleTickWorker`, which calls `invoker.tickWorker(kind)` and refreshes worker status (same pattern as start/stop). Tests cover the click path and that Rescan is hidden for stopped workers; the test mock invoker gains `tickWorker`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08c1a95bf2be3e686df4831d49434d947af1be9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->