### PR TITLE
[Recreate task queue authority repro](1) Give blocker-slow real concurrency instead of a fixed sleep

### DIFF
--- a/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
@@ -35,8 +35,10 @@ BLOCKER_RECREATE_STDOUT="$TMP_DIR/blocker-recreate.stdout.log"
 BLOCKER_RECREATE_STDERR="$TMP_DIR/blocker-recreate.stderr.log"
 TARGET_RECREATE_STDOUT="$TMP_DIR/target-recreate.stdout.log"
 TARGET_RECREATE_STDERR="$TMP_DIR/target-recreate.stderr.log"
+BLOCKER_RELEASE_PATH="$TMP_DIR/blocker-release"
 
 cleanup() {
+  touch "$BLOCKER_RELEASE_PATH" >/dev/null 2>&1 || true
   if [[ -n "${BLOCKER_RECREATE_PID:-}" ]]; then
     kill "$BLOCKER_RECREATE_PID" >/dev/null 2>&1 || true
     wait "$BLOCKER_RECREATE_PID" >/dev/null 2>&1 || true
@@ -151,7 +153,18 @@ git -C "$REPO_FIXTURE_DIR" commit -m "Initial fixture" >/dev/null 2>&1
 
 cat > "$CONFIG_PATH" <<'EOF'
 {
-  "maxConcurrency": 2
+  "maxConcurrency": 2,
+  "worktreeTargets": {
+    "repro-local": {}
+  },
+  "executionPools": {
+    "repro-local": {
+      "members": [
+        { "type": "worktree", "id": "repro-local", "maxConcurrentTasks": 2 }
+      ]
+    }
+  },
+  "defaultPoolId": "repro-local"
 }
 EOF
 
@@ -166,7 +179,7 @@ tasks:
   - id: blocker-slow
     description: Running task whose recreate-task mutation keeps the workflow mutation queue occupied
     command: >-
-      bash -lc 'sleep 20'
+      bash -lc 'while [ ! -e "$BLOCKER_RELEASE_PATH" ]; do sleep 0.1; done'
 EOF
 
 HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test \


### PR DESCRIPTION
## Summary

`required/23a-recreate-task-queue-authority.sh` was timing out on master: `repro: timed out waiting for wf-.../blocker-slow to reach status running (last=completed)`.

The repro seeds two tasks and assumes they run at the same time under `maxConcurrency: 2`, but the default local execution pool always caps a single worktree member at capacity 1. So the two tasks ran one after another instead of overlapping, and `blocker-slow` always finished before the repro's gating check on it ever fired.

This gives the repro its own 2-slot pool config and swaps `blocker-slow`'s fixed `sleep 20` for a release-file wait, so the two tasks genuinely overlap and the script tests what it says it tests.

## Review Claim

Approve widening the repro's own config to real 2-way concurrency and making the blocker task wait on a release file instead of a fixed timer, so the script's gating assertion is meaningful instead of timing-dependent.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only one test-fixture shell script changes; no product code is touched. The change cannot alter runtime scheduling behavior in Invoker itself — it only fixes how the repro exercises that behavior.

## Slice Rationale

A self-contained fix for one failing required check, independent of the other unrelated fixes landing alongside it in this pass.

## Non-goals

- Does not touch any product code.
- Does not carry over other unrelated changes from prior unlanded attempts at this same script (a separate poll-loop rewrite, a separate CLI helper) — kept to the minimal change that makes the check pass.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/23a-recreate-task-queue-authority.sh` — before: `repro: timed out waiting for wf-.../blocker-slow to reach status running (last=completed)`, exit 1; after: `repro: confirmed fix`, exit 0. Run twice, both clean.
- [x] `shellcheck scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh` — clean.
- [x] `node scripts/check-added-comments.mjs` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the repro shell script changes; no product scheduling or runtime behavior is modified.
> 
> **Overview**
> Fixes a flaky required repro that timed out because **`blocker-slow` never stayed `running`** when the test expected it to.
> 
> The repro’s generated **`config.json`** now defines a dedicated **`repro-local`** execution pool with **`maxConcurrentTasks: 2`**, so `target-fast` and `blocker-slow` can overlap instead of serializing under the default single-slot worktree cap.
> 
> **`blocker-slow`** no longer uses a fixed **`sleep 20`**; it blocks until a **`BLOCKER_RELEASE_PATH`** file exists, and **`cleanup`** touches that file so teardown can’t hang. The script can reliably wait for **`blocker-slow` = `running`** while the fast task completes, then exercise recreate-task queue authority as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e65052e75495684b763c6b1d0ac2fc5a9617b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->