### PR TITLE
Add Rescan button and invoker.tickWorker UI

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -382,6 +382,28 @@ describe('buildWebInvokerDispatch', () => {
     });
   });
 
+  describe('worker lifecycle routes', () => {
+    it('routes start/stop/tick worker through guiMutations when wired', async () => {
+      const guiMutations = vi.fn(async () => ({ ok: true }));
+      const { dispatch } = makeDispatch({ guiMutations });
+
+      await expect(dispatch('invoker:start-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+      await expect(dispatch('invoker:stop-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+      await expect(dispatch('invoker:tick-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+
+      expect(guiMutations).toHaveBeenCalledWith('invoker:start-worker', ['pr-status']);
+      expect(guiMutations).toHaveBeenCalledWith('invoker:stop-worker', ['pr-status']);
+      expect(guiMutations).toHaveBeenCalledWith('invoker:tick-worker', ['pr-status']);
+    });
+
+    it('rejects worker lifecycle channels when guiMutations is absent', async () => {
+      const { dispatch } = makeDispatch();
+      await expect(dispatch('invoker:tick-worker', ['pr-status'])).rejects.toMatchObject({
+        code: 'unsupported_on_web',
+      });
+    });
+  });
+
   describe('planning routes', () => {
     it('routes planning-chat channels through owner capabilities when wired', async () => {
       const ownerCapabilities = new OwnerCapabilityRegistry();

--- a/packages/app/src/__tests__/worker-control-delegation.test.ts
+++ b/packages/app/src/__tests__/worker-control-delegation.test.ts
@@ -18,6 +18,14 @@ describe('resolveWorkerControlMutation', () => {
     });
   });
 
+  it('maps `worker tick <kind>` to the tick-worker gui mutation', () => {
+    expect(resolveWorkerControlMutation(['worker', 'tick', 'autofix'])).toEqual({
+      action: 'tick',
+      channel: 'invoker:tick-worker',
+      kind: 'autofix',
+    });
+  });
+
   it('returns null for worker read subcommands so they run locally', () => {
     expect(resolveWorkerControlMutation(['worker'])).toBeNull();
     expect(resolveWorkerControlMutation(['worker', 'list'])).toBeNull();

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -611,6 +611,27 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     return;
   }
 
+  if (subCommand === 'tick') {
+    const kind = args[1];
+    if (!kind) {
+      throw new Error('Missing worker kind. Usage: --headless worker tick <kind>');
+    }
+    if (!registry.get(kind)) {
+      const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+      throw new Error(`Unknown worker kind: "${kind}". Use: ${knownKinds}`);
+    }
+    const controller = deps.getWorkerRuntimeController?.();
+    if (!controller) {
+      throw new Error(
+        `Cannot tick worker "${kind}": no live owner worker runtime in this process. `
+        + 'Run this against a live "owner-serve" process.',
+      );
+    }
+    const entry = await controller.tick(kind);
+    process.stdout.write(`${kind}: ticked (desiredEnabled=${entry.desiredEnabled})\n`);
+    return;
+  }
+
   const definition = registry.get(subCommand);
   if (!definition) {
     const knownKinds = registry.list().map((worker) => worker.kind).join(', ');

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1917,6 +1917,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return workerRuntimeController.stop(String(kindArg), { source: 'gui-ipc' });
   });
 
+  registerGuiMutationHandler('invoker:tick-worker', async (kindArg: unknown) => {
+    if (!workerRuntimeController) {
+      throw new Error('Worker runtime controller is unavailable');
+    }
+    return workerRuntimeController.tick(String(kindArg));
+  });
+
   ipcMain.handle('invoker:get-queue-status', (_event, options?: { refresh?: boolean }) => resolveGuiQueueStatusRead({
     ownerMode,
     messageBus,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1666,6 +1666,13 @@ function startHeadlessMode(): void {
         return workerRuntimeController.stop(String(payload.args[0]));
       });
 
+      registerStandaloneOwnerCapability('invoker:tick-worker', async (payload) => {
+        if (!workerRuntimeController) {
+          throw new Error('Worker runtime controller is unavailable');
+        }
+        return workerRuntimeController.tick(String(payload.args[0]));
+      });
+
       registerStandaloneOwnerCapability('invoker:inject-task-states', async (payload) => {
         if (process.env.NODE_ENV !== 'test') {
           throw new Error('inject-task-states is only available in tests');

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -423,6 +423,27 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
+      case 'invoker:start-worker':
+      case 'invoker:stop-worker':
+      case 'invoker:tick-worker':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+
+      case 'invoker:plan-from-goal':
+      case 'invoker:planning-chat-create':
+      case 'invoker:planning-chat-list':
+      case 'invoker:planning-chat-send':
+      case 'invoker:planning-chat-submit':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-delete':
+      case 'invoker:planning-chat-delete-submitted':
+      case 'invoker:planning-chat-rebind-repo':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+      case 'invoker:planning-chat-set-terminal-mode':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
         if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };

--- a/packages/app/src/worker-control-delegation.ts
+++ b/packages/app/src/worker-control-delegation.ts
@@ -1,7 +1,10 @@
-export type WorkerControlChannel = 'invoker:start-worker' | 'invoker:stop-worker';
+export type WorkerControlChannel =
+  | 'invoker:start-worker'
+  | 'invoker:stop-worker'
+  | 'invoker:tick-worker';
 
 export interface WorkerControlMutation {
-  readonly action: 'start' | 'stop';
+  readonly action: 'start' | 'stop' | 'tick';
   readonly channel: WorkerControlChannel;
   readonly kind: string;
 }
@@ -14,9 +17,13 @@ export function resolveWorkerControlMutation(args: readonly string[]): WorkerCon
   if (!kind) {
     throw new Error(`Missing worker kind. Usage: --headless worker ${action} <kind>`);
   }
+  const channel: WorkerControlChannel =
+    action === 'start' ? 'invoker:start-worker'
+    : action === 'stop' ? 'invoker:stop-worker'
+    : 'invoker:tick-worker';
   return {
     action,
-    channel: action === 'start' ? 'invoker:start-worker' : 'invoker:stop-worker',
+    channel,
     kind,
   };
 }

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -180,6 +180,7 @@ export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
   start(kind: string, options?: { persistDesiredState?: boolean; source?: string }): WorkerStatusEntry;
   stop(kind: string, options?: { source?: string }): Promise<WorkerStatusEntry>;
+  tick(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
 }
@@ -516,6 +517,18 @@ export function createWorkerRuntimeController(options: {
         return rowForKind(kind);
       }
       await stopHandle(kind, handle);
+      invalidateSnapshot();
+      return rowForKind(kind);
+    },
+
+    async tick(kind: string): Promise<WorkerStatusEntry> {
+      requireDefinition(kind);
+      invalidateSnapshot();
+      const handle = handles.get(kind);
+      if (!handle || !handle.runtime.isRunning()) {
+        throw new Error(`Worker "${kind}" is not running; start it before tick.`);
+      }
+      await handle.runtime.tick('manual');
       invalidateSnapshot();
       return rowForKind(kind);
     },

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1310,6 +1310,10 @@ export const IpcChannels = {
     request: [kind: string];
     response: WorkerStatusEntry;
   },
+  'invoker:tick-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "composite": false,
+    "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true
   },
   "include": [

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -548,6 +548,10 @@ export function App() {
     await invoker.stopWorker(kind);
     void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
+  const handleTickWorker = useCallback(async (kind: string) => {
+    await invoker.tickWorker(kind);
+    void refreshWorkerStatus();
+  }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
@@ -4350,6 +4354,7 @@ export function App() {
                 readOnly={runtimeStatus?.readOnly === true}
                 onStartWorker={handleStartWorker}
                 onStopWorker={handleStopWorker}
+                onTickWorker={handleTickWorker}
               />
               <button
                 type="button"

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -456,6 +456,10 @@ export function createMockInvoker(
       const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
       return row;
     }),
+    tickWorker: vi.fn(async (kind: string) => {
+      const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
+      return row;
+    }),
     getActionGraph: vi.fn(async () => actionGraphSnapshot),
     getClaudeSession: vi.fn(async () => null),
     getAgentSession: vi.fn(async () => null),

--- a/packages/ui/src/__tests__/worker-detail-control.test.tsx
+++ b/packages/ui/src/__tests__/worker-detail-control.test.tsx
@@ -140,4 +140,36 @@ describe('WorkerDetailControl', () => {
 
     expect(screen.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'stop');
   });
+
+  it('rescans a running worker when onTickWorker is provided', async () => {
+    const onTickWorker = vi.fn(async () => {});
+    render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+        onTickWorker={onTickWorker}
+      />,
+    );
+
+    const rescan = screen.getByTestId('worker-detail-rescan');
+    expect(rescan).toHaveTextContent('Rescan');
+
+    fireEvent.click(rescan);
+
+    await waitFor(() => expect(onTickWorker).toHaveBeenCalledWith('pr-status'));
+  });
+
+  it('hides the rescan button for stopped workers', () => {
+    render(
+      <WorkerDetailControl
+        worker={makeWorker({ lifecycle: 'stopped', startable: true, stoppable: false })}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+        onTickWorker={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('worker-detail-rescan')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/WorkerDetailControl.tsx
+++ b/packages/ui/src/components/WorkerDetailControl.tsx
@@ -6,6 +6,7 @@ interface WorkerDetailControlProps {
   readOnly?: boolean;
   onStartWorker: (kind: string) => Promise<void> | void;
   onStopWorker: (kind: string) => Promise<void> | void;
+  onTickWorker?: (kind: string) => Promise<void> | void;
 }
 
 type OptimisticLifecycle = 'running' | 'stopped';
@@ -15,9 +16,11 @@ export function WorkerDetailControl({
   readOnly = false,
   onStartWorker,
   onStopWorker,
+  onTickWorker,
 }: WorkerDetailControlProps) {
   const [optimistic, setOptimistic] = useState<OptimisticLifecycle | null>(null);
   const [pending, setPending] = useState(false);
+  const [tickPending, setTickPending] = useState(false);
 
   useEffect(() => {
     setOptimistic(null);
@@ -36,28 +39,50 @@ export function WorkerDetailControl({
   const showStart = lifecycle !== 'running';
   const disabledReason = readOnly ? 'Read-only window' : worker.controlDisabledReason;
   const disabled = Boolean(disabledReason) || pending;
+  const canRescan = !showStart && onTickWorker !== undefined && !readOnly;
 
   return (
-    <button
-      type="button"
-      data-testid="worker-detail-start-stop"
-      data-action={showStart ? 'start' : 'stop'}
-      title={disabledReason}
-      disabled={disabled}
-      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
-      onClick={() => {
-        if (disabled) return;
-        setOptimistic(showStart ? 'running' : 'stopped');
-        setPending(true);
-        void Promise.resolve(showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind))
-          .catch((error: unknown) => {
-            setOptimistic(null);
-            console.error(`Failed to ${showStart ? 'enable' : 'disable'} worker ${worker.kind}`, error);
-          })
-          .finally(() => setPending(false));
-      }}
-    >
-      {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        data-testid="worker-detail-start-stop"
+        data-action={showStart ? 'start' : 'stop'}
+        title={disabledReason}
+        disabled={disabled}
+        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+        onClick={() => {
+          if (disabled) return;
+          setOptimistic(showStart ? 'running' : 'stopped');
+          setPending(true);
+          void Promise.resolve(showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind))
+            .catch((error: unknown) => {
+              setOptimistic(null);
+              console.error(`Failed to ${showStart ? 'enable' : 'disable'} worker ${worker.kind}`, error);
+            })
+            .finally(() => setPending(false));
+        }}
+      >
+        {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
+      </button>
+      {canRescan ? (
+        <button
+          type="button"
+          data-testid="worker-detail-rescan"
+          disabled={tickPending}
+          className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+          onClick={() => {
+            if (tickPending) return;
+            setTickPending(true);
+            void Promise.resolve(onTickWorker!(worker.kind))
+              .catch((error: unknown) => {
+                console.error(`Failed to rescan worker ${worker.kind}`, error);
+              })
+              .finally(() => setTickPending(false));
+          }}
+        >
+          {tickPending ? 'Rescanning…' : 'Rescan'}
+        </button>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only control wiring and tests; triggers an existing invoker API with status refresh, no auth or data-model changes in this diff.
> 
> **Overview**
> Adds a manual **Rescan** action on the worker detail surface so operators can trigger an immediate worker tick without stopping and restarting the process.
> 
> `WorkerDetailControl` now accepts an optional `onTickWorker` callback and shows a **Rescan** button (with **Rescanning…** pending state) next to enable/disable when the worker is running, the UI is not read-only, and the callback is provided. Stopped workers do not show the button.
> 
> `App` wires this through `handleTickWorker`, which calls `invoker.tickWorker(kind)` and refreshes worker status—the same pattern as start/stop. Tests cover the rescan click path and visibility rules; the mock invoker implements `tickWorker` for unit tests.
> 
> Depends on backend/preload support for `tickWorker` (see Depends-On PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd94ecfd560078f77d3d19514dd2c442501f256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Depends-On: #11981