### PR TITLE
[Conversation Save Divergence](1) Repro the silent drop when a stored row outruns memory

### DIFF
--- a/packages/data-store/src/__tests__/conversation-repository.test.ts
+++ b/packages/data-store/src/__tests__/conversation-repository.test.ts
@@ -157,6 +157,49 @@ describe('ConversationRepository', () => {
     });
   });
 
+  // ── saved-count divergence (repro: PR #7518 Non-goals) ───
+
+  describe('saveConversation when the stored row holds more messages than memory', () => {
+    function seedOrphanedRow(threadTs: string): void {
+      seedConversation(threadTs);
+      adapter.appendMessage(threadTs, 'user', 'orphan question one');
+      adapter.appendMessage(threadTs, 'assistant', 'orphan answer one');
+      adapter.appendMessage(threadTs, 'user', 'orphan question two');
+      adapter.appendMessage(threadTs, 'assistant', 'orphan answer two');
+    }
+
+    it('documents the live defect: a fresh transcript is silently dropped', () => {
+      seedOrphanedRow('ts-orphan');
+
+      repo.saveConversation('ts-orphan', [
+        { role: 'user', content: 'brand new session, first message' },
+        { role: 'assistant', content: 'brand new session, first reply' },
+      ]);
+
+      const stored = repo.loadConversation('ts-orphan')!.messages.map((m) => m.content);
+      expect(stored).toHaveLength(4);
+      expect(stored).not.toContain('brand new session, first message');
+    });
+
+    it('documents the live defect: nothing reports the divergence', () => {
+      const warnings: string[] = [];
+      const errors: string[] = [];
+      const loudRepo = new ConversationRepository(adapter, {
+        info: () => {},
+        warn: (message: string) => warnings.push(message),
+        error: (message: string) => errors.push(message),
+      });
+      seedOrphanedRow('ts-orphan-log');
+
+      loudRepo.saveConversation('ts-orphan-log', [
+        { role: 'user', content: 'brand new session, first message' },
+      ]);
+
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+  });
+
   // ── loadConversation ─────────────────────────────────────
 
   describe('loadConversation', () => {


### PR DESCRIPTION
## Summary

A Slack planning thread can lose every message it writes, silently, and the log says the save succeeded.

The save path picks which messages are new by slicing the in-memory transcript at the stored row count. When the in-memory transcript is shorter than the stored row, that slice is empty, so nothing is written and the success line still prints.

Two ways to get there in production: a load that refused or failed, which leaves memory empty while the row holds rows, or a fresh session that reuses a thread id whose old rows are still there.

This slice only pins the behavior.

PR #7518 named this defect in its own Non-goals and said it was "being tracked separately". No follow-up PR exists, and this repo has issues disabled, so nothing tracked it.

## Review Claim

Two tests hold the current save path to what it actually does with a diverged row, so the next slice's change is visible as a diff in behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only: no product file changes, and the new tests use the same in-memory SQLite adapter and seed helper as the file's other cases. They assert today's behavior, so this slice is green on master and does not gate anything.

## Slice Rationale

Repro before fix, per the repo's bug-fix rule: the defect is demonstrated on unmodified master first, so a reviewer can see the drop before approving the change that reports it.

## Non-goals

Does not change the save path. Does not attempt recovery of messages already lost, and does not decide whether a reused thread id should be cleared or reloaded.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/conversation-repository.test.ts` — 42 tests, OK on unmodified master
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU2pPKob4MJ1NqjsfTNyYJ
