### PR TITLE
[Worker-submitted task priority](1) Default worker-submitted tasks to lower scheduler priority

### DIFF
--- a/packages/app/src/__tests__/plan-submission-loader.test.ts
+++ b/packages/app/src/__tests__/plan-submission-loader.test.ts
@@ -132,4 +132,50 @@ workflows:
       gatePolicy: 'review_ready',
     });
   });
+
+  it('defaults worker-submitted task priority below human-submitted default', async () => {
+    const { deps, loadedPlans } = makeDeps();
+    const plan = `
+name: Worker Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: build
+    description: Build it
+`;
+
+    await loadPlanSubmissionBundle(plan, deps, { submittedBy: 'worker' });
+
+    expect(loadedPlans[0]?.tasks[0]?.priority).toBeLessThan(0);
+  });
+
+  it('leaves task priority unset for a human-submitted plan', async () => {
+    const { deps, loadedPlans } = makeDeps();
+    const plan = `
+name: Human Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: build
+    description: Build it
+`;
+
+    await loadPlanSubmissionBundle(plan, deps);
+
+    expect(loadedPlans[0]?.tasks[0]?.priority).toBeUndefined();
+  });
+
+  it('does not override an explicit task priority on a worker-submitted plan', async () => {
+    const { deps, loadedPlans } = makeDeps();
+    const plan = `
+name: Worker Plan With Explicit Priority
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: build
+    description: Build it
+    priority: 5
+`;
+
+    await loadPlanSubmissionBundle(plan, deps, { submittedBy: 'worker' });
+
+    expect(loadedPlans[0]?.tasks[0]?.priority).toBe(5);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1398,15 +1398,16 @@ function startHeadlessMode(): void {
         planText: string,
         repositoryBinding?: InAppPlanningRepoBinding,
         staged = true,
+        submittedBy?: 'worker' | 'human',
       ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => (
         loadPlanSubmissionBundle(planText, {
           persistence,
           orchestrator,
           allowGraphMutation: invokerConfig.allowGraphMutation,
           logger,
-        }, { staged, repositoryBinding })
+        }, { staged, repositoryBinding, submittedBy })
       );
-      submitAdminBypassE2eBabysitPlan = (planText) => loadGeneratedPlan(planText);
+      submitAdminBypassE2eBabysitPlan = (planText) => loadGeneratedPlan(planText, undefined, true, 'worker');
 
       // Web clients get planning-chat token streaming over SSE. The bridge does
       // not exist yet when these handlers are built, so route through a
@@ -3177,7 +3178,7 @@ startMainProcessBootstrap({
       orchestrator,
       allowGraphMutation: invokerConfig.allowGraphMutation,
       logger,
-    }, { staged: true });
+    }, { staged: true, submittedBy: 'worker' });
 
     const guiMutationRegistrationContext: GuiMutationRegistrationContext = {
       ipcMain,

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -60,6 +60,17 @@ export function applyConfiguredPlanDefaults(plan: PlanDefinition): PlanDefinitio
   return applyPlanExecutionAgentDefault(plan, resolveDefaultExecutionAgent(loadConfig()));
 }
 
+export const WORKER_SUBMITTED_TASK_PRIORITY = -10;
+
+export function applyWorkerSubmittedTaskPriorityDefault(plan: PlanDefinition): PlanDefinition {
+  return {
+    ...plan,
+    tasks: plan.tasks.map((task) => (
+      task.priority === undefined ? { ...task, priority: WORKER_SUBMITTED_TASK_PRIORITY } : task
+    )),
+  };
+}
+
 
 export interface RawExperimentVariant {
   id?: string;
@@ -89,6 +100,7 @@ export interface RawPlanTask {
   executionAgent?: string;
   executionModel?: string;
   maxTurns?: number;
+  priority?: number;
   freshness?: unknown;
 }
 
@@ -523,6 +535,11 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
         throw new PlanParseError(`Task "${task.id}" field "maxTurns" must be a positive integer when provided`);
       }
     }
+    if (task.priority !== undefined) {
+      if (typeof task.priority !== 'number' || !Number.isInteger(task.priority)) {
+        throw new PlanParseError(`Task "${task.id}" field "priority" must be an integer when provided`);
+      }
+    }
 
     const freshness = (() => {
       try {
@@ -547,6 +564,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
       executionAgent: task.executionAgent?.trim() || undefined,
       executionModel: task.executionModel?.trim() || undefined,
       maxTurns: task.maxTurns,
+      priority: task.priority,
       ...(freshness !== undefined ? { freshness } : {}),
     };
   });

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -25,6 +25,7 @@ export interface PlanSubmissionLoadOptions {
   repositoryBinding?: InAppPlanningRepoBinding;
   taskHandles?: { clear(): void };
   staged?: boolean;
+  submittedBy?: 'worker' | 'human';
 }
 
 export async function loadPlanSubmissionBundle(
@@ -32,7 +33,11 @@ export async function loadPlanSubmissionBundle(
   deps: PlanSubmissionLoadDeps,
   options?: PlanSubmissionLoadOptions,
 ): Promise<PlanSubmissionLoadResult> {
-  const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
+  const {
+    applyConfiguredPlanDefaults,
+    applyWorkerSubmittedTaskPriorityDefault,
+    parsePlanSubmissionBundle,
+  } = await import('./plan-parser.js');
   const submission = parsePlanSubmissionBundle(planText);
   const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
   const loadedWorkflowIds: string[] = [];
@@ -53,6 +58,9 @@ export async function loadPlanSubmissionBundle(
       ? { ...parsedPlan, repoUrl: options.repositoryBinding.repoUrl }
       : parsedPlan;
     let plan = applyConfiguredPlanDefaults(resolvedPlan);
+    if (options?.submittedBy === 'worker') {
+      plan = applyWorkerSubmittedTaskPriorityDefault(plan);
+    }
     if (!submission.isStack) {
       plan = { ...plan, baseBranch: PINNED_WORKFLOW_BASE_BRANCH };
     }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4745,6 +4745,33 @@ describe('Orchestrator', () => {
       expect(orchestrator.getAllTasks().filter((t) => t.status === 'running')).toHaveLength(3);
       expect(orchestrator.getAllTasks().filter((t) => t.status === 'pending')).toHaveLength(2);
     });
+
+    it('launches a higher-priority ready task before a lower-priority one under constrained capacity', () => {
+      const reproPersistence = new InMemoryPersistence();
+      const reproBus = new InMemoryBus();
+      const repro = new Orchestrator({
+        persistence: reproPersistence,
+        messageBus: reproBus,
+        maxConcurrency: 1,
+      });
+
+      repro.loadPlan({
+        name: 'priority-order-test',
+        tasks: [
+          { id: 'a-worker-task', description: 'Worker task', priority: -10 },
+          { id: 'z-human-task', description: 'Human task' },
+        ],
+      });
+
+      const humanId = sid(repro, 0, 'z-human-task');
+      const workerId = sid(repro, 0, 'a-worker-task');
+
+      const started = repro.startExecution();
+      expect(started).toHaveLength(1);
+      expect(started[0]!.id).toBe(humanId);
+      expect(repro.getTask(humanId)?.status).toBe('running');
+      expect(repro.getTask(workerId)?.status).toBe('pending');
+    });
   });
 
   // ── DB-is-source-of-truth invariants ──────────────────

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -460,6 +460,7 @@ export interface PlanDefinition {
     executionAgent?: string;
     executionModel?: string;
     maxTurns?: number;
+    priority?: number;
     freshness?: TaskFreshnessSpec;
   }>;
 }
@@ -1530,6 +1531,7 @@ export class Orchestrator {
         executionAgent: taskDef.executionAgent,
         executionModel: taskDef.executionModel,
         maxTurns: taskDef.maxTurns,
+        priority: taskDef.priority,
         ...(taskDef.freshness !== undefined ? { freshness: taskDef.freshness } : {}),
       } as const;
       let taskConfig: TaskConfig;

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -78,7 +78,8 @@ function getCandidatePriority(host: SchedulerDomainHost, task: TaskState, fallba
   const attempt = task.execution.selectedAttemptId
     ? host.loadAttemptById(task.execution.selectedAttemptId)
     : undefined;
-  return Math.max(fallback, attempt?.queuePriority ?? fallback);
+  const base = fallback === 0 ? task.config.priority ?? 0 : fallback;
+  return Math.max(base, attempt?.queuePriority ?? base);
 }
 
 function hasActiveLaunchAttempt(


### PR DESCRIPTION
## Summary

A prior change added an optional priority number to a task's config, but nothing used it yet when the scheduler picked which ready task to launch next under limited capacity.

This makes the scheduler actually use that number, and gives one specific worker's own submitted plans a lower default so they do not compete evenly with a person's own work for launch slots.

Only the admin-bypass-e2e-babysit worker's plan submissions get the lower default; every other submission path keeps today's behavior unchanged.

## Review Claim

Approve wiring the existing priority field into launch ordering, and applying a lower default only to one named worker's own plan submissions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Purely additive to launch ordering: a task's priority now defaults to its own configured number instead of always zero, and the existing boost given to an expedited retry is unchanged. The lower default only applies when a caller explicitly passes a worker marker, which today is wired to exactly one submission path. Every other submission path still defaults to zero and behaves exactly as before.

## Slice Rationale

A self-contained first slice: wires the existing field into real ordering and applies it to the one worker path named for this change. A wider rollout to other workers is a later, separate slice.

## Visual Proof

This diff touches `packages/app/src/main.ts`, which the repository's path-based check always treats as UI-impacting. The actual change here only threads a marker parameter through one headless worker's internal plan-submission call; it does not touch any window, menu, or rendering code.

![App DAG view, unaffected by this change](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260904-341b4c/dag-loaded.png)

Manually inspected: opened the captured screenshot above (the app's normal task-graph view) after building with this change applied. Nothing renders differently, matching the Safety Invariant above that no submission path outside the one named worker changes behavior.

## Non-goals

- Does not change how other workers submit their own retries; those go through a different mechanism entirely and are not touched here.
- Does not add any bound on the priority number itself.
- Does not change behavior for any submission that omits the worker marker.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Ordering repro, fix reverted: `AssertionError: expected 'wf-test-1/a-worker-task' to be 'wf-test-1/z-human-task'` (task ids chosen so the assertion cannot pass by id order alone); fix restored: passes.
- [x] `pnpm test` in `packages/workflow-core` (`orchestrator.test.ts`) — 293/293 pass.
- [x] `pnpm test` in `packages/app` (`plan-submission-loader.test.ts`) — 7/7 pass.
- [x] `pnpm test` in `packages/app` (`plan-parser.test.ts`) — 86/86 pass.
- [x] `pnpm run check:types` (repo-wide) — exit 0.
- [x] `pnpm test` in `packages/workflow-core` (full package) — 61 files, 1010 passed, exit 0.
- [x] `pnpm test` in `packages/app` (full package) — same 20/231 files failed with this change fully reverted from the working tree, confirmed unrelated to this change (machine load average 146 on a 10-core box from unrelated concurrent work at the time).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive scheduling and opt-in worker marking; only the named babysit worker submission path changes defaults, so human and other loaders behave as before.
> 
> **Overview**
> Under limited concurrency, the scheduler now honors each task’s configured **priority** when picking which ready task to launch (expedited retry boosts via attempt queue priority are unchanged).
> 
> Plan YAML may set an integer **`priority`** on tasks; worker submissions can get a default of **-10** when the field is omitted. **`loadPlanSubmissionBundle`** accepts **`submittedBy: 'worker' | 'human'`** and applies that default only for **`worker`**; explicit priorities are left alone, and human paths do not set a default. The **admin-bypass-e2e-babysit** investigative plan submitter is wired to pass **`submittedBy: 'worker'`** in both standalone and GUI owner bootstrap paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad643c80b17da11ed0fce0dff2a92b387cd8ab37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->