### PR TITLE
[E2E Autofix Abort Signal](1) Kill the e2e-autofix worker's spawned sweep when its tick is aborted

### DIFF
--- a/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
@@ -115,6 +115,27 @@ function makeExitWithoutCloseHarness(options: { exitCode?: number } = {}): {
   return { calls, spawnProcess: spawnProcess as unknown as typeof spawn };
 }
 
+function makeHangingSpawnHarness(): { calls: SpawnCall[]; spawnProcess: typeof spawn; child: ChildProcess & { kill: ReturnType<typeof vi.fn> } } {
+  const calls: SpawnCall[] = [];
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    stdin: null,
+    killed: false,
+    pid: 4242,
+    kill: vi.fn(),
+  }) as unknown as ChildProcess & { kill: ReturnType<typeof vi.fn> };
+
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    return child;
+  });
+
+  return { calls, spawnProcess: spawnProcess as unknown as typeof spawn, child };
+}
+
 describe('e2e auto-fix worker', () => {
   let tmpRoot: string | undefined;
 
@@ -233,6 +254,50 @@ describe('e2e auto-fix worker', () => {
     });
 
     await expect(tick(makeCtx())).rejects.toThrow('exited with code 1');
+  });
+
+  it('kills the spawned child when the tick is aborted mid-flight, instead of leaving it running past a worker disable', async () => {
+    const repoRoot = makeRepoRoot();
+    const harness = makeHangingSpawnHarness();
+    const tick = createE2eAutoFixTick({
+      logger: makeLogger(),
+      repoRoot,
+      spawnProcess: harness.spawnProcess,
+    });
+    const controller = new AbortController();
+
+    const tickPromise = tick({
+      identity: { kind: E2E_AUTOFIX_WORKER_KIND, instanceId: `${E2E_AUTOFIX_WORKER_KIND}-test` },
+      reason: 'manual',
+      tickNumber: 1,
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.calls).toHaveLength(1);
+    });
+
+    controller.abort();
+    await vi.waitFor(() => {
+      expect(harness.child.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    harness.child.emit('close', null, 'SIGTERM');
+    await expect(tickPromise).resolves.toBeUndefined();
+  });
+
+  it('spawns the child detached so a process-group kill can reach its own grandchildren', async () => {
+    const repoRoot = makeRepoRoot();
+    const harness = makeSpawnHarness({ exitCode: 0 });
+    const tick = createE2eAutoFixTick({
+      logger: makeLogger(),
+      repoRoot,
+      spawnProcess: harness.spawnProcess,
+    });
+
+    await tick(makeCtx());
+
+    expect(harness.calls[0]?.options.detached).toBe(process.platform !== 'win32');
   });
 
   it('resolves via exit when close never fires within the grace window, instead of hanging forever', async () => {

--- a/packages/execution-engine/src/workers/e2e-autofix-worker.ts
+++ b/packages/execution-engine/src/workers/e2e-autofix-worker.ts
@@ -4,6 +4,7 @@ import type { Readable } from 'node:stream';
 
 import { resolveRepoRoot, type Logger } from '@invoker/contracts';
 
+import { terminateChildProcessGroup } from '../process-utils.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
@@ -95,12 +96,13 @@ export function createE2eAutoFixWorker(options: E2eAutoFixWorkerOptions): Worker
 }
 
 export function createE2eAutoFixTick(options: E2eAutoFixTickOptions): WorkerTick {
-  return async () => {
-    await runE2eAutoFixEntrypoint(options);
+  return async (ctx) => {
+    await runE2eAutoFixEntrypoint(options, ctx?.signal);
   };
 }
 
-async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<void> {
+async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
   const repoRoot = options.repoRoot ? resolve(options.repoRoot) : resolveRepoRoot(process.cwd());
   const scriptPath = resolve(repoRoot, E2E_AUTOFIX_SCRIPT_RELATIVE_PATH);
   const shell = options.shell ?? 'bash';
@@ -122,6 +124,7 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
       cwd: repoRoot,
       env: childEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
     });
   } catch (err) {
     options.logger.error(`[worker:${E2E_AUTOFIX_WORKER_KIND}] spawn failed`, {
@@ -150,13 +153,13 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
       fn();
     };
 
-    const finish = (code: number | null, signal: NodeJS.Signals | null, source: 'close' | 'exit'): void => {
+    const finish = (code: number | null, exitSignal: NodeJS.Signals | null, source: 'close' | 'exit'): void => {
       settle(() => {
         const fields = {
           module: 'e2e-autofix-worker',
           worker: E2E_AUTOFIX_WORKER_KIND,
           code,
-          signal,
+          signal: exitSignal,
           source,
         };
         if (code === 0) {
@@ -171,14 +174,32 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
           resolvePromise();
           return;
         }
+        if (signal?.aborted) {
+          options.logger.info(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint aborted by stop`, fields);
+          resolvePromise();
+          return;
+        }
         const message = `e2e auto-fix worker exited with code ${code ?? 'null'}`
-          + (signal ? ` signal ${signal}` : '');
+          + (exitSignal ? ` signal ${exitSignal}` : '');
         options.logger.error(`[worker:${E2E_AUTOFIX_WORKER_KIND}] shell entrypoint failed`, fields);
         rejectPromise(new Error(message));
       });
     };
 
+    const onAbort = (): void => {
+      void terminateChildProcessGroup(child, () => settled);
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
     child.once('error', (err) => {
+      signal?.removeEventListener('abort', onAbort);
       settle(() => {
         options.logger.error(`[worker:${E2E_AUTOFIX_WORKER_KIND}] process error`, {
           module: 'e2e-autofix-worker',
@@ -189,11 +210,17 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
       });
     });
 
-    child.once('close', (code, signal) => finish(code, signal, 'close'));
+    child.once('close', (code, exitSignal) => {
+      signal?.removeEventListener('abort', onAbort);
+      finish(code, exitSignal, 'close');
+    });
 
-    child.once('exit', (code, signal) => {
+    child.once('exit', (code, exitSignal) => {
       if (settled) return;
-      graceTimer = setTimeout(() => finish(code, signal, 'exit'), closeGraceMs);
+      graceTimer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        finish(code, exitSignal, 'exit');
+      }, closeGraceMs);
       graceTimer.unref?.();
     });
   });


### PR DESCRIPTION
## Summary

Every worker already has a way to ask its current unit of work to wind down early. One worker's own unit of work never learned to listen.

That worker hands its real labor to a separate program and waits for it to finish, with nothing tying the two together once they start.

A sibling worker already solved exactly this for its own separate program, years earlier by calendar time in this codebase's history. This borrows that same solution.

## Review Claim

Approve wiring the tick's own cancellation signal into the spawned program, and terminating that program's whole family when the signal fires, mirroring the sibling worker's already-proven approach.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The signal-wiring only changes what happens when a worker's own runtime asks a tick to wind down; the happy path (child exits 0, tick resolves) and the failure path (child exits non-zero, tick rejects) are unchanged, proven by every pre-existing test in the same file still passing unmodified. The termination helper reused here already carries its own test coverage and is already the live pattern for one other worker's identical shape.

## Slice Rationale

One worker, one gap, one existing sibling pattern applied — no new mechanism invented.

## Non-goals

Does not add a standalone time-based cap on how long a single run of the spawned program may take; the sibling worker has one, this one still does not, and that gap is left for separate consideration rather than folded in here.

Does not change the worker that was already correct (the plain, non-web repair worker never spawns a separate program at all, so it was never affected).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/e2e-autofix-worker.test.ts -t "kills the spawned child when the tick is aborted"` (run from `packages/execution-engine`) — times out waiting for the kill call before this change, passes after
- [x] `bash node_modules/.bin/vitest run src/__tests__/e2e-autofix-worker.test.ts -t "spawns the child detached"` (run from `packages/execution-engine`) — fails before this change, passes after
- [x] `bash node_modules/.bin/vitest run src/__tests__/e2e-autofix-worker.test.ts src/__tests__/pr-maintenance-workers.test.ts src/__tests__/process-utils.test.ts` (run from `packages/execution-engine`) — 52/52 pass, no regressions
- [x] `pnpm --filter @invoker/execution-engine build` — clean build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
