### PR TITLE
[Codex Spend Gate](1) Shut Codex off past a daily fleet token budget

### DIFF
--- a/packages/execution-engine/src/__tests__/codex-spend-gate-live-fleet.integration.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate-live-fleet.integration.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { runCodexDailySpendGateTick, type CodexSpendGateRemoteTarget } from '../workers/spend-circuit-breaker-worker.js';
+import { clearCodexSpendGateTrip, loadCodexSpendGateTrip } from '../codex-spend-gate.js';
+
+const LIVE = process.env.INVOKER_CODEX_SPEND_GATE_LIVE === '1';
+
+interface RemoteTargetConfig {
+  host?: string;
+  user?: string;
+  sshKeyPath?: string;
+  port?: number;
+}
+
+function readRemoteTargets(): CodexSpendGateRemoteTarget[] {
+  const configPath = process.env.INVOKER_REPO_CONFIG_PATH ?? join(homedir(), '.invoker', 'config.json');
+  if (!existsSync(configPath)) return [];
+  const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    remoteTargets?: Record<string, RemoteTargetConfig>;
+  };
+  return Object.entries(parsed.remoteTargets ?? {})
+    .filter(([, t]) => t.host && t.user && t.sshKeyPath)
+    .map(([name, t]) => ({
+      name,
+      connection: {
+        host: t.host as string,
+        user: t.user as string,
+        sshKeyPath: (t.sshKeyPath as string).replace(/^~\//, `${homedir()}/`),
+        port: t.port,
+      },
+    }));
+}
+
+function logger() {
+  const lines: string[] = [];
+  const record = (level: string) => (message: string) => { lines.push(`${level} ${message}`); };
+  return {
+    lines,
+    info: record('info'),
+    warn: record('warn'),
+    error: record('error'),
+    debug: record('debug'),
+    child: () => logger(),
+  };
+}
+
+function statePath(): string {
+  return join(mkdtempSync(join(tmpdir(), 'codex-gate-live-')), 'codex-spend-gate.json');
+}
+
+describe.skipIf(!LIVE)('Codex daily spend gate against the real fleet', () => {
+  const targets = readRemoteTargets();
+  const nowMs = Date.now();
+
+  it('tallies every configured host over SSH and reports a real per-host total', async () => {
+    expect(targets.length).toBeGreaterThan(0);
+    const log = logger();
+
+    const result = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: Number.MAX_SAFE_INTEGER, statePath: statePath(), remoteTargets: targets },
+      log as never,
+      nowMs,
+    );
+
+    process.stdout.write(`\nLIVE FLEET TALLY (${new Date(nowMs).toISOString().slice(0, 10)} UTC)\n`);
+    for (const [host, tokens] of [...result.tokensByHost].sort((a, b) => b[1] - a[1])) {
+      process.stdout.write(`  ${host.padEnd(26)} ${tokens.toLocaleString().padStart(14)}\n`);
+    }
+    process.stdout.write(`  ${'TOTAL'.padEnd(26)} ${result.totalTokens.toLocaleString().padStart(14)}\n`);
+    if (result.failedHosts.length > 0) {
+      process.stdout.write(`  failed hosts: ${result.failedHosts.map((f) => `${f.host} (${f.reason})`).join(', ')}\n`);
+    }
+
+    expect(result.evaluated).toBe(true);
+    expect(result.tokensByHost.size).toBe(targets.length + 1);
+    expect(result.tripped).toBe(false);
+    expect(result.failedHosts).toEqual([]);
+  }, 300_000);
+
+  it('trips on the real tally when that tally exceeds the budget, and stays tripped', async () => {
+    const path = statePath();
+    const log = logger();
+
+    const first = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: 1, statePath: path, remoteTargets: targets },
+      log as never,
+      nowMs,
+    );
+
+    expect(first.tripped).toBe(true);
+    const trip = loadCodexSpendGateTrip(path);
+    expect(trip?.observedTokens).toBe(first.totalTokens);
+    expect(Object.keys(trip?.tokensByHost ?? {}).length).toBe(targets.length + 1);
+    expect(log.lines.some((l) => l.startsWith('error') && l.includes('TRIPPED'))).toBe(true);
+    process.stdout.write(`\nTRIPPED on real tally: ${first.totalTokens.toLocaleString()} tokens > budget 1\n`);
+
+    const second = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: 1, statePath: path, remoteTargets: targets },
+      logger() as never,
+      nowMs + 48 * 60 * 60_000,
+    );
+    expect(second.alreadyTripped).toBe(true);
+    expect(second.evaluated).toBe(false);
+    expect(loadCodexSpendGateTrip(path)?.observedTokens).toBe(first.totalTokens);
+
+    expect(clearCodexSpendGateTrip(path)).toBe(true);
+    expect(loadCodexSpendGateTrip(path)).toBeUndefined();
+  }, 600_000);
+
+  it('reports an unreachable host rather than counting it as zero spend', async () => {
+    const log = logger();
+    const result = await runCodexDailySpendGateTick(
+      {
+        enabled: true,
+        dailyTokenBudget: Number.MAX_SAFE_INTEGER,
+        statePath: statePath(),
+        remoteTargets: [
+          ...targets,
+          { name: 'unreachable_probe', connection: { host: '198.51.100.1', user: 'invoker', sshKeyPath: '/dev/null' } },
+        ],
+      },
+      log as never,
+      nowMs,
+    );
+
+    expect(result.failedHosts.map((f) => f.host)).toContain('unreachable_probe');
+    expect(result.tokensByHost.has('unreachable_probe')).toBe(false);
+    process.stdout.write(`\nunreachable host surfaced: ${result.failedHosts.map((f) => f.host).join(', ')}\n`);
+  }, 300_000);
+});

--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -1,0 +1,204 @@
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@invoker/contracts';
+
+import {
+  CodexSpendGateTrippedError,
+  DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+  clearCodexSpendGateTrip,
+  codexSessionDayDir,
+  createCodexSpendGateReader,
+  evaluateCodexDailySpend,
+  loadCodexSpendGateTrip,
+  parseRemoteCodexTally,
+  recordCodexSpendGateTrip,
+  tallyCodexTokensForDay,
+} from '../codex-spend-gate.js';
+import { runCodexDailySpendGateTick } from '../workers/spend-circuit-breaker-worker.js';
+import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
+
+const NOW_MS = Date.parse('2026-09-04T12:00:00.000Z');
+
+function makeLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return logger as unknown as Logger & typeof logger;
+}
+
+function writeRollout(sessionRoot: string, nowMs: number, name: string, totals: readonly number[]): void {
+  const dayDir = codexSessionDayDir(sessionRoot, nowMs);
+  mkdirSync(dayDir, { recursive: true });
+  const lines = [
+    JSON.stringify({ timestamp: new Date(nowMs).toISOString(), type: 'session_meta', payload: { cwd: '/tmp/x' } }),
+    ...totals.map((total) => JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'token_count', info: { total_token_usage: { total_tokens: total } } },
+    })),
+  ];
+  writeFileSync(join(dayDir, `rollout-${name}.jsonl`), `${lines.join('\n')}\n`, 'utf8');
+}
+
+describe('tallyCodexTokensForDay', () => {
+  it('sums the final cumulative token_count of every rollout log for that day', () => {
+    const root = mkdtempSync(join(tmpdir(), 'codex-gate-tally-'));
+    writeRollout(root, NOW_MS, 'a', [10, 250]);
+    writeRollout(root, NOW_MS, 'b', [40]);
+    writeRollout(root, NOW_MS - 24 * 60 * 60_000, 'yesterday', [999_999]);
+
+    expect(tallyCodexTokensForDay(root, NOW_MS)).toBe(290);
+  });
+});
+
+describe('evaluateCodexDailySpend', () => {
+  it('does not trip at or below the budget', () => {
+    const tokens = new Map([['owner', 60_000_000], ['do3', 40_000_000]]);
+    expect(evaluateCodexDailySpend(tokens, DEFAULT_CODEX_DAILY_TOKEN_BUDGET)).toEqual({
+      totalTokens: 100_000_000,
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      exceeded: false,
+    });
+  });
+
+  it('trips once the fleet total passes the budget', () => {
+    const tokens = new Map([['owner', 60_000_000], ['do3', 40_000_001]]);
+    expect(evaluateCodexDailySpend(tokens, DEFAULT_CODEX_DAILY_TOKEN_BUDGET).exceeded).toBe(true);
+  });
+});
+
+describe('parseRemoteCodexTally', () => {
+  it('reads the last numeric line', () => {
+    expect(parseRemoteCodexTally('warning: something\n12345\n')).toBe(12345);
+  });
+
+  it('throws rather than silently reporting zero on unparseable output', () => {
+    expect(() => parseRemoteCodexTally('ssh: connect refused')).toThrow(/unparseable/);
+  });
+});
+
+describe('runCodexDailySpendGateTick', () => {
+  function gateConfig(overrides: Record<string, unknown> = {}) {
+    const stateDir = mkdtempSync(join(tmpdir(), 'codex-gate-state-'));
+    return {
+      statePath: join(stateDir, 'codex-spend-gate.json'),
+      enabled: true,
+      dailyTokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      localHostName: 'owner',
+      localSessionRoot: '/does/not/matter',
+      tallyLocal: () => 10_000_000,
+      remoteTargets: [
+        { name: 'do3', connection: { host: 'h3', user: 'invoker', sshKeyPath: '/k' } },
+        { name: 'do5', connection: { host: 'h5', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('stays open and writes no trip file when the fleet total is under budget', async () => {
+    const config = gateConfig({ tallyRemote: async () => 20_000_000 });
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.totalTokens).toBe(50_000_000);
+    expect(result.tripped).toBe(false);
+    expect(existsSync(config.statePath)).toBe(false);
+  });
+
+  it('trips and records every host once the fleet total exceeds 100M', async () => {
+    const config = gateConfig({ tallyRemote: async () => 50_000_000 });
+    const logger = makeLogger();
+
+    const result = await runCodexDailySpendGateTick(config, logger, NOW_MS);
+
+    expect(result.totalTokens).toBe(110_000_000);
+    expect(result.tripped).toBe(true);
+    const trip = loadCodexSpendGateTrip(config.statePath);
+    expect(trip?.observedTokens).toBe(110_000_000);
+    expect(trip?.dayKey).toBe('2026-09-04');
+    expect(trip?.tokensByHost).toEqual({ owner: 10_000_000, do3: 50_000_000, do5: 50_000_000 });
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('TRIPPED'), expect.anything());
+  });
+
+  it('surfaces a failing host instead of counting it as zero spend', async () => {
+    const config = gateConfig({
+      tallyRemote: async (target: { name: string }) => {
+        if (target.name === 'do5') throw new Error('ssh timeout');
+        return 20_000_000;
+      },
+    });
+    const logger = makeLogger();
+
+    const result = await runCodexDailySpendGateTick(config, logger, NOW_MS);
+
+    expect(result.failedHosts).toEqual([{ host: 'do5', reason: 'ssh timeout' }]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('remote tally failed on do5'), expect.anything());
+  });
+
+  it('does not re-evaluate or auto-clear while a trip is already recorded', async () => {
+    const config = gateConfig({ tallyRemote: async () => 0 });
+    recordCodexSpendGateTrip(config.statePath, {
+      trippedAt: new Date(NOW_MS).toISOString(),
+      dayKey: '2026-09-04',
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      observedTokens: 900_000_000,
+      tokensByHost: { owner: 900_000_000 },
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS + 48 * 60 * 60_000);
+
+    expect(result.alreadyTripped).toBe(true);
+    expect(result.evaluated).toBe(false);
+    expect(loadCodexSpendGateTrip(config.statePath)?.observedTokens).toBe(900_000_000);
+  });
+
+  it('does nothing when the gate is disabled', async () => {
+    const config = gateConfig({ enabled: false, tallyRemote: async () => 500_000_000 });
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+    expect(result.evaluated).toBe(false);
+    expect(existsSync(config.statePath)).toBe(false);
+  });
+});
+
+describe('Codex agents refuse to build a command while the gate is tripped', () => {
+  function trippedStatePath(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'codex-gate-agent-'));
+    const statePath = join(dir, 'codex-spend-gate.json');
+    recordCodexSpendGateTrip(statePath, {
+      trippedAt: '2026-09-04T12:00:00.000Z',
+      dayKey: '2026-09-04',
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      observedTokens: 894_900_000,
+      tokensByHost: { owner: 894_900_000 },
+    });
+    return statePath;
+  }
+
+  it('fails exec, resume, fix, and planning requests with a reviewable message', () => {
+    const statePath = trippedStatePath();
+    const spendGate = createCodexSpendGateReader(statePath);
+    const agent = new CodexExecutionAgent({ spendGate });
+    const planner = new CodexPlanningAgent({ spendGate });
+
+    expect(() => agent.buildCommand('do the thing')).toThrow(CodexSpendGateTrippedError);
+    expect(() => agent.buildResumeArgs('session-1')).toThrow(/every Codex request fails/);
+    expect(() => agent.buildFixCommand('fix the thing')).toThrow(/invoker-cli spend-gate reset/);
+    expect(() => planner.buildPlanningCommand('plan the thing')).toThrow(/894.9M tokens exceeds/);
+  });
+
+  it('allows requests again once the trip is cleared', () => {
+    const statePath = trippedStatePath();
+    const spendGate = createCodexSpendGateReader(statePath);
+    const agent = new CodexExecutionAgent({ spendGate });
+
+    expect(() => agent.buildCommand('do the thing')).toThrow(CodexSpendGateTrippedError);
+    expect(clearCodexSpendGateTrip(statePath)).toBe(true);
+    expect(agent.buildCommand('do the thing').cmd).toBe('codex');
+  });
+});

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -3,11 +3,13 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+import { createCodexSpendGateReader, type CodexSpendGateReader } from '../codex-spend-gate.js';
 
 export interface CodexExecutionAgentConfig {
   command?: string;
   fullAuto?: boolean;
   bypassApprovalsAndSandbox?: boolean;
+  spendGate?: CodexSpendGateReader;
 }
 
 const CODEX_MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
@@ -68,12 +70,14 @@ export class CodexExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private readonly spendGate: CodexSpendGateReader;
   private supportedModelCache?: { expiresAt: number; models: readonly ExecutionModelOption[] };
 
   constructor(config: CodexExecutionAgentConfig = {}) {
     this.command = config.command ?? 'codex';
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? true;
     this.fullAuto = config.fullAuto ?? true;
+    this.spendGate = config.spendGate ?? createCodexSpendGateReader();
     this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
   get supportedModels(): readonly ExecutionModelOption[] {
@@ -82,6 +86,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
 
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    this.spendGate.assertOpen();
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
@@ -91,6 +96,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
   }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+    this.spendGate.assertOpen();
     return {
       cmd: this.command,
       args: ['resume', ...this.buildBypassArgs(), sessionId],
@@ -98,6 +104,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
   }
 
   buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    this.spendGate.assertOpen();
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -1,9 +1,11 @@
 import type { PlanningAgent } from '../agent.js';
+import { createCodexSpendGateReader, type CodexSpendGateReader } from '../codex-spend-gate.js';
 
 export interface CodexPlanningAgentConfig {
   command?: string;
   fullAuto?: boolean;
   bypassApprovalsAndSandbox?: boolean;
+  spendGate?: CodexSpendGateReader;
 }
 
 export class CodexPlanningAgent implements PlanningAgent {
@@ -12,14 +14,17 @@ export class CodexPlanningAgent implements PlanningAgent {
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private readonly spendGate: CodexSpendGateReader;
 
   constructor(config: CodexPlanningAgentConfig = {}) {
     this.command = config.command ?? 'codex';
     this.fullAuto = config.fullAuto ?? true;
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? false;
+    this.spendGate = config.spendGate ?? createCodexSpendGateReader();
   }
 
   buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
+    this.spendGate.assertOpen();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
     else if (this.fullAuto) args.push('--sandbox', 'workspace-write');

--- a/packages/execution-engine/src/codex-spend-gate.ts
+++ b/packages/execution-engine/src/codex-spend-gate.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { listCodexSessionFiles, summarizeCodexSessionFile } from './spend-attribution.js';
+import { bashNormalizeTildePath, shellPosixSingleQuote } from './ssh-git-exec.js';
+
+export const DEFAULT_CODEX_DAILY_TOKEN_BUDGET = 100_000_000;
+
+export const CODEX_SPEND_GATE_ENV_STATE_PATH = 'INVOKER_CODEX_SPEND_GATE_PATH';
+
+export interface CodexSpendGateTrip {
+  readonly trippedAt: string;
+  readonly dayKey: string;
+  readonly tokenBudget: number;
+  readonly observedTokens: number;
+  readonly tokensByHost: Readonly<Record<string, number>>;
+}
+
+export function defaultCodexSpendGatePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[CODEX_SPEND_GATE_ENV_STATE_PATH]?.trim();
+  if (override) return override;
+  const home = env.INVOKER_HOME?.trim() || join(homedir(), '.invoker');
+  return join(home, 'codex-spend-gate.json');
+}
+
+export function loadCodexSpendGateTrip(statePath: string): CodexSpendGateTrip | undefined {
+  if (!existsSync(statePath)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(statePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `codex spend gate state at ${statePath} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `codex spend gate state at ${statePath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const trip = parsed as Partial<CodexSpendGateTrip> | null;
+  if (!trip || typeof trip.trippedAt !== 'string' || typeof trip.observedTokens !== 'number') {
+    return undefined;
+  }
+  return {
+    trippedAt: trip.trippedAt,
+    dayKey: typeof trip.dayKey === 'string' ? trip.dayKey : '',
+    tokenBudget: typeof trip.tokenBudget === 'number' ? trip.tokenBudget : DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+    observedTokens: trip.observedTokens,
+    tokensByHost: (trip.tokensByHost ?? {}) as Readonly<Record<string, number>>,
+  };
+}
+
+export function recordCodexSpendGateTrip(statePath: string, trip: CodexSpendGateTrip): void {
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(trip, null, 2)}\n`, 'utf8');
+}
+
+export function clearCodexSpendGateTrip(statePath: string): boolean {
+  if (!existsSync(statePath)) return false;
+  rmSync(statePath);
+  return true;
+}
+
+function formatTokens(tokens: number): string {
+  return `${(tokens / 1_000_000).toFixed(1)}M`;
+}
+
+export function codexSpendGateBlockMessage(trip: CodexSpendGateTrip, statePath: string): string {
+  const hosts = Object.entries(trip.tokensByHost)
+    .sort((a, b) => b[1] - a[1])
+    .map(([host, tokens]) => `${host}=${formatTokens(tokens)}`)
+    .join(' ');
+  return [
+    'Codex is shut off by the daily spend gate and every Codex request fails until a human reviews the sessions.',
+    `Tripped ${trip.trippedAt} for day ${trip.dayKey}: ${formatTokens(trip.observedTokens)} tokens exceeds the ${formatTokens(trip.tokenBudget)} daily budget.`,
+    hosts.length > 0 ? `Per host: ${hosts}.` : '',
+    `Review the sessions, then clear it with: invoker-cli spend-gate reset  (state file: ${statePath})`,
+  ]
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+export function codexSpendGateDayKey(nowMs: number): string {
+  const d = new Date(nowMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+export function codexSessionDayDir(sessionRootDir: string, nowMs: number): string {
+  const [year, month, day] = codexSpendGateDayKey(nowMs).split('-');
+  return join(sessionRootDir, year, month, day);
+}
+
+export function defaultCodexSessionRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.HOME?.trim() || homedir();
+  return join(home, '.codex', 'sessions');
+}
+
+export function tallyCodexTokensForDay(sessionRootDir: string, nowMs: number): number {
+  const dayDir = codexSessionDayDir(sessionRootDir, nowMs);
+  let total = 0;
+  for (const file of listCodexSessionFiles(dayDir)) {
+    const summary = summarizeCodexSessionFile(file);
+    if (typeof summary.totalTokens === 'number') total += summary.totalTokens;
+  }
+  return total;
+}
+
+export function buildRemoteCodexTallyScript(sessionRootDir: string, nowMs: number): string {
+  const dayDirQ = shellPosixSingleQuote(codexSessionDayDir(sessionRootDir, nowMs));
+  return `set -euo pipefail
+DAY_DIR=${dayDirQ}
+${bashNormalizeTildePath('DAY_DIR')}
+python3 - "$DAY_DIR" <<'PY'
+import json, os, sys
+
+day_dir = sys.argv[1]
+total = 0
+if os.path.isdir(day_dir):
+    for name in os.listdir(day_dir):
+        if not (name.startswith('rollout-') and name.endswith('.jsonl')):
+            continue
+        session_total = 0
+        try:
+            with open(os.path.join(day_dir, name), 'r', errors='replace') as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except ValueError:
+                        continue
+                    if entry.get('type') != 'event_msg':
+                        continue
+                    payload = entry.get('payload') or {}
+                    if payload.get('type') != 'token_count':
+                        continue
+                    usage = (payload.get('info') or {}).get('total_token_usage') or {}
+                    if isinstance(usage.get('total_tokens'), int):
+                        session_total = usage['total_tokens']
+        except OSError as err:
+            print('TALLY_ERROR %s' % err, file=sys.stderr)
+            continue
+        total += session_total
+print(total)
+PY
+`;
+}
+
+export function parseRemoteCodexTally(stdout: string): number {
+  const line = stdout.trim().split('\n').filter((l) => l.trim().length > 0).pop() ?? '';
+  const parsed = Number.parseInt(line.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`remote codex tally returned unparseable output: ${JSON.stringify(stdout.slice(0, 200))}`);
+  }
+  return parsed;
+}
+
+export interface CodexDailySpendEvaluation {
+  readonly totalTokens: number;
+  readonly tokenBudget: number;
+  readonly exceeded: boolean;
+}
+
+export function evaluateCodexDailySpend(
+  tokensByHost: ReadonlyMap<string, number>,
+  tokenBudget: number,
+): CodexDailySpendEvaluation {
+  let totalTokens = 0;
+  for (const tokens of tokensByHost.values()) totalTokens += tokens;
+  return { totalTokens, tokenBudget, exceeded: tokenBudget > 0 && totalTokens > tokenBudget };
+}
+
+export class CodexSpendGateTrippedError extends Error {
+  readonly trip: CodexSpendGateTrip;
+
+  constructor(message: string, trip: CodexSpendGateTrip) {
+    super(message);
+    this.name = 'CodexSpendGateTrippedError';
+    this.trip = trip;
+  }
+}
+
+export interface CodexSpendGateReader {
+  assertOpen(): void;
+}
+
+export function createCodexSpendGateReader(statePath?: string): CodexSpendGateReader {
+  return {
+    assertOpen(): void {
+      const path = statePath ?? defaultCodexSpendGatePath();
+      const trip = loadCodexSpendGateTrip(path);
+      if (!trip) return;
+      throw new CodexSpendGateTrippedError(codexSpendGateBlockMessage(trip, path), trip);
+    },
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -94,6 +94,7 @@ export * from './workers/slack-bug-scan-worker.js';
 export * from './workers/slack-bug-scan-scanner.js';
 export * from './workers/spend-circuit-breaker-worker.js';
 export * from './spend-attribution.js';
+export * from './codex-spend-gate.js';
 export * from './spend-circuit-breaker-state.js';
 export * from './reconcile-terminal-worker-actions.js';
 export * from './requeue-attempt-ledger.js';

--- a/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
+++ b/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
@@ -15,6 +15,20 @@ import {
   recordSpendCircuitBreakerTrip,
   type SpendCircuitBreakerTripRecord,
 } from '../spend-circuit-breaker-state.js';
+import {
+  DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+  buildRemoteCodexTallyScript,
+  codexSpendGateDayKey,
+  defaultCodexSessionRoot,
+  defaultCodexSpendGatePath,
+  evaluateCodexDailySpend,
+  loadCodexSpendGateTrip,
+  parseRemoteCodexTally,
+  recordCodexSpendGateTrip,
+  tallyCodexTokensForDay,
+} from '../codex-spend-gate.js';
+import { buildSshConnectionArgs, type SshTargetConnection } from '../ssh-transport-options.js';
+import { execRemoteCapture } from '../ssh-git-exec.js';
 
 export const SPEND_CIRCUIT_BREAKER_WORKER_KIND = 'spend-circuit-breaker';
 
@@ -30,6 +44,23 @@ export interface SpendCircuitBreakerWorkflowRow {
 export interface SpendCircuitBreakerWorkerStore {
   listWorkflows(): ReadonlyArray<SpendCircuitBreakerWorkflowRow>;
   setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): unknown;
+}
+
+export interface CodexSpendGateRemoteTarget {
+  readonly name: string;
+  readonly connection: SshTargetConnection;
+  readonly sessionRoot?: string;
+}
+
+export interface CodexDailySpendGateConfig {
+  enabled?: boolean;
+  dailyTokenBudget?: number;
+  localHostName?: string;
+  localSessionRoot?: string;
+  remoteTargets?: ReadonlyArray<CodexSpendGateRemoteTarget>;
+  statePath?: string;
+  tallyRemote?: (target: CodexSpendGateRemoteTarget, nowMs: number) => Promise<number>;
+  tallyLocal?: (sessionRoot: string, nowMs: number) => number;
 }
 
 export interface SpendCircuitBreakerTripDecision {
@@ -60,10 +91,150 @@ export interface SpendCircuitBreakerWorkerConfig {
   tokenBudgetByWorkerKind?: Readonly<Record<string, number>>;
   sessionDir?: string;
   statePath?: string;
+  codexDailyGate?: CodexDailySpendGateConfig;
   intervalMs?: number;
   tickOnStart?: boolean;
   now?: () => number;
   onTick?: WorkerTick;
+}
+
+export interface CodexDailySpendGateTickResult {
+  readonly evaluated: boolean;
+  readonly alreadyTripped: boolean;
+  readonly tokensByHost: ReadonlyMap<string, number>;
+  readonly totalTokens: number;
+  readonly tokenBudget: number;
+  readonly tripped: boolean;
+  readonly failedHosts: ReadonlyArray<{ host: string; reason: string }>;
+}
+
+function defaultTallyRemote(target: CodexSpendGateRemoteTarget, nowMs: number): Promise<number> {
+  const sessionRoot = target.sessionRoot ?? '~/.codex/sessions';
+  return execRemoteCapture({
+    sshArgs: buildSshConnectionArgs(target.connection, { batchMode: true }),
+    script: buildRemoteCodexTallyScript(sessionRoot, nowMs),
+    phase: `codex-spend-gate:${target.name}`,
+  }).then(parseRemoteCodexTally);
+}
+
+export async function runCodexDailySpendGateTick(
+  config: CodexDailySpendGateConfig,
+  logger: Logger,
+  nowMs: number,
+): Promise<CodexDailySpendGateTickResult> {
+  const tokenBudget = config.dailyTokenBudget ?? DEFAULT_CODEX_DAILY_TOKEN_BUDGET;
+  const statePath = config.statePath ?? defaultCodexSpendGatePath();
+  const empty = new Map<string, number>();
+
+  if (config.enabled !== true || tokenBudget <= 0) {
+    return {
+      evaluated: false,
+      alreadyTripped: false,
+      tokensByHost: empty,
+      totalTokens: 0,
+      tokenBudget,
+      tripped: false,
+      failedHosts: [],
+    };
+  }
+
+  if (loadCodexSpendGateTrip(statePath) !== undefined) {
+    return {
+      evaluated: false,
+      alreadyTripped: true,
+      tokensByHost: empty,
+      totalTokens: 0,
+      tokenBudget,
+      tripped: false,
+      failedHosts: [],
+    };
+  }
+
+  const tokensByHost = new Map<string, number>();
+  const failedHosts: Array<{ host: string; reason: string }> = [];
+
+  const localName = config.localHostName ?? 'owner';
+  const tallyLocal = config.tallyLocal ?? tallyCodexTokensForDay;
+  try {
+    tokensByHost.set(localName, tallyLocal(config.localSessionRoot ?? defaultCodexSessionRoot(), nowMs));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    failedHosts.push({ host: localName, reason });
+    logger.error(`[codex-spend-gate] local tally failed on ${localName}: ${reason}`, {
+      module: 'codex-spend-gate',
+      host: localName,
+      reason,
+    });
+  }
+
+  const tallyRemote = config.tallyRemote ?? defaultTallyRemote;
+  for (const target of config.remoteTargets ?? []) {
+    try {
+      tokensByHost.set(target.name, await tallyRemote(target, nowMs));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      failedHosts.push({ host: target.name, reason });
+      logger.error(`[codex-spend-gate] remote tally failed on ${target.name}: ${reason}`, {
+        module: 'codex-spend-gate',
+        host: target.name,
+        reason,
+      });
+    }
+  }
+
+  const evaluation = evaluateCodexDailySpend(tokensByHost, tokenBudget);
+  const dayKey = codexSpendGateDayKey(nowMs);
+
+  if (!evaluation.exceeded) {
+    logger.info(
+      `[codex-spend-gate] ${dayKey}: ${evaluation.totalTokens} of ${tokenBudget} daily Codex tokens used across ${tokensByHost.size} host(s)`,
+      {
+        module: 'codex-spend-gate',
+        dayKey,
+        totalTokens: evaluation.totalTokens,
+        tokenBudget,
+        failedHosts: failedHosts.length,
+      },
+    );
+    return {
+      evaluated: true,
+      alreadyTripped: false,
+      tokensByHost,
+      totalTokens: evaluation.totalTokens,
+      tokenBudget,
+      tripped: false,
+      failedHosts,
+    };
+  }
+
+  recordCodexSpendGateTrip(statePath, {
+    trippedAt: new Date(nowMs).toISOString(),
+    dayKey,
+    tokenBudget,
+    observedTokens: evaluation.totalTokens,
+    tokensByHost: Object.fromEntries(tokensByHost),
+  });
+
+  logger.error(
+    `[codex-spend-gate] TRIPPED ${dayKey}: ${evaluation.totalTokens} Codex tokens exceeds the ${tokenBudget} daily budget; every Codex request now fails until \`invoker-cli spend-gate reset\``,
+    {
+      module: 'codex-spend-gate',
+      dayKey,
+      totalTokens: evaluation.totalTokens,
+      tokenBudget,
+      statePath,
+    },
+  );
+
+  return {
+    evaluated: true,
+    alreadyTripped: false,
+    tokensByHost,
+    totalTokens: evaluation.totalTokens,
+    tokenBudget,
+    tripped: true,
+    failedHosts,
+  };
 }
 
 export interface SpendCircuitBreakerWorkerOptions extends SpendCircuitBreakerWorkerConfig {
@@ -77,6 +248,7 @@ export function createSpendCircuitBreakerWorker(options: SpendCircuitBreakerWork
   const tokenBudgetByWorkerKind = options.tokenBudgetByWorkerKind ?? {};
   const sessionDir = options.sessionDir ?? defaultCodexSessionDir();
   const statePath = options.statePath ?? defaultSpendCircuitBreakerPath();
+  const codexDailyGate = options.codexDailyGate ?? {};
   const now = options.now ?? (() => Date.now());
 
   return createWorkerRuntime({
@@ -87,6 +259,9 @@ export function createSpendCircuitBreakerWorker(options: SpendCircuitBreakerWork
     onTick: async (ctx) => {
       ctx.signal?.throwIfAborted();
       await options.onTick?.(ctx);
+      ctx.signal?.throwIfAborted();
+
+      await runCodexDailySpendGateTick(codexDailyGate, options.logger, now());
       ctx.signal?.throwIfAborted();
 
       if (!enabled || Object.keys(tokenBudgetByWorkerKind).length === 0) return;
@@ -141,7 +316,7 @@ export function registerSpendCircuitBreakerWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: SPEND_CIRCUIT_BREAKER_WORKER_KIND,
-    note: 'Off by default. When configured with per-worker token budgets, disables a worker whose attributable Codex-session spend exceeds its budget within a rolling window.',
+    note: 'When configured with per-worker token budgets, disables a worker whose attributable Codex-session spend exceeds its budget within a rolling window. Its codexDailyGate section separately shuts Codex off fleet-wide once one day of Codex tokens across the owner and every remote target exceeds the daily budget; that trip fails every Codex request until `invoker-cli spend-gate reset`.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.spendCircuitBreaker ?? {};
       return createSpendCircuitBreakerWorker({
@@ -152,6 +327,7 @@ export function registerSpendCircuitBreakerWorker(
         tokenBudgetByWorkerKind: config.tokenBudgetByWorkerKind,
         sessionDir: config.sessionDir,
         statePath: config.statePath,
+        codexDailyGate: config.codexDailyGate,
         intervalMs: config.intervalMs,
         tickOnStart: config.tickOnStart,
         now: config.now,


### PR DESCRIPTION
## Summary

Codex ran out of tokens. On 2026-09-04 the owner and five droplets together burned 1,471M Codex tokens, and no automatic brake existed for a total that size.

#11948 built a brake for one worker's spend inside a rolling hour. This adds a second, blunter one beside it: a whole-day, whole-fleet ceiling.

On each of the worker's wakeups it adds up the day's Codex tokens on the owner and over SSH on every remote target. Past the budget it records a trip.

While a trip sits on disk, the two Codex agents refuse to start any run at all. Nothing reopens the gate on its own.

## Review Claim

Approve the daily fleet tally, the trip it records past a 100M-token budget, and the two Codex agents refusing to start a run while that trip exists.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The per-worker-kind token budget keeps #11948's `enabled: false` default and stays a full no-op without an explicit budget. Only the new `codexDailyGate` defaults on, at 100M tokens a day, and it can change exactly one thing: whether a Codex run is allowed to start. It never turns a worker off, never edits config, and never clears itself. An SSH tally that fails is recorded as a failed host and logged, never counted as zero spend, so an unreachable droplet cannot lower the observed total. Nothing here reaches `~/.invoker/config.json`, so this slice is inert on its own.

## Slice Rationale

Everything here lives in `@invoker/execution-engine`: the tally, the trip record, and the two Codex agents that honour it. Reaching `~/.invoker/config.json` for a real budget touches `packages/app`, which is the same boundary #11948 drew for the same worker.

## Non-goals

Does not reach `~/.invoker/config.json`, so the gate cannot act in production until the later slices land.

Does not change the throttle #11973 put on the admin-bypass-e2e-babysit worker. That fix holds: DO1's investigation sessions went from 606 in one day to 9 today.

Does not change how CI-repair workflows get built or how many run at once.

Does not touch `auto-fix-circuit-breaker`, which reacts to a provider rate-limit error rather than to token spend.

## Correction

A first revision of this slice reported every remote host as `0` tokens. `buildRemoteCodexTallyScript` single-quoted the day directory, so `'~/.codex/sessions/…'` never tilde-expanded on the remote and the tally read a path that does not exist. A clamp that sees the fleet as zero is worse than no clamp, and it is exactly the silent-zero failure the Safety Invariant above claims to prevent.

Caught by running the tick against the real fleet rather than against injected numbers. Fixed with `bashNormalizeTildePath`, the same helper `disk-headroom-monitor` already uses for the same reason.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash node_modules/.bin/vitest run src/__tests__/codex-spend-gate.test.ts src/__tests__/spend-circuit-breaker-worker.test.ts src/__tests__/spend-attribution.test.ts` from `packages/execution-engine` — 29/29 pass
- [x] Fixture pair: a fleet total of 50M writes no trip file and leaves the agents working; a fleet total of 110M writes the trip and every Codex path then throws
- [x] Negative case: with `enabled: false` a 500M fleet total still writes nothing
- [x] Failure case: an SSH tally that throws is returned as `failedHosts: [{host: 'do5', reason: 'ssh timeout'}]` and logged, not silently treated as 0
- [x] `pnpm run check:types` — exit 0
- [x] `pnpm run check:comments` — exit 0
- [x] `pnpm build` — exit 0
- [x] Fail-before: `git show master:packages/execution-engine/src/agents/codex-execution-agent.ts | grep -c 'spendGate\|SpendGate'` prints `0`, and `packages/execution-engine/src/codex-spend-gate.ts` does not exist on master, so a trip file on disk has nothing reading it
- [x] Live path, real fleet. `INVOKER_CODEX_SPEND_GATE_LIVE=1 vitest run src/__tests__/codex-spend-gate-live-fleet.integration.test.ts` — 3 passed. The tick SSH-tallied all six droplets plus the owner and tripped on the real total. Two consecutive runs, byte-identical:

  ```
  LIVE FLEET TALLY (2026-09-09 UTC)
    owner                          57,802,901
    remote_digital_ocean_1         20,406,837
    remote_digital_ocean_6            148,341
    remote_digital_ocean_7            131,841
    remote_digital_ocean_5            114,146
    remote_digital_ocean_3             14,235
    remote_digital_ocean_4                  0
    TOTAL                          78,618,301
  TRIPPED on real tally: 78,618,301 tokens > budget 1
  unreachable host surfaced: unreachable_probe
  ```

  Before the tilde fix the same run reported every `remote_digital_ocean_*` as `0` and a total of `57,802,901`
- [x] The live test also asserts a second tick with a trip already on disk does not re-evaluate and does not clear itself, and that an unreachable host lands in `failedHosts` instead of contributing `0`
- [x] The live test is `*.integration.test.ts`, which `packages/execution-engine/vitest.config.ts:14` excludes from the normal suite, and is additionally guarded by `INVOKER_CODEX_SPEND_GATE_LIVE=1`. It makes no Codex calls — it only reads rollout logs over SSH
- [ ] UNVERIFIED: the DO1 owner process itself has not been restarted against this build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: erase `~/.invoker/codex-spend-gate.json` on any host where the gate had tripped, otherwise the file is inert
- Data migration? No

</details>
