### PR TITLE
[Run-Worker Stack](1) Add one-shot worker run(args) and WorkerTickContext.args

### DIFF
--- a/packages/execution-engine/src/__tests__/external-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/external-worker.test.ts
@@ -49,12 +49,38 @@ describe('external worker registration', () => {
   });
 });
 
+function createShortLivedExternalWorker(): ExternalWorkerRuntime {
+  const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+  registerExternalWorkers(registry, [
+    {
+      kind: 'external-short-lived',
+      launch: {
+        executable: 'true',
+        args: [],
+      },
+    },
+  ]);
+
+  const definition = registry.get('external-short-lived');
+  expect(definition).toBeDefined();
+  return definition!.factory({} as WorkerRuntimeDependencies) as ExternalWorkerRuntime;
+}
+
 describe('external worker runtime', () => {
   it('returns from a manual tick after spawning the external process', async () => {
     const runtime = createSleepingExternalWorker();
 
     await runtime.tick();
     await runtime.stop();
+    await runtime.finished;
+  });
+
+  it('satisfies the WorkerRuntime run(args) contract by awaiting the spawned process to exit', async () => {
+    const runtime = createShortLivedExternalWorker();
+
+    await runtime.run(['ignored', 'args']);
+
+    expect(runtime.isRunning()).toBe(false);
     await runtime.finished;
   });
 });

--- a/packages/execution-engine/src/__tests__/worker-runtime-run.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-runtime-run.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createWorkerRuntime } from '../worker-runtime.js';
+
+describe('WorkerRuntime.run', () => {
+  it('passes the supplied CLI args through the tick context', async () => {
+    const onTick = vi.fn();
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const runtime = createWorkerRuntime({
+      kind: 'test-run-worker',
+      onTick,
+      logger: logger as any,
+      intervalMs: 0,
+    });
+
+    await runtime.run(['delete-all-retry']);
+
+    expect(onTick).toHaveBeenCalledOnce();
+    expect(onTick.mock.calls[0][0].args).toEqual(['delete-all-retry']);
+  });
+});

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -877,6 +877,7 @@ export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRunt
     start,
     wake: runtime.wake,
     tick: runtime.tick,
+    run: runtime.run,
     stop,
     isRunning: runtime.isRunning,
   };

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -131,6 +131,11 @@ function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWork
     launch();
   };
 
+  const run = async (_args?: string[]): Promise<void> => {
+    launch();
+    await (closePromise ?? Promise.resolve());
+  };
+
   return {
     identity,
     finished: finishedGate.promise,
@@ -139,6 +144,7 @@ function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWork
       void launch();
     },
     tick,
+    run,
     stop,
     isRunning: () => started && !stopped && child !== null,
   };

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -34,6 +34,7 @@ export interface WorkerTickContext {
   readonly tickNumber: number;
   /** Aborted when `stop()` is requested; ticks should check between units of work. */
   readonly signal: AbortSignal;
+  readonly args?: string[];
 }
 
 /** The unit of work a worker performs on each tick. */
@@ -94,6 +95,7 @@ export interface WorkerRuntime {
   wake(reason?: WorkerTickReason): void;
   /** Run a single tick now and await it (manual/test hook). */
   tick(reason?: WorkerTickReason): Promise<void>;
+  run(args?: string[]): Promise<void>;
   /**
    * Request stop: clear the timer, drop signal handlers, abort the tick
    * signal. Resolves promptly unless `settleTimeoutMs` is set for a bounded
@@ -142,8 +144,9 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   let stopped = false;
   let interval: ReturnType<typeof setInterval> | null = null;
   let startDelayTimer: ReturnType<typeof setTimeout> | null = null;
-  let inFlight: Promise<void> | null = null;
+  let inFlight: Promise<boolean> | null = null;
   let pendingReason: WorkerTickReason | null = null;
+  let pendingArgs: string[] | undefined;
   let tickNumber = 0;
   let lastTickActivityAt = Date.now();
   let watchdogTimer: NodeJS.Timeout | null = null;
@@ -151,13 +154,14 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   const signalHandlers = new Map<NodeJS.Signals, () => void>();
   let abortController = new AbortController();
 
-  const runOnce = async (reason: WorkerTickReason): Promise<boolean> => {
+  const runOnce = async (reason: WorkerTickReason, args?: string[]): Promise<boolean> => {
     tickNumber += 1;
     const ctx: WorkerTickContext = {
       identity,
       reason,
       tickNumber,
       signal: abortController.signal,
+      args,
     };
     lastTickActivityAt = Date.now();
     try {
@@ -179,21 +183,27 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   // Coalescing scheduler: at most one tick runs at a time. Requests that arrive
   // while a tick is in flight collapse into a single follow-up (keeping the most
   // recent reason), so a burst of wakeups never queues a backlog of ticks.
-  const schedule = (reason: WorkerTickReason): Promise<void> => {
-    if (stopped) return Promise.resolve();
+  const schedule = (reason: WorkerTickReason, args?: string[]): Promise<boolean> => {
+    if (stopped) return Promise.resolve(true);
     if (inFlight) {
       pendingReason = reason;
+      pendingArgs = args;
       return inFlight;
     }
-    const drain = async (firstReason: WorkerTickReason): Promise<void> => {
+    const drain = async (firstReason: WorkerTickReason, firstArgs?: string[]): Promise<boolean> => {
       let nextReason: WorkerTickReason | null = firstReason;
+      let nextArgs: string[] | undefined = firstArgs;
       let consecutiveFailures = 0;
+      let succeeded = true;
       while (nextReason !== null && !stopped) {
         const current = nextReason;
+        const currentArgs = nextArgs;
         pendingReason = null;
-        const succeeded = await runOnce(current);
+        pendingArgs = undefined;
+        succeeded = await runOnce(current, currentArgs);
         consecutiveFailures = succeeded ? 0 : consecutiveFailures + 1;
         nextReason = pendingReason;
+        nextArgs = pendingArgs;
         if (nextReason !== null && !succeeded && !stopped) {
           const backoffMs = Math.min(
             (options.backoffBaseMs ?? 250) * 2 ** (consecutiveFailures - 1),
@@ -202,8 +212,9 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
           await delay(backoffMs);
         }
       }
+      return succeeded;
     };
-    inFlight = drain(reason).finally(() => {
+    inFlight = drain(reason, args).finally(() => {
       inFlight = null;
     });
     return inFlight;
@@ -214,7 +225,12 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     void schedule(reason);
   };
 
-  const tick = (reason: WorkerTickReason = 'manual'): Promise<void> => schedule(reason);
+  const tick = (reason: WorkerTickReason = 'manual'): Promise<void> => schedule(reason).then(() => {});
+
+  const run = (args?: string[]): Promise<void> =>
+    schedule('manual', args).then((ok) => {
+      if (!ok) throw new Error(`Worker ${identity.kind} run failed`);
+    });
 
   const beginStop = (): void => {
     if (stopped) return;
@@ -350,5 +366,5 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
 
   const isRunning = (): boolean => started && !stopped;
 
-  return { identity, start, wake, tick, stop, isRunning };
+  return { identity, start, wake, tick, run, stop, isRunning };
 }

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -527,6 +527,7 @@ export function createAutoApproveWorker(options: AutoApproveWorkerOptions): Work
     start,
     wake: runtime.wake,
     tick: runtime.tick,
+    run: runtime.run,
     stop,
     isRunning: runtime.isRunning,
   };

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -1258,6 +1258,7 @@ export function createInfraRepairWorker(options: InfraRepairWorkerOptions): Work
     start,
     wake: runtime.wake,
     tick: runtime.tick,
+    run: runtime.run,
     stop,
     isRunning: runtime.isRunning,
   };

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -325,6 +325,7 @@ export function createRequeueWorker(options: RequeueWorkerOptions): WorkerRuntim
     start,
     wake: runtime.wake,
     tick: runtime.tick,
+    run: runtime.run,
     stop,
     isRunning: runtime.isRunning,
   };

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -225,6 +225,7 @@ export function createWorkflowResumeWorker(options: WorkflowResumeWorkerOptions)
     start,
     wake: runtime.wake,
     tick: runtime.tick,
+    run: runtime.run,
     stop,
     isRunning: runtime.isRunning,
   };


### PR DESCRIPTION
## Summary

Worker ticks already carry a reason and a tick number, but nothing lets a caller pass its own arguments into a single tick.

This adds an optional `args` field to the tick context, threaded through the existing coalescing scheduler, plus a `run(args)` method on `WorkerRuntime` for firing one deliberate tick with those arguments.

A burst of `run()` calls while one is already in flight collapses into a single follow-up tick carrying the most recent args, matching how the scheduler already coalesces plain wakeups.

## Review Claim

Approve adding CLI-style arguments to a worker tick's context, via one new `run(args)` entry point on the existing coalescing scheduler, with no change to how a plain scheduled tick behaves.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A tick invoked without `run()` still gets `args: undefined`, matching current behavior exactly. The coalescing rule for reason (most-recent-wins on a burst) now applies identically to args — no new coalescing policy, the same policy extended to one more field.

## Slice Rationale

This is the runtime-level plumbing only: the type, the scheduler change, and its own test. CLI/IPC/UI wiring that actually calls `run()` with real arguments is a separate slice.

## Non-goals

Does not wire any CLI command, IPC channel, or UI control to call `run()` yet. Does not change the coalescing policy itself, only extends it to carry one more field.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/worker-runtime-run.test.ts` (run from `packages/execution-engine`) — pass
- [x] `pnpm run check:types` (repo-wide) — clean
- [x] `pnpm run check:deps` — 0 errors (98 pre-existing warnings, unchanged)
- [x] `pnpm run check:comments` — clean
- [x] `bash scripts/required-builds.sh` — exit 0
- [x] `node scripts/check-large-files.mjs` — pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runtime plumbing and interface extensions only; scheduled worker behavior is unchanged unless callers adopt `run(args)`.
> 
> **Overview**
> Adds **one-shot worker execution** with optional CLI-style arguments: `WorkerRuntime.run(args)` schedules a manual tick and rejects if that tick fails, while ordinary `wake`/`tick`/`poll` paths stay unchanged (`args` remains undefined).
> 
> **`WorkerTickContext`** now carries optional `args`, threaded through the existing coalescing scheduler so overlapping `run()` calls while a tick is in flight keep the **most recent** args (same policy as tick reason). Built-in worker facades (auto-fix, auto-approve, infra-repair, requeue, workflow-resume) and **external** workers expose `run`; external `run` launches the supervised process and **awaits exit** (args are accepted for contract parity but not passed to the child).
> 
> New tests cover args propagation in `createWorkerRuntime` and external-worker `run` behavior. No CLI/IPC wiring in this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5e156d9a47ee7e11d3a9b8cef31359a053806e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->