### PR TITLE
[Session miner token rule](4) Score Codex sessions from the rollout log, not the exec mirror

### DIFF
--- a/scripts/worker-session-mine-resolve.mjs
+++ b/scripts/worker-session-mine-resolve.mjs
@@ -21,6 +21,40 @@ export function agentSessionsDir() {
   return join(base, 'agent-sessions');
 }
 
+export function codexSessionsDir() {
+  const base = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+  return join(base, 'sessions');
+}
+
+function listDirs(path) {
+  try {
+    return readdirSync(path, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+export function findCodexRollout(sessionId, root = codexSessionsDir()) {
+  if (!sessionId || !existsSync(root)) return null;
+  const suffix = `-${sessionId}.jsonl`;
+  for (const year of listDirs(root).sort().reverse()) {
+    for (const month of listDirs(join(root, year)).sort().reverse()) {
+      for (const day of listDirs(join(root, year, month)).sort().reverse()) {
+        const dayDir = join(root, year, month, day);
+        let names;
+        try {
+          names = readdirSync(dayDir);
+        } catch {
+          continue;
+        }
+        const hit = names.find((name) => name.startsWith('rollout-') && name.endsWith(suffix));
+        if (hit) return join(dayDir, hit);
+      }
+    }
+  }
+  return null;
+}
+
 function findInClaudeProjects(sessionId, roots = claudeProjectRoots()) {
   for (const root of roots) {
     if (!existsSync(root)) continue;
@@ -50,6 +84,8 @@ export function resolveTranscriptPath(agentName, sessionId) {
     return findInClaudeProjects(sessionId);
   }
   if (name === 'codex') {
+    const rollout = findCodexRollout(sessionId);
+    if (rollout) return rollout;
     const p = join(agentSessionsDir(), `${sessionId}.jsonl`);
     return existsSync(p) ? p : null;
   }
@@ -65,5 +101,6 @@ export function resolveTranscriptPathSelfTest() {
   return {
     claudeRoots: claudeProjectRoots(),
     agentSessionsDir: agentSessionsDir(),
+    codexSessionsDir: codexSessionsDir(),
   };
 }

--- a/scripts/worker-session-mine-resolve.selftest.mjs
+++ b/scripts/worker-session-mine-resolve.selftest.mjs
@@ -12,6 +12,7 @@ try {
   process.env.INVOKER_CLAUDE_CONFIG_DIR = join(root, 'claude-worker');
   process.env.CLAUDE_CONFIG_DIR = process.env.INVOKER_CLAUDE_CONFIG_DIR;
   process.env.INVOKER_DB_DIR = root;
+  process.env.CODEX_HOME = join(root, 'codex-home');
 
   const claudeProjects = join(process.env.CLAUDE_CONFIG_DIR, 'projects', 'enc-cwd');
   mkdirSync(claudeProjects, { recursive: true });
@@ -22,19 +23,27 @@ try {
   writeFileSync(join(sessions, 'sid-codex.jsonl'), '{}\n');
   writeFileSync(join(sessions, 'sid-omp.omp.txt'), 'hi\n');
 
+  const rolloutDay = join(process.env.CODEX_HOME, 'sessions', '2026', '09', '08');
+  mkdirSync(rolloutDay, { recursive: true });
+  writeFileSync(join(rolloutDay, 'rollout-2026-09-08T20-44-26-sid-rollout.jsonl'), '{}\n');
+  writeFileSync(join(sessions, 'sid-rollout.jsonl'), '{}\n');
+
   const claudePath = resolveTranscriptPath('claude', 'sid-claude');
   const codexPath = resolveTranscriptPath('codex', 'sid-codex');
+  const codexRolloutPath = resolveTranscriptPath('codex', 'sid-rollout');
   const ompPath = resolveTranscriptPath('omp', 'sid-omp');
   const missing = resolveTranscriptPath('kimi', 'sid-x');
 
   if (!claudePath?.includes('claude-worker')) throw new Error(`claude path wrong: ${claudePath}`);
   if (!codexPath?.endsWith('sid-codex.jsonl')) throw new Error(`codex path wrong: ${codexPath}`);
+  if (!codexRolloutPath?.endsWith('rollout-2026-09-08T20-44-26-sid-rollout.jsonl')) throw new Error(`codex rollout should win over the mirror: ${codexRolloutPath}`);
   if (!ompPath?.endsWith('sid-omp.omp.txt')) throw new Error(`omp path wrong: ${ompPath}`);
   if (missing !== null) throw new Error('kimi should be null');
-  console.log(JSON.stringify({ ok: true, claudePath, codexPath, ompPath }, null, 2));
+  console.log(JSON.stringify({ ok: true, claudePath, codexPath, codexRolloutPath, ompPath }, null, 2));
 } finally {
   rmSync(root, { recursive: true, force: true });
   delete process.env.INVOKER_CLAUDE_CONFIG_DIR;
   delete process.env.CLAUDE_CONFIG_DIR;
   delete process.env.INVOKER_DB_DIR;
+  delete process.env.CODEX_HOME;
 }

--- a/scripts/worker-session-mine.mjs
+++ b/scripts/worker-session-mine.mjs
@@ -157,12 +157,13 @@ function listFromDiskFallback() {
         continue;
       }
       if (name.endsWith('.jsonl')) {
+        const sessionId = name.replace(/\.jsonl$/, '');
         out.push({
           workflowName: '',
-          sessionId: name.replace(/\.jsonl$/, ''),
+          sessionId,
           agentName: 'codex',
           status: 'failed',
-          path,
+          path: resolveTranscriptPath('codex', sessionId) ?? path,
         });
       } else if (name.endsWith('.omp.txt')) {
         out.push({

--- a/skills/worker-session-mine/SKILL.md
+++ b/skills/worker-session-mine/SKILL.md
@@ -35,7 +35,7 @@ description: >
 
 ## Detector
 
-`scripts/worker-session-mine-thrash.mjs` — thrash if any of assistant/Codex turns >= 40, cache_read >= 10M, same bash argv >= 5, or catstack `token_audit.py` flags when `CATSTACK_ROOT` is set.
+`scripts/worker-session-mine-thrash.mjs` — thrash if any of assistant/Codex turns >= 40, cache_read >= 10M, total tokens (input + cached + output, what the quota meter charges) >= 10M, same bash argv >= 5, or catstack `token_audit.py` flags when `CATSTACK_ROOT` is set.
 
 Self-test: `node scripts/worker-session-mine-thrash.mjs --self-test`
 Resolve self-test: `node scripts/worker-session-mine-resolve.selftest.mjs`


### PR DESCRIPTION
## Summary

The miner read each Codex session from Invoker's mirror of `codex exec --json`. That mirror records token usage only when a turn completes.

A session that died on a usage limit therefore scored zero tokens, and every Codex session counted as a single turn, so the turn rule could never fire for Codex.

Codex keeps its own per-call rollout log under `~/.codex/sessions`. The miner now reads that file when it exists and keeps the mirror as the fallback.

## Review Claim

A Codex session resolves to its rollout log when one exists, so turn counts and token totals come from the per-call record rather than the exec mirror.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

When no rollout log exists the path resolves exactly as before, to the mirror file, so no session that scored before is dropped.

## Slice Rationale

Path resolution is one concern on its own; the threshold rule and the CLI toggle landed as their own slices earlier in this stack.

## Non-goals

No change to thresholds, follow-up filing, or Claude and OMP resolution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine-resolve.selftest.mjs` (new rollout-wins assertion; against the previous resolver it failed with "codex rollout should win over the mirror")
- [x] `node scripts/worker-session-mine-thrash.mjs --self-test`
- [x] Standalone on DO1 over the eleven 2026-09-08 sessions: every one resolves to its rollout; the 45-turn babysit session that scored 0 tokens and 1 turn from the mirror now reports 45 turns and 2,377,523 tokens

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
