### PR TITLE
[Run-Worker Stack](2) Add invoker-cli run-worker <kind> -- <args...>

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -208,6 +208,7 @@ function usage(): string {
     '  invoker-cli mcp',
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli worker toggles [--enable <id>|--disable <id> ...]',
+    '  invoker-cli run-worker <kind> -- <args...>',
     '  invoker-cli auto-approve-authors [--json] [--set <login...>|--add <login>|--add-current-github-user|--clear]',
     '  invoker-cli --help',
     '  invoker-cli --version',
@@ -1241,6 +1242,53 @@ async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>
   process.stdout.write(`${workerDisplayName(definition.kind)} worker stopped.\n`);
   return 0;
 }
+
+async function runWorkerOnce(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus, runArgs: string[]): Promise<number> {
+  const homeRoot = resolveInvokerHomeRoot();
+  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
+
+  let lock;
+  let persistence;
+  let worker: WorkerRuntime | undefined;
+  let autoFixAttemptLedger;
+  try {
+    lock = acquireWorkerLock({ kind: definition.kind, homeRoot, logger: silentLogger });
+    persistence = await SQLiteAdapter.create(join(homeRoot, 'invoker.db'), {
+      outputDir: join(homeRoot, 'outputs'),
+    });
+    autoFixAttemptLedger = createAutoFixAttemptLedger();
+    worker = definition.factory({
+      logger: silentLogger,
+      messageBus: bus,
+      store: persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, mutationArgs) =>
+          persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority),
+      },
+      autoFix: {
+        defaultAutoFixRetries: autoFixRetries,
+        attemptLedger: autoFixAttemptLedger,
+        getAutoFixAgent: () => autoFixAgent,
+      },
+    });
+
+    process.stdout.write(`${workerDisplayName(definition.kind)} worker running.\n`);
+    await worker.run(runArgs);
+  } catch (err) {
+    if (err instanceof WorkerLockHeldError) {
+      process.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  } finally {
+    await worker?.stop({ settleTimeoutMs: 5_000 });
+    lock?.release();
+    persistence?.close();
+  }
+  process.stdout.write(`${workerDisplayName(definition.kind)} worker finished.\n`);
+  return 0;
+}
 async function runHeadlessOwnerServe(deps: CliDeps): Promise<number> {
   const repoRoot = resolveRepoRoot(__dirname, { fallback: resolve(__dirname, '../../../..') });
   const launchSpec = (deps.resolveOwnerLaunchSpec ?? resolveHeadlessOwnerLaunchSpec)(repoRoot);
@@ -1309,6 +1357,25 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       }
       bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
       return await runWorker(definition, bus);
+    }
+    if (argv[0] === 'run-worker') {
+      const kind = argv[1];
+      if (!kind) {
+        throw new Error('Missing worker kind. Usage: invoker-cli run-worker <kind> -- <args...>');
+      }
+      const dashDash = argv.indexOf('--', 2);
+      const workerArgs = dashDash === -1 ? [] : argv.slice(dashDash + 1);
+      const registry = registerExternalWorkers(
+        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+        readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
+      );
+      const definition = registry.get(kind);
+      if (!definition) {
+        const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+        throw new Error(`Unknown worker kind: "${kind}". Usage: invoker-cli run-worker <${knownKinds}>`);
+      }
+      bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
+      return await runWorkerOnce(definition, bus, workerArgs);
     }
     if (argv[0] === 'query') {
       return await runQuery(parseQueryArgs(argv.slice(1)), deps);


### PR DESCRIPTION
## Summary

The previous slice in this stack added a one-shot worker entrypoint (`run(args)`) that a worker can implement to handle a single invocation instead of its normal recurring tick.

There was no way to trigger that entrypoint from a terminal — only the app's own internal callers could reach it.

This adds `invoker-cli run-worker <kind> -- <args...>`, a thin CLI wrapper that calls the same entrypoint directly.

## Review Claim

Approve exposing the existing one-shot worker entrypoint as a new `invoker-cli run-worker` subcommand, with no change to the entrypoint itself.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Adds one new subcommand to `packages/cli/src/index.ts`'s existing dispatch, following the exact pattern already used for `worker <kind>`. No existing subcommand's behavior changes.

## Slice Rationale

The entrypoint (previous slice) and its CLI exposure (this slice) are reviewable as separate questions: does the one-shot mechanism work, and is it reachable from a terminal.

## Non-goals

Does not change the one-shot worker entrypoint's own behavior. Does not add a UI surface for this — CLI only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (repo-wide) — 2 pre-existing failures remain in `packages/app/src/web/web-invoker-dispatch.ts` and `packages/execution-engine/src/external-worker.ts`, both confirmed unrelated to this PR's own diff (which touches only `packages/cli/src/index.ts`) — tracked separately with the PRs that own those files
- [x] `pnpm run check:deps` — 0 errors, 98 pre-existing warnings (unchanged)
- [x] `bash scripts/required-builds.sh` — exit 0
- [x] `pnpm run check:comments` — clean
- [x] `node scripts/check-large-files.mjs` — clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only addition with isolated dispatch; reuses existing worker lock and persistence patterns without altering other subcommands.
> 
> **Overview**
> Adds **`invoker-cli run-worker <kind> -- <args...>`** so the existing one-shot `WorkerRuntime.run(args)` path can be triggered from the terminal without changing worker implementations.
> 
> The new flow mirrors **`invoker-cli worker <kind>`** for registry lookup (built-in autofix plus configured external workers) but uses a new **`runWorkerOnce`** helper: acquire the per-kind lock, wire SQLite persistence and autofix config, call **`worker.run(runArgs)`** once, then stop with a 5s settle timeout and release resources. Arguments after **`--`** are passed through to the worker; omitting **`--`** means an empty arg list.
> 
> Help text documents the subcommand. Long-running **`worker`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0cbd2edfdd94aa5f5bdd07f78acd0638a90ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->