### PR TITLE
[Tick-Worker IPC](1) Add invoker:tick-worker IPC contract and tsconfig compatibility

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1310,6 +1310,10 @@ export const IpcChannels = {
     request: [kind: string];
     response: WorkerStatusEntry;
   },
+  'invoker:tick-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "composite": false,
+    "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true
   },
   "include": [


### PR DESCRIPTION
## Summary

A later slice needs a way to ask the owner to run one worker's tick on demand and get its resulting status back, over the existing typed IPC contract.

This adds that one channel's request/response shape to the shared contract file, alongside the other worker-status channels already there.

A separate tsconfig option is also flipped so this package's own type declarations build correctly for downstream consumers.

## Review Claim

Approve adding one new typed IPC channel entry (`invoker:tick-worker`) to the shared contract, with no consumer wired to it yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Purely additive: one new key in an existing const object, plus one tsconfig compiler flag. Nothing existing changes shape, and nothing in the running app calls this channel yet — a later slice wires a real handler.

## Slice Rationale

The typed contract is the shared shape every later slice (an owner handler, then callers) depends on, so it lands first and alone.

## Non-goals

Does not add an owner-side handler for this channel. Does not add any caller. Does not change any other channel's shape.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (repo-wide) — clean
- [x] `pnpm run check:deps` — 0 errors (98 pre-existing warnings, unrelated to this diff)
- [x] `pnpm run check:large-files` — clean
- [x] `pnpm run check:comments` — clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
