### PR TITLE
[Task Priority Scheduler](2) Wire priority 1-5 through parsing and the dispatch queue

### DIFF
--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -252,7 +252,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       taskId: dispatch.taskId,
       attemptId: dispatch.attemptId,
       ownerId: dispatch.dispatchOwner,
-      priority: dispatch.priority === 'high' ? 1 : dispatch.priority === 'normal' ? 0 : -1,
+      priority: dispatch.priority,
       createdAt: dispatch.enqueuedAt,
       startedAt: dispatch.leasedAt,
       completedAt: dispatch.completedAt,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1491,7 +1491,7 @@ describe('SQLiteAdapter', () => {
 
       expect(inserted.id).toBeGreaterThan(0);
       expect(inserted.state).toBe('enqueued');
-      expect(inserted.priority).toBe('normal');
+      expect(inserted.priority).toBe(2);
       expect(inserted.attemptsCount).toBe(0);
 
       const byId = adapter.loadLaunchDispatchById(inserted.id);
@@ -1514,7 +1514,7 @@ describe('SQLiteAdapter', () => {
         attemptId: 'attempt-1',
         workflowId: 'wf-launch',
         generation: 0,
-        priority: 'normal',
+        priority: 2,
       });
     });
 
@@ -1524,19 +1524,19 @@ describe('SQLiteAdapter', () => {
         taskId: 'wf-launch/t1',
         attemptId: 'attempt-dup',
         workflowId: 'wf-launch',
-        priority: 'high',
+        priority: 1,
         generation: 0,
       });
       const second = adapter.enqueueLaunchDispatch({
         taskId: 'wf-launch/t1',
         attemptId: 'attempt-dup',
         workflowId: 'wf-launch',
-        priority: 'low',
+        priority: 4,
         generation: 0,
       });
 
       expect(second.id).toBe(first.id);
-      expect(second.priority).toBe('high');
+      expect(second.priority).toBe(1);
       expect(
         adapter.listLaunchDispatchesByState(['enqueued', 'leased']),
       ).toHaveLength(1);
@@ -1863,14 +1863,14 @@ describe('SQLiteAdapter', () => {
           taskId: 'wf-launch/t-low',
           attemptId: 'attempt-low',
           workflowId: 'wf-launch',
-          priority: 'low',
+          priority: 4,
           generation: 0,
         });
         const high = adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t-high',
           attemptId: 'attempt-high',
           workflowId: 'wf-launch',
-          priority: 'high',
+          priority: 1,
           generation: 0,
         });
 
@@ -1933,14 +1933,14 @@ describe('SQLiteAdapter', () => {
           taskId: 'wf-launch/t-stale',
           attemptId: 'attempt-stale',
           workflowId: 'wf-launch',
-          priority: 'high',
+          priority: 1,
           generation: 0,
         });
         const valid = adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t-valid',
           attemptId: 'attempt-valid',
           workflowId: 'wf-launch',
-          priority: 'normal',
+          priority: 2,
           generation: 0,
         });
 

--- a/packages/data-store/src/__tests__/task-launch-dispatch-priority.test.ts
+++ b/packages/data-store/src/__tests__/task-launch-dispatch-priority.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import { resolveTaskConfig, type TaskState } from '@invoker/workflow-core';
+
+const WORKFLOW_ID = 'wf-priority-dispatch';
+
+function makeWorkflow(): Workflow {
+  const now = new Date('2026-09-04T00:00:00.000Z').toISOString();
+  return {
+    id: WORKFLOW_ID,
+    name: 'priority dispatch test',
+    status: 'running',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makeTask(id: string, selectedAttemptId: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-09-04T00:00:00.000Z'),
+    taskStateVersion: 1,
+    config: resolveTaskConfig({ workflowId: WORKFLOW_ID }),
+    execution: { generation: 1, selectedAttemptId },
+  };
+}
+
+describe('task_launch_dispatch priority ordering', () => {
+  let adapter: SQLiteAdapter | undefined;
+  let cleanupDir: string | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = undefined;
+    }
+  });
+
+  async function createAdapter(): Promise<SQLiteAdapter> {
+    cleanupDir = mkdtempSync(join(tmpdir(), 'invoker-priority-dispatch-'));
+    return SQLiteAdapter.create(join(cleanupDir, 'invoker.db'), { ownerCapability: true });
+  }
+
+  it('leases a priority-1 task before a priority-4 task queued earlier', async () => {
+    adapter = await createAdapter();
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask(WORKFLOW_ID, makeTask('t-worker', 't-worker-attempt-1'));
+    adapter.saveTask(WORKFLOW_ID, makeTask('t-human', 't-human-attempt-1'));
+
+    adapter.enqueueLaunchDispatch({
+      taskId: 't-worker',
+      attemptId: 't-worker-attempt-1',
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+      priority: 4,
+    });
+    adapter.enqueueLaunchDispatch({
+      taskId: 't-human',
+      attemptId: 't-human-attempt-1',
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+      priority: 1,
+    });
+
+    const leased = adapter.claimLaunchDispatchAtomic({ ownerId: 'test-owner' });
+
+    expect(leased?.taskId).toBe('t-human');
+    expect(leased?.priority).toBe(1);
+  });
+
+  it('falls back to FIFO (id ascending) among equal priorities', async () => {
+    adapter = await createAdapter();
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask(WORKFLOW_ID, makeTask('t-first', 't-first-attempt-1'));
+    adapter.saveTask(WORKFLOW_ID, makeTask('t-second', 't-second-attempt-1'));
+
+    adapter.enqueueLaunchDispatch({
+      taskId: 't-first',
+      attemptId: 't-first-attempt-1',
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+      priority: 2,
+    });
+    adapter.enqueueLaunchDispatch({
+      taskId: 't-second',
+      attemptId: 't-second-attempt-1',
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+      priority: 2,
+    });
+
+    const leased = adapter.claimLaunchDispatchAtomic({ ownerId: 'test-owner' });
+
+    expect(leased?.taskId).toBe('t-first');
+  });
+
+  it('defaults to priority 2 when the caller omits it', async () => {
+    adapter = await createAdapter();
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask(WORKFLOW_ID, makeTask('t-default', 't-default-attempt-1'));
+
+    const dispatch = adapter.enqueueLaunchDispatch({
+      taskId: 't-default',
+      attemptId: 't-default-attempt-1',
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+    });
+
+    expect(dispatch.priority).toBe(2);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -588,7 +588,7 @@ export type TaskLaunchDispatchState =
   | 'completed'
   | 'abandoned';
 
-export type TaskLaunchDispatchPriority = 'high' | 'normal' | 'low';
+export type TaskLaunchDispatchPriority = 1 | 2 | 3 | 4 | 5;
 
 export interface TaskLaunchDispatch {
   id: number;
@@ -4109,7 +4109,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     generation: number;
     suppressEvent?: boolean;
   }): TaskLaunchDispatch {
-    const priority: TaskLaunchDispatchPriority = input.priority ?? 'normal';
+    const priority: TaskLaunchDispatchPriority = input.priority ?? 2;
     return this.runTransaction(() => {
       const inserted = this.queryOne(
         `INSERT OR IGNORE INTO task_launch_dispatch (
@@ -4234,11 +4234,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
            FROM task_launch_dispatch d
            LEFT JOIN tasks t ON t.id = d.task_id
            WHERE d.state = 'enqueued'
-           ORDER BY CASE d.priority
-             WHEN 'high' THEN 0
-             WHEN 'normal' THEN 1
-             ELSE 2
-           END, d.id
+           ORDER BY CAST(d.priority AS INTEGER) ASC, d.id ASC
            LIMIT 1`,
         );
         if (!candidate || candidate.id == null) return undefined;

--- a/packages/data-store/src/sqlite-migrations.ts
+++ b/packages/data-store/src/sqlite-migrations.ts
@@ -87,6 +87,7 @@ export function migrate(exec: SqliteExecutor, reconcileTerminalSessionInvariants
     backfillEventTypeCounters(exec);
     migrateTestCommands(exec);
     migrateGatePolicyApprovedToCompleted(exec);
+    migrateTaskLaunchDispatchPriorityToNumeric(exec);
     migrateTaskExternalDependenciesToWorkflows(exec);
     runCompatibilityMigration(exec);
   }
@@ -530,6 +531,16 @@ export function migrateGatePolicyApprovedToCompleted(exec: SqliteExecutor): void
  * This is intentionally idempotent: once task rows are cleared, later runs
  * only see the workflow-level source of truth.
  */
+export function migrateTaskLaunchDispatchPriorityToNumeric(exec: SqliteExecutor): void {
+  try {
+    exec.execRun("UPDATE task_launch_dispatch SET priority = '1' WHERE priority = 'high'");
+    exec.execRun("UPDATE task_launch_dispatch SET priority = '2' WHERE priority = 'normal'");
+    exec.execRun("UPDATE task_launch_dispatch SET priority = '4' WHERE priority = 'low'");
+  } catch (err) {
+    logSwallowedMigrationError('migrateTaskLaunchDispatchPriorityToNumeric', err);
+  }
+}
+
 export function migrateTaskExternalDependenciesToWorkflows(exec: SqliteExecutor): void {
   try {
     const rows = exec.queryAll(

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -192,9 +192,11 @@ export function mapRowToAttempt(row: any): Attempt {
 }
 
 export function mapRowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLaunchDispatch {
-  const priorityRaw = String(row.priority ?? 'normal');
+  const priorityParsed = Number.parseInt(String(row.priority ?? '2'), 10);
   const priority: TaskLaunchDispatchPriority =
-    priorityRaw === 'high' || priorityRaw === 'low' ? priorityRaw : 'normal';
+    Number.isInteger(priorityParsed) && priorityParsed >= 1 && priorityParsed <= 5
+      ? (priorityParsed as TaskLaunchDispatchPriority)
+      : 2;
   return {
     id: Number(row.id),
     taskId: String(row.task_id),

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -416,7 +416,7 @@ export const SCHEMA_DDL = `
         attempt_id TEXT NOT NULL,
         workflow_id TEXT NOT NULL,
         state TEXT NOT NULL DEFAULT 'enqueued',
-        priority TEXT NOT NULL DEFAULT 'normal',
+        priority TEXT NOT NULL DEFAULT '2',
         dispatch_owner TEXT,
         enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
         leased_at TEXT,

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -269,4 +269,51 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow(expected);
   });
+
+  it('threads an explicit task-level priority through to the parsed task', () => {
+    const yaml = `
+name: Priority Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: urgent
+    description: Do it now
+    command: echo ok
+    priority: 1
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.tasks[0].priority).toBe(1);
+  });
+
+  it('a task priority overrides the plan-level priority', () => {
+    const yaml = `
+name: Priority Override Plan
+repoUrl: git@github.com:test/repo.git
+priority: 4
+tasks:
+  - id: overridden
+    description: Overridden
+    command: echo ok
+    priority: 1
+  - id: inherits
+    description: Inherits plan default
+    command: echo ok
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.tasks[0].priority).toBe(1);
+    expect(plan.tasks[1].priority).toBe(4);
+  });
+
+  it.each([0, 6, 1.5])('rejects a task priority outside 1-5: %s', (badPriority) => {
+    const yaml = `
+name: Bad Priority Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo ok
+    priority: ${badPriority}
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/priority.*1.*5/i);
+  });
 });

--- a/packages/workflow-core/src/__tests__/task-priority-default.test.ts
+++ b/packages/workflow-core/src/__tests__/task-priority-default.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator, DEFAULT_TASK_PRIORITY, DEFAULT_WORKER_TASK_PRIORITY } from '../orchestrator.js';
+import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('task config priority defaults', () => {
+  it('defaults an unset task priority to the human baseline', () => {
+    const orchestrator = new Orchestrator({
+      persistence: new InMemoryPersistence(),
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 2,
+    });
+
+    orchestrator.loadPlan({
+      name: 'no-priority-plan',
+      baseBranch: 'master',
+      featureBranch: 'feature/no-priority',
+      tasks: [{ id: 'a', description: 'A' }],
+    });
+
+    const task = orchestrator.getAllTasks().find((t) => !t.config.isMergeNode);
+    expect(task?.config.priority).toBe(DEFAULT_TASK_PRIORITY);
+    expect(DEFAULT_TASK_PRIORITY).toBe(2);
+  });
+
+  it('keeps an explicit worker-style priority instead of the human default', () => {
+    const orchestrator = new Orchestrator({
+      persistence: new InMemoryPersistence(),
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 2,
+    });
+
+    orchestrator.loadPlan({
+      name: 'worker-priority-plan',
+      baseBranch: 'master',
+      featureBranch: 'feature/worker-priority',
+      tasks: [{ id: 'a', description: 'A', priority: DEFAULT_WORKER_TASK_PRIORITY }],
+    });
+
+    const task = orchestrator.getAllTasks().find((t) => !t.config.isMergeNode);
+    expect(task?.config.priority).toBe(DEFAULT_WORKER_TASK_PRIORITY);
+    expect(DEFAULT_WORKER_TASK_PRIORITY).toBe(4);
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -47,6 +47,9 @@ function mergeTrace(tag: string, data: Record<string, unknown>): void {
 }
 
 // ── Typed domain error codes ────────────────────────────────────
+export const DEFAULT_TASK_PRIORITY = 2;
+export const DEFAULT_WORKER_TASK_PRIORITY = 4;
+
 export const OrchestratorErrorCode = {
   TASK_NOT_FOUND: 'TASK_NOT_FOUND',
   TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
@@ -381,13 +384,13 @@ export interface OrchestratorPersistence {
     taskId: string;
     attemptId: string;
     workflowId: string;
-    priority?: 'high' | 'normal' | 'low';
+    priority?: 1 | 2 | 3 | 4 | 5;
     generation: number;
     suppressEvent?: boolean;
   }): {
     id: number;
     state?: 'enqueued' | 'leased' | 'completed' | 'abandoned';
-    priority?: 'high' | 'normal' | 'low';
+    priority?: 1 | 2 | 3 | 4 | 5;
   };
   abandonLaunchDispatchesForTasks?(
     taskIds: readonly string[],
@@ -1531,7 +1534,7 @@ export class Orchestrator {
         executionAgent: taskDef.executionAgent,
         executionModel: taskDef.executionModel,
         maxTurns: taskDef.maxTurns,
-        priority: taskDef.priority,
+        priority: taskDef.priority ?? DEFAULT_TASK_PRIORITY,
         ...(taskDef.freshness !== undefined ? { freshness: taskDef.freshness } : {}),
       } as const;
       let taskConfig: TaskConfig;

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -532,11 +532,16 @@ export function drainSchedulerImpl(
       && task.config.workflowId
     ) {
       try {
+        const rawPriority = task.config.priority;
+        const dispatchPriority = Number.isInteger(rawPriority) && rawPriority! >= 1 && rawPriority! <= 5
+          ? (rawPriority as 1 | 2 | 3 | 4 | 5)
+          : 2;
         const dispatch = host.persistence.enqueueLaunchDispatch({
           taskId: job.taskId,
           attemptId: launchAttemptId,
           workflowId: task.config.workflowId,
           generation: host.getExecutionGeneration(task),
+          priority: dispatchPriority,
           suppressEvent: true,
         });
         host.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -143,6 +143,7 @@ export interface RawPlanTask {
   executionAgent?: string;
   executionModel?: string;
   maxTurns?: number;
+  priority?: number;
   freshness?: unknown;
 }
 
@@ -158,6 +159,7 @@ export interface RawPlan {
   repoUrl?: string;
   scratch?: boolean;
   poolId?: string;
+  priority?: number;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -363,6 +365,15 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const planPoolId = typeof raw.poolId === 'string' ? raw.poolId.trim() : undefined;
 
+  const validatePriority = (owner: string, value: number | undefined): number | undefined => {
+    if (value === undefined) return undefined;
+    if (!Number.isInteger(value) || value < 1 || value > 5) {
+      throw new PlanParseError(`${owner} "priority" must be an integer from 1 (highest) to 5 (lowest); got ${value}.`);
+    }
+    return value;
+  };
+  const planPriority = validatePriority('Plan', raw.priority);
+
   const topLevelExternalDependencies = parseExternalDependencies('Plan', raw.externalDependencies);
   const seenTaskIds = new Set<string>();
   const tasks = raw.tasks.map((task, index) => {
@@ -475,6 +486,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       })(),
       executionModel: task.executionModel?.trim() || undefined,
       maxTurns: task.maxTurns,
+      priority: validatePriority(`Task "${task.id}"`, task.priority) ?? planPriority,
       ...(freshness !== undefined ? { freshness } : {}),
     };
   });


### PR DESCRIPTION
Widens the dispatch queue's existing 3-tier rank (task_launch_dispatch,
claimLaunchDispatchAtomic) to a plain 1 (highest) - 5 (lowest) integer,
parses it from plan/task YAML with range validation, and defaults an
unset task to 2 (DEFAULT_TASK_PRIORITY) at workflow creation --
DEFAULT_WORKER_TASK_PRIORITY (4) is exported for callers that stamp
their own plans.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable queue ordering and DB migration for `task_launch_dispatch`, which affects which tasks get leased first; scope is bounded by validation and backward-compatible migration.
> 
> **Overview**
> Replaces the launch dispatch queue’s three string tiers (`high` / `normal` / `low`) with **integer priorities 1 (highest) through 5 (lowest)**. Claims now order by ascending numeric priority, then FIFO by dispatch id.
> 
> **Plan YAML** can set `priority` at plan or task level (task overrides plan), with validation that rejects non-integers outside 1–5. Unset task priority defaults to **2** at orchestrator load (`DEFAULT_TASK_PRIORITY`); **`DEFAULT_WORKER_TASK_PRIORITY` (4)** is exported for worker-style plans.
> 
> The scheduler passes validated `task.config.priority` into `enqueueLaunchDispatch`. SQLite schema default, row mapping, and a one-time migration map legacy strings (`high`→1, `normal`→2, `low`→4). Action graph diagnostics surfaces the numeric priority directly instead of mapping to -1/0/1.
> 
> New tests cover dispatch ordering, plan parsing, and priority defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1370f3e293894d4ca180b09582385ee15e2b289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->