### PR TITLE
[Skill category](2) setup script forwarding

### DIFF
--- a/scripts/setup-agent-skills.sh
+++ b/scripts/setup-agent-skills.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+INVOKER_SKILL_CATEGORY="${INVOKER_SKILL_CATEGORY:-}"
+
 log() {
   echo "[setup] $*"
 }
@@ -44,7 +46,11 @@ install_bundled_skills() {
   local mode="${1:-reinstall}"
   log "Installing bundled Invoker skills with prefix invoker-..."
   unset ELECTRON_RUN_AS_NODE
-  node scripts/electron.cjs packages/app/dist/main.js --headless install-skills "$mode"
+  if [ -n "$INVOKER_SKILL_CATEGORY" ]; then
+    node scripts/electron.cjs packages/app/dist/main.js --headless install-skills "$mode" "$INVOKER_SKILL_CATEGORY"
+  else
+    node scripts/electron.cjs packages/app/dist/main.js --headless install-skills "$mode"
+  fi
 }
 
 check_required_commands


### PR DESCRIPTION
## Summary

`scripts/setup-agent-skills.sh` now reads one optional environment variable, `INVOKER_SKILL_CATEGORY`.

When it is set, the script forwards its value as a third argument to the local skill installer.

When it is unset, the script's install command runs exactly as it did before this change.

This lets a machine opt into a narrower skill install without changing the setup script's default behavior.

## Review Claim

`scripts/setup-agent-skills.sh` appends `INVOKER_SKILL_CATEGORY` as a third positional argument to the bundled-skill install call only when that variable is non-empty; the two-argument call is unchanged when it is empty or unset.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Running the script with `INVOKER_SKILL_CATEGORY` unset produces a byte-identical install invocation to before this change, so machines that never set the variable see no behavior change.

## Slice Rationale

This is one local-machine-tooling slice: the setup script's own forwarding of an already-existing selection value, kept separate from the value's origin (an earlier stacked step) and from the per-item labeling that follows (a later stacked step).

## Non-goals

Does not add or change the underlying `INVOKER_SKILL_CATEGORY` selection value or its entry point. Does not add per-item labeling. Does not add a new bundled skill item.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `unset INVOKER_SKILL_CATEGORY; grep -n 'install-skills' scripts/setup-agent-skills.sh` — confirms the two-argument call is unchanged
- [ ] `INVOKER_SKILL_CATEGORY=example bash -c 'source scripts/setup-agent-skills.sh 2>/dev/null; true'` — variable is read near the top of the script
- [ ] `node scripts/check-pr-body-keywords.mjs --body-file /tmp/skill-category-2-pr.md --declared-unit tooling-policy`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file /tmp/skill-category-2-pr.md --base master`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
