### PR TITLE
[Worker Session Mine](1) Parse real Codex response_item/event_msg log shape

### DIFF
--- a/scripts/worker-session-mine-thrash.mjs
+++ b/scripts/worker-session-mine-thrash.mjs
@@ -53,12 +53,28 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
     } catch {
       continue;
     }
+    let countedByFormat = false;
+
+    // Legacy Codex stream
+    if (row.type === 'turn.completed' || row.type === 'turn.failed') {
+      assistantTurns += 1;
+      const usage = row.usage ?? {};
+      cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.input_tokens ?? usage.cached_tokens ?? 0) || 0;
+      countedByFormat = true;
+    }
+    if (row.type === 'item.completed' && row.item?.type === 'command_execution') {
+      const cmd = String(row.item?.command ?? row.item?.cmd ?? '').trim();
+      if (cmd) bashCounts.set(cmd, (bashCounts.get(cmd) ?? 0) + 1);
+      countedByFormat = true;
+    }
+
+    // Current Codex stream
     if (row.type === 'event_msg' && row.payload?.type === 'token_count') {
       assistantTurns += 1;
       const usage = row.payload?.info?.total_token_usage ?? {};
       const cached = Number(usage.cached_input_tokens ?? 0) || 0;
       if (cached > codexCacheReadTokens) codexCacheReadTokens = cached;
-      continue;
+      countedByFormat = true;
     }
     if (row.type === 'response_item') {
       const payload = row.payload ?? {};
@@ -69,11 +85,11 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
         codexCmd = extractCodexExecCommandFromArguments(payload.arguments);
       }
       if (codexCmd) bashCounts.set(codexCmd, (bashCounts.get(codexCmd) ?? 0) + 1);
-      continue;
+      countedByFormat = true;
     }
     const msg = row.message ?? row;
     const role = msg.role ?? row.type;
-    if (role === 'assistant' || row.type === 'assistant') {
+    if (!countedByFormat && (role === 'assistant' || row.type === 'assistant')) {
       assistantTurns += 1;
       const usage = msg.usage ?? row.usage ?? {};
       cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.cacheReadInputTokens ?? 0) || 0;

--- a/scripts/worker-session-mine-thrash.mjs
+++ b/scripts/worker-session-mine-thrash.mjs
@@ -17,10 +17,32 @@ export function sessionHash(sessionId, workflowName = '') {
   return createHash('sha256').update(`${workflowName}\0${sessionId}`).digest('hex').slice(0, 16);
 }
 
+function extractCodexExecCommandFromJsInput(input) {
+  if (typeof input !== 'string') return '';
+  const match = /cmd\s*:\s*"((?:\\.|[^"\\])*)"/.exec(input);
+  if (!match) return '';
+  try {
+    return String(JSON.parse(`"${match[1]}"`)).trim();
+  } catch {
+    return '';
+  }
+}
+
+function extractCodexExecCommandFromArguments(args) {
+  if (typeof args !== 'string') return '';
+  try {
+    const parsed = JSON.parse(args);
+    return String(parsed?.cmd ?? parsed?.command ?? '').trim();
+  } catch {
+    return '';
+  }
+}
+
 export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
   const lines = text.split(/\r?\n/).filter(Boolean);
   let assistantTurns = 0;
   let cacheReadTokens = 0;
+  let codexCacheReadTokens = 0;
   const bashCounts = new Map();
   let workflowHint = '';
 
@@ -31,16 +53,23 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
     } catch {
       continue;
     }
-    // Codex structured stream
-    if (row.type === 'turn.completed' || row.type === 'turn.failed') {
+    if (row.type === 'event_msg' && row.payload?.type === 'token_count') {
       assistantTurns += 1;
-      const usage = row.usage ?? {};
-      cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.input_tokens ?? 0) || 0;
+      const usage = row.payload?.info?.total_token_usage ?? {};
+      const cached = Number(usage.cached_input_tokens ?? 0) || 0;
+      if (cached > codexCacheReadTokens) codexCacheReadTokens = cached;
       continue;
     }
-    if (row.type === 'item.completed' && row.item?.type === 'command_execution') {
-      const cmd = String(row.item?.command ?? row.item?.cmd ?? '').trim();
-      if (cmd) bashCounts.set(cmd, (bashCounts.get(cmd) ?? 0) + 1);
+    if (row.type === 'response_item') {
+      const payload = row.payload ?? {};
+      let codexCmd = '';
+      if (payload.type === 'custom_tool_call' && payload.name === 'exec') {
+        codexCmd = extractCodexExecCommandFromJsInput(payload.input);
+      } else if (payload.type === 'function_call' && payload.name === 'exec_command') {
+        codexCmd = extractCodexExecCommandFromArguments(payload.arguments);
+      }
+      if (codexCmd) bashCounts.set(codexCmd, (bashCounts.get(codexCmd) ?? 0) + 1);
+      continue;
     }
     const msg = row.message ?? row;
     const role = msg.role ?? row.type;
@@ -71,6 +100,8 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
       else if (/Failed check:/i.test(joined)) workflowHint = 'admin-bypass-repair';
     }
   }
+
+  cacheReadTokens += codexCacheReadTokens;
 
   let maxSameBash = 0;
   let maxSameBashCmd = '';
@@ -181,10 +212,76 @@ function selfTest() {
   const neg = analyzeClaudeJsonl(clean);
   if (!pos.thrash) throw new Error('expected thrash fixture to fire');
   if (neg.thrash) throw new Error('expected clean fixture to stay silent');
-  const codexThrashy = Array.from({ length: 40 }, () => JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } })).join('\n');
-  const codexPos = analyzeClaudeJsonl(codexThrashy);
-  if (!codexPos.thrash) throw new Error('expected codex turn.completed thrash');
-  console.log(JSON.stringify({ ok: true, positiveReasons: pos.reasons, negativeThrash: neg.thrash, codexReasons: codexPos.reasons }, null, 2));
+
+  const codexTokenCountRow = (cachedInputTokens) => JSON.stringify({
+    timestamp: '2026-09-01T00:00:00.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: { input_tokens: cachedInputTokens * 2, cached_input_tokens: cachedInputTokens },
+        last_token_usage: { input_tokens: cachedInputTokens, cached_input_tokens: cachedInputTokens },
+      },
+    },
+  });
+  const codexExecRow = (cmd) => JSON.stringify({
+    timestamp: '2026-09-01T00:00:00.000Z',
+    type: 'response_item',
+    payload: {
+      type: 'custom_tool_call',
+      status: 'completed',
+      call_id: 'call_x',
+      name: 'exec',
+      input: `const r = await tools.exec_command({cmd:"${cmd}","workdir":"/repo","yield_time_ms":10000,"max_output_tokens":20000});\ntext(r.output);`,
+    },
+  });
+  const codexFunctionCallExecRow = (cmd) => JSON.stringify({
+    timestamp: '2026-07-03T00:00:00.000Z',
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      name: 'exec_command',
+      arguments: JSON.stringify({ cmd, workdir: '/repo', yield_time_ms: 10_000, max_output_tokens: 20_000 }),
+      call_id: 'call_y',
+    },
+  });
+
+  const codexTurnsRows = Array.from({ length: 40 }, (_, i) => codexTokenCountRow(100 * (i + 1)));
+  const codexRepeatedExecRows = Array.from({ length: 5 }, () => codexExecRow('pnpm test'));
+  const codexJsThrashy = [...codexTurnsRows, ...codexRepeatedExecRows].join('\n');
+  const codexJsPos = analyzeClaudeJsonl(codexJsThrashy);
+  if (!codexJsPos.thrash) throw new Error('expected codex response_item/event_msg thrash to fire');
+  if (codexJsPos.assistantTurns !== 40) throw new Error(`expected 40 codex assistant turns, got ${codexJsPos.assistantTurns}`);
+  if (codexJsPos.cacheReadTokens !== 4000) throw new Error(`expected codex cache_read_tokens to take the final cumulative value (4000), got ${codexJsPos.cacheReadTokens}`);
+  if (codexJsPos.maxSameBash !== 5) throw new Error(`expected 5 repeated codex exec commands, got ${codexJsPos.maxSameBash}`);
+
+  const codexFnCallThrashy = [
+    codexTokenCountRow(100),
+    codexTokenCountRow(200),
+    ...Array.from({ length: 5 }, () => codexFunctionCallExecRow('rg -n foo .')),
+  ].join('\n');
+  const codexFnCallPos = analyzeClaudeJsonl(codexFnCallThrashy);
+  if (!codexFnCallPos.thrash) throw new Error('expected codex function_call/exec_command thrash to fire');
+  if (codexFnCallPos.maxSameBash !== 5) throw new Error(`expected 5 repeated codex exec_command commands, got ${codexFnCallPos.maxSameBash}`);
+
+  const codexClean = [
+    codexTokenCountRow(100),
+    codexTokenCountRow(200),
+    codexTokenCountRow(300),
+    codexExecRow('git status'),
+    codexExecRow('pnpm build'),
+  ].join('\n');
+  const codexNeg = analyzeClaudeJsonl(codexClean);
+  if (codexNeg.thrash) throw new Error('expected clean codex fixture to stay silent');
+
+  console.log(JSON.stringify({
+    ok: true,
+    positiveReasons: pos.reasons,
+    negativeThrash: neg.thrash,
+    codexJsReasons: codexJsPos.reasons,
+    codexFnCallReasons: codexFnCallPos.reasons,
+    codexNegativeThrash: codexNeg.thrash,
+  }, null, 2));
 }
 
 const isMain = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('worker-session-mine-thrash.mjs');


### PR DESCRIPTION
## Summary

The worker-session-mine thrash detector's Codex parser looked for row shapes that never appear in real Codex agent session logs.

Real logs use `event_msg`, `response_item`, `token_count`, and `function_call` rows. The detector only recognized `turn.completed`, `item.completed`, and `command_execution`.

Confirmed against a real 715-line Codex rollout JSONL: before this fix the detector read zero assistant turns and zero cached tokens.

After the fix it correctly reads 135 turns and flags thrash.

This fix teaches the parser the real row shape. It does not change how Claude JSONL sessions are parsed.

## Review Claim

The mechanical thrash detector correctly reads real Codex agent session logs (previously blind to them) without changing its existing Claude-session parsing behavior.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only widens which row shapes the mechanical thrash parser recognizes (adds Codex `event_msg`/`response_item`/`token_count`/`function_call` handling). The existing Claude JSONL shape (`type: 'assistant'`/`'user'`) parsing is untouched, its self-test assertions still pass unchanged, and no other file or behavior is touched.

## Slice Rationale

Single-file, single-concern fix isolated from a much larger uncommitted branch that also contained many already-superseded drafts; those were discarded rather than bundled here.

## Non-goals

Does not change worker scheduling, session mining orchestration, thresholds, or any file other than `scripts/worker-session-mine-thrash.mjs`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine-thrash.mjs --self-test` — exits 0
- [x] Before fix, against a real Codex rollout JSONL: `assistantTurns=0, cacheReadTokens=0, maxSameBash=0` (fully blind)
- [x] After fix, same real file: `assistantTurns=135, cacheReadTokens=15967360, thrash=true`
- [x] `node scripts/check-added-comments.mjs --base origin/master` — no disallowed comments

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qwpVhbH1D99mQPxiAYpS3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session usage analysis for structured event streams.
  * Token and cached-input counts are now tracked more accurately.
  * Repeated command executions are now recognized across supported command formats.
  * Updated validation coverage to verify analysis across legacy and structured session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thrash-detection outcomes for Codex session logs (previously always under-counted); Claude parsing is gated but policy impact depends on newly flagged sessions.
> 
> **Overview**
> The mechanical thrash parser in `worker-session-mine-thrash.mjs` was effectively **blind to real Codex agent JSONL** because it only handled legacy `turn.completed` / `item.completed` rows, not the shapes that actually appear in rollouts.
> 
> **This PR extends `analyzeClaudeJsonl`** to recognize the current Codex stream: `event_msg` + `token_count` for assistant turns and cumulative `cached_input_tokens`, and `response_item` rows for repeated shell work via `custom_tool_call`/`exec` (JS `cmd:` snippet) and `function_call`/`exec_command` (JSON arguments). Legacy Codex rows still count, with an extra `cached_tokens` fallback and a `countedByFormat` guard so Claude `assistant`/`user` parsing is unchanged when Codex rows already handled the line.
> 
> **Self-tests** replace the old synthetic `turn.completed`-only Codex fixture with fixtures that mirror `event_msg`/`response_item` and assert turn counts, max cached tokens, repeated exec detection, and a clean negative case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed0b3cf0a90507a97f01619c98d9e1493bcdbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->