### PR TITLE
Add codex-session-insight-miner.py

### DIFF
--- a/scripts/codex-session-insight-miner.py
+++ b/scripts/codex-session-insight-miner.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Mine Codex CLI sessions for insight: workflow, model, token spend, and prompt type."""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+CWD_WORKTREE = re.compile(r"experiment-(wf-\d+-\d+)-(.+)-g\d+\.t\d+\.a-")
+CWD_SCRATCH = re.compile(r"/tmp/invoker-scratch-[^/]+$")
+CWD_MERGE = re.compile(r"merge-clones/(?:gate-|approve-|consolidate-)?(?:__merge__)?(wf-\d+-\d+)")
+FILENAME_TS = re.compile(r"rollout-(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-")
+
+
+def default_session_dir():
+    return os.path.expanduser("~/.codex/sessions")
+
+
+def parse_filename_timestamp(fname):
+    m = FILENAME_TS.match(fname)
+    if not m:
+        return None
+    return f"{m.group(1)}T{m.group(2)}:{m.group(3)}:{m.group(4)}"
+
+
+def parse_filename_date(fname):
+    m = FILENAME_TS.match(fname)
+    if not m:
+        return None
+    return m.group(1)
+
+
+def classify(cwd):
+    m = CWD_SCRATCH.search(cwd)
+    if m:
+        return None, "scratch"
+    m = CWD_MERGE.search(cwd)
+    if m:
+        return m.group(1), "merge-clone"
+    m = CWD_WORKTREE.search(cwd)
+    if m:
+        return m.group(1), m.group(2)
+    return None, "unknown"
+
+
+def user_text(payload):
+    content = payload.get("content", "")
+    text = ""
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                text += (item.get("text") or "") + " "
+    elif isinstance(content, str):
+        text = content
+    if not text:
+        text = payload.get("message", "")
+    return text.strip()
+
+
+def classify_prompt(text):
+    if "worker-lifecycle finding" in text:
+        return "worker-start"
+    if "repair-filings finding" in text:
+        return "repair-filing-delete"
+    if "e2e-regression-watch finding" in text:
+        return "e2e-regression-needs-human"
+    return "unknown"
+
+
+def summarize(path):
+    session_file = os.path.basename(path)
+    date = parse_filename_date(session_file)
+    timestamp = parse_filename_timestamp(session_file)
+    workflow_id = None
+    task_type = None
+    model = None
+    total_tokens = None
+    plan_type = None
+    prompt = ""
+    prompt_type = "unknown"
+    note = None
+    user_messages = []
+
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = e.get("type")
+                p = e.get("payload") or {}
+                if t == "session_meta" and workflow_id is None:
+                    cwd = p.get("cwd", "")
+                    workflow_id, task_type = classify(cwd)
+                if t == "turn_context":
+                    model = p.get("model") or model
+                if t == "event_msg" and p.get("type") == "token_count":
+                    info = p.get("info") or {}
+                    tu = info.get("total_token_usage") or {}
+                    total_tokens = tu.get("total_tokens")
+                    rl = info.get("rate_limits") or {}
+                    primary = rl.get("primary") or {}
+                    plan_type = rl.get("plan_type") or plan_type
+                if t == "response_item" and p.get("role") == "user":
+                    text = user_text(p)
+                    if text:
+                        user_messages.append(text)
+
+        if not user_messages:
+            prompt = ""
+        else:
+            prompt = next(
+                (text for text in user_messages if "Assume zero prior context" in text or "Investigate a production" in text),
+                user_messages[0],
+            )
+    except OSError as ex:
+        note = f"read-error:{ex}"
+
+    if prompt:
+        prompt_type = classify_prompt(prompt)
+
+    return {
+        "session_file": session_file,
+        "date": date,
+        "timestamp": timestamp,
+        "workflow_id": workflow_id,
+        "task_type": task_type,
+        "model": model,
+        "total_tokens": total_tokens,
+        "plan_type": plan_type,
+        "prompt_type": prompt_type,
+        "prompt_snippet": prompt[:300],
+        "note": note,
+    }
+
+
+def audit(session_dir, cutoff=None):
+    results = []
+    if not os.path.isdir(session_dir):
+        return results
+    for root, _dirs, files in os.walk(session_dir):
+        for f in files:
+            if not (f.startswith("rollout-") and f.endswith(".jsonl")):
+                continue
+            path = os.path.join(root, f)
+            row = summarize(path)
+            if cutoff and row["timestamp"] and row["timestamp"] < cutoff:
+                continue
+            results.append(row)
+    return sorted(results, key=lambda r: r["session_file"])
+
+
+def aggregate(rows, key):
+    out = defaultdict(lambda: {"sessions": 0, "tokens": 0})
+    for r in rows:
+        k = r.get(key) or "unknown"
+        v = r.get("total_tokens") or 0
+        out[k]["sessions"] += 1
+        out[k]["tokens"] += v
+    return dict(out)
+
+
+def html_escape(s):
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+
+
+def build_html(rows, title, generated_at):
+    total_sessions = len(rows)
+    with_tokens = [r for r in rows if r.get("total_tokens") is not None]
+    total_tokens = sum(r["total_tokens"] for r in with_tokens)
+    by_type = aggregate(rows, "task_type")
+    by_date = aggregate(rows, "date")
+    by_model = aggregate(rows, "model")
+    by_prompt = aggregate(rows, "prompt_type")
+    top = sorted(rows, key=lambda r: -(r.get("total_tokens") or 0))[:50]
+
+    def cards():
+        return (
+            f'<div class="card"><div class="label">Sessions</div><div class="value">{total_sessions:,}</div></div>'
+            f'<div class="card"><div class="label">Sessions with token data</div><div class="value">{len(with_tokens):,}</div></div>'
+            f'<div class="card"><div class="label">Missing token data</div><div class="value">{total_sessions - len(with_tokens):,}</div></div>'
+            f'<div class="card"><div class="label">Measured tokens</div><div class="value">{total_tokens:,}</div></div>'
+            f'<div class="card"><div class="label">Unique task types</div><div class="value">{len(by_type):,}</div></div>'
+            f'<div class="card"><div class="label">Unique models</div><div class="value">{len(by_model):,}</div></div>'
+        )
+
+    def table(data, headers):
+        head = "".join(f"<th>{h}</th>" for h in headers)
+        body = ""
+        for k, v in sorted(data.items(), key=lambda x: -x[1]["tokens"]):
+            body += f'<tr><td>{html_escape(str(k))}</td><td>{v["sessions"]:,}</td><td>{v["tokens"]:,}</td></tr>'
+        return f'<table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table>'
+
+    top_rows = ""
+    for r in top:
+        snippet = html_escape(r.get("prompt_snippet", ""))
+        top_rows += (
+            f'<tr><td>{html_escape(str(r.get("date")))}</td>'
+            f'<td>{html_escape(str(r.get("task_type")))}</td>'
+            f'<td>{html_escape(str(r.get("model")))}</td>'
+            f'<td>{r.get("total_tokens") or 0:,}</td>'
+            f'<td>{html_escape(str(r.get("prompt_type")))}</td>'
+            f'<td title="{snippet}">{snippet[:120]}</td></tr>'
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{html_escape(title)}</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 40px; color: #1a1a1a; background: #fafafa; }}
+.container {{ max-width: 1200px; margin: 0 auto; background: #fff; padding: 32px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }}
+h1 {{ margin-top: 0; }}
+h2 {{ border-bottom: 1px solid #e0e0e0; padding-bottom: 8px; margin-top: 40px; }}
+.summary {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 16px; margin: 20px 0; }}
+.card {{ background: #f4f4f4; padding: 16px; border-radius: 6px; }}
+.card .label {{ font-size: 12px; color: #666; text-transform: uppercase; }}
+.card .value {{ font-size: 24px; font-weight: 600; margin-top: 4px; }}
+table {{ width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 13px; }}
+th {{ text-align: left; background: #f0f0f0; padding: 8px; border-bottom: 2px solid #ccc; }}
+td {{ padding: 8px; border-bottom: 1px solid #eee; }}
+tr:nth-child(even) {{ background: #fafafa; }}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>{html_escape(title)}</h1>
+<p>Generated: {html_escape(generated_at)}</p>
+<div class="summary">{cards()}</div>
+<h2>By task type</h2>
+{table(by_type, ["task_type", "sessions", "tokens"])}
+<h2>By date</h2>
+{table(by_date, ["date", "sessions", "tokens"])}
+<h2>By model</h2>
+{table(by_model, ["model", "sessions", "tokens"])}
+<h2>By prompt type</h2>
+{table(by_prompt, ["prompt_type", "sessions", "tokens"])}
+<h2>Top 50 sessions by tokens</h2>
+<table><thead><tr><th>date</th><th>task_type</th><th>model</th><th>tokens</th><th>prompt_type</th><th>prompt snippet</th></tr></thead><tbody>{top_rows}</tbody></table>
+</div>
+</body>
+</html>"""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Mine Codex session JSONL files for workflow, token, and prompt insight.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--session-dir", default=None, help="Directory to scan recursively for rollout-*.jsonl files")
+    parser.add_argument("--cutoff", default=None, help="ISO8601 date (YYYY-MM-DD); skip earlier sessions")
+    parser.add_argument("--scratch-only", action="store_true", help="Only include scratch sessions")
+    parser.add_argument("--format", choices=["json", "html"], default="json", help="Output format")
+    parser.add_argument("--output", default=None, help="Output file (default: stdout)")
+    parser.add_argument("--title", default="Codex session insight", help="HTML report title")
+    args = parser.parse_args()
+
+    session_dir = args.session_dir or default_session_dir()
+    rows = audit(session_dir, args.cutoff)
+
+    if args.scratch_only:
+        rows = [r for r in rows if r.get("task_type") == "scratch"]
+
+    if args.format == "json":
+        output = json.dumps(rows, indent=2)
+    else:
+        generated_at = datetime.now(timezone.utc).isoformat() + " UTC"
+        output = build_html(rows, args.title, generated_at)
+
+    if args.output:
+        with open(args.output, "w") as fh:
+            fh.write(output)
+    else:
+        sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-codex-session-insight-miner.py
+++ b/scripts/test-codex-session-insight-miner.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+
+def load_miner():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "codex-session-insight-miner.py")
+    spec = importlib.util.spec_from_file_location("codex_session_insight_miner", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+miner = load_miner()
+
+
+def write_session(session_dir, filename, lines):
+    path = os.path.join(session_dir, filename)
+    with open(path, "w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return path
+
+
+class TestClassify(unittest.TestCase):
+    def test_worktree_cwd_parses_workflow_and_task(self):
+        cwd = (
+            "/home/invoker/.invoker/worktrees/abc/"
+            "experiment-wf-1786788062899-48-fix-ci-2363032-required-fast-vitest-workspace-g0.t0.a-a88bbe6d1"
+        )
+        workflow_id, task_type = miner.classify(cwd)
+        self.assertEqual(workflow_id, "wf-1786788062899-48")
+        self.assertEqual(task_type, "fix-ci-2363032-required-fast-vitest-workspace")
+
+    def test_scratch_cwd(self):
+        workflow_id, task_type = miner.classify("/tmp/invoker-scratch-abc123")
+        self.assertIsNone(workflow_id)
+        self.assertEqual(task_type, "scratch")
+
+    def test_merge_clone_cwd(self):
+        cwd = "/home/invoker/.invoker/merge-clones/gate-__merge__wf-1788212196049-2-2nmCSk"
+        workflow_id, task_type = miner.classify(cwd)
+        self.assertEqual(workflow_id, "wf-1788212196049-2")
+        self.assertEqual(task_type, "merge-clone")
+
+    def test_unknown_cwd(self):
+        workflow_id, task_type = miner.classify("/some/other/path")
+        self.assertIsNone(workflow_id)
+        self.assertEqual(task_type, "unknown")
+
+
+class TestSummarize(unittest.TestCase):
+    def test_extracts_tokens_model_and_prompt_type(self):
+        session_dir = tempfile.mkdtemp()
+        write_session(
+            session_dir,
+            "rollout-2026-08-31T20-00-00-abc123.jsonl",
+            [
+                {"type": "session_meta", "payload": {"cwd": "/tmp/invoker-scratch-abc123"}},
+                {"type": "turn_context", "payload": {"model": "gpt-5.6-sol"}},
+                {"type": "response_item", "payload": {"role": "user", "content": [{"text": "<recommended_plugins>"}]}},
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "role": "user",
+                        "content": [{"text": "Assume zero prior context. Investigate a production repair-filings finding: delete stale row."}],
+                    },
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {"total_token_usage": {"total_tokens": 12345}},
+                        "rate_limits": {"primary": {"used_percent": 42.0}, "plan_type": "pro"},
+                    },
+                },
+            ],
+        )
+        path = os.path.join(session_dir, "rollout-2026-08-31T20-00-00-abc123.jsonl")
+        row = miner.summarize(path)
+        self.assertEqual(row["task_type"], "scratch")
+        self.assertEqual(row["model"], "gpt-5.6-sol")
+        self.assertEqual(row["total_tokens"], 12345)
+        self.assertEqual(row["prompt_type"], "repair-filing-delete")
+
+    def test_missing_payload_info_does_not_crash(self):
+        session_dir = tempfile.mkdtemp()
+        write_session(
+            session_dir,
+            "rollout-2026-08-31T20-00-00-sparse.jsonl",
+            [
+                {"type": "session_meta", "payload": {"cwd": "/tmp/invoker-scratch-xyz"}},
+                {"type": "event_msg", "payload": {"type": "token_count", "info": None}},
+            ],
+        )
+        path = os.path.join(session_dir, "rollout-2026-08-31T20-00-00-sparse.jsonl")
+        row = miner.summarize(path)
+        self.assertEqual(row["task_type"], "scratch")
+        self.assertIsNone(row["total_tokens"])
+
+
+class TestAudit(unittest.TestCase):
+    def test_filters_by_cutoff(self):
+        session_dir = tempfile.mkdtemp()
+        write_session(
+            session_dir,
+            "rollout-2026-08-31T06-00-00-early.jsonl",
+            [{"type": "session_meta", "payload": {"cwd": "/tmp/invoker-scratch-early"}}],
+        )
+        write_session(
+            session_dir,
+            "rollout-2026-08-31T20-00-00-late.jsonl",
+            [{"type": "session_meta", "payload": {"cwd": "/tmp/invoker-scratch-late"}}],
+        )
+        results = miner.audit(session_dir, cutoff="2026-08-31T07:00:00")
+        files = [r["session_file"] for r in results]
+        self.assertNotIn("rollout-2026-08-31T06-00-00-early.jsonl", files)
+        self.assertIn("rollout-2026-08-31T20-00-00-late.jsonl", files)
+
+
+class TestHtmlOutput(unittest.TestCase):
+    def test_build_html_contains_summary(self):
+        html = miner.build_html(
+            [
+                {"session_file": "x", "date": "2026-08-31", "task_type": "scratch", "model": "gpt-5.6-sol", "total_tokens": 12345, "prompt_type": "repair-filing-delete", "prompt_snippet": ""},
+            ],
+            "test",
+            "2026-08-31T00:00:00Z",
+        )
+        self.assertIn("Measured tokens", html)
+        self.assertIn("repair-filing-delete", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add `scripts/codex-session-insight-miner.py` and matching unit tests. The new Python file walks `~/.codex/sessions/*/rollout-*.jsonl` files.

It classifies each session by workspace kind, gathers the model, token count, and the first meaningful user prompt, then emits JSON or HTML summaries.

It is meant to be invoked by operators who want to see where Codex tokens are going without one-off pipelines.

A sample run against `remote_digital_ocean_1` found that filing work accounts for the bulk of scratch-plan token spend. The full numbers are below.

## Review Claim

Add a reusable miner that turns Codex session JSONL into a spend/intent report.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This change only adds new files under `scripts/` and a matching test file. No existing worker, CI gate, or runtime path is modified, so it cannot change production behavior.

## Slice Rationale

This PR keeps the miner independent so the script, its tests, and a sample real-world output can be reviewed as one tooling addition.

## Non-goals

- Does not change the `admin-bypass-e2e-babysit` worker or its cooldown.
- Does not alter `codex-session-audit.py`; the new script is a richer, HTML-capable sibling.
- Does not persist reports or run automatically; it is invoked by hand.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test-codex-session-insight-miner.py`
- [ ] `python3 scripts/codex-session-insight-miner.py --session-dir ~/.codex/sessions --scratch-only --format html --output /tmp/scratch-report.html`
- [ ] Open `/tmp/scratch-report.html` and confirm summary cards and tables render.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

## Real output

Sample run against `remote_digital_ocean_1` scratch sessions:

| Metric | Value |
| --- | --- |
| Scratch sessions | 451 |
| Sessions with token data | 220 |
| Missing token data | 231 |
| Measured tokens | 948,854,111 |

| Task type | Sessions | Tokens |
| --- | --- | --- |
| scratch | 451 | 948,854,111 |

| Prompt type | Sessions | Tokens |
| --- | --- | --- |
| repair-filing-delete | 449 | 948,854,111 |
| e2e-regression-needs-human | 2 | 0 |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New scripts-only addition with no production or runtime wiring; reads local session files when run manually.
> 
> **Overview**
> Adds **`scripts/codex-session-insight-miner.py`**, a standalone operator tool that recursively scans `rollout-*.jsonl` Codex session logs (default `~/.codex/sessions`) and produces spend/intent reports without touching workers or CI.
> 
> For each session it **derives** workflow/task context from `cwd` (worktree experiments, merge clones, scratch dirs), **pulls** model and `token_count` events, **picks** a representative user prompt (preferring production-investigation phrasing), and **labels** prompt types (e.g. repair-filing-delete, e2e-regression-needs-human). CLI flags support `--cutoff`, `--scratch-only`, JSON vs **`--format html`** (summary cards, aggregates by task/date/model/prompt, top-50 by tokens), and `--output`.
> 
> **`scripts/test-codex-session-insight-miner.py`** covers cwd classification, summarize/audit edge cases, and HTML generation via dynamic import of the script module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf863f6061cb3a7f6e8ac7c1e5ee90db4cc60c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->