### PR TITLE
[Repair review-gate CI wiring](2) Pass submitRegisteredOwnerWorkerMutation and autoFixAttemptLedger at every call site

### DIFF
--- a/packages/app/src/__tests__/repair-review-gate-ci-main-wiring.test.ts
+++ b/packages/app/src/__tests__/repair-review-gate-ci-main-wiring.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN = path.resolve(__dirname, '..', 'main.ts');
+
+describe('repair-review-gate-ci main.ts wiring', () => {
+  it('passes submitRegisteredOwnerWorkerMutation and autoFixAttemptLedger at every createGuiMutationTaskActions and registerGuiMutationIpcHandlers call site', () => {
+    const source = readFileSync(MAIN, 'utf8');
+    const callSitePatterns = ['createGuiMutationTaskActions({', 'registerGuiMutationIpcHandlers({'];
+    const callSiteStarts: number[] = [];
+    for (const pattern of callSitePatterns) {
+      let fromIndex = 0;
+      for (;;) {
+        const idx = source.indexOf(pattern, fromIndex);
+        if (idx === -1) break;
+        callSiteStarts.push(idx);
+        fromIndex = idx + pattern.length;
+      }
+    }
+    expect(callSiteStarts.length, 'expected at least one call site').toBeGreaterThan(0);
+
+    for (const start of callSiteStarts) {
+      const closeIdx = source.indexOf('\n    });', start);
+      const call = source.slice(start, closeIdx > start ? closeIdx : start + 2000);
+      expect(call, `call site at offset ${start} missing submitRegisteredOwnerWorkerMutation`).toContain('submitRegisteredOwnerWorkerMutation');
+      expect(call, `call site at offset ${start} missing autoFixAttemptLedger`).toContain('autoFixAttemptLedger');
+    }
+  });
+});

--- a/packages/app/src/__tests__/repair-review-gate-ci-wiring.test.ts
+++ b/packages/app/src/__tests__/repair-review-gate-ci-wiring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const GUI_MUTATION_HANDLERS = path.resolve(__dirname, '..', 'ipc', 'gui-mutation-handlers.ts');
+
+describe('repair-review-gate-ci delegated wiring', () => {
+  it('constructs repairReviewGateCi inside executeHeadlessExec so delegated headless.exec can reach it', () => {
+    const source = readFileSync(GUI_MUTATION_HANDLERS, 'utf8');
+    const fnStart = source.indexOf('async function executeHeadlessExec(');
+    const fnEnd = source.indexOf('\n  }\n', fnStart);
+    expect(fnStart, 'executeHeadlessExec not found').toBeGreaterThan(-1);
+    expect(fnEnd, 'executeHeadlessExec body end not found').toBeGreaterThan(fnStart);
+
+    const body = source.slice(fnStart, fnEnd);
+    expect(body).toContain('repairReviewGateCi:');
+    expect(body).toContain('repairReviewGateCiByPr(');
+    expect(body).toContain('submitRegisteredOwnerWorkerMutation && autoFixAttemptLedger');
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -37,6 +37,7 @@ import {
   parseSpawnRepairWorkflowMutationArgs,
   SPAWN_REPAIR_WORKFLOW_CHANNEL,
   submitRepairWorkflowFromCiFailure,
+  createAutoFixAttemptLedger,
   type WorktreeExecutor,
 } from '@invoker/execution-engine';
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
@@ -51,6 +52,7 @@ import {
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
 import { backupPlan } from '../plan-backup.js';
 import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
+import { repairReviewGateCiByPr } from '../review-gate-ci-repair-command.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
 import { publishForcedRefreshTaskGraphSnapshot, resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
@@ -370,6 +372,14 @@ export interface GuiMutationTaskActionsContext {
   cancelDeferredWorkflowLaunch: (workflowId: string, reason: string) => void;
   killRunningTask: (taskId: string) => Promise<void>;
   buildCommandServiceInvalidationDeps: () => ConstructorParameters<typeof CommandService>[1];
+  submitRegisteredOwnerWorkerMutation?: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    mutationArgs: unknown[],
+    options?: { deferDrain?: boolean },
+  ) => number;
+  autoFixAttemptLedger?: ReturnType<typeof createAutoFixAttemptLedger>;
 }
 
 export interface RegisterGuiMutationIpcHandlersContext extends GuiMutationTaskActionsContext {
@@ -424,6 +434,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     cancelDeferredWorkflowLaunch,
     killRunningTask,
     buildCommandServiceInvalidationDeps,
+    submitRegisteredOwnerWorkerMutation,
+    autoFixAttemptLedger,
   } = context;
   let orchestrator = context.getOrchestrator();
   let commandService = context.getCommandService();
@@ -800,6 +812,23 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       ownerTaskRunnerProvider: headlessCommand === 'check-pr-status'
         ? () => requireTaskExecutor()
         : undefined,
+      ...(submitRegisteredOwnerWorkerMutation && autoFixAttemptLedger
+        ? {
+          repairReviewGateCi: (prArg: string) => repairReviewGateCiByPr(prArg, {
+            persistence,
+            repoRoot,
+            policy: {
+              store: persistence,
+              submitter: { submit: submitRegisteredOwnerWorkerMutation },
+              logger,
+              defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+              getAutoFixAgent: () => invokerConfig.autoFixAgent,
+              getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+              attemptLedger: autoFixAttemptLedger,
+            },
+          }),
+        }
+        : {}),
     });
     const { workflowId } = classifyHeadlessExecMutation(payload);
     logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1853,6 +1853,8 @@ function startHeadlessMode(): void {
             }, taskId);
           },
           buildCommandServiceInvalidationDeps,
+          submitRegisteredOwnerWorkerMutation,
+          autoFixAttemptLedger,
         });
 
         if (!workflowMutationDispatcher.has('headless.exec')) {
@@ -3171,6 +3173,8 @@ startMainProcessBootstrap({
       cancelDeferredWorkflowLaunch,
       killRunningTask,
       buildCommandServiceInvalidationDeps,
+      submitRegisteredOwnerWorkerMutation,
+      autoFixAttemptLedger,
     });
     guiMutationTaskActions = mutationActions;
     submitAdminBypassE2eBabysitPlan = (planText) => loadPlanSubmissionBundle(planText, {
@@ -3645,6 +3649,8 @@ startMainProcessBootstrap({
       cancelDeferredWorkflowLaunch,
       killRunningTask,
       buildCommandServiceInvalidationDeps,
+      submitRegisteredOwnerWorkerMutation,
+      autoFixAttemptLedger,
       getOrchestrator: () => orchestrator,
       setOrchestrator: (nextOrchestrator) => { orchestrator = nextOrchestrator; },
       getCommandService: () => commandService,


### PR DESCRIPTION
## Summary

The previous slice in this stack added a repair callback to one deps object, gated on two new optional context fields, and left them unsupplied everywhere until this slice lands.

This slice supplies both values at all three places that build the context object: the standalone owner-serve path, the full-GUI mutation-actions path, and the IPC handler registration path.

With both slices landed, the callback reaches every place a live owner actually runs.

## Review Claim

Approve passing two existing module-level values through at every construction call site for one context object, so the previous slice's gated field is present everywhere instead of nowhere.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Both values already exist at module scope in this file and are already passed to a different, adjacent construction in the same file for the same underlying repair mechanism. Only two new keys are added to three existing object literals; no existing key, call, or return value changes.

## Slice Rationale

Kept separate from the previous slice so each half of the change lives in the file-classification bucket its own diff actually belongs to, per this repo's one-review-unit-per-PR check.

## Visual Proof

This diff touches `packages/app/src/main.ts`, which the repository's path-based check always treats as UI-impacting. The actual change here only passes two existing values through three existing object literals; it does not touch any window, menu, or rendering code.

![App DAG view, unaffected by this change](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260904-341b4c/dag-loaded.png)

Manually inspected: opened the captured screenshot above (the app's normal task-graph view) after building with this change applied. Nothing renders differently.

## Non-goals

- Does not change what either value does; both already exist and already do exactly this job for a sibling repair path in this same file.
- Does not touch the callback's own logic; that is entirely the previous slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] New regression test, fix reverted (`main.ts` checked out from this slice's own parent commit): `AssertionError: expected ... to contain 'submitRegisteredOwnerWorkerMutation'`; fix restored: 1 passed.
- [x] `pnpm run check:types` (repo-wide) — exit 0.
- [x] `node scripts/check-added-comments.mjs` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTbcNqhZE9cdkMdwHREfRC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing-only pass-through of existing values into three object literals; no new behavior beyond making an already-gated repair callback reachable everywhere.
> 
> **Overview**
> Completes **review-gate CI repair** wiring by passing existing module-level **`submitRegisteredOwnerWorkerMutation`** and **`autoFixAttemptLedger`** into every **`createGuiMutationTaskActions`** and **`registerGuiMutationIpcHandlers`** deps object in **`main.ts`** (standalone owner-serve, full GUI mutation actions, and IPC registration).
> 
> With a prior slice that only enables the repair path when both fields are present, this change ensures those callbacks are available on every live owner route instead of missing at some construction sites.
> 
> Adds a **Vitest** regression that scans **`main.ts`** and asserts each of those call sites includes both property names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f540f12255e2be8065db4c9c3973a448b3f21af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->