### PR TITLE
Fix dead guiMutations routing and tick-action rejection

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -383,23 +383,29 @@ describe('buildWebInvokerDispatch', () => {
   });
 
   describe('worker lifecycle routes', () => {
-    it('routes start/stop/tick worker through guiMutations when wired', async () => {
-      const guiMutations = vi.fn(async () => ({ ok: true }));
-      const { dispatch } = makeDispatch({ guiMutations });
+    it('routes start/stop/tick worker through owner capabilities when wired', async () => {
+      const ownerCapabilities = new OwnerCapabilityRegistry();
+      const start = vi.fn(async () => ({ ok: true, channel: 'invoker:start-worker' }));
+      const stop = vi.fn(async () => ({ ok: true, channel: 'invoker:stop-worker' }));
+      const tick = vi.fn(async () => ({ ok: true, channel: 'invoker:tick-worker' }));
+      ownerCapabilities.register('invoker:start-worker', start);
+      ownerCapabilities.register('invoker:stop-worker', stop);
+      ownerCapabilities.register('invoker:tick-worker', tick);
+      const { dispatch } = makeDispatch({ ownerCapabilities });
 
-      await expect(dispatch('invoker:start-worker', ['pr-status'])).resolves.toEqual({ ok: true });
-      await expect(dispatch('invoker:stop-worker', ['pr-status'])).resolves.toEqual({ ok: true });
-      await expect(dispatch('invoker:tick-worker', ['pr-status'])).resolves.toEqual({ ok: true });
+      await dispatch('invoker:start-worker', ['pr-status']);
+      await dispatch('invoker:stop-worker', ['pr-status']);
+      await dispatch('invoker:tick-worker', ['pr-status']);
 
-      expect(guiMutations).toHaveBeenCalledWith('invoker:start-worker', ['pr-status']);
-      expect(guiMutations).toHaveBeenCalledWith('invoker:stop-worker', ['pr-status']);
-      expect(guiMutations).toHaveBeenCalledWith('invoker:tick-worker', ['pr-status']);
+      expect(start).toHaveBeenCalledWith('pr-status');
+      expect(stop).toHaveBeenCalledWith('pr-status');
+      expect(tick).toHaveBeenCalledWith('pr-status');
     });
 
-    it('rejects worker lifecycle channels when guiMutations is absent', async () => {
+    it('reports a missing owner provider for worker lifecycle channels', async () => {
       const { dispatch } = makeDispatch();
       await expect(dispatch('invoker:tick-worker', ['pr-status'])).rejects.toMatchObject({
-        code: 'unsupported_on_web',
+        code: 'capability_provider_missing',
       });
     });
   });

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -423,27 +423,6 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
-      case 'invoker:start-worker':
-      case 'invoker:stop-worker':
-      case 'invoker:tick-worker':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return unsupported(channel);
-
-      case 'invoker:plan-from-goal':
-      case 'invoker:planning-chat-create':
-      case 'invoker:planning-chat-list':
-      case 'invoker:planning-chat-send':
-      case 'invoker:planning-chat-submit':
-      case 'invoker:planning-chat-discard-draft':
-      case 'invoker:planning-chat-reset':
-      case 'invoker:planning-chat-delete':
-      case 'invoker:planning-chat-delete-submitted':
-      case 'invoker:planning-chat-rebind-repo':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return unsupported(channel);
-      case 'invoker:planning-chat-set-terminal-mode':
-        if (deps.guiMutations) return deps.guiMutations(channel, args);
-        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
         if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };

--- a/packages/app/src/worker-control-delegation.ts
+++ b/packages/app/src/worker-control-delegation.ts
@@ -12,7 +12,7 @@ export interface WorkerControlMutation {
 export function resolveWorkerControlMutation(args: readonly string[]): WorkerControlMutation | null {
   if (args[0] !== 'worker') return null;
   const action = args[1];
-  if (action !== 'start' && action !== 'stop') return null;
+  if (action !== 'start' && action !== 'stop' && action !== 'tick') return null;
   const kind = args[2];
   if (!kind) {
     throw new Error(`Missing worker kind. Usage: --headless worker ${action} <kind>`);


### PR DESCRIPTION
Two real bugs found reviewing the worker-tick stack:

1. web-invoker-dispatch.ts routed start/stop/tick-worker (and several
   planning-chat channels) through a `deps.guiMutations` property that
   is not defined anywhere in the codebase, and called an `unsupported()`
   helper that does not exist in this file either. Both were dead,
   unreachable code -- every one of these channels is already registered
   via ownerCapabilities and intercepted before the switch statement
   ever runs. Removed the dead branches; the switch's existing default
   case already returns the correct capability_provider_missing/
   unknown_channel result for an unregistered channel.

2. worker-control-delegation.ts's resolveWorkerControlMutation
   explicitly rejected action === 'tick', so `worker tick <kind>`
   silently returned null instead of dispatching.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

Depends-On: #11982

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing cleanup and a small CLI delegation fix; behavior aligns with the existing owner-capability path with updated tests.
> 
> **Overview**
> Removes **dead switch branches** in `web-invoker-dispatch.ts` that forwarded worker lifecycle (`start`/`stop`/`tick`) and planning-chat invoker channels through a non-existent `deps.guiMutations` path and an undefined `unsupported()` helper. Those channels are already handled earlier via **`ownerCapabilities`**; when no provider is registered, the switch **default** now consistently surfaces **`capability_provider_missing`** (or **`unknown_channel`**) instead of stale web-only errors.
> 
> **`resolveWorkerControlMutation`** now treats **`tick`** like `start`/`stop`, mapping `worker tick <kind>` to **`invoker:tick-worker`** instead of returning `null`.
> 
> Tests for worker lifecycle dispatch were updated to assert **owner capability** registration and the new missing-provider error code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9f93b52d0b7111bbb1aa91463c9e432164a0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->