### PR TITLE
Add invoker:tick-worker IPC contract and tsconfig compatibility

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1310,6 +1310,10 @@ export const IpcChannels = {
     request: [kind: string];
     response: WorkerStatusEntry;
   },
+  'invoker:tick-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "composite": false,
+    "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true
   },
   "include": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-contract and build-config only; no runtime behavior in this diff.
> 
> **Overview**
> Adds **`invoker:tick-worker`** to the IPC channel registry so renderer/main code can type a one-shot worker “tick” the same way as **`start-worker`** / **`stop-worker`**: pass a worker **`kind`**, get back a **`WorkerStatusEntry`**. The derived **`InvokerAPI`** picks up a **`tickWorker`** method automatically from the registry.
> 
> For **`packages/contracts`**, sets **`emitDeclarationOnly: true`** in **`tsconfig.json`** so the package build emits **`.d.ts` only** (no JS), aligning with **`allowImportingTsExtensions`** and avoiding incompatible dual emit in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486c199f058fed53d0d42f459db4d9bf7cfdccb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->