### PR TITLE
[Codex OAuth Race](1) Widen the Codex OAuth proactive-refresh window from 5 minutes to a day

### DIFF
--- a/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
@@ -233,7 +233,7 @@ function jwtWithExp(expSeconds: number): string {
 }
 
 function codexAuthJson(now: number, overrides: { lastRefresh?: string; expSeconds?: number } = {}): string {
-  const expSeconds = overrides.expSeconds ?? Math.floor((now + 60 * 60 * 1000) / 1000);
+  const expSeconds = overrides.expSeconds ?? Math.floor((now + 30 * 60 * 60 * 1000) / 1000);
   return JSON.stringify({
     auth_mode: 'chatgpt',
     tokens: {

--- a/packages/execution-engine/src/__tests__/codex-oauth-refresh.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-oauth-refresh.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { OAUTH_EXPIRY_BUFFER_MS } from '../claude-oauth-refresh.js';
 import {
   applyRefreshedCodexToken,
+  CODEX_JWT_EXPIRY_BUFFER_MS,
   CODEX_LAST_REFRESH_MAX_AGE_MS,
   isCodexAuthExpiring,
   parseCodexAuthFile,
@@ -77,7 +77,7 @@ describe('isCodexAuthExpiring', () => {
   });
 
   it('is true when the access-token JWT is inside the refresh buffer', () => {
-    const expSeconds = Math.floor((now + OAUTH_EXPIRY_BUFFER_MS - 1000) / 1000);
+    const expSeconds = Math.floor((now + CODEX_JWT_EXPIRY_BUFFER_MS - 1000) / 1000);
     expect(isCodexAuthExpiring(authJson({
       accessToken: jwtWithExp(expSeconds),
       lastRefresh: new Date(now).toISOString(),
@@ -85,11 +85,19 @@ describe('isCodexAuthExpiring', () => {
   });
 
   it('is false when the JWT has more than the buffer left and last_refresh is recent', () => {
-    const expSeconds = Math.floor((now + OAUTH_EXPIRY_BUFFER_MS + 60_000) / 1000);
+    const expSeconds = Math.floor((now + CODEX_JWT_EXPIRY_BUFFER_MS + 60_000) / 1000);
     expect(isCodexAuthExpiring(authJson({
       accessToken: jwtWithExp(expSeconds),
       lastRefresh: new Date(now).toISOString(),
     }), now)).toBe(false);
+  });
+
+  it('is true a full day before the JWT actually expires, closing the narrow multi-host refresh-collision window', () => {
+    const expSeconds = Math.floor((now + 12 * 60 * 60 * 1000) / 1000);
+    expect(isCodexAuthExpiring(authJson({
+      accessToken: jwtWithExp(expSeconds),
+      lastRefresh: new Date(now).toISOString(),
+    }), now)).toBe(true);
   });
 
   it('is true when last_refresh is older than seven days', () => {

--- a/packages/execution-engine/src/codex-oauth-refresh.ts
+++ b/packages/execution-engine/src/codex-oauth-refresh.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { OAUTH_EXPIRY_BUFFER_MS, type OauthFetchFn } from './claude-oauth-refresh.js';
+import { type OauthFetchFn } from './claude-oauth-refresh.js';
 
 const DEFAULT_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 // Public Codex CLI OAuth client id — not a secret, the same value the
@@ -9,6 +9,7 @@ const DEFAULT_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const REFRESH_TIMEOUT_MS = 10_000;
 export const CODEX_LAST_REFRESH_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const CODEX_JWT_EXPIRY_BUFFER_MS = 24 * 60 * 60 * 1000;
 
 interface CodexTokenBlob {
   access_token?: unknown;
@@ -88,7 +89,7 @@ export function isCodexAuthExpiring(authJson: string, now: number = Date.now()):
   const jwtExpMs = typeof accessToken === 'string' ? readJwtExpMs(accessToken) : null;
   const lastRefreshMs = readLastRefreshMs(parsed?.last_refresh);
   if (jwtExpMs === null && lastRefreshMs === null) return true;
-  if (jwtExpMs !== null && now + OAUTH_EXPIRY_BUFFER_MS >= jwtExpMs) return true;
+  if (jwtExpMs !== null && now + CODEX_JWT_EXPIRY_BUFFER_MS >= jwtExpMs) return true;
   if (lastRefreshMs !== null && now - lastRefreshMs >= CODEX_LAST_REFRESH_MAX_AGE_MS) return true;
   return false;
 }


### PR DESCRIPTION
## Summary

Five machines share one Codex login, copied as a single file. Its refresh token works once: whichever machine rotates it first invalidates every other copy.

A five-minute window decided when rotation should happen, checked hourly by the one machine meant to own it. Five other machines, constantly busy, checked the same boundary far more often on their own.

That narrow window was almost always won by a busy machine instead of the intended owner. The loser then failed outright next time it needed its now-dead copy.

## Review Claim

Approve widening that one window from five minutes to a full day, so the intended owner's much slower check gets dozens of chances to win before a busy machine's own check ever gets close enough to race it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is one constant, used in exactly one staleness decision that only ever governs Codex credentials. The equivalent decision for the separate Claude credential path is untouched, still keyed to its own five-minute constant. The existing seven-day fallback staleness check, which serves a different purpose (catching a copy that was never properly stamped at all), is also untouched.

## Slice Rationale

One constant, one decision function, one root cause — nothing here depends on or blocks any other change.

## Non-goals

Does not change the Claude credential refresh path, the seven-day fallback check, how often the owning machine's check itself runs, or anything about how a machine obtains its very first login.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/codex-oauth-refresh.test.ts -t "closing the narrow multi-host refresh-collision window"` (run from `packages/execution-engine`) — fails with `expected false to be true` before the change, passes after
- [x] `bash node_modules/.bin/vitest run src/__tests__/codex-oauth-refresh.test.ts src/__tests__/claude-oauth-refresh-worker.test.ts src/__tests__/claude-oauth-refresh.test.ts` (run from `packages/execution-engine`) — 52/52 pass, no regressions
- [x] `pnpm run check:comments` — clean

This is a live-timing/live-OAuth-behavior bug: the actual collision (two real machines racing an external OAuth token endpoint) cannot be reproduced deterministically in a unit test. The test above proves the fixed decision function's new boundary directly; the live effect was observed and diagnosed against a real incident on the production fleet (see below), not reproduced synthetically.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

---

**Evidence behind this fix**, gathered from the live production fleet before writing any code:

- A real task's `execution.error` field showed the exact failure: `codex_login::auth::manager: Failed to refresh token: Your access token could not be refreshed because your refresh token was already used.` — on `remote_digital_ocean_3`, 2026-09-04T00:55:55Z.
- `invoker-cli query workflows` confirmed 27 separate CI-repair workflows failed with the identical symptom in the same ~9-minute window (00:49–00:58 UTC), consistent with one shared-credential incident, not 27 independent causes.
- Read the current production `~/.codex/auth.json`'s access-token JWT directly: real lifetime is 10 days (`exp - iat = 864000` seconds).
- Ran a real `codex exec` call against a token with ~10 days of remaining life: the auth file was byte-for-byte unchanged afterward, confirming Codex's own client does not refresh far ahead of expiry — only close to its own boundary, which is what makes the shared five-minute window the actual collision point.
- Read `codex-oauth-refresh.ts` and `claude-oauth-refresh-worker.ts` in full: confirmed the one machine meant to own redistribution only checks hourly, while the other five machines' own Codex clients evaluate the identical boundary on every task run, with no coordination between any of these checks.
