### PR TITLE
[Session miner token rule](2) Expose worker-session-mine as a CLI worker toggle

### DIFF
--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -40,6 +40,14 @@ describe('ONBOARDING_WORKER_TOGGLES', () => {
     expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'autofix')).toBe(false);
     expect(WORKER_TOGGLES.some((spec) => spec.id === 'pr-status')).toBe(true);
   });
+
+  it('exposes worker-session-mine as an opt-in desired-state toggle outside onboarding', () => {
+    const mine = findWorkerToggle('worker-session-mine')!;
+    expect(isDesiredStateWorkerToggle(mine)).toBe(true);
+    expect(mine.workerKinds).toEqual(['worker-session-mine']);
+    expect(mine.defaultEnabled).toBeUndefined();
+    expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'worker-session-mine')).toBe(false);
+  });
 });
 
 describe('policy applyWorkerToggle / readWorkerToggleValue', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -229,7 +229,7 @@ function usage(): string {
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
-    '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
+    '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, worker-session-mine, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
     '  auto-approve-authors  Show or set GitHub logins in config.json that auto-approve may act on. Does not enable the auto-approve toggle.',
     '',
     'Options:',

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -15,6 +15,7 @@ import {
   PR_DUPLICATE_CLOSE_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
+  WORKER_SESSION_MINE_WORKER_KIND,
 } from '@invoker/execution-engine';
 
 /**
@@ -102,6 +103,13 @@ export const WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
     description: 'Automatically reclaims disk space when a machine gets critically full. The monitoring worker always runs; this only controls whether it is allowed to delete anything.',
     configPath: 'diskHeadroom.cleanupEnabled',
     defaultEnabled: true,
+  },
+  {
+    id: 'worker-session-mine',
+    label: 'Worker session mine',
+    description: 'Mines finished worker agent sessions (Claude, Codex, OMP) for thrash: 40+ turns, 10M+ cache-read or total tokens, or the same shell command 5+ times. Files one Invoker follow-up per session, capped at 1 per tick and 2 per day. Off by default; enable on the DO1 owner only.',
+    workerKinds: [WORKER_SESSION_MINE_WORKER_KIND],
+    includeInOnboarding: false,
   },
   {
     id: 'idle-task-cleanup',

--- a/scripts/worker-session-mine-thrash.mjs
+++ b/scripts/worker-session-mine-thrash.mjs
@@ -10,6 +10,7 @@ import { spawnSync } from 'node:child_process';
 export const DEFAULT_THRESHOLDS = Object.freeze({
   minAssistantTurns: 40,
   minCacheReadTokens: 10_000_000,
+  minTotalTokens: 10_000_000,
   minSameBashArgv: 5,
 });
 
@@ -43,6 +44,8 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
   let assistantTurns = 0;
   let cacheReadTokens = 0;
   let codexCacheReadTokens = 0;
+  let totalTokens = 0;
+  let codexTotalTokens = 0;
   const bashCounts = new Map();
   let workflowHint = '';
 
@@ -60,6 +63,7 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
       assistantTurns += 1;
       const usage = row.usage ?? {};
       cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.input_tokens ?? usage.cached_tokens ?? 0) || 0;
+      totalTokens += (Number(usage.input_tokens ?? 0) || 0) + (Number(usage.output_tokens ?? 0) || 0);
       countedByFormat = true;
     }
     if (row.type === 'item.completed' && row.item?.type === 'command_execution') {
@@ -74,6 +78,8 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
       const usage = row.payload?.info?.total_token_usage ?? {};
       const cached = Number(usage.cached_input_tokens ?? 0) || 0;
       if (cached > codexCacheReadTokens) codexCacheReadTokens = cached;
+      const total = Number(usage.total_tokens ?? 0) || (Number(usage.input_tokens ?? 0) || 0) + (Number(usage.output_tokens ?? 0) || 0);
+      if (total > codexTotalTokens) codexTotalTokens = total;
       countedByFormat = true;
     }
     if (row.type === 'response_item') {
@@ -93,6 +99,10 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
       assistantTurns += 1;
       const usage = msg.usage ?? row.usage ?? {};
       cacheReadTokens += Number(usage.cache_read_input_tokens ?? usage.cacheReadInputTokens ?? 0) || 0;
+      totalTokens += (Number(usage.input_tokens ?? 0) || 0)
+        + (Number(usage.output_tokens ?? 0) || 0)
+        + (Number(usage.cache_read_input_tokens ?? usage.cacheReadInputTokens ?? 0) || 0)
+        + (Number(usage.cache_creation_input_tokens ?? usage.cacheCreationInputTokens ?? 0) || 0);
       const content = Array.isArray(msg.content) ? msg.content : [];
       for (const block of content) {
         if (block?.type === 'tool_use' && (block.name === 'Bash' || block.name === 'bash')) {
@@ -118,6 +128,7 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
   }
 
   cacheReadTokens += codexCacheReadTokens;
+  totalTokens += codexTotalTokens;
 
   let maxSameBash = 0;
   let maxSameBashCmd = '';
@@ -135,6 +146,9 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
   if (cacheReadTokens >= thresholds.minCacheReadTokens) {
     reasons.push(`cache_read_tokens=${cacheReadTokens}>=${thresholds.minCacheReadTokens}`);
   }
+  if (totalTokens >= thresholds.minTotalTokens) {
+    reasons.push(`total_tokens=${totalTokens}>=${thresholds.minTotalTokens}`);
+  }
   if (maxSameBash >= thresholds.minSameBashArgv) {
     reasons.push(`same_bash_argv=${maxSameBash}>=${thresholds.minSameBashArgv}`);
   }
@@ -145,6 +159,7 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
     maxSameBash,
     maxSameBashCmd: maxSameBashCmd.slice(0, 200),
     workflowHint,
+    totalTokens,
     thrash: reasons.length > 0,
     reasons,
   };
@@ -152,7 +167,7 @@ export function analyzeClaudeJsonl(text, thresholds = DEFAULT_THRESHOLDS) {
 
 export function analyzeClaudeJsonlFile(path, thresholds = DEFAULT_THRESHOLDS) {
   if (!existsSync(path)) {
-    return { thrash: false, reasons: [`missing:${path}`], assistantTurns: 0, cacheReadTokens: 0, maxSameBash: 0 };
+    return { thrash: false, reasons: [`missing:${path}`], assistantTurns: 0, cacheReadTokens: 0, totalTokens: 0, maxSameBash: 0 };
   }
   return analyzeClaudeJsonl(readFileSync(path, 'utf8'), thresholds);
 }
@@ -229,6 +244,30 @@ function selfTest() {
   if (!pos.thrash) throw new Error('expected thrash fixture to fire');
   if (neg.thrash) throw new Error('expected clean fixture to stay silent');
 
+  const heavyClaude = [
+    JSON.stringify({ type: 'user', message: { role: 'user', content: 'Fix CI job required-fast / Vitest Workspace' } }),
+    ...Array.from({ length: 12 }, () => JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: { input_tokens: 400_000, output_tokens: 5_000, cache_read_input_tokens: 500_000, cache_creation_input_tokens: 20_000 },
+        content: [{ type: 'text', text: 'working' }],
+      },
+    })),
+  ].join('\n');
+  const heavy = analyzeClaudeJsonl(heavyClaude);
+  if (heavy.totalTokens !== 11_100_000) throw new Error(`expected 11,100,000 total tokens, got ${heavy.totalTokens}`);
+  if (!heavy.reasons.some((r) => r.startsWith('total_tokens='))) throw new Error(`expected total_tokens reason, got ${JSON.stringify(heavy.reasons)}`);
+  if (heavy.reasons.some((r) => r.startsWith('cache_read_tokens=') || r.startsWith('assistant_turns='))) throw new Error('heavy fixture must trip only on total tokens');
+
+  const heavyCodex = [
+    JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 9_000_000, cached_input_tokens: 8_900_000, output_tokens: 40_000 } }),
+    JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1_500_000, cached_input_tokens: 1_400_000, output_tokens: 10_000 } }),
+  ].join('\n');
+  const heavyCodexRes = analyzeClaudeJsonl(heavyCodex, { ...DEFAULT_THRESHOLDS, minCacheReadTokens: 50_000_000 });
+  if (heavyCodexRes.totalTokens !== 10_550_000) throw new Error(`expected 10,550,000 codex mirror total tokens, got ${heavyCodexRes.totalTokens}`);
+  if (!heavyCodexRes.reasons.some((r) => r.startsWith('total_tokens='))) throw new Error('expected codex mirror total_tokens reason');
+
   const codexTokenCountRow = (cachedInputTokens) => JSON.stringify({
     timestamp: '2026-09-01T00:00:00.000Z',
     type: 'event_msg',
@@ -269,6 +308,7 @@ function selfTest() {
   if (!codexJsPos.thrash) throw new Error('expected codex response_item/event_msg thrash to fire');
   if (codexJsPos.assistantTurns !== 40) throw new Error(`expected 40 codex assistant turns, got ${codexJsPos.assistantTurns}`);
   if (codexJsPos.cacheReadTokens !== 4000) throw new Error(`expected codex cache_read_tokens to take the final cumulative value (4000), got ${codexJsPos.cacheReadTokens}`);
+  if (codexJsPos.totalTokens !== 8000) throw new Error(`expected codex total_tokens to take the final cumulative value (8000), got ${codexJsPos.totalTokens}`);
   if (codexJsPos.maxSameBash !== 5) throw new Error(`expected 5 repeated codex exec commands, got ${codexJsPos.maxSameBash}`);
 
   const codexFnCallThrashy = [
@@ -293,6 +333,8 @@ function selfTest() {
   console.log(JSON.stringify({
     ok: true,
     positiveReasons: pos.reasons,
+    heavyReasons: heavy.reasons,
+    heavyCodexReasons: heavyCodexRes.reasons,
     negativeThrash: neg.thrash,
     codexJsReasons: codexJsPos.reasons,
     codexFnCallReasons: codexFnCallPos.reasons,


### PR DESCRIPTION
## Summary

The worker-session-mine skill tells an operator to turn the miner on with `invoker-cli worker toggles --enable worker-session-mine`.

The CLI's toggle table never listed that worker, so the command answered "Unknown worker toggle id". On a headless owner such as DO1 there was no other way to enable it.

This adds the miner as an opt-in desired-state toggle. It stays out of onboarding so a fresh install is not prompted for it.

## Review Claim

`invoker-cli worker toggles --enable worker-session-mine` writes the miner's desired state exactly as the other worker toggles do.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The toggle has no default, so the miner stays off unless an operator enables it; onboarding does not present it.

## Slice Rationale

The toggle is a CLI activation change, separate from the scorer rule and the doc line.

## Non-goals

No change to the worker itself, its caps, or the desktop Workers surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && pnpm exec vitest run src/__tests__/worker-toggles.test.ts` (14 passed, including the new opt-in toggle assertion)
- [x] On DO1's 0.1.0 CLI the command answers `Unknown worker toggle id: "worker-session-mine"`, the failure this fixes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
