### PR TITLE
[Task Priority Scheduler](1) Add an optional priority field to BaseTaskConfig

### DIFF
--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -62,6 +62,7 @@ export interface BaseTaskConfig {
   readonly executionModel?: string;
   /** Finite agent turn budget (Claude `--max-turns`) when set. */
   readonly maxTurns?: number;
+  readonly priority?: number;
   readonly freshness?: TaskFreshnessSpec;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];


### PR DESCRIPTION
## Summary

The dispatch queue is about to learn to rank waiting tasks. This piece just carries a rank number alongside every per-task setting a plan already declares.

Nothing reads this yet -- it exists so the next slice's real wiring stays focused on the actual behavior, not the shape of the data.

## Review Claim

Approve one optional 1-5 field on the existing per-task settings type, with no consumer yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Purely additive: an existing type gains one optional field. Nothing in the running app reads it, so this changes no behavior by itself.

## Slice Rationale

The next slice (queue enforcement and its defaults) is easier to review when the shape it consumes already exists and is settled on its own.

## Non-goals

Does not read or enforce the field anywhere. Does not change the dispatch queue's actual ordering.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (repo-wide) -- clean except one pre-existing, unrelated error in `action-graph-diagnostics.ts` (confirmed present on unpatched master)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
