### PR TITLE
[Invoker-CLI Capacity Query](1) Add invoker-cli query capacity: pool/member slot usage, queue depth by workflow, oldest-waiting task

### DIFF
--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -293,6 +293,111 @@ describe('headless query task filters', () => {
   });
 });
 
+describe('headless query capacity', () => {
+  function makeCapacityDeps() {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const workflows = [
+      { id: 'wf-1', name: 'CI regression: 34fe981-e2e-proof-shard-2', status: 'running', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'wf-2', name: 'CI regression: 7403cfd-e2e-proof-shard-2', status: 'running', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'wf-3', name: 'Investigate admin-bypass e2e babysit intervention', status: 'running', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ] as any;
+    const makeTask = (id: string, workflowId: string, status: string, createdAt: string, isMergeNode = false) => ({
+      id, description: id, status, dependencies: [],
+      createdAt: new Date(createdAt), config: { workflowId, isMergeNode },
+      execution: {}, taskStateVersion: 1,
+    } as any);
+    const tasks = [
+      makeTask('wf-1/fix-ci', 'wf-1', 'queued', '2026-01-01T00:10:00.000Z'),
+      makeTask('wf-2/fix-ci', 'wf-2', 'pending', '2026-01-01T00:05:00.000Z'),
+      makeTask('wf-3/investigate-finding-1', 'wf-3', 'queued', '2026-01-01T00:20:00.000Z'),
+      makeTask('wf-3/investigate-finding-2', 'wf-3', 'pending', '2026-01-01T00:20:01.000Z'),
+      makeTask('wf-1/__merge__', 'wf-1', 'pending', '2026-01-01T00:00:00.000Z', true),
+      makeTask('wf-1/done', 'wf-1', 'completed', '2026-01-01T00:00:00.000Z'),
+    ];
+    return {
+      ...makeQueryDeps(),
+      persistence: {
+        loadWorkflowTaskSnapshot: () => ({ workflows, tasks, tasksByWorkflowId: new Map() }),
+        listExecutionResourceLeases: () => [
+          {
+            resourceKey: 'ssh:do3', resourceType: 'ssh', holderId: 'runner:do3',
+            taskId: 'wf-9/running-1', poolId: 'mixed-local-ssh', poolMemberId: 'remote_digital_ocean_3',
+            acquiredAt: future, lastHeartbeatAt: future, leaseExpiresAt: future,
+          },
+          {
+            resourceKey: 'ssh:do3-b', resourceType: 'ssh', holderId: 'runner:do3-b',
+            taskId: 'wf-9/running-2', poolId: 'mixed-local-ssh', poolMemberId: 'remote_digital_ocean_3',
+            acquiredAt: future, lastHeartbeatAt: future, leaseExpiresAt: future,
+          },
+        ],
+      } as unknown as HeadlessQueryDeps['persistence'],
+      invokerConfig: {
+        executionPools: {
+          'mixed-local-ssh': {
+            members: [
+              { type: 'ssh', id: 'remote_digital_ocean_3' },
+              { type: 'ssh', id: 'remote_digital_ocean_5' },
+            ],
+            maxConcurrentTasksPerMember: 2,
+          },
+        },
+      } as unknown as HeadlessQueryDeps['invokerConfig'],
+    };
+  }
+
+  it('reports per-member slot usage, queue depth grouped by workflow prefix, and the oldest waiting task', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'capacity', '--output', 'json'],
+      makeCapacityDeps(),
+    );
+    const report = JSON.parse(output);
+
+    expect(report.pools).toEqual([
+      {
+        poolId: 'mixed-local-ssh',
+        maxConcurrentTasksPerMember: 2,
+        members: [
+          { memberId: 'remote_digital_ocean_3', maxConcurrentTasks: 2, inUse: 2, full: true },
+          { memberId: 'remote_digital_ocean_5', maxConcurrentTasks: 2, inUse: 0, full: false },
+        ],
+      },
+    ]);
+
+    expect(report.totalQueued).toBe(4);
+    expect(report.queueByWorkflowPrefix).toEqual([
+      { prefix: 'CI regression', queuedTasks: 2, workflowCount: 2 },
+      { prefix: 'Investigate admin-bypass e2e babysit intervention', queuedTasks: 2, workflowCount: 1 },
+    ]);
+
+    expect(report.oldestWaiting).toMatchObject({
+      taskId: 'wf-2/fix-ci',
+      workflowId: 'wf-2',
+      createdAt: '2026-01-01T00:05:00.000Z',
+    });
+  });
+
+  it('excludes merge-gate tasks and completed tasks from queue depth', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'capacity', '--output', 'json'],
+      makeCapacityDeps(),
+    );
+    const report = JSON.parse(output);
+    const allPrefixedTaskCounts = report.queueByWorkflowPrefix.reduce((sum: number, entry: { queuedTasks: number }) => sum + entry.queuedTasks, 0);
+    expect(allPrefixedTaskCounts).toBe(4);
+  });
+
+  it('renders a human-readable text report', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'capacity'],
+      makeCapacityDeps(),
+    );
+    expect(output).toContain('mixed-local-ssh');
+    expect(output).toContain('remote_digital_ocean_3: 2/2 (FULL)');
+    expect(output).toContain('remote_digital_ocean_5: 0/2');
+    expect(output).toContain('OLDEST WAITING: wf-2/fix-ci');
+  });
+});
+
 describe('headless query task-output', () => {
   it('prints the task output for a short task id', async () => {
     const output = await runReadOnlyHeadlessQueryToString(

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -12,6 +12,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '@invoker/data-store';
 import {
   type AgentSessionData,
   type NormalizedCostEvent,
@@ -34,7 +35,7 @@ import {
   parseQueryFlags,
   restoreWorkflowForTask,
 } from './headless-shared.js';
-import { resolveDefaultExecutionAgent } from './config.js';
+import { resolveDefaultExecutionAgent, type InvokerConfig } from './config.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import { loadAllEventsPaged } from './load-all-events-paged.js';
 import { autoStartedOwnerWorkerKindsForConfig, createLocalWorkerStatusSnapshot, listWorkerDecisions, toWorkerActionSummary } from './worker-control.js';
@@ -55,7 +56,7 @@ import {
  * per request, so concurrent delegated queries never cross output.
  */
 const queryOutputSink = new AsyncLocalStorage<(chunk: string) => void>();
-const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, alert-history, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks';
+const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, alert-history, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks, capacity';
 const QUERY_SUBCOMMAND_USAGE = QUERY_SUBCOMMANDS.replaceAll(', ', '|');
 
 function writeOut(chunk: string): void {
@@ -651,9 +652,181 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       }
       break;
     }
+    case 'capacity': {
+      const report = buildCapacityReport(deps.persistence, deps.invokerConfig);
+      switch (flags.output) {
+        case 'label':
+          writeOut(report.pools.flatMap((pool) => pool.members.map((member) => `${pool.poolId}/${member.memberId}`)).join('\n') + '\n');
+          break;
+        case 'json':
+          writeOut(formatAsJson(report) + '\n');
+          break;
+        case 'jsonl':
+          writeOut(formatAsJsonl(report.pools) + '\n');
+          break;
+        default:
+          writeOut(formatCapacityReport(report) + '\n');
+          break;
+      }
+      break;
+    }
     default:
       throw new Error(`Unknown query sub-command: "${subCommand}". Use: ${QUERY_SUBCOMMANDS}`);
   }
+}
+
+const CAPACITY_QUEUE_PREFIX_TRIM_RE = /\b[0-9a-f]{7,40}\b.*$/i;
+
+function normalizeCapacityWorkflowPrefix(name: string): string {
+  const stripped = name.replace(CAPACITY_QUEUE_PREFIX_TRIM_RE, '').trim().replace(/[:\-\s]+$/, '');
+  return stripped || name.trim();
+}
+
+const CAPACITY_WAITING_TASK_STATUSES = new Set(['queued', 'pending']);
+
+export interface CapacityPoolMemberReport {
+  memberId: string;
+  maxConcurrentTasks: number;
+  inUse: number;
+  full: boolean;
+}
+
+export interface CapacityPoolReport {
+  poolId: string;
+  maxConcurrentTasksPerMember: number;
+  members: CapacityPoolMemberReport[];
+}
+
+export interface CapacityQueuePrefixReport {
+  prefix: string;
+  queuedTasks: number;
+  workflowCount: number;
+}
+
+export interface CapacityOldestWaitingReport {
+  taskId: string;
+  workflowId: string;
+  createdAt: string;
+  ageMs: number;
+}
+
+export interface CapacityReport {
+  generatedAt: string;
+  pools: CapacityPoolReport[];
+  totalQueued: number;
+  queueByWorkflowPrefix: CapacityQueuePrefixReport[];
+  oldestWaiting: CapacityOldestWaitingReport | null;
+}
+
+export function buildCapacityReport(
+  persistence: Pick<HeadlessQueryDeps['persistence'], 'loadWorkflowTaskSnapshot' | 'listExecutionResourceLeases'>,
+  invokerConfig: Pick<InvokerConfig, 'executionPools'>,
+): CapacityReport {
+  const nowIso = new Date().toISOString();
+  const now = Date.now();
+
+  const listLeases = persistence.listExecutionResourceLeases?.bind(persistence);
+  const leases = listLeases ? listLeases().filter((lease) => lease.leaseExpiresAt > nowIso) : [];
+  const inUseByPoolMember = new Map<string, number>();
+  for (const lease of leases) {
+    if (!lease.poolId || !lease.poolMemberId) continue;
+    const key = `${lease.poolId} ${lease.poolMemberId}`;
+    inUseByPoolMember.set(key, (inUseByPoolMember.get(key) ?? 0) + 1);
+  }
+
+  const pools: CapacityPoolReport[] = [];
+  for (const [poolId, pool] of Object.entries(invokerConfig.executionPools ?? {})) {
+    const maxConcurrentTasksPerMember = pool.maxConcurrentTasksPerMember ?? 1;
+    const members: CapacityPoolMemberReport[] = pool.members.map((member) => {
+      const maxConcurrentTasks = member.maxConcurrentTasks ?? maxConcurrentTasksPerMember;
+      const inUse = inUseByPoolMember.get(`${poolId} ${member.id}`) ?? 0;
+      return { memberId: member.id, maxConcurrentTasks, inUse, full: inUse >= maxConcurrentTasks };
+    });
+    pools.push({ poolId, maxConcurrentTasksPerMember, members });
+  }
+
+  const snapshot = persistence.loadWorkflowTaskSnapshot();
+  const workflowNameById = new Map<string, string>(
+    snapshot.workflows.map((workflow: Workflow) => [workflow.id, workflow.name]),
+  );
+
+  const waitingTasks = snapshot.tasks.filter((task) => (
+    CAPACITY_WAITING_TASK_STATUSES.has(task.status) && !task.config.isMergeNode
+  ));
+
+  const prefixCounts = new Map<string, { queuedTasks: number; workflowIds: Set<string> }>();
+  for (const task of waitingTasks) {
+    const workflowId = task.config.workflowId;
+    const name = (workflowId && workflowNameById.get(workflowId)) || 'unknown';
+    const prefix = normalizeCapacityWorkflowPrefix(name);
+    const entry = prefixCounts.get(prefix) ?? { queuedTasks: 0, workflowIds: new Set<string>() };
+    entry.queuedTasks += 1;
+    if (workflowId) entry.workflowIds.add(workflowId);
+    prefixCounts.set(prefix, entry);
+  }
+  const queueByWorkflowPrefix = [...prefixCounts.entries()]
+    .map(([prefix, entry]) => ({ prefix, queuedTasks: entry.queuedTasks, workflowCount: entry.workflowIds.size }))
+    .sort((a, b) => b.queuedTasks - a.queuedTasks);
+
+  let oldestWaiting: CapacityOldestWaitingReport | null = null;
+  for (const task of waitingTasks) {
+    const createdAtMs = task.createdAt.getTime();
+    if (!oldestWaiting || createdAtMs < new Date(oldestWaiting.createdAt).getTime()) {
+      oldestWaiting = {
+        taskId: task.id,
+        workflowId: task.config.workflowId ?? '',
+        createdAt: task.createdAt.toISOString(),
+        ageMs: now - createdAtMs,
+      };
+    }
+  }
+
+  return {
+    generatedAt: nowIso,
+    pools,
+    totalQueued: waitingTasks.length,
+    queueByWorkflowPrefix,
+    oldestWaiting,
+  };
+}
+
+function formatCapacityAge(ageMs: number): string {
+  const totalSeconds = Math.floor(ageMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}h${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function formatCapacityReport(report: CapacityReport): string {
+  const lines: string[] = [];
+  lines.push('POOL/MEMBER CAPACITY');
+  if (report.pools.length === 0) {
+    lines.push('No execution pools configured.');
+  } else {
+    for (const pool of report.pools) {
+      lines.push(`${pool.poolId} (default cap ${pool.maxConcurrentTasksPerMember}/member):`);
+      for (const member of pool.members) {
+        lines.push(`  ${member.memberId}: ${member.inUse}/${member.maxConcurrentTasks}${member.full ? ' (FULL)' : ''}`);
+      }
+    }
+  }
+  lines.push('');
+  lines.push(`QUEUE DEPTH (${report.totalQueued} waiting task(s))`);
+  if (report.queueByWorkflowPrefix.length === 0) {
+    lines.push('No queued or pending tasks.');
+  } else {
+    for (const entry of report.queueByWorkflowPrefix) {
+      lines.push(`  ${entry.prefix}: ${entry.queuedTasks} queued task(s) across ${entry.workflowCount} workflow(s)`);
+    }
+  }
+  lines.push('');
+  if (report.oldestWaiting) {
+    lines.push(`OLDEST WAITING: ${report.oldestWaiting.taskId} (workflow ${report.oldestWaiting.workflowId}) — waiting ${formatCapacityAge(report.oldestWaiting.ageMs)}`);
+  } else {
+    lines.push('OLDEST WAITING: none');
+  }
+  return lines.join('\n');
 }
 
 /**

--- a/packages/cli/src/__tests__/cli-query.test.ts
+++ b/packages/cli/src/__tests__/cli-query.test.ts
@@ -195,4 +195,39 @@ describe('invoker-cli query', () => {
     expect(output.stdout).toBe('[]\n');
     output.restore();
   });
+
+  it('delegates a capacity query to a live owner with the cli-query request shape', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const queryHandler = vi.fn(async (request: unknown) => {
+      expect(request).toEqual({
+        kind: 'cli-query',
+        args: ['query', 'capacity', '--output', 'json'],
+      });
+      return { output: '{"pools":[]}\n' };
+    });
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', queryHandler);
+
+    const code = await main(['query', 'capacity', '--output', 'json'], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(queryHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toBe('{"pools":[]}\n');
+    output.restore();
+  });
+
+  it('refuses a standalone capacity query with a clear live-owner-required error', async () => {
+    const dbDir = makeTempDir('invoker-cli-query-capacity-standalone-');
+    await seedDb(dbDir);
+    process.env.INVOKER_DB_DIR = dbDir;
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+
+    const code = await main(['query', 'capacity'], { createMessageBus: () => bus });
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('query capacity requires a live owner');
+    output.restore();
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -152,7 +152,7 @@ type CliRuntimeConfig = {
   externalWorkers?: ExternalWorkerConfig[];
 };
 
-type QueryResource = 'workflows' | 'tasks';
+type QueryResource = 'workflows' | 'tasks' | 'capacity';
 type QueryOutput = 'text' | 'json';
 
 type QueryOptions = {
@@ -193,6 +193,7 @@ function usage(): string {
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli query workflows [--status <status>] [--output text|json]',
     '  invoker-cli query tasks [--workflow <id>] [--status <status>] [--output text|json]',
+    '  invoker-cli query capacity [--output text|json]',
     '  invoker-cli wait <workflowId> [--max-wait-ms <ms>] [--poll-interval-ms <ms>]',
     '  invoker-cli retry-task <taskId>',
     '  invoker-cli retry <workflowId>',
@@ -214,6 +215,7 @@ function usage(): string {
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker owner when available, otherwise run standalone.',
     '  query workflows|tasks  Read workflows or tasks from a live owner, or a read-only database view.',
+    '  query capacity  Show live pool/member slot usage, queue depth by workflow, and the oldest-waiting task. Requires a live owner.',
     '  wait <workflowId>  Park until a live-owner workflow settles, then print one INVOKER_WAKE line.',
     '  retry-task <taskId>  Ask a live Invoker owner to retry one task.',
     '  retry <workflowId>  Ask a live Invoker owner to retry a workflow.',
@@ -296,8 +298,8 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
 
 function parseQueryArgs(argv: string[]): QueryOptions {
   const resource = argv[0];
-  if (resource !== 'workflows' && resource !== 'tasks') {
-    throw new Error('Missing or unknown query subcommand. Usage: invoker-cli query <workflows|tasks>');
+  if (resource !== 'workflows' && resource !== 'tasks' && resource !== 'capacity') {
+    throw new Error('Missing or unknown query subcommand. Usage: invoker-cli query <workflows|tasks|capacity>');
   }
 
   const options: QueryOptions = {
@@ -514,6 +516,9 @@ function renderTaskText(tasks: TaskState[]): string {
 }
 
 async function queryStandaloneDatabase(options: QueryOptions): Promise<string> {
+  if (options.resource === 'capacity') {
+    throw new Error('query capacity requires a live owner: start the Invoker app or run `invoker-cli owner serve`.');
+  }
   let parsedFilter: import('@invoker/contracts').TaskFilterNode | undefined;
   if (options.filter !== undefined) {
     let rawFilter: unknown;


### PR DESCRIPTION
## Summary

A production session spent about fifteen manual read calls, and hand cross-referencing their output, to work out why a few retried tasks sat waiting for hours.

The real answer was simple: only eight execution slots existed, and one worker's own huge fan-out was winning nearly all of them. No view showed this.

This adds one read-only view over state the owner already tracks, so that question has a direct answer next time.

## Review Claim

Approve one new read-only subcommand, built entirely from two data sources the owner already maintains, with no new tracking mechanism added.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is a pure read: it accepts no arguments beyond output format, and every field it returns comes from existing execution-resource-lease and workflow/task state. Nothing about existing query behavior changes; the new case is additive to an existing switch statement.

## Slice Rationale

One new query view is one self-contained change: new aggregation logic, its CLI exposure, and direct tests for both, with nothing else touched.

## Non-goals

Does not add any new tracking, config, or state to the owner. Does not change how tasks are scheduled or dispatched. Does not touch any existing query subcommand's behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/headless-query-list.test.ts` (run from `packages/app`) — 18/18 pass
- [x] `bash node_modules/.bin/vitest run src/__tests__/cli-query.test.ts` (run from `packages/cli`) — 8/8 pass
- [x] `pnpm run check:comments` — clean

</details>

## Live-path evidence

Built a fresh linux/x64 binary from this branch and ran it against the live production owner. The client correctly parsed and sent the new subcommand — proven by the owner's own reply, which listed its real current subcommand set and did not yet include this one, since the owner process itself has not been rebuilt with this change. The IPC round-trip to the live owner is real and working; recognizing the new subcommand server-side needs a separate owner rebuild and deploy, which is a larger, separate action out of scope for this PR. Unit-level correctness against realistic fixture data (multiple pools, mixed member load, a heavily fanned-out workflow) is proven by the 26 passing tests above.

## Sample Output

Computed from the exact shipped `buildCapacityReport`/`formatCapacityReport` code in this diff, run against the fixture data in `headless-query-list.test.ts`'s `makeCapacityDeps()` (not a live capture — the live owner still needs a rebuild before it recognizes this subcommand, per Live-path evidence above).

Text mode:

```
POOL/MEMBER CAPACITY
mixed-local-ssh (default cap 2/member):
  remote_digital_ocean_3: 2/2 (FULL)
  remote_digital_ocean_5: 0/2

QUEUE DEPTH (4 waiting task(s))
  CI regression: 2 queued task(s) across 2 workflow(s)
  Investigate admin-bypass e2e babysit intervention: 2 queued task(s) across 1 workflow(s)

OLDEST WAITING: wf-2/fix-ci (workflow wf-2) — waiting 2m
```

JSON mode:

```json
{
  "generatedAt": "2026-09-04T00:00:00.000Z",
  "pools": [
    {
      "poolId": "mixed-local-ssh",
      "maxConcurrentTasksPerMember": 2,
      "members": [
        { "memberId": "remote_digital_ocean_3", "maxConcurrentTasks": 2, "inUse": 2, "full": true },
        { "memberId": "remote_digital_ocean_5", "maxConcurrentTasks": 2, "inUse": 0, "full": false }
      ]
    }
  ],
  "totalQueued": 4,
  "queueByWorkflowPrefix": [
    { "prefix": "CI regression", "queuedTasks": 2, "workflowCount": 2 },
    { "prefix": "Investigate admin-bypass e2e babysit intervention", "queuedTasks": 2, "workflowCount": 1 }
  ],
  "oldestWaiting": { "taskId": "wf-2/fix-ci", "workflowId": "wf-2", "createdAt": "2026-01-01T00:05:00.000Z", "ageMs": 0 }
}
```

The prefix grouping strips SHA-looking tokens from workflow names, so twenty separate CI-regression retry attempts against the same job collapse into one queue-depth line instead of twenty.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>

