### PR TITLE
Wire worker tick through runtime, CLI, IPC, and web dispatch

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -382,6 +382,28 @@ describe('buildWebInvokerDispatch', () => {
     });
   });
 
+  describe('worker lifecycle routes', () => {
+    it('routes start/stop/tick worker through guiMutations when wired', async () => {
+      const guiMutations = vi.fn(async () => ({ ok: true }));
+      const { dispatch } = makeDispatch({ guiMutations });
+
+      await expect(dispatch('invoker:start-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+      await expect(dispatch('invoker:stop-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+      await expect(dispatch('invoker:tick-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+
+      expect(guiMutations).toHaveBeenCalledWith('invoker:start-worker', ['pr-status']);
+      expect(guiMutations).toHaveBeenCalledWith('invoker:stop-worker', ['pr-status']);
+      expect(guiMutations).toHaveBeenCalledWith('invoker:tick-worker', ['pr-status']);
+    });
+
+    it('rejects worker lifecycle channels when guiMutations is absent', async () => {
+      const { dispatch } = makeDispatch();
+      await expect(dispatch('invoker:tick-worker', ['pr-status'])).rejects.toMatchObject({
+        code: 'unsupported_on_web',
+      });
+    });
+  });
+
   describe('planning routes', () => {
     it('routes planning-chat channels through owner capabilities when wired', async () => {
       const ownerCapabilities = new OwnerCapabilityRegistry();

--- a/packages/app/src/__tests__/worker-control-delegation.test.ts
+++ b/packages/app/src/__tests__/worker-control-delegation.test.ts
@@ -18,6 +18,14 @@ describe('resolveWorkerControlMutation', () => {
     });
   });
 
+  it('maps `worker tick <kind>` to the tick-worker gui mutation', () => {
+    expect(resolveWorkerControlMutation(['worker', 'tick', 'autofix'])).toEqual({
+      action: 'tick',
+      channel: 'invoker:tick-worker',
+      kind: 'autofix',
+    });
+  });
+
   it('returns null for worker read subcommands so they run locally', () => {
     expect(resolveWorkerControlMutation(['worker'])).toBeNull();
     expect(resolveWorkerControlMutation(['worker', 'list'])).toBeNull();

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -611,6 +611,27 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     return;
   }
 
+  if (subCommand === 'tick') {
+    const kind = args[1];
+    if (!kind) {
+      throw new Error('Missing worker kind. Usage: --headless worker tick <kind>');
+    }
+    if (!registry.get(kind)) {
+      const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+      throw new Error(`Unknown worker kind: "${kind}". Use: ${knownKinds}`);
+    }
+    const controller = deps.getWorkerRuntimeController?.();
+    if (!controller) {
+      throw new Error(
+        `Cannot tick worker "${kind}": no live owner worker runtime in this process. `
+        + 'Run this against a live "owner-serve" process.',
+      );
+    }
+    const entry = await controller.tick(kind);
+    process.stdout.write(`${kind}: ticked (desiredEnabled=${entry.desiredEnabled})\n`);
+    return;
+  }
+
   const definition = registry.get(subCommand);
   if (!definition) {
     const knownKinds = registry.list().map((worker) => worker.kind).join(', ');

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1917,6 +1917,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return workerRuntimeController.stop(String(kindArg), { source: 'gui-ipc' });
   });
 
+  registerGuiMutationHandler('invoker:tick-worker', async (kindArg: unknown) => {
+    if (!workerRuntimeController) {
+      throw new Error('Worker runtime controller is unavailable');
+    }
+    return workerRuntimeController.tick(String(kindArg));
+  });
+
   ipcMain.handle('invoker:get-queue-status', (_event, options?: { refresh?: boolean }) => resolveGuiQueueStatusRead({
     ownerMode,
     messageBus,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1666,6 +1666,13 @@ function startHeadlessMode(): void {
         return workerRuntimeController.stop(String(payload.args[0]));
       });
 
+      registerStandaloneOwnerCapability('invoker:tick-worker', async (payload) => {
+        if (!workerRuntimeController) {
+          throw new Error('Worker runtime controller is unavailable');
+        }
+        return workerRuntimeController.tick(String(payload.args[0]));
+      });
+
       registerStandaloneOwnerCapability('invoker:inject-task-states', async (payload) => {
         if (process.env.NODE_ENV !== 'test') {
           throw new Error('inject-task-states is only available in tests');

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -423,6 +423,27 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
+      case 'invoker:start-worker':
+      case 'invoker:stop-worker':
+      case 'invoker:tick-worker':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+
+      case 'invoker:plan-from-goal':
+      case 'invoker:planning-chat-create':
+      case 'invoker:planning-chat-list':
+      case 'invoker:planning-chat-send':
+      case 'invoker:planning-chat-submit':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-delete':
+      case 'invoker:planning-chat-delete-submitted':
+      case 'invoker:planning-chat-rebind-repo':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+      case 'invoker:planning-chat-set-terminal-mode':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
         if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };

--- a/packages/app/src/worker-control-delegation.ts
+++ b/packages/app/src/worker-control-delegation.ts
@@ -1,7 +1,10 @@
-export type WorkerControlChannel = 'invoker:start-worker' | 'invoker:stop-worker';
+export type WorkerControlChannel =
+  | 'invoker:start-worker'
+  | 'invoker:stop-worker'
+  | 'invoker:tick-worker';
 
 export interface WorkerControlMutation {
-  readonly action: 'start' | 'stop';
+  readonly action: 'start' | 'stop' | 'tick';
   readonly channel: WorkerControlChannel;
   readonly kind: string;
 }
@@ -14,9 +17,13 @@ export function resolveWorkerControlMutation(args: readonly string[]): WorkerCon
   if (!kind) {
     throw new Error(`Missing worker kind. Usage: --headless worker ${action} <kind>`);
   }
+  const channel: WorkerControlChannel =
+    action === 'start' ? 'invoker:start-worker'
+    : action === 'stop' ? 'invoker:stop-worker'
+    : 'invoker:tick-worker';
   return {
     action,
-    channel: action === 'start' ? 'invoker:start-worker' : 'invoker:stop-worker',
+    channel,
     kind,
   };
 }

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -180,6 +180,7 @@ export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
   start(kind: string, options?: { persistDesiredState?: boolean; source?: string }): WorkerStatusEntry;
   stop(kind: string, options?: { source?: string }): Promise<WorkerStatusEntry>;
+  tick(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
 }
@@ -516,6 +517,18 @@ export function createWorkerRuntimeController(options: {
         return rowForKind(kind);
       }
       await stopHandle(kind, handle);
+      invalidateSnapshot();
+      return rowForKind(kind);
+    },
+
+    async tick(kind: string): Promise<WorkerStatusEntry> {
+      requireDefinition(kind);
+      invalidateSnapshot();
+      const handle = handles.get(kind);
+      if (!handle || !handle.runtime.isRunning()) {
+        throw new Error(`Worker "${kind}" is not running; start it before tick.`);
+      }
+      await handle.runtime.tick('manual');
       invalidateSnapshot();
       return rowForKind(kind);
     },

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1310,6 +1310,10 @@ export const IpcChannels = {
     request: [kind: string];
     response: WorkerStatusEntry;
   },
+  'invoker:tick-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "composite": false,
+    "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true
   },
   "include": [


### PR DESCRIPTION




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Manual tick can trigger immediate worker side effects (mutations, scans); scope is operational worker control rather than auth, but misuse or a missing `tick` guard in `resolveWorkerControlMutation` could leave CLI delegation incomplete.
> 
> **Overview**
> Adds **manual worker tick** as a first-class control alongside start/stop, so operators can force a running background worker to scan once without waiting for its timer.
> 
> **Runtime:** `WorkerRuntimeController` gains `tick(kind)` — validates the kind, requires an active handle, runs `runtime.tick('manual')`, and returns an updated status row.
> 
> **Surfaces:** New `invoker:tick-worker` handlers in GUI IPC and standalone owner capabilities; headless `--headless worker tick <kind>` when a live owner runtime is present; web dispatch forwards `invoker:start-worker` / `stop-worker` / `tick-worker` through `guiMutations` (or `unsupported_on_web` without it).
> 
> **Delegation:** Worker control mutation types/channels extended for `tick` → `invoker:tick-worker` (paired with tests for web dispatch and delegation mapping).
> 
> The web invoker dispatch change also groups several **planning-chat** channels to route via `guiMutations`, with a explicit downgrade for planning terminal mode on web.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854d432abca4eb24dec1d110146adafaef1921be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Depends-On: #11980