### PR TITLE
[Repair review-gate CI wiring](1) Wire repairReviewGateCi into delegated headless.exec

### DIFF
--- a/packages/app/src/__tests__/repair-review-gate-ci-wiring.test.ts
+++ b/packages/app/src/__tests__/repair-review-gate-ci-wiring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const GUI_MUTATION_HANDLERS = path.resolve(__dirname, '..', 'ipc', 'gui-mutation-handlers.ts');
+
+describe('repair-review-gate-ci delegated wiring', () => {
+  it('constructs repairReviewGateCi inside executeHeadlessExec so delegated headless.exec can reach it', () => {
+    const source = readFileSync(GUI_MUTATION_HANDLERS, 'utf8');
+    const fnStart = source.indexOf('async function executeHeadlessExec(');
+    const fnEnd = source.indexOf('\n  }\n', fnStart);
+    expect(fnStart, 'executeHeadlessExec not found').toBeGreaterThan(-1);
+    expect(fnEnd, 'executeHeadlessExec body end not found').toBeGreaterThan(fnStart);
+
+    const body = source.slice(fnStart, fnEnd);
+    expect(body).toContain('repairReviewGateCi:');
+    expect(body).toContain('repairReviewGateCiByPr(');
+    expect(body).toContain('submitRegisteredOwnerWorkerMutation && autoFixAttemptLedger');
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -37,6 +37,7 @@ import {
   parseSpawnRepairWorkflowMutationArgs,
   SPAWN_REPAIR_WORKFLOW_CHANNEL,
   submitRepairWorkflowFromCiFailure,
+  createAutoFixAttemptLedger,
   type WorktreeExecutor,
 } from '@invoker/execution-engine';
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
@@ -51,6 +52,7 @@ import {
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
 import { backupPlan } from '../plan-backup.js';
 import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
+import { repairReviewGateCiByPr } from '../review-gate-ci-repair-command.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
 import { publishForcedRefreshTaskGraphSnapshot, resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
@@ -370,6 +372,14 @@ export interface GuiMutationTaskActionsContext {
   cancelDeferredWorkflowLaunch: (workflowId: string, reason: string) => void;
   killRunningTask: (taskId: string) => Promise<void>;
   buildCommandServiceInvalidationDeps: () => ConstructorParameters<typeof CommandService>[1];
+  submitRegisteredOwnerWorkerMutation?: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    mutationArgs: unknown[],
+    options?: { deferDrain?: boolean },
+  ) => number;
+  autoFixAttemptLedger?: ReturnType<typeof createAutoFixAttemptLedger>;
 }
 
 export interface RegisterGuiMutationIpcHandlersContext extends GuiMutationTaskActionsContext {
@@ -424,6 +434,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     cancelDeferredWorkflowLaunch,
     killRunningTask,
     buildCommandServiceInvalidationDeps,
+    submitRegisteredOwnerWorkerMutation,
+    autoFixAttemptLedger,
   } = context;
   let orchestrator = context.getOrchestrator();
   let commandService = context.getCommandService();
@@ -800,6 +812,23 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       ownerTaskRunnerProvider: headlessCommand === 'check-pr-status'
         ? () => requireTaskExecutor()
         : undefined,
+      ...(submitRegisteredOwnerWorkerMutation && autoFixAttemptLedger
+        ? {
+          repairReviewGateCi: (prArg: string) => repairReviewGateCiByPr(prArg, {
+            persistence,
+            repoRoot,
+            policy: {
+              store: persistence,
+              submitter: { submit: submitRegisteredOwnerWorkerMutation },
+              logger,
+              defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+              getAutoFixAgent: () => invokerConfig.autoFixAgent,
+              getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+              attemptLedger: autoFixAttemptLedger,
+            },
+          }),
+        }
+        : {}),
     });
     const { workflowId } = classifyHeadlessExecMutation(payload);
     logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {


### PR DESCRIPTION
## Summary

`--headless repair-review-gate-ci <PR>` exists and works when a fresh standalone process runs it directly, but production never runs it that way.

A live owner-serve process always intercepts a delegated call first, and the deps object built for that path never included the repair callback. Every real call failed with "Review-gate CI repair is unavailable in this process."

This wires the callback into the same deps object the delegated path actually uses, matching how the direct path already builds it.

## Review Claim

Approve constructing the repair callback inside `executeHeadlessExec`'s own deps object, gated on two new optional context fields a follow-up slice supplies, so a delegated call can reach the same code a direct call already does.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely additive: one new field is added to an existing deps object and to an existing context type, built the same way an already-working sibling path builds it. No existing field, call, or behavior changes; every other command dispatched through this deps object keeps its exact current behavior.

## Slice Rationale

A self-contained fix for one missing wire, isolated from the unrelated fixes and the feature slice landing alongside it in this pass.

## Non-goals

- Does not change the command's own logic; only makes it reachable.
- Does not add a way to override the acting agent for this command; it already uses the owner's configured default agent.
- Does not wire the two new context fields from `main.ts`'s own call sites yet — that's the immediate follow-up slice in this stack. Until it lands, the two new fields are simply absent on every existing caller and the callback stays omitted, so this slice alone changes no observable behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Live repro against a real running owner (not a mock): `Delegation error: Review-gate CI repair is unavailable in this process.` before this fix (still true until the follow-up slice lands, since nothing passes the new fields yet).
- [x] New regression test, fix reverted (`gui-mutation-handlers.ts` checked out from the parent commit): `AssertionError: expected ... to contain 'repairReviewGateCi:'`; fix restored: 1 passed.
- [x] `pnpm run check:types` (repo-wide, this slice alone, `main.ts` untouched) — exit 0.
- [x] Related existing suite together — `repair-review-gate-ci-wiring.test.ts`, `headless-repair-review-gate-ci.test.ts`, `review-gate-ci-repair-command.test.ts`, `standalone-owner-handler-ordering.test.ts`, `headless-exec-ack-ok-precedence.test.ts` — 5 files, 15/15 pass.
- [x] `node scripts/check-added-comments.mjs` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional deps on the delegated headless path; no behavior change until context fields are supplied from main.
> 
> **Overview**
> **Delegated `headless.exec` can now supply `repairReviewGateCi`** when the GUI mutation context includes both `submitRegisteredOwnerWorkerMutation` and `autoFixAttemptLedger`. Inside `executeHeadlessExec`, the `runHeadless` deps object conditionally adds a callback that delegates to `repairReviewGateCiByPr` with persistence, repo root, and auto-fix policy (mutation submitter, retries, agent/model, attempt ledger).
> 
> `GuiMutationTaskActionsContext` grows those two optional fields so a follow-up can pass them from the owner process; **until that wiring lands, existing callers omit them and behavior stays the same** (the repair command remains unavailable on the delegated path).
> 
> A **source-level regression test** asserts `executeHeadlessExec` contains the gated `repairReviewGateCi` construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2697c413a930fe8cbad9ceb0721d9fb2fea10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Headless execution now correctly connects to the repair-review-gate CI workflow when the required configuration is available.
  - Automated repair attempts can now use the configured submitter, retry settings, agent, model, and attempt tracking.

- **Tests**
  - Added coverage to verify that headless execution includes the repair-review-gate CI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->