### PR TITLE
[Admin-bypass bot-thread repair](1) Give bot-thread repair plans publication authority

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -418,7 +418,8 @@ def build_repair_bot_thread_plan(
         f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
     )
     yaml_text = _write_plan_header(
-        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review"
+        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review", on_finish="pull_request",
+        description=f"Resolve an unresolved bot review thread on PR #{pr.number} with a real code change.",
     )
     yaml_text += _repair_task_yaml(description=f"Resolve bot review thread on PR #{pr.number}", prompt=prompt)
     yaml_text += _safe_push_task_yaml(

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -80,14 +80,14 @@ class AsyncRepairPlanTests(unittest.TestCase):
         bot_thread_plan = async_repair.build_repair_bot_thread_plan(
             pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
-        for plan, expected_task_ids, expected_merge_mode in (
-            (checks_plan, ["repair", "normalize", "safe-push"], "manual"),
-            (rebase_plan, ["repair", "safe-push"], "manual"),
-            (bot_thread_plan, ["repair", "safe-push"], "external_review"),
+        for plan, expected_task_ids, expected_merge_mode, expected_on_finish in (
+            (checks_plan, ["repair", "normalize", "safe-push"], "manual", "none"),
+            (rebase_plan, ["repair", "safe-push"], "manual", "none"),
+            (bot_thread_plan, ["repair", "safe-push"], "external_review", "pull_request"),
         ):
             with self.subTest(plan=plan.plan_name):
                 doc = yaml.safe_load(plan.yaml_text)
-                self.assertEqual(doc["onFinish"], "none")
+                self.assertEqual(doc["onFinish"], expected_on_finish)
                 self.assertEqual(doc["mergeMode"], expected_merge_mode)
                 self.assertEqual(doc["repoUrl"], "https://github.com/owner/repo.git")
                 self.assertEqual([task["id"] for task in doc["tasks"]], expected_task_ids)
@@ -336,6 +336,16 @@ class AsyncRepairPlanTests(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 async_repair.submit_async_repair_plan(plan)
 
+    def test_bot_thread_plan_yaml_is_accepted_by_invokers_real_plan_validator(self):
+        plan = async_repair.build_repair_bot_thread_plan(
+            pr(number=12006, head_ref_name="stack/bot-thread-example", merge_state_status="BLOCKED"),
+            "PRRT_example",
+            repo="owner/repo",
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assert_plan_accepted_by_real_validator(plan, "bot-thread")
+
     def test_requeue_stuck_plan_yaml_is_accepted_by_invokers_real_plan_validator(self):
         plan = async_repair.build_requeue_stuck_plan(
             pr(number=11441, head_ref_name="stack/requeue-stuck-example", merge_state_status="BLOCKED"),
@@ -344,7 +354,9 @@ class AsyncRepairPlanTests(unittest.TestCase):
             start_head=HEAD,
             state_file=Path("/tmp/ledger.jsonl"),
         )
+        self.assert_plan_accepted_by_real_validator(plan, "requeue-stuck")
 
+    def assert_plan_accepted_by_real_validator(self, plan, label):
         repo_root = Path(__file__).resolve().parent.parent
         validator = repo_root / "skills" / "plan-to-invoker" / "scripts" / "validate-plan.sh"
         self.assertTrue(validator.exists(), f"real validator missing at {validator}")
@@ -374,7 +386,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
             unexpected = [e for e in errors if e.get("errorType") != "non_portable_pipefail"]
             self.assertEqual(
                 unexpected, [],
-                f"requeue-stuck plan failed real Invoker plan validation: {unexpected}",
+                f"{label} plan failed real Invoker plan validation: {unexpected}",
             )
 
 


### PR DESCRIPTION
## Summary

The admin-bypass worker files a repair workflow when a PR is held only by an unresolved bot review thread. Since #11620 the owner rejects that workflow before it starts, because the plan asked for external review without permission to publish.

Every attempt for PR #12006 died at dispatch with that rejection, five minutes apart, so the PR sat unrepaired. The sibling requeue-stuck plan already declares the right pair, so this change makes the bot-thread plan match it.

A new test feeds the generated bot-thread plan through the real plan validator, the same way the requeue-stuck plan is already covered, so the two plans cannot drift apart again.

## Review Claim

The bot-thread repair plan now declares `onFinish: pull_request` with a plan description, so the owner accepts it instead of rejecting it at dispatch.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The generated plan still only commits locally and pushes through the same guarded safe-push task; the change touches the plan header, not what the repair task may do.

## Slice Rationale

One generator, one header fix, and the validator test that proves it form a single reviewable unit.

## Non-goals

Does not change the repair-check or rebase plans, the worker schedule, Mergify rules, or how the owner validates plans.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `INVOKER_REPO_ROOT=<checkout> python3 -m unittest scripts.test_mergify_admin_requeue_async_repair` (20 tests OK; the new bot-thread validator test failed before the change with `conflicting_fields` on mergeMode)
- [x] `node scripts/check-added-comments.mjs --base origin/master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated repair workflow handling for bot-review-thread issues by ensuring completed repairs are correctly associated with the relevant pull request.
  - Added descriptive information to these repair plans for clearer processing and status reporting.

- **Tests**
  - Expanded validation coverage to confirm repair plans use the correct completion behavior across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->