### PR TITLE
[Task Priority Scheduler](2) Default the ci-regression-watch formula to worker priority

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -7,6 +7,7 @@ onFinish: pull_request
 mergeMode: external_review
 baseBranch: {{base_branch}}
 repoUrl: {{repo_url}}
+priority: 4
 
 tasks:
   - id: fix-ci-{{job_slug}}


### PR DESCRIPTION
This formula is the one that flooded DO1's 8-slot execution pool with
hundreds of investigate-finding-shaped repair tasks this session,
starving manually-retried fixes for 2.5+ hours. Stamps the new
priority field (previous slice) at 4, matching the worker default, so
future output from this template no longer competes evenly with a
human's own work for the same slots.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

Depends-On: #11964

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line template default for scheduler priority with no runtime logic or security impact.
> 
> **Overview**
> Sets **`priority: 4`** on the `ci-regression-watch` workflow formula so plans emitted from this template inherit the worker default instead of competing at the same scheduler weight as manually queued repair work.
> 
> This only changes generated workflow metadata for automated CI regression tasks; task definitions, merge behavior, and verification steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41a90aa6e81c5d3406a207518fa6ad01becc096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->