### PR TITLE
[Conversation Save Divergence](2) Report a diverged conversation instead of a silent save

### DIFF
--- a/packages/data-store/src/__tests__/conversation-repository.test.ts
+++ b/packages/data-store/src/__tests__/conversation-repository.test.ts
@@ -157,7 +157,7 @@ describe('ConversationRepository', () => {
     });
   });
 
-  // ── saved-count divergence (repro: PR #7518 Non-goals) ───
+  // ── saved-count divergence ───────────────────────────────
 
   describe('saveConversation when the stored row holds more messages than memory', () => {
     function seedOrphanedRow(threadTs: string): void {
@@ -168,7 +168,7 @@ describe('ConversationRepository', () => {
       adapter.appendMessage(threadTs, 'assistant', 'orphan answer two');
     }
 
-    it('documents the live defect: a fresh transcript is silently dropped', () => {
+    it('leaves the stored transcript intact rather than interleaving a divergent one', () => {
       seedOrphanedRow('ts-orphan');
 
       repo.saveConversation('ts-orphan', [
@@ -181,7 +181,7 @@ describe('ConversationRepository', () => {
       expect(stored).not.toContain('brand new session, first message');
     });
 
-    it('documents the live defect: nothing reports the divergence', () => {
+    it('reports the divergence with both counts instead of a silent success', () => {
       const warnings: string[] = [];
       const errors: string[] = [];
       const loudRepo = new ConversationRepository(adapter, {
@@ -195,7 +195,11 @@ describe('ConversationRepository', () => {
         { role: 'user', content: 'brand new session, first message' },
       ]);
 
-      expect(errors).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('ts-orphan-log');
+      expect(errors[0]).toContain('memory holds 1 message(s)');
+      expect(errors[0]).toContain('the stored row holds 4');
+      expect(errors[0]).toContain('NOT persisted');
       expect(warnings).toEqual([]);
     });
   });

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -97,6 +97,15 @@ export class ConversationRepository {
 
     // Determine how many messages already exist without reading the transcript.
     const existingMessageCount = this.adapter.countMessages(threadTs);
+    if (messages.length < existingMessageCount) {
+      this.log.error(
+        `Diverged conversation ${threadTs}: memory holds ${messages.length} message(s), `
+        + `the stored row holds ${existingMessageCount}. The in-memory transcript is not an `
+        + 'extension of the stored one, so these messages are NOT persisted. Reconcile the '
+        + 'row (reload the thread, or clear it if the thread id was reused) before saving again.',
+      );
+      return;
+    }
     const newMessages = messages.slice(existingMessageCount);
 
     for (const msg of newMessages) {


### PR DESCRIPTION
## Summary

The save path now says so when the in-memory transcript diverges from the stored row, instead of logging a successful save that wrote nothing.

The root cause is a count taken from one source and applied to another: new messages are chosen by slicing the in-memory transcript at the stored row count, which is only correct while memory is a superset of what is stored. After a refused or failed load, or on a reused thread id, memory is shorter, the slice is empty, and every later message is dropped.

The error names the thread and both counts, and the write does not happen rather than interleaving, so a mismatched thread id still cannot bleed one session's messages into another.

The test gap that let it through: the change that introduced the count only covered memory being longer than the store.

The channel-bleed fix then deferred the shorter direction to a follow-up nobody opened.

## Review Claim

A save whose in-memory transcript is shorter than the stored row logs an error naming both counts and writes nothing, instead of reporting success.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The new branch only fires when the in-memory transcript is shorter than the stored count, a state that is already broken today; every other save takes the same path as before, proven by the file's other 40 tests passing unchanged. Nothing is deleted or overwritten, no schema changes, and the error goes through the repository's injected logger rather than a new sink.

## Slice Rationale

The behavior change lands on top of the repro slice, so the diff a reviewer approves is the error branch alone.

## Non-goals

Does not recover the dropped messages or reconcile the row: choosing between reloading the thread and clearing a reused id is the caller's decision and needs its own slice. Does not change any caller. Does not touch content deserialization, which was a separate defect on this same file.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/conversation-repository.test.ts` — the divergence test fails before this commit (`1 failed | 41 passed`) and passes after (`42 passed`)
- [x] `cd packages/data-store && pnpm test` — 35 files, 549 tests, OK
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the silent drop.
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU2pPKob4MJ1NqjsfTNyYJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation persistence on an already-broken divergence path; normal append-only saves are unchanged, but operators may now see errors where saves previously appeared to succeed while dropping data.
> 
> **Overview**
> **`ConversationRepository.saveConversation`** now **refuses to append** when the in-memory transcript is **shorter** than the stored message count (e.g. failed load or reused thread id). It **logs an error** with the thread id, both counts, and that messages were **NOT persisted**, then **returns early**—instead of slicing to zero new messages and looking like a successful save.
> 
> Tests for the “stored row has more messages than memory” case were updated from documenting the old silent-drop behavior to asserting the **DB transcript stays unchanged** and the **injected logger receives the divergence error**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47c01c87eff6eace6d5d5dd2ff698f261f8aa18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->