### PR TITLE
[Admin-Bypass Babysit Cooldown](1) Throttle admin-bypass-e2e-babysit worker scratch-plan submissions

### DIFF
--- a/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
@@ -290,4 +290,42 @@ describe('runAdminBypassE2eBabysitTick', () => {
       status: 'failed',
     });
   });
+
+  it('throttles duplicate investigation plans for the same worker or repair filing within the cooldown window', async () => {
+    const staleRow: RepairFilingRow = {
+      kind: 'admin-requeue:rebase-conflict',
+      subject: '11219',
+      stateSha: 'sha-stale',
+      createdAt: new Date(Date.now() - REPAIR_FILING_STALE_TTL_MS - 60_000).toISOString(),
+    };
+    const workerLifecycle = new FakeWorkerLifecycle([
+      { kind: DEFAULT_WATCHED_WORKER_KINDS[0], desiredEnabled: true, lifecycle: 'stopped' },
+    ]);
+    const repairFilings = new FakeRepairFilingStore([staleRow]);
+    const planSubmitter = new FakeInvestigativePlanSubmitter();
+    const { store } = makeDecisionStore();
+    const recentInvestigations = new Map<string, number>();
+
+    const baseOptions = {
+      logger: makeLogger(),
+      workerLifecycle,
+      repairFilings,
+      planSubmitter,
+      store,
+      investigationCooldownMs: 60_000,
+      recentInvestigations,
+    };
+
+    await runAdminBypassE2eBabysitTick(baseOptions);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(workerLifecycle.startCalls).toHaveLength(1);
+    expect(repairFilings.deleteCalls).toHaveLength(1);
+
+    // A second tick immediately should not file another plan, but should still
+    // attempt the start and delete operations.
+    await runAdminBypassE2eBabysitTick(baseOptions);
+    expect(planSubmitter.submittedPlans).toHaveLength(1);
+    expect(workerLifecycle.startCalls).toHaveLength(2);
+    expect(repairFilings.deleteCalls).toHaveLength(2);
+  });
 });

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -30,6 +30,7 @@ export const E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX = 'ci-regression-needs-human
 export const E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX = 'ci-regression-needs-human-investigated:';
 
 const DEFAULT_INTERVAL_MS = 10 * 60_000;
+const DEFAULT_INVESTIGATION_COOLDOWN_MS = 60 * 60_000;
 
 export interface WorkerLifecycleSnapshot {
   readonly kind: string;
@@ -76,6 +77,7 @@ export interface AdminBypassE2eBabysitWorkerConfig {
   tickOnStart?: boolean;
   watchedWorkerKinds?: readonly string[];
   staleTtlMs?: number;
+  investigationCooldownMs?: number;
   store?: WorkerDecisionStore;
   onTick?: WorkerTick;
 }
@@ -86,6 +88,8 @@ export interface AdminBypassE2eBabysitWorkerOptions {
   tickOnStart?: boolean;
   watchedWorkerKinds?: readonly string[];
   staleTtlMs?: number;
+  investigationCooldownMs?: number;
+  recentInvestigations?: Map<string, number>;
   workerLifecycle: WorkerLifecycleReader & WorkerLifecycleStarter;
   repairFilings: RepairFilingStore;
   planSubmitter: InvestigativePlanSubmitter;
@@ -193,12 +197,31 @@ export async function runAdminBypassE2eBabysitTick(
   const actions: AdminBypassE2eBabysitAction[] = [];
   const watchedWorkerKinds = new Set(options.watchedWorkerKinds ?? DEFAULT_WATCHED_WORKER_KINDS);
   const workers = await options.workerLifecycle.listWorkers();
+  const cooldownMs = options.investigationCooldownMs ?? DEFAULT_INVESTIGATION_COOLDOWN_MS;
+  const recentInvestigations = options.recentInvestigations ?? new Map<string, number>();
+  const now = Date.now();
+
+  const isInvestigationThrottled = (externalKey: string): boolean => {
+    if (cooldownMs <= 0) return false;
+    const last = recentInvestigations.get(externalKey);
+    return last !== undefined && now - last < cooldownMs;
+  };
+
+  const markInvestigation = (externalKey: string): void => {
+    if (cooldownMs > 0) {
+      recentInvestigations.set(externalKey, now);
+    }
+  };
 
   for (const worker of workers) {
     if (!watchedWorkerKinds.has(worker.kind)) continue;
     if (worker.desiredEnabled !== true || worker.lifecycle !== 'stopped') continue;
 
-    actions.push({ type: 'worker-start', kind: worker.kind });
+    const externalKey = `worker:${worker.kind}`;
+    if (!isInvestigationThrottled(externalKey)) {
+      actions.push({ type: 'worker-start', kind: worker.kind });
+      markInvestigation(externalKey);
+    }
     try {
       await options.workerLifecycle.start(worker.kind);
       options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] started stopped desired-enabled worker`, {
@@ -238,13 +261,17 @@ export async function runAdminBypassE2eBabysitTick(
     if (!(Date.now() - Date.parse(row.createdAt) > staleTtlMs)) continue;
 
     const subjectId = `${row.kind}:${row.subject}:${row.stateSha}`;
-    actions.push({
-      type: 'repair-filing-delete',
-      kind: row.kind,
-      subject: row.subject,
-      stateSha: row.stateSha,
-      createdAt: row.createdAt,
-    });
+    const externalKey = `repair-filing-delete:${subjectId}`;
+    if (!isInvestigationThrottled(externalKey)) {
+      actions.push({
+        type: 'repair-filing-delete',
+        kind: row.kind,
+        subject: row.subject,
+        stateSha: row.stateSha,
+        createdAt: row.createdAt,
+      });
+      markInvestigation(externalKey);
+    }
     try {
       await options.repairFilings.deleteRepairFiling(row.kind, row.subject, row.stateSha);
       options.logger.info(`[${ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND}] deleted stale repair filing`, {
@@ -370,12 +397,15 @@ export function createAdminBypassE2eBabysitWorker(
     planSubmitter: InvestigativePlanSubmitter;
   },
 ): WorkerRuntime {
+  const recentInvestigations = new Map<string, number>();
   const options: AdminBypassE2eBabysitWorkerOptions = {
     logger: config.logger,
     intervalMs: config.intervalMs,
     tickOnStart: config.tickOnStart,
     watchedWorkerKinds: config.watchedWorkerKinds,
     staleTtlMs: config.staleTtlMs,
+    investigationCooldownMs: config.investigationCooldownMs ?? DEFAULT_INVESTIGATION_COOLDOWN_MS,
+    recentInvestigations,
     workerLifecycle: config.workerLifecycle,
     repairFilings: config.repairFilings,
     planSubmitter: config.planSubmitter,


### PR DESCRIPTION
## Summary

The admin-bypass-e2e-babysit worker wakes up on a fixed interval and files a `scratch: true` investigation plan for each stopped watched worker or repair filing older than the TTL it sees.

When the same lifecycle condition persists across ticks, repeated wakeups file another plan each time, which burned a large amount of token spend on remote_digital_ocean_1 — confirmed by a real session audit this same day.

This change coalesces repeated wakeups for the same lifecycle key into one investigation plan per cooldown window.

## Review Claim

Approve coalescing repeated admin-bypass-e2e-babysit wakeups so the worker does not file a new scratch plan for the same lifecycle state on every tick.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is localized to `admin-bypass-e2e-babysit-worker.ts` and its unit tests. It only avoids filing a new investigation plan for a key that already has one in flight; it does not stop the worker from starting stopped workers or deleting repair filings older than the TTL.

## Slice Rationale

This slice targets the exact worker that is producing the token burn, with the cooldown logic inline. A follow-up slice generalizes it into a reusable helper.

## Non-goals

- No event-driven rewrite of the worker runtime.
- No change to the ten-minute poll interval.
- No change to the set of watched workers or the repair-filing TTL.
- Does not add a manual on/off toggle for this worker. Checked whether one was needed: `WorkerRuntimeController.start()` re-persists `desiredEnabled: true` on every call unless the caller opts out, and both on-demand trigger sites in `main.ts` call `.start(kind)` with no options — so a toggle entry alone would not actually stop this worker; the trigger sites would need updating too. That is a separate, riskier change to the app's main process, left for its own reviewed slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/admin-bypass-e2e-babysit-worker.test.ts` (run from `packages/execution-engine`) — pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
