### PR TITLE
[Session miner token rule](3) Document the total-tokens rule in the session-mine skill

### DIFF
--- a/skills/worker-session-mine/SKILL.md
+++ b/skills/worker-session-mine/SKILL.md
@@ -35,7 +35,7 @@ description: >
 
 ## Detector
 
-`scripts/worker-session-mine-thrash.mjs` — thrash if any of assistant/Codex turns >= 40, cache_read >= 10M, same bash argv >= 5, or catstack `token_audit.py` flags when `CATSTACK_ROOT` is set.
+`scripts/worker-session-mine-thrash.mjs` — thrash if any of assistant/Codex turns >= 40, cache_read >= 10M, total tokens (input + cached + output, what the quota meter charges) >= 10M, same bash argv >= 5, or catstack `token_audit.py` flags when `CATSTACK_ROOT` is set.
 
 Self-test: `node scripts/worker-session-mine-thrash.mjs --self-test`
 Resolve self-test: `node scripts/worker-session-mine-resolve.selftest.mjs`


### PR DESCRIPTION
## Summary

The worker-session-mine skill page lists the rules that mark a session as wasteful. This sentence adds the 10M total-tokens rule so the page matches what now runs.

## Review Claim

The skill page names the 10M total-tokens rule alongside the existing ones.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Prose-only change to one skill page.

## Slice Rationale

The page text is reviewed on its own, apart from the earlier slices.

## Non-goals

No other skill pages change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --stat` shows only `skills/worker-session-mine/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to one skill page; no runtime or behavior changes.
> 
> **Overview**
> Updates the **worker-session-mine** skill **Detector** section so it documents the **10M total-tokens** thrash condition (input + cached + output—the same total the quota meter uses), alongside the existing turn, cache-read, bash-repeat, and `token_audit.py` rules.
> 
> This is prose-only alignment with behavior already implemented in `scripts/worker-session-mine-thrash.mjs`; no code or routing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 509afdd9e43befd111873a5594704cc8a19695ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->