### PR TITLE
[Cancel cascade skipped status](1) Treat an already-skipped dependent as never-started during cancel

### DIFF
--- a/packages/workflow-core/src/__tests__/cancel-task.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-task.test.ts
@@ -220,6 +220,22 @@ describe('cancelTask', () => {
     const attemptA = persistence.loadAttempt(orchestrator.getTask('a')!.execution.selectedAttemptId!);
     expect(attemptA?.status).toBe('failed');
     expect(orchestrator.getTask('b')!.execution.selectedAttemptId).toBeUndefined();
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+  });
+
+  it('keeps an already-skipped dependent blocked instead of reviving it as failed', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: sid(orchestrator, 0, 'a'), status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+    );
+    expect(orchestrator.getTask('b')!.status).toBe('skipped');
+
+    const result = orchestrator.cancelTask('a');
+
+    expect(result.cancelled).toContain(sid(orchestrator, 0, 'b'));
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+    expect(orchestrator.getTask('b')!.execution.error).toBeUndefined();
   });
 
   it('throws when cancelling a completed task', () => {

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -260,7 +260,7 @@ export function cancelTaskImpl(
     const neverStarted =
       id !== rootId &&
       !t.execution.startedAt &&
-      (t.status === 'pending' || (t.status as string) === 'queued' || t.status === 'blocked');
+      (t.status === 'pending' || (t.status as string) === 'queued' || t.status === 'blocked' || t.status === 'skipped');
 
     if (neverStarted) {
       const blockedChanges: TaskStateChanges = {


### PR DESCRIPTION
## Summary

`case-2.10-cancel-downstream.sh` failed on master: after task A is cancelled, downstream task B should end up blocked, but it ended up failed instead.

The cancel cascade's never-started check only covered pending, queued, and blocked tasks. A dependent already in the earlier-failure resting status (meaning it does not run) was not covered by that check, so a later cancel cascade overwrote it to failed with a terminated message, even though it does not actually execute.

This widens the check so that resting status is treated as never-started too, and it stays blocked instead.

## Review Claim

Approve widening the cancel cascade's never-started check to also cover a dependent already in the earlier-failure resting status, so it does not get overwritten to failed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only widens which prior task status counts as never-started during a cancel cascade, adding exactly one status value to an existing set. A dependent already in pending, queued, or blocked keeps its current outcome; only a dependent already in the earlier-failure resting status changes outcome, from failed to blocked, which is correct since it does not actually execute.

## Slice Rationale

A self-contained fix for one failing required check, independent of the other unrelated fixes landing alongside it in this pass.

## Non-goals

- Does not touch the separate downstream-workflow-detach cascade mechanism (a different code path, unrelated to this single-task cancel check).
- Does not change behavior for any dependent status other than the one added here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Unit repro, fix reverted: `expected 'failed' to be 'blocked'`; fix restored: passes.
- [x] `pnpm test` in `packages/workflow-core` (`cancel-task.test.ts`) — 19/19 pass.
- [x] `pnpm test` in `packages/workflow-core` (full package) — 61 files, 1010 passed, 3 pre-existing (does not relate to this change), exit 0.
- [x] `bash scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh` — before: `FAIL case 2.10: expected B=blocked|pending, got B='failed'`; after: `PASS case 2.10 (cancel A -> A=failed, B=blocked)`, exit 0, two consecutive runs.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-status widening in cancel cascade routing; only changes outcome for dependents already in `skipped`, with targeted tests and e2e coverage.
> 
> **Overview**
> Fixes cancel cascade incorrectly marking **skipped** downstream tasks as **failed** when the upstream task is cancelled after an earlier failure already skipped them.
> 
> The `neverStarted` branch in `cancelTaskImpl` now treats `skipped` like `pending`/`queued`/`blocked`: dependents that never actually ran get **`blocked`** with an upstream-terminated `blockedBy` message and **no** termination error, instead of a fake run failure.
> 
> Adds unit coverage for cancel-after-upstream-fail (B stays `skipped` then `blocked` on cancel A) and asserts running-cancel leaves never-started B as `blocked`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cffec2bac74adbc6a56c1eeb52997c2b6f8eb212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->