### PR TITLE
[Session miner discovery](1) Mine sessions from the live owner, not a checkout's run.sh

### DIFF
--- a/scripts/worker-session-mine.mjs
+++ b/scripts/worker-session-mine.mjs
@@ -34,13 +34,14 @@ const MAX_PER_TICK = Number(process.env.INVOKER_SESSION_MINE_MAX_PER_TICK ?? '1'
 const MAX_PER_DAY = Number(process.env.INVOKER_SESSION_MINE_MAX_PER_DAY ?? '2');
 const LOOKBACK_HOURS = Number(process.env.INVOKER_SESSION_MINE_LOOKBACK_HOURS ?? '168');
 const WORKFLOW_PREFIXES = (process.env.INVOKER_SESSION_MINE_WORKFLOW_PREFIXES
-  ?? 'admin-bypass-repair-')
+  ?? 'admin-bypass-repair-,CI regression')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
 const EXCLUDE_NAME_RE = /(session-mine|reflect-ci-|worker-session-mine)/i;
 const POOL_ID = process.env.INVOKER_SESSION_MINE_POOL_ID ?? 'remote_digital_ocean_1';
 const DRY_RUN = process.env.INVOKER_SESSION_MINE_DRY_RUN === '1';
+const OWNER_CLI = process.env.INVOKER_SESSION_MINE_CLI ?? 'invoker-cli';
 const TERMINAL = new Set(['completed', 'failed', 'cancelled', 'stale']);
 
 function loadLedger() {
@@ -61,8 +62,8 @@ function dayKey(d = new Date()) {
   return d.toISOString().slice(0, 10);
 }
 
-function runHeadlessJson(args) {
-  const result = spawnSync('bash', [join(REPO_ROOT, 'run.sh'), '--headless', ...args, '--output', 'json'], {
+function runOwnerQueryJson(args) {
+  const result = spawnSync(OWNER_CLI, [...args, '--output', 'json'], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
     env: { ...process.env },
@@ -90,15 +91,15 @@ function listFromInventoryFile(path) {
   })).filter((r) => r.sessionId);
 }
 
-function listFromHeadless() {
-  const workflows = runHeadlessJson(['query', 'workflows']);
+function listFromOwner() {
+  const workflows = runOwnerQueryJson(['query', 'workflows']);
   if (!Array.isArray(workflows)) return null;
   const out = [];
   for (const wf of workflows) {
     const name = wf.name || wf.id || '';
     if (EXCLUDE_NAME_RE.test(name)) continue;
     if (!WORKFLOW_PREFIXES.some((p) => name.startsWith(p) || name.includes(p))) continue;
-    const tasks = runHeadlessJson(['query', 'tasks', '--workflow', wf.id]);
+    const tasks = runOwnerQueryJson(['query', 'tasks', '--workflow', wf.id]);
     if (!Array.isArray(tasks)) continue;
     for (const task of tasks) {
       const status = task.status || '';
@@ -266,9 +267,9 @@ function main() {
   if (process.env.INVOKER_SESSION_MINE_INVENTORY_JSON) {
     candidates = listFromInventoryFile(process.env.INVOKER_SESSION_MINE_INVENTORY_JSON);
   } else {
-    candidates = listFromHeadless();
-    if (!candidates) {
-      console.log('session-mine: headless inventory unavailable; using disk fallback');
+    candidates = listFromOwner();
+    if (!candidates || candidates.length === 0) {
+      console.log('session-mine: owner inventory empty or unavailable; using disk fallback');
       candidates = listFromDiskFallback();
     }
   }

--- a/scripts/worker-session-mine.selftest.mjs
+++ b/scripts/worker-session-mine.selftest.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MINER = join(__dirname, 'worker-session-mine.mjs');
+
+const SESSION_ID = '01a082c3-d260-7e90-a870-f4e0a390f604';
+const CI_WORKFLOW = 'CI regression: 9fe1d9a-required-fast-vitest-workspace';
+
+function thrashyRollout() {
+  const rows = [];
+  for (let i = 1; i <= 60; i += 1) {
+    rows.push(JSON.stringify({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: { input_tokens: 200_000 * i, cached_input_tokens: 190_000 * i, output_tokens: 500 * i } },
+      },
+    }));
+  }
+  return rows.join('\n');
+}
+
+function makeFakeCli(dir, { workflows, tasks }) {
+  const binDir = join(dir, 'fakebin');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(dir, 'workflows.json'), JSON.stringify(workflows));
+  writeFileSync(join(dir, 'tasks.json'), JSON.stringify(tasks));
+  const cli = join(binDir, 'fake-invoker-cli');
+  writeFileSync(cli, `#!/usr/bin/env bash
+if [ "$2" = "workflows" ]; then cat ${join(dir, 'workflows.json')}; exit 0; fi
+if [ "$2" = "tasks" ]; then cat ${join(dir, 'tasks.json')}; exit 0; fi
+echo null
+`);
+  chmodSync(cli, 0o755);
+  return cli;
+}
+
+function runMiner(dir, cli, extraEnv = {}) {
+  const plansDir = join(dir, 'plans');
+  mkdirSync(plansDir, { recursive: true });
+  const result = spawnSync('node', [MINER], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TMPDIR: plansDir,
+      TMP: plansDir,
+      TEMP: plansDir,
+      INVOKER_SESSION_MINE_DRY_RUN: '1',
+      INVOKER_SESSION_MINE_STATE_DIR: join(dir, 'state'),
+      INVOKER_SESSION_MINE_CLI: cli,
+      INVOKER_DB_DIR: dir,
+      CODEX_HOME: join(dir, 'codex'),
+      CATSTACK_ROOT: '',
+      ...extraEnv,
+    },
+  });
+  return `${result.stdout || ''}${result.stderr || ''}`;
+}
+
+function seedSession(dir) {
+  mkdirSync(join(dir, 'agent-sessions'), { recursive: true });
+  writeFileSync(join(dir, 'agent-sessions', `${SESSION_ID}.jsonl`), '{"type":"thread.started"}\n');
+  const day = join(dir, 'codex', 'sessions', '2026', '09', '08');
+  mkdirSync(day, { recursive: true });
+  writeFileSync(join(day, `rollout-2026-09-08T20-44-26-${SESSION_ID}.jsonl`), thrashyRollout());
+}
+
+const failures = [];
+function check(label, condition, detail) {
+  if (condition) return;
+  failures.push(`${label}: ${detail}`);
+}
+
+const roots = [];
+function freshRoot() {
+  const d = mkdtempSync(join(tmpdir(), 'session-mine-selftest-'));
+  roots.push(d);
+  seedSession(d);
+  return d;
+}
+
+try {
+  {
+    const dir = freshRoot();
+    const cli = makeFakeCli(dir, {
+      workflows: [{ id: 'wf-1', name: CI_WORKFLOW, status: 'failed' }],
+      tasks: [{
+        id: 'wf-1/fix-ci',
+        status: 'failed',
+        execution: { agentSessionId: SESSION_ID, agentName: 'codex' },
+      }],
+    });
+    const out = runMiner(dir, cli);
+    check('ci-workflow-is-mined', /filed 1/.test(out), `expected one filing, got:\n${out}`);
+    check('ci-workflow-reason', /total_tokens=/.test(out), `expected a total_tokens reason, got:\n${out}`);
+  }
+
+  {
+    const dir = freshRoot();
+    const cli = makeFakeCli(dir, { workflows: [], tasks: [] });
+    const out = runMiner(dir, cli, { INVOKER_SESSION_MINE_ALLOW_UNHINTTED: '1' });
+    check('empty-inventory-falls-back', /using disk fallback/.test(out), `expected the disk fallback to run, got:\n${out}`);
+    check('empty-inventory-still-files', /filed 1/.test(out), `expected the disk fallback to file, got:\n${out}`);
+  }
+
+  {
+    const dir = freshRoot();
+    const cli = makeFakeCli(dir, {
+      workflows: [{ id: 'wf-1', name: 'worker-session-mine-abc', status: 'failed' }],
+      tasks: [{ id: 'wf-1/x', status: 'failed', execution: { agentSessionId: SESSION_ID, agentName: 'codex' } }],
+    });
+    const out = runMiner(dir, cli);
+    check('self-mining-excluded', /filed 0/.test(out), `expected the miner to skip its own workflows, got:\n${out}`);
+  }
+
+  {
+    const dir = freshRoot();
+    const cli = join(dir, 'fakebin', 'does-not-exist');
+    const out = runMiner(dir, cli, { INVOKER_SESSION_MINE_ALLOW_UNHINTTED: '1' });
+    check('missing-cli-falls-back', /using disk fallback/.test(out), `expected a missing owner CLI to fall back, got:\n${out}`);
+  }
+
+  if (failures.length > 0) {
+    for (const f of failures) console.error(`FAIL ${f}`);
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ ok: true, checks: 6 }, null, 2));
+} finally {
+  for (const d of roots) rmSync(d, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

The session miner reads finished worker sessions and files a follow-up when one looks wasteful. It was reading its list of sessions from the wrong place.

It shelled out to a checkout script that opens its own database. On the production host that database held 60 workflows whose newest was eight days old, while the live owner held 18 whose newest was from today.

Two smaller faults kept it quiet anyway. An empty list is still a list, so the disk fallback never ran. And the default allowlist covered only admin-bypass repairs, leaving out the CI-repair sessions that spend the most.

This asks the owner directly, falls back to disk when the list is empty as well as missing, and includes CI-regression work by default.

## Review Claim

The miner builds its candidate list from the live owner and can therefore see CI-repair sessions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every existing guard is untouched: the same thresholds decide what counts as wasteful, the same per-tick and per-day caps apply, the exclusion that stops the miner mining its own follow-ups still holds, and a dry run still writes a plan instead of submitting one.

## Slice Rationale

All three edits serve one claim about candidate discovery, and none of them changes behavior on its own: with any one or two applied the miner still files nothing.

## Non-goals

No change to the thresholds, the follow-up plan, the caps, or how Claude and OMP sessions are resolved.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine.selftest.mjs` (new; six checks covering a CI workflow being mined, an empty inventory falling back to disk, self-mining staying excluded, and a missing owner CLI falling back. Against the previous script the first two fail with `headless inventory unavailable` and `filed 0`)
- [x] `node scripts/worker-session-mine-resolve.selftest.mjs`
- [x] `node scripts/worker-session-mine-thrash.mjs --self-test`
- [x] Dry run on the production host against its live owner: files the 39,458,756-token and 11,439,698-token sessions; the same command on the previous script files none

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session mining now supports CI regression workflows.
  * Added fallback behavior when workflow inventory is empty or unavailable.
  * Added configuration for selecting the owner command-line tool.

* **Tests**
  * Added self-tests covering failed workflows, disk fallback, workflow exclusion, and missing-tool scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to how candidates are listed; filing guards and submit path are unchanged, with new self-tests locking discovery behavior.
> 
> **Overview**
> **Session miner candidate discovery** now queries the live owner via `invoker-cli` (override with `INVOKER_SESSION_MINE_CLI`) instead of `run.sh --headless`, so production sees current workflows rather than a checkout-local DB.
> 
> Default workflow allowlist adds **`CI regression`** alongside `admin-bypass-repair-`. **Disk fallback** runs when owner queries fail *or* return an empty candidate list (previously an empty array skipped fallback). Thrash thresholds, caps, exclusions, and dry-run behavior are unchanged.
> 
> Adds **`worker-session-mine.selftest.mjs`** with fake CLI fixtures covering CI workflow filing, empty/missing owner inventory fallback, self-workflow exclusion, and missing CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88255d7f339be768994b46623852f56ab2175c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->