### PR TITLE
[Admin-Bypass Babysit Cooldown](2) Add generic InvestigationPlanThrottle helper and unit tests

### DIFF
--- a/packages/execution-engine/src/__tests__/investigation-plan-throttle.test.ts
+++ b/packages/execution-engine/src/__tests__/investigation-plan-throttle.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createInvestigationPlanThrottle,
+  DEFAULT_INVESTIGATION_COOLDOWN_MS,
+} from '../workers/investigation-plan-throttle.js';
+
+describe('createInvestigationPlanThrottle', () => {
+  it('returns DEFAULT_INVESTIGATION_COOLDOWN_MS equal to one hour', () => {
+    expect(DEFAULT_INVESTIGATION_COOLDOWN_MS).toBe(60 * 60_000);
+  });
+
+  it('allows the first investigation for a key', () => {
+    const throttle = createInvestigationPlanThrottle(60_000);
+    expect(throttle.isThrottled('worker:foo')).toBe(false);
+  });
+
+  it('marks an investigation so a second call within cooldown is throttled', () => {
+    const throttle = createInvestigationPlanThrottle(60_000);
+    throttle.mark('worker:foo');
+    expect(throttle.isThrottled('worker:foo')).toBe(true);
+  });
+
+  it('does not throttle different keys', () => {
+    const throttle = createInvestigationPlanThrottle(60_000);
+    throttle.mark('worker:foo');
+    expect(throttle.isThrottled('worker:bar')).toBe(false);
+  });
+
+  it('respects a custom now value for deterministic testing', () => {
+    const throttle = createInvestigationPlanThrottle(60_000);
+    const now = 1_000_000;
+    throttle.mark('worker:foo', now);
+    expect(throttle.isThrottled('worker:foo', now + 30_000)).toBe(true);
+    expect(throttle.isThrottled('worker:foo', now + 60_001)).toBe(false);
+  });
+
+  it('can be rehydrated from an existing entries map', () => {
+    const entries = new Map<string, number>([['worker:baz', Date.now()]]);
+    const throttle = createInvestigationPlanThrottle(60_000, entries);
+    expect(throttle.isThrottled('worker:baz')).toBe(true);
+  });
+
+  it('disables throttling when cooldownMs is zero or negative', () => {
+    const throttle = createInvestigationPlanThrottle(0);
+    throttle.mark('worker:foo');
+    expect(throttle.isThrottled('worker:foo')).toBe(false);
+
+    const negativeThrottle = createInvestigationPlanThrottle(-1000);
+    negativeThrottle.mark('worker:bar');
+    expect(negativeThrottle.isThrottled('worker:bar')).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -4,6 +4,11 @@ import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-dec
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+import {
+  createInvestigationPlanThrottle,
+  DEFAULT_INVESTIGATION_COOLDOWN_MS,
+  type InvestigationPlanThrottle,
+} from './investigation-plan-throttle.js';
 
 export const ADMIN_BYPASS_E2E_BABYSIT_WORKER_KIND = 'admin-bypass-e2e-babysit';
 
@@ -30,7 +35,6 @@ export const E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX = 'ci-regression-needs-human
 export const E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX = 'ci-regression-needs-human-investigated:';
 
 const DEFAULT_INTERVAL_MS = 10 * 60_000;
-const DEFAULT_INVESTIGATION_COOLDOWN_MS = 60 * 60_000;
 
 export interface WorkerLifecycleSnapshot {
   readonly kind: string;
@@ -197,30 +201,19 @@ export async function runAdminBypassE2eBabysitTick(
   const actions: AdminBypassE2eBabysitAction[] = [];
   const watchedWorkerKinds = new Set(options.watchedWorkerKinds ?? DEFAULT_WATCHED_WORKER_KINDS);
   const workers = await options.workerLifecycle.listWorkers();
-  const cooldownMs = options.investigationCooldownMs ?? DEFAULT_INVESTIGATION_COOLDOWN_MS;
-  const recentInvestigations = options.recentInvestigations ?? new Map<string, number>();
-  const now = Date.now();
-
-  const isInvestigationThrottled = (externalKey: string): boolean => {
-    if (cooldownMs <= 0) return false;
-    const last = recentInvestigations.get(externalKey);
-    return last !== undefined && now - last < cooldownMs;
-  };
-
-  const markInvestigation = (externalKey: string): void => {
-    if (cooldownMs > 0) {
-      recentInvestigations.set(externalKey, now);
-    }
-  };
+  const throttle = createInvestigationPlanThrottle(
+    options.investigationCooldownMs ?? DEFAULT_INVESTIGATION_COOLDOWN_MS,
+    options.recentInvestigations,
+  );
 
   for (const worker of workers) {
     if (!watchedWorkerKinds.has(worker.kind)) continue;
     if (worker.desiredEnabled !== true || worker.lifecycle !== 'stopped') continue;
 
     const externalKey = `worker:${worker.kind}`;
-    if (!isInvestigationThrottled(externalKey)) {
+    if (!throttle.isThrottled(externalKey)) {
       actions.push({ type: 'worker-start', kind: worker.kind });
-      markInvestigation(externalKey);
+      throttle.mark(externalKey);
     }
     try {
       await options.workerLifecycle.start(worker.kind);
@@ -262,7 +255,7 @@ export async function runAdminBypassE2eBabysitTick(
 
     const subjectId = `${row.kind}:${row.subject}:${row.stateSha}`;
     const externalKey = `repair-filing-delete:${subjectId}`;
-    if (!isInvestigationThrottled(externalKey)) {
+    if (!throttle.isThrottled(externalKey)) {
       actions.push({
         type: 'repair-filing-delete',
         kind: row.kind,
@@ -270,7 +263,7 @@ export async function runAdminBypassE2eBabysitTick(
         stateSha: row.stateSha,
         createdAt: row.createdAt,
       });
-      markInvestigation(externalKey);
+      throttle.mark(externalKey);
     }
     try {
       await options.repairFilings.deleteRepairFiling(row.kind, row.subject, row.stateSha);

--- a/packages/execution-engine/src/workers/investigation-plan-throttle.ts
+++ b/packages/execution-engine/src/workers/investigation-plan-throttle.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_INVESTIGATION_COOLDOWN_MS = 60 * 60_000;
+
+export interface InvestigationPlanThrottle {
+  isThrottled(externalKey: string, now?: number): boolean;
+  mark(externalKey: string, now?: number): void;
+}
+
+export function createInvestigationPlanThrottle(
+  cooldownMs: number,
+  entries?: Map<string, number>,
+): InvestigationPlanThrottle {
+  const lastInvestigationAt = entries ?? new Map<string, number>();
+
+  return {
+    isThrottled(externalKey: string, now = Date.now()): boolean {
+      if (cooldownMs <= 0) return false;
+      const last = lastInvestigationAt.get(externalKey);
+      return last !== undefined && now - last < cooldownMs;
+    },
+    mark(externalKey: string, now = Date.now()): void {
+      if (cooldownMs > 0) {
+        lastInvestigationAt.set(externalKey, now);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

The previous slice added inline scratch-plan-limiting logic directly inside the admin-bypass-e2e-babysit worker's own wakeup handling.

That logic is generic — a last-seen timestamp per key, compared against a duration — and could serve other workers whose wakeup routing has the same shape, instead of each carrying its own copy.

This packages it as a standalone `createInvestigationPlanThrottle` module with its own unit tests, and updates the worker's wakeup routing to import it.

## Review Claim

Approve packaging the previous slice's inline wakeup-routing logic as a standalone, independently-tested module, with the worker's own behavior unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

no behavior change: the default duration and per-key comparison are byte-identical before and after this extraction — only the code's location moves into a shared, independently-tested module.

## Slice Rationale

Separating "does the logic work" (previous slice) from "is the logic reusable" (this slice) keeps each change reviewable as its own question.

## Non-goals

Does not change the default duration, the per-key comparison, or the worker's own tick behavior. Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/admin-bypass-e2e-babysit-worker.test.ts src/__tests__/investigation-plan-throttle.test.ts` (run from `packages/execution-engine`) — 15/15 pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of cooldown bookkeeping in a babysit worker with dedicated unit tests; no new APIs or config defaults beyond moving shared logic.
> 
> **Overview**
> Pulls the admin-bypass-e2e-babysit worker’s inline per-key investigation cooldown into a shared **`createInvestigationPlanThrottle`** module (`isThrottled` / `mark`, default **1 hour**, optional `Map` rehydration, injectable `now` for tests, no-op when cooldown ≤ 0).
> 
> The babysit tick now wires that helper for worker-start and stale repair-filing-delete paths instead of local closures, still honoring `investigationCooldownMs` and `recentInvestigations`. **Vitest** coverage for the helper is added; routing behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f13b6bd9e2185b8273f2ff802fd0bc94424258a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->