### PR TITLE
[Codex Spend Gate](4) Wire the resolver into the app owner

### DIFF
--- a/packages/app/e2e/codex-spend-gate-blocks-task.spec.ts
+++ b/packages/app/e2e/codex-spend-gate-blocks-task.spec.ts
@@ -1,0 +1,52 @@
+import {
+  test,
+  expect,
+  loadPlan,
+  startPlan,
+  waitForTaskStatus,
+  E2E_REPO_URL,
+  getTasks,
+  findTaskByIdSuffix,
+} from './fixtures/electron-app.js';
+
+const PLAN = {
+  name: 'E2E Codex Spend Gate Plan',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'gated-codex-task',
+      description: 'Codex task blocked by the daily spend gate',
+      prompt: 'Repair the failing CI job',
+      executionAgent: 'codex',
+      dependencies: [],
+    },
+  ],
+};
+
+test.use({ codexSpendGateTripped: true, repoConfig: { autoFixRetries: 0, autoApproveAIFixes: false } });
+
+test.describe('Codex daily spend gate', () => {
+  test('a tripped gate fails the Codex task in the app owner', async ({ page }) => {
+    await loadPlan(page, PLAN);
+    await startPlan(page);
+    await waitForTaskStatus(page, 'gated-codex-task', 'failed', 60000);
+
+    const node = page.locator('.react-flow__node[data-testid$="/gated-codex-task"]');
+    await expect(node.locator('text=FAILED')).toBeVisible({ timeout: 10000 });
+
+    const task = findTaskByIdSuffix(await getTasks(page), 'gated-codex-task');
+    const errorText = JSON.stringify(task ?? {});
+    expect(errorText).toContain('every Codex request fails');
+    expect(errorText).toContain('invoker-cli spend-gate reset');
+
+    if (process.env.INVOKER_CODEX_SPEND_GATE_PROOF_DIR) {
+      await node.click();
+      await page.waitForTimeout(1000);
+      await page.screenshot({
+        path: `${process.env.INVOKER_CODEX_SPEND_GATE_PROOF_DIR}/codex-spend-gate-task-failed.png`,
+        fullPage: false,
+      });
+    }
+  });
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -30,11 +30,28 @@ export type ElectronFixtures = {
   breakPlanningPresets: boolean;
   standaloneOwnerIdleTimeoutMs: string;
   repoConfig: Partial<InvokerConfig>;
+  codexSpendGateTripped: boolean;
   page: Page;
   testDir: string;
 };
 
 const repoRoot = resolveRepoRoot(__dirname);
+
+function writeTrippedCodexSpendGate(testDir: string): string {
+  const statePath = path.join(testDir, 'codex-spend-gate.json');
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      trippedAt: '2026-09-04T04:11:00.000Z',
+      dayKey: '2026-09-04',
+      tokenBudget: 100_000_000,
+      observedTokens: 1_471_200_000,
+      tokensByHost: { owner: 894_900_000, remote_digital_ocean_3: 202_900_000 },
+    }),
+    'utf8',
+  );
+  return statePath;
+}
 type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only' | 'connection-lost';
 
 async function removeTestDir(dir: string): Promise<void> {
@@ -124,6 +141,7 @@ export const test = base.extend<ElectronFixtures>({
   breakPlanningPresets: [false, { option: true }],
   standaloneOwnerIdleTimeoutMs: [process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000', { option: true }],
   repoConfig: [{ autoFixRetries: 0 }, { option: true }],
+  codexSpendGateTripped: [false, { option: true }],
 
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
@@ -133,7 +151,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, breakPlanningPresets, standaloneOwnerIdleTimeoutMs, repoConfig, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, breakPlanningPresets, standaloneOwnerIdleTimeoutMs, repoConfig, codexSpendGateTripped, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -263,6 +281,9 @@ exit 64
           : {}),
         ...(process.env.INVOKER_E2E_CODEX_DEMO_RENDERER
           ? { INVOKER_E2E_CODEX_DEMO_RENDERER: process.env.INVOKER_E2E_CODEX_DEMO_RENDERER }
+          : {}),
+        ...(codexSpendGateTripped
+          ? { INVOKER_CODEX_SPEND_GATE_PATH: writeTrippedCodexSpendGate(testDir) }
           : {}),
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(breakPlanningPresets ? { INVOKER_E2E_BREAK_PLANNING_PRESETS: '1' } : {}),

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -11,7 +11,12 @@ import { homedir } from 'node:os';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
-import type { E2eAutoFixWorkerConfig, PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
+import type {
+  E2eAutoFixWorkerConfig,
+  PrMaintenanceWorkerConfig,
+  SpendCircuitBreakerWorkerConfig,
+} from '@invoker/execution-engine';
+import { DEFAULT_CODEX_DAILY_TOKEN_BUDGET } from '@invoker/execution-engine';
 import { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
 
 export { BUILT_IN_LOCAL_EXECUTION_POOL_ID } from '@invoker/workflow-core';
@@ -239,6 +244,22 @@ export interface SelfDeployConfig {
 }
 
 export const DEFAULT_SELF_DEPLOY_INTERVAL_MINUTES = 30;
+
+export interface CodexDailySpendGateConfigEntry {
+  enabled?: boolean;
+  dailyTokenBudget?: number;
+  statePath?: string;
+}
+
+export interface SpendCircuitBreakerConfig {
+  enabled?: boolean;
+  windowMinutes?: number;
+  tokenBudgetByWorkerKind?: Record<string, number>;
+  intervalMinutes?: number;
+  codexDailyGate?: CodexDailySpendGateConfigEntry;
+}
+
+export const DEFAULT_SPEND_CIRCUIT_BREAKER_INTERVAL_MINUTES = 10;
 
 export interface DbReaperConfig {
   intervalMinutes?: number;
@@ -620,6 +641,7 @@ export interface InvokerConfig {
   selfDeploy?: SelfDeployConfig;
   adminBypassE2eBabysit?: AdminBypassE2eBabysitConfig;
   dbReaper?: DbReaperConfig;
+  spendCircuitBreaker?: SpendCircuitBreakerConfig;
 }
 
 export const BUILT_IN_LOCAL_WORKTREE_TARGET_ID = 'local-worktree';
@@ -872,6 +894,36 @@ export function resolveSecretsFilePath(config: InvokerConfig): string | undefine
  * SQLite desired state; this only threads interval/lock/repoRoot/env/shell
  * so a started PR-maintenance worker still gets launch settings.
  */
+export function resolveSpendCircuitBreakerWorkerConfig(
+  invokerConfig: InvokerConfig,
+): SpendCircuitBreakerWorkerConfig {
+  const configured = invokerConfig.spendCircuitBreaker;
+  const gate = configured?.codexDailyGate;
+  return {
+    enabled: configured?.enabled,
+    windowMinutes: configured?.windowMinutes,
+    tokenBudgetByWorkerKind: configured?.tokenBudgetByWorkerKind,
+    intervalMs: configured?.intervalMinutes !== undefined
+      ? configured.intervalMinutes * 60_000
+      : undefined,
+    codexDailyGate: {
+      enabled: gate?.enabled ?? true,
+      dailyTokenBudget: gate?.dailyTokenBudget ?? DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      statePath: gate?.statePath,
+      localHostName: 'owner',
+      remoteTargets: Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
+        name,
+        connection: {
+          host: target.host,
+          user: target.user,
+          sshKeyPath: target.sshKeyPath,
+          port: target.port,
+        },
+      })),
+    },
+  };
+}
+
 export function resolvePrMaintenanceWorkerConfig(
   config: InvokerConfig,
 ): PrMaintenanceWorkerConfig | undefined {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -37,7 +37,7 @@ import {
   setWorkflowMergeMode,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
-import { resolvePrMaintenanceWorkerConfig } from './config.js';
+import { resolvePrMaintenanceWorkerConfig, resolveSpendCircuitBreakerWorkerConfig } from './config.js';
 import { resolveAutoFixRetries } from './autofix-defaults.js';
 import {
   isDispatchableLaunch,
@@ -669,6 +669,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
       },
       prMaintenance: resolvePrMaintenanceWorkerConfig(deps.invokerConfig),
       diskHeadroom: resolveHeadlessDiskHeadroomConfig(deps.invokerConfig),
+      spendCircuitBreaker: resolveSpendCircuitBreakerWorkerConfig(deps.invokerConfig),
       infraRepair: resolveHeadlessInfraRepairConfig(deps.invokerConfig, deps.repoRoot),
       claudeOauthRefresh: resolveHeadlessClaudeOauthRefreshConfig(deps.invokerConfig),
       catstackDeploy: resolveHeadlessCatstackDeployConfig(deps.invokerConfig),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,6 +129,7 @@ import {
   resolveConfigFileState,
   resolveE2eAutoFixWorkerConfig,
   resolvePrMaintenanceWorkerConfig,
+  resolveSpendCircuitBreakerWorkerConfig,
   type InvokerConfig,
 } from './config.js';
 import {
@@ -434,6 +435,7 @@ function buildRegisteredOwnerWorkerDeps(
     claudeOauthRefresh: {
       remoteTargets: remoteTargets.map((target) => ({ name: target.name, connection: target.connection })),
     },
+    spendCircuitBreaker: resolveSpendCircuitBreakerWorkerConfig(invokerConfig),
     infraRepair: {
       ownerRepoRoot: repoRoot,
       ownerInvokerHome: resolveInvokerHomeRoot(),

--- a/packages/cli/src/__tests__/spend-gate-command.test.ts
+++ b/packages/cli/src/__tests__/spend-gate-command.test.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { CodexExecutionAgent, createCodexSpendGateReader } from '@invoker/execution-engine';
+
+import { runSpendGateCommand } from '../spend-gate-command.js';
+
+function newStatePath(): string {
+  return join(mkdtempSync(join(tmpdir(), 'spend-gate-cmd-')), 'codex-spend-gate.json');
+}
+
+function writeTrip(statePath: string): void {
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      trippedAt: '2026-09-04T04:11:00.000Z',
+      dayKey: '2026-09-04',
+      tokenBudget: 100_000_000,
+      observedTokens: 1_471_200_000,
+      tokensByHost: { owner: 894_900_000, remote_digital_ocean_3: 202_900_000 },
+    }),
+  );
+}
+
+describe('invoker-cli spend-gate', () => {
+  it('reports an open gate and lets Codex run', () => {
+    const statePath = newStatePath();
+    let out = '';
+
+    expect(runSpendGateCommand(['status'], { statePath, write: (t) => { out += t; } })).toBe(0);
+    expect(out).toContain('open');
+
+    const agent = new CodexExecutionAgent({ spendGate: createCodexSpendGateReader(statePath) });
+    expect(agent.buildCommand('repair the failing CI job').cmd).toBe('codex');
+  });
+
+  it('reports a tripped gate with a non-zero exit and blocks every Codex request', () => {
+    const statePath = newStatePath();
+    writeTrip(statePath);
+    let out = '';
+
+    expect(runSpendGateCommand(['status'], { statePath, write: (t) => { out += t; } })).toBe(1);
+    expect(out).toContain('every Codex request fails');
+    expect(out).toContain('1471.2M tokens exceeds the 100.0M daily budget');
+    expect(out).toContain('owner=894.9M');
+    expect(out).toContain('invoker-cli spend-gate reset');
+
+    const agent = new CodexExecutionAgent({ spendGate: createCodexSpendGateReader(statePath) });
+    expect(() => agent.buildCommand('repair')).toThrow(/every Codex request fails/);
+    expect(() => agent.buildResumeArgs('session-1')).toThrow(/every Codex request fails/);
+    expect(() => agent.buildFixCommand('fix')).toThrow(/every Codex request fails/);
+  });
+
+  it('reopens the gate only on an explicit reset', () => {
+    const statePath = newStatePath();
+    writeTrip(statePath);
+    let out = '';
+
+    expect(runSpendGateCommand(['reset'], { statePath, write: (t) => { out += t; } })).toBe(0);
+    expect(out).toContain('Cleared the Codex daily spend gate trip');
+    expect(existsSync(statePath)).toBe(false);
+
+    const agent = new CodexExecutionAgent({ spendGate: createCodexSpendGateReader(statePath) });
+    expect(agent.buildCommand('repair').cmd).toBe('codex');
+  });
+
+  it('rejects an unknown subcommand instead of silently reopening the gate', () => {
+    const statePath = newStatePath();
+    writeTrip(statePath);
+
+    expect(() => runSpendGateCommand(['clear'], { statePath, write: () => {} })).toThrow(
+      /Usage: invoker-cli spend-gate/,
+    );
+    expect(existsSync(statePath)).toBe(true);
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -75,6 +75,7 @@ import {
   resolveCliInstanceProfile,
 } from './worker-toggles.js';
 import { runAutoApproveAuthorsCommand } from './auto-approve-authors-config.js';
+import { runSpendGateCommand } from './spend-gate-command.js';
 
 const VERSION = '0.1.1';
 
@@ -209,6 +210,7 @@ function usage(): string {
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli worker toggles [--enable <id>|--disable <id> ...]',
     '  invoker-cli run-worker <kind> -- <args...>',
+    '  invoker-cli spend-gate [status|reset]',
     '  invoker-cli auto-approve-authors [--json] [--set <login...>|--add <login>|--add-current-github-user|--clear]',
     '  invoker-cli --help',
     '  invoker-cli --version',
@@ -230,6 +232,7 @@ function usage(): string {
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
     '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, worker-session-mine, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
+    '  spend-gate      Show or clear the Codex daily-spend shutoff. While tripped, every Codex request fails; `reset` reopens it after you review the sessions.',
     '  auto-approve-authors  Show or set GitHub logins in config.json that auto-approve may act on. Does not enable the auto-approve toggle.',
     '',
     'Options:',
@@ -1327,6 +1330,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'mcp') {
       await (deps.runMcpServer ?? runMcpServer)();
       return 0;
+    }
+    if (argv[0] === 'spend-gate') {
+      return runSpendGateCommand(argv.slice(1));
     }
     if (argv[0] === 'auto-approve-authors') {
       return await runAutoApproveAuthorsCommand(argv.slice(1), { configPath: defaultConfigPath() });

--- a/packages/cli/src/spend-gate-command.ts
+++ b/packages/cli/src/spend-gate-command.ts
@@ -1,0 +1,42 @@
+import {
+  clearCodexSpendGateTrip,
+  codexSpendGateBlockMessage,
+  defaultCodexSpendGatePath,
+  loadCodexSpendGateTrip,
+} from '@invoker/execution-engine';
+
+export interface SpendGateCommandDeps {
+  statePath?: string;
+  write?: (text: string) => void;
+}
+
+export function runSpendGateCommand(argv: readonly string[], deps: SpendGateCommandDeps = {}): number {
+  const write = deps.write ?? ((text: string) => process.stdout.write(text));
+  const statePath = deps.statePath ?? defaultCodexSpendGatePath();
+  const subcommand = argv[0] ?? 'status';
+
+  if (subcommand !== 'status' && subcommand !== 'reset') {
+    throw new Error('Unknown spend-gate command. Usage: invoker-cli spend-gate [status|reset]');
+  }
+
+  const trip = loadCodexSpendGateTrip(statePath);
+
+  if (subcommand === 'status') {
+    if (!trip) {
+      write(`Codex daily spend gate: open (no trip recorded at ${statePath}).\n`);
+      return 0;
+    }
+    write(`${codexSpendGateBlockMessage(trip, statePath)}\n`);
+    return 1;
+  }
+
+  if (!trip) {
+    write(`Codex daily spend gate was already open (no trip recorded at ${statePath}).\n`);
+    return 0;
+  }
+  clearCodexSpendGateTrip(statePath);
+  write(
+    `Cleared the Codex daily spend gate trip from ${trip.trippedAt} (${trip.observedTokens} tokens on ${trip.dayKey}). Codex requests are allowed again.\n`,
+  );
+  return 0;
+}

--- a/packages/execution-engine/src/__tests__/codex-spend-gate-live-fleet.integration.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate-live-fleet.integration.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { runCodexDailySpendGateTick, type CodexSpendGateRemoteTarget } from '../workers/spend-circuit-breaker-worker.js';
+import { clearCodexSpendGateTrip, loadCodexSpendGateTrip } from '../codex-spend-gate.js';
+
+const LIVE = process.env.INVOKER_CODEX_SPEND_GATE_LIVE === '1';
+
+interface RemoteTargetConfig {
+  host?: string;
+  user?: string;
+  sshKeyPath?: string;
+  port?: number;
+}
+
+function readRemoteTargets(): CodexSpendGateRemoteTarget[] {
+  const configPath = process.env.INVOKER_REPO_CONFIG_PATH ?? join(homedir(), '.invoker', 'config.json');
+  if (!existsSync(configPath)) return [];
+  const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    remoteTargets?: Record<string, RemoteTargetConfig>;
+  };
+  return Object.entries(parsed.remoteTargets ?? {})
+    .filter(([, t]) => t.host && t.user && t.sshKeyPath)
+    .map(([name, t]) => ({
+      name,
+      connection: {
+        host: t.host as string,
+        user: t.user as string,
+        sshKeyPath: (t.sshKeyPath as string).replace(/^~\//, `${homedir()}/`),
+        port: t.port,
+      },
+    }));
+}
+
+function logger() {
+  const lines: string[] = [];
+  const record = (level: string) => (message: string) => { lines.push(`${level} ${message}`); };
+  return {
+    lines,
+    info: record('info'),
+    warn: record('warn'),
+    error: record('error'),
+    debug: record('debug'),
+    child: () => logger(),
+  };
+}
+
+function statePath(): string {
+  return join(mkdtempSync(join(tmpdir(), 'codex-gate-live-')), 'codex-spend-gate.json');
+}
+
+describe.skipIf(!LIVE)('Codex daily spend gate against the real fleet', () => {
+  const targets = readRemoteTargets();
+  const nowMs = Date.now();
+
+  it('tallies every configured host over SSH and reports a real per-host total', async () => {
+    expect(targets.length).toBeGreaterThan(0);
+    const log = logger();
+
+    const result = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: Number.MAX_SAFE_INTEGER, statePath: statePath(), remoteTargets: targets },
+      log as never,
+      nowMs,
+    );
+
+    process.stdout.write(`\nLIVE FLEET TALLY (${new Date(nowMs).toISOString().slice(0, 10)} UTC)\n`);
+    for (const [host, tokens] of [...result.tokensByHost].sort((a, b) => b[1] - a[1])) {
+      process.stdout.write(`  ${host.padEnd(26)} ${tokens.toLocaleString().padStart(14)}\n`);
+    }
+    process.stdout.write(`  ${'TOTAL'.padEnd(26)} ${result.totalTokens.toLocaleString().padStart(14)}\n`);
+    if (result.failedHosts.length > 0) {
+      process.stdout.write(`  failed hosts: ${result.failedHosts.map((f) => `${f.host} (${f.reason})`).join(', ')}\n`);
+    }
+
+    expect(result.evaluated).toBe(true);
+    expect(result.tokensByHost.size).toBe(targets.length + 1);
+    expect(result.tripped).toBe(false);
+    expect(result.failedHosts).toEqual([]);
+  }, 300_000);
+
+  it('trips on the real tally when that tally exceeds the budget, and stays tripped', async () => {
+    const path = statePath();
+    const log = logger();
+
+    const first = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: 1, statePath: path, remoteTargets: targets },
+      log as never,
+      nowMs,
+    );
+
+    expect(first.tripped).toBe(true);
+    const trip = loadCodexSpendGateTrip(path);
+    expect(trip?.observedTokens).toBe(first.totalTokens);
+    expect(Object.keys(trip?.tokensByHost ?? {}).length).toBe(targets.length + 1);
+    expect(log.lines.some((l) => l.startsWith('error') && l.includes('TRIPPED'))).toBe(true);
+    process.stdout.write(`\nTRIPPED on real tally: ${first.totalTokens.toLocaleString()} tokens > budget 1\n`);
+
+    const second = await runCodexDailySpendGateTick(
+      { enabled: true, dailyTokenBudget: 1, statePath: path, remoteTargets: targets },
+      logger() as never,
+      nowMs + 48 * 60 * 60_000,
+    );
+    expect(second.alreadyTripped).toBe(true);
+    expect(second.evaluated).toBe(false);
+    expect(loadCodexSpendGateTrip(path)?.observedTokens).toBe(first.totalTokens);
+
+    expect(clearCodexSpendGateTrip(path)).toBe(true);
+    expect(loadCodexSpendGateTrip(path)).toBeUndefined();
+  }, 600_000);
+
+  it('reports an unreachable host rather than counting it as zero spend', async () => {
+    const log = logger();
+    const result = await runCodexDailySpendGateTick(
+      {
+        enabled: true,
+        dailyTokenBudget: Number.MAX_SAFE_INTEGER,
+        statePath: statePath(),
+        remoteTargets: [
+          ...targets,
+          { name: 'unreachable_probe', connection: { host: '198.51.100.1', user: 'invoker', sshKeyPath: '/dev/null' } },
+        ],
+      },
+      log as never,
+      nowMs,
+    );
+
+    expect(result.failedHosts.map((f) => f.host)).toContain('unreachable_probe');
+    expect(result.tokensByHost.has('unreachable_probe')).toBe(false);
+    process.stdout.write(`\nunreachable host surfaced: ${result.failedHosts.map((f) => f.host).join(', ')}\n`);
+  }, 300_000);
+});

--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -1,0 +1,204 @@
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@invoker/contracts';
+
+import {
+  CodexSpendGateTrippedError,
+  DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+  clearCodexSpendGateTrip,
+  codexSessionDayDir,
+  createCodexSpendGateReader,
+  evaluateCodexDailySpend,
+  loadCodexSpendGateTrip,
+  parseRemoteCodexTally,
+  recordCodexSpendGateTrip,
+  tallyCodexTokensForDay,
+} from '../codex-spend-gate.js';
+import { runCodexDailySpendGateTick } from '../workers/spend-circuit-breaker-worker.js';
+import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
+
+const NOW_MS = Date.parse('2026-09-04T12:00:00.000Z');
+
+function makeLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return logger as unknown as Logger & typeof logger;
+}
+
+function writeRollout(sessionRoot: string, nowMs: number, name: string, totals: readonly number[]): void {
+  const dayDir = codexSessionDayDir(sessionRoot, nowMs);
+  mkdirSync(dayDir, { recursive: true });
+  const lines = [
+    JSON.stringify({ timestamp: new Date(nowMs).toISOString(), type: 'session_meta', payload: { cwd: '/tmp/x' } }),
+    ...totals.map((total) => JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'token_count', info: { total_token_usage: { total_tokens: total } } },
+    })),
+  ];
+  writeFileSync(join(dayDir, `rollout-${name}.jsonl`), `${lines.join('\n')}\n`, 'utf8');
+}
+
+describe('tallyCodexTokensForDay', () => {
+  it('sums the final cumulative token_count of every rollout log for that day', () => {
+    const root = mkdtempSync(join(tmpdir(), 'codex-gate-tally-'));
+    writeRollout(root, NOW_MS, 'a', [10, 250]);
+    writeRollout(root, NOW_MS, 'b', [40]);
+    writeRollout(root, NOW_MS - 24 * 60 * 60_000, 'yesterday', [999_999]);
+
+    expect(tallyCodexTokensForDay(root, NOW_MS)).toBe(290);
+  });
+});
+
+describe('evaluateCodexDailySpend', () => {
+  it('does not trip at or below the budget', () => {
+    const tokens = new Map([['owner', 60_000_000], ['do3', 40_000_000]]);
+    expect(evaluateCodexDailySpend(tokens, DEFAULT_CODEX_DAILY_TOKEN_BUDGET)).toEqual({
+      totalTokens: 100_000_000,
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      exceeded: false,
+    });
+  });
+
+  it('trips once the fleet total passes the budget', () => {
+    const tokens = new Map([['owner', 60_000_000], ['do3', 40_000_001]]);
+    expect(evaluateCodexDailySpend(tokens, DEFAULT_CODEX_DAILY_TOKEN_BUDGET).exceeded).toBe(true);
+  });
+});
+
+describe('parseRemoteCodexTally', () => {
+  it('reads the last numeric line', () => {
+    expect(parseRemoteCodexTally('warning: something\n12345\n')).toBe(12345);
+  });
+
+  it('throws rather than silently reporting zero on unparseable output', () => {
+    expect(() => parseRemoteCodexTally('ssh: connect refused')).toThrow(/unparseable/);
+  });
+});
+
+describe('runCodexDailySpendGateTick', () => {
+  function gateConfig(overrides: Record<string, unknown> = {}) {
+    const stateDir = mkdtempSync(join(tmpdir(), 'codex-gate-state-'));
+    return {
+      statePath: join(stateDir, 'codex-spend-gate.json'),
+      enabled: true,
+      dailyTokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      localHostName: 'owner',
+      localSessionRoot: '/does/not/matter',
+      tallyLocal: () => 10_000_000,
+      remoteTargets: [
+        { name: 'do3', connection: { host: 'h3', user: 'invoker', sshKeyPath: '/k' } },
+        { name: 'do5', connection: { host: 'h5', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('stays open and writes no trip file when the fleet total is under budget', async () => {
+    const config = gateConfig({ tallyRemote: async () => 20_000_000 });
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.totalTokens).toBe(50_000_000);
+    expect(result.tripped).toBe(false);
+    expect(existsSync(config.statePath)).toBe(false);
+  });
+
+  it('trips and records every host once the fleet total exceeds 100M', async () => {
+    const config = gateConfig({ tallyRemote: async () => 50_000_000 });
+    const logger = makeLogger();
+
+    const result = await runCodexDailySpendGateTick(config, logger, NOW_MS);
+
+    expect(result.totalTokens).toBe(110_000_000);
+    expect(result.tripped).toBe(true);
+    const trip = loadCodexSpendGateTrip(config.statePath);
+    expect(trip?.observedTokens).toBe(110_000_000);
+    expect(trip?.dayKey).toBe('2026-09-04');
+    expect(trip?.tokensByHost).toEqual({ owner: 10_000_000, do3: 50_000_000, do5: 50_000_000 });
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('TRIPPED'), expect.anything());
+  });
+
+  it('surfaces a failing host instead of counting it as zero spend', async () => {
+    const config = gateConfig({
+      tallyRemote: async (target: { name: string }) => {
+        if (target.name === 'do5') throw new Error('ssh timeout');
+        return 20_000_000;
+      },
+    });
+    const logger = makeLogger();
+
+    const result = await runCodexDailySpendGateTick(config, logger, NOW_MS);
+
+    expect(result.failedHosts).toEqual([{ host: 'do5', reason: 'ssh timeout' }]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('remote tally failed on do5'), expect.anything());
+  });
+
+  it('does not re-evaluate or auto-clear while a trip is already recorded', async () => {
+    const config = gateConfig({ tallyRemote: async () => 0 });
+    recordCodexSpendGateTrip(config.statePath, {
+      trippedAt: new Date(NOW_MS).toISOString(),
+      dayKey: '2026-09-04',
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      observedTokens: 900_000_000,
+      tokensByHost: { owner: 900_000_000 },
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS + 48 * 60 * 60_000);
+
+    expect(result.alreadyTripped).toBe(true);
+    expect(result.evaluated).toBe(false);
+    expect(loadCodexSpendGateTrip(config.statePath)?.observedTokens).toBe(900_000_000);
+  });
+
+  it('does nothing when the gate is disabled', async () => {
+    const config = gateConfig({ enabled: false, tallyRemote: async () => 500_000_000 });
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+    expect(result.evaluated).toBe(false);
+    expect(existsSync(config.statePath)).toBe(false);
+  });
+});
+
+describe('Codex agents refuse to build a command while the gate is tripped', () => {
+  function trippedStatePath(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'codex-gate-agent-'));
+    const statePath = join(dir, 'codex-spend-gate.json');
+    recordCodexSpendGateTrip(statePath, {
+      trippedAt: '2026-09-04T12:00:00.000Z',
+      dayKey: '2026-09-04',
+      tokenBudget: DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+      observedTokens: 894_900_000,
+      tokensByHost: { owner: 894_900_000 },
+    });
+    return statePath;
+  }
+
+  it('fails exec, resume, fix, and planning requests with a reviewable message', () => {
+    const statePath = trippedStatePath();
+    const spendGate = createCodexSpendGateReader(statePath);
+    const agent = new CodexExecutionAgent({ spendGate });
+    const planner = new CodexPlanningAgent({ spendGate });
+
+    expect(() => agent.buildCommand('do the thing')).toThrow(CodexSpendGateTrippedError);
+    expect(() => agent.buildResumeArgs('session-1')).toThrow(/every Codex request fails/);
+    expect(() => agent.buildFixCommand('fix the thing')).toThrow(/invoker-cli spend-gate reset/);
+    expect(() => planner.buildPlanningCommand('plan the thing')).toThrow(/894.9M tokens exceeds/);
+  });
+
+  it('allows requests again once the trip is cleared', () => {
+    const statePath = trippedStatePath();
+    const spendGate = createCodexSpendGateReader(statePath);
+    const agent = new CodexExecutionAgent({ spendGate });
+
+    expect(() => agent.buildCommand('do the thing')).toThrow(CodexSpendGateTrippedError);
+    expect(clearCodexSpendGateTrip(statePath)).toBe(true);
+    expect(agent.buildCommand('do the thing').cmd).toBe('codex');
+  });
+});

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -3,11 +3,13 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+import { createCodexSpendGateReader, type CodexSpendGateReader } from '../codex-spend-gate.js';
 
 export interface CodexExecutionAgentConfig {
   command?: string;
   fullAuto?: boolean;
   bypassApprovalsAndSandbox?: boolean;
+  spendGate?: CodexSpendGateReader;
 }
 
 const CODEX_MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
@@ -68,12 +70,14 @@ export class CodexExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private readonly spendGate: CodexSpendGateReader;
   private supportedModelCache?: { expiresAt: number; models: readonly ExecutionModelOption[] };
 
   constructor(config: CodexExecutionAgentConfig = {}) {
     this.command = config.command ?? 'codex';
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? true;
     this.fullAuto = config.fullAuto ?? true;
+    this.spendGate = config.spendGate ?? createCodexSpendGateReader();
     this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
   get supportedModels(): readonly ExecutionModelOption[] {
@@ -82,6 +86,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
 
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    this.spendGate.assertOpen();
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
@@ -91,6 +96,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
   }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+    this.spendGate.assertOpen();
     return {
       cmd: this.command,
       args: ['resume', ...this.buildBypassArgs(), sessionId],
@@ -98,6 +104,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
   }
 
   buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    this.spendGate.assertOpen();
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -1,9 +1,11 @@
 import type { PlanningAgent } from '../agent.js';
+import { createCodexSpendGateReader, type CodexSpendGateReader } from '../codex-spend-gate.js';
 
 export interface CodexPlanningAgentConfig {
   command?: string;
   fullAuto?: boolean;
   bypassApprovalsAndSandbox?: boolean;
+  spendGate?: CodexSpendGateReader;
 }
 
 export class CodexPlanningAgent implements PlanningAgent {
@@ -12,14 +14,17 @@ export class CodexPlanningAgent implements PlanningAgent {
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private readonly spendGate: CodexSpendGateReader;
 
   constructor(config: CodexPlanningAgentConfig = {}) {
     this.command = config.command ?? 'codex';
     this.fullAuto = config.fullAuto ?? true;
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? false;
+    this.spendGate = config.spendGate ?? createCodexSpendGateReader();
   }
 
   buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
+    this.spendGate.assertOpen();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
     else if (this.fullAuto) args.push('--sandbox', 'workspace-write');

--- a/packages/execution-engine/src/codex-spend-gate.ts
+++ b/packages/execution-engine/src/codex-spend-gate.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { listCodexSessionFiles, summarizeCodexSessionFile } from './spend-attribution.js';
+import { bashNormalizeTildePath, shellPosixSingleQuote } from './ssh-git-exec.js';
+
+export const DEFAULT_CODEX_DAILY_TOKEN_BUDGET = 100_000_000;
+
+export const CODEX_SPEND_GATE_ENV_STATE_PATH = 'INVOKER_CODEX_SPEND_GATE_PATH';
+
+export interface CodexSpendGateTrip {
+  readonly trippedAt: string;
+  readonly dayKey: string;
+  readonly tokenBudget: number;
+  readonly observedTokens: number;
+  readonly tokensByHost: Readonly<Record<string, number>>;
+}
+
+export function defaultCodexSpendGatePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[CODEX_SPEND_GATE_ENV_STATE_PATH]?.trim();
+  if (override) return override;
+  const home = env.INVOKER_HOME?.trim() || join(homedir(), '.invoker');
+  return join(home, 'codex-spend-gate.json');
+}
+
+export function loadCodexSpendGateTrip(statePath: string): CodexSpendGateTrip | undefined {
+  if (!existsSync(statePath)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(statePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `codex spend gate state at ${statePath} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `codex spend gate state at ${statePath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const trip = parsed as Partial<CodexSpendGateTrip> | null;
+  if (!trip || typeof trip.trippedAt !== 'string' || typeof trip.observedTokens !== 'number') {
+    return undefined;
+  }
+  return {
+    trippedAt: trip.trippedAt,
+    dayKey: typeof trip.dayKey === 'string' ? trip.dayKey : '',
+    tokenBudget: typeof trip.tokenBudget === 'number' ? trip.tokenBudget : DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+    observedTokens: trip.observedTokens,
+    tokensByHost: (trip.tokensByHost ?? {}) as Readonly<Record<string, number>>,
+  };
+}
+
+export function recordCodexSpendGateTrip(statePath: string, trip: CodexSpendGateTrip): void {
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(trip, null, 2)}\n`, 'utf8');
+}
+
+export function clearCodexSpendGateTrip(statePath: string): boolean {
+  if (!existsSync(statePath)) return false;
+  rmSync(statePath);
+  return true;
+}
+
+function formatTokens(tokens: number): string {
+  return `${(tokens / 1_000_000).toFixed(1)}M`;
+}
+
+export function codexSpendGateBlockMessage(trip: CodexSpendGateTrip, statePath: string): string {
+  const hosts = Object.entries(trip.tokensByHost)
+    .sort((a, b) => b[1] - a[1])
+    .map(([host, tokens]) => `${host}=${formatTokens(tokens)}`)
+    .join(' ');
+  return [
+    'Codex is shut off by the daily spend gate and every Codex request fails until a human reviews the sessions.',
+    `Tripped ${trip.trippedAt} for day ${trip.dayKey}: ${formatTokens(trip.observedTokens)} tokens exceeds the ${formatTokens(trip.tokenBudget)} daily budget.`,
+    hosts.length > 0 ? `Per host: ${hosts}.` : '',
+    `Review the sessions, then clear it with: invoker-cli spend-gate reset  (state file: ${statePath})`,
+  ]
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+export function codexSpendGateDayKey(nowMs: number): string {
+  const d = new Date(nowMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+export function codexSessionDayDir(sessionRootDir: string, nowMs: number): string {
+  const [year, month, day] = codexSpendGateDayKey(nowMs).split('-');
+  return join(sessionRootDir, year, month, day);
+}
+
+export function defaultCodexSessionRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.HOME?.trim() || homedir();
+  return join(home, '.codex', 'sessions');
+}
+
+export function tallyCodexTokensForDay(sessionRootDir: string, nowMs: number): number {
+  const dayDir = codexSessionDayDir(sessionRootDir, nowMs);
+  let total = 0;
+  for (const file of listCodexSessionFiles(dayDir)) {
+    const summary = summarizeCodexSessionFile(file);
+    if (typeof summary.totalTokens === 'number') total += summary.totalTokens;
+  }
+  return total;
+}
+
+export function buildRemoteCodexTallyScript(sessionRootDir: string, nowMs: number): string {
+  const dayDirQ = shellPosixSingleQuote(codexSessionDayDir(sessionRootDir, nowMs));
+  return `set -euo pipefail
+DAY_DIR=${dayDirQ}
+${bashNormalizeTildePath('DAY_DIR')}
+python3 - "$DAY_DIR" <<'PY'
+import json, os, sys
+
+day_dir = sys.argv[1]
+total = 0
+if os.path.isdir(day_dir):
+    for name in os.listdir(day_dir):
+        if not (name.startswith('rollout-') and name.endswith('.jsonl')):
+            continue
+        session_total = 0
+        try:
+            with open(os.path.join(day_dir, name), 'r', errors='replace') as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except ValueError:
+                        continue
+                    if entry.get('type') != 'event_msg':
+                        continue
+                    payload = entry.get('payload') or {}
+                    if payload.get('type') != 'token_count':
+                        continue
+                    usage = (payload.get('info') or {}).get('total_token_usage') or {}
+                    if isinstance(usage.get('total_tokens'), int):
+                        session_total = usage['total_tokens']
+        except OSError as err:
+            print('TALLY_ERROR %s' % err, file=sys.stderr)
+            continue
+        total += session_total
+print(total)
+PY
+`;
+}
+
+export function parseRemoteCodexTally(stdout: string): number {
+  const line = stdout.trim().split('\n').filter((l) => l.trim().length > 0).pop() ?? '';
+  const parsed = Number.parseInt(line.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`remote codex tally returned unparseable output: ${JSON.stringify(stdout.slice(0, 200))}`);
+  }
+  return parsed;
+}
+
+export interface CodexDailySpendEvaluation {
+  readonly totalTokens: number;
+  readonly tokenBudget: number;
+  readonly exceeded: boolean;
+}
+
+export function evaluateCodexDailySpend(
+  tokensByHost: ReadonlyMap<string, number>,
+  tokenBudget: number,
+): CodexDailySpendEvaluation {
+  let totalTokens = 0;
+  for (const tokens of tokensByHost.values()) totalTokens += tokens;
+  return { totalTokens, tokenBudget, exceeded: tokenBudget > 0 && totalTokens > tokenBudget };
+}
+
+export class CodexSpendGateTrippedError extends Error {
+  readonly trip: CodexSpendGateTrip;
+
+  constructor(message: string, trip: CodexSpendGateTrip) {
+    super(message);
+    this.name = 'CodexSpendGateTrippedError';
+    this.trip = trip;
+  }
+}
+
+export interface CodexSpendGateReader {
+  assertOpen(): void;
+}
+
+export function createCodexSpendGateReader(statePath?: string): CodexSpendGateReader {
+  return {
+    assertOpen(): void {
+      const path = statePath ?? defaultCodexSpendGatePath();
+      const trip = loadCodexSpendGateTrip(path);
+      if (!trip) return;
+      throw new CodexSpendGateTrippedError(codexSpendGateBlockMessage(trip, path), trip);
+    },
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -94,6 +94,7 @@ export * from './workers/slack-bug-scan-worker.js';
 export * from './workers/slack-bug-scan-scanner.js';
 export * from './workers/spend-circuit-breaker-worker.js';
 export * from './spend-attribution.js';
+export * from './codex-spend-gate.js';
 export * from './spend-circuit-breaker-state.js';
 export * from './reconcile-terminal-worker-actions.js';
 export * from './requeue-attempt-ledger.js';

--- a/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
+++ b/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
@@ -15,6 +15,20 @@ import {
   recordSpendCircuitBreakerTrip,
   type SpendCircuitBreakerTripRecord,
 } from '../spend-circuit-breaker-state.js';
+import {
+  DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
+  buildRemoteCodexTallyScript,
+  codexSpendGateDayKey,
+  defaultCodexSessionRoot,
+  defaultCodexSpendGatePath,
+  evaluateCodexDailySpend,
+  loadCodexSpendGateTrip,
+  parseRemoteCodexTally,
+  recordCodexSpendGateTrip,
+  tallyCodexTokensForDay,
+} from '../codex-spend-gate.js';
+import { buildSshConnectionArgs, type SshTargetConnection } from '../ssh-transport-options.js';
+import { execRemoteCapture } from '../ssh-git-exec.js';
 
 export const SPEND_CIRCUIT_BREAKER_WORKER_KIND = 'spend-circuit-breaker';
 
@@ -30,6 +44,23 @@ export interface SpendCircuitBreakerWorkflowRow {
 export interface SpendCircuitBreakerWorkerStore {
   listWorkflows(): ReadonlyArray<SpendCircuitBreakerWorkflowRow>;
   setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): unknown;
+}
+
+export interface CodexSpendGateRemoteTarget {
+  readonly name: string;
+  readonly connection: SshTargetConnection;
+  readonly sessionRoot?: string;
+}
+
+export interface CodexDailySpendGateConfig {
+  enabled?: boolean;
+  dailyTokenBudget?: number;
+  localHostName?: string;
+  localSessionRoot?: string;
+  remoteTargets?: ReadonlyArray<CodexSpendGateRemoteTarget>;
+  statePath?: string;
+  tallyRemote?: (target: CodexSpendGateRemoteTarget, nowMs: number) => Promise<number>;
+  tallyLocal?: (sessionRoot: string, nowMs: number) => number;
 }
 
 export interface SpendCircuitBreakerTripDecision {
@@ -60,10 +91,150 @@ export interface SpendCircuitBreakerWorkerConfig {
   tokenBudgetByWorkerKind?: Readonly<Record<string, number>>;
   sessionDir?: string;
   statePath?: string;
+  codexDailyGate?: CodexDailySpendGateConfig;
   intervalMs?: number;
   tickOnStart?: boolean;
   now?: () => number;
   onTick?: WorkerTick;
+}
+
+export interface CodexDailySpendGateTickResult {
+  readonly evaluated: boolean;
+  readonly alreadyTripped: boolean;
+  readonly tokensByHost: ReadonlyMap<string, number>;
+  readonly totalTokens: number;
+  readonly tokenBudget: number;
+  readonly tripped: boolean;
+  readonly failedHosts: ReadonlyArray<{ host: string; reason: string }>;
+}
+
+function defaultTallyRemote(target: CodexSpendGateRemoteTarget, nowMs: number): Promise<number> {
+  const sessionRoot = target.sessionRoot ?? '~/.codex/sessions';
+  return execRemoteCapture({
+    sshArgs: buildSshConnectionArgs(target.connection, { batchMode: true }),
+    script: buildRemoteCodexTallyScript(sessionRoot, nowMs),
+    phase: `codex-spend-gate:${target.name}`,
+  }).then(parseRemoteCodexTally);
+}
+
+export async function runCodexDailySpendGateTick(
+  config: CodexDailySpendGateConfig,
+  logger: Logger,
+  nowMs: number,
+): Promise<CodexDailySpendGateTickResult> {
+  const tokenBudget = config.dailyTokenBudget ?? DEFAULT_CODEX_DAILY_TOKEN_BUDGET;
+  const statePath = config.statePath ?? defaultCodexSpendGatePath();
+  const empty = new Map<string, number>();
+
+  if (config.enabled !== true || tokenBudget <= 0) {
+    return {
+      evaluated: false,
+      alreadyTripped: false,
+      tokensByHost: empty,
+      totalTokens: 0,
+      tokenBudget,
+      tripped: false,
+      failedHosts: [],
+    };
+  }
+
+  if (loadCodexSpendGateTrip(statePath) !== undefined) {
+    return {
+      evaluated: false,
+      alreadyTripped: true,
+      tokensByHost: empty,
+      totalTokens: 0,
+      tokenBudget,
+      tripped: false,
+      failedHosts: [],
+    };
+  }
+
+  const tokensByHost = new Map<string, number>();
+  const failedHosts: Array<{ host: string; reason: string }> = [];
+
+  const localName = config.localHostName ?? 'owner';
+  const tallyLocal = config.tallyLocal ?? tallyCodexTokensForDay;
+  try {
+    tokensByHost.set(localName, tallyLocal(config.localSessionRoot ?? defaultCodexSessionRoot(), nowMs));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    failedHosts.push({ host: localName, reason });
+    logger.error(`[codex-spend-gate] local tally failed on ${localName}: ${reason}`, {
+      module: 'codex-spend-gate',
+      host: localName,
+      reason,
+    });
+  }
+
+  const tallyRemote = config.tallyRemote ?? defaultTallyRemote;
+  for (const target of config.remoteTargets ?? []) {
+    try {
+      tokensByHost.set(target.name, await tallyRemote(target, nowMs));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      failedHosts.push({ host: target.name, reason });
+      logger.error(`[codex-spend-gate] remote tally failed on ${target.name}: ${reason}`, {
+        module: 'codex-spend-gate',
+        host: target.name,
+        reason,
+      });
+    }
+  }
+
+  const evaluation = evaluateCodexDailySpend(tokensByHost, tokenBudget);
+  const dayKey = codexSpendGateDayKey(nowMs);
+
+  if (!evaluation.exceeded) {
+    logger.info(
+      `[codex-spend-gate] ${dayKey}: ${evaluation.totalTokens} of ${tokenBudget} daily Codex tokens used across ${tokensByHost.size} host(s)`,
+      {
+        module: 'codex-spend-gate',
+        dayKey,
+        totalTokens: evaluation.totalTokens,
+        tokenBudget,
+        failedHosts: failedHosts.length,
+      },
+    );
+    return {
+      evaluated: true,
+      alreadyTripped: false,
+      tokensByHost,
+      totalTokens: evaluation.totalTokens,
+      tokenBudget,
+      tripped: false,
+      failedHosts,
+    };
+  }
+
+  recordCodexSpendGateTrip(statePath, {
+    trippedAt: new Date(nowMs).toISOString(),
+    dayKey,
+    tokenBudget,
+    observedTokens: evaluation.totalTokens,
+    tokensByHost: Object.fromEntries(tokensByHost),
+  });
+
+  logger.error(
+    `[codex-spend-gate] TRIPPED ${dayKey}: ${evaluation.totalTokens} Codex tokens exceeds the ${tokenBudget} daily budget; every Codex request now fails until \`invoker-cli spend-gate reset\``,
+    {
+      module: 'codex-spend-gate',
+      dayKey,
+      totalTokens: evaluation.totalTokens,
+      tokenBudget,
+      statePath,
+    },
+  );
+
+  return {
+    evaluated: true,
+    alreadyTripped: false,
+    tokensByHost,
+    totalTokens: evaluation.totalTokens,
+    tokenBudget,
+    tripped: true,
+    failedHosts,
+  };
 }
 
 export interface SpendCircuitBreakerWorkerOptions extends SpendCircuitBreakerWorkerConfig {
@@ -77,6 +248,7 @@ export function createSpendCircuitBreakerWorker(options: SpendCircuitBreakerWork
   const tokenBudgetByWorkerKind = options.tokenBudgetByWorkerKind ?? {};
   const sessionDir = options.sessionDir ?? defaultCodexSessionDir();
   const statePath = options.statePath ?? defaultSpendCircuitBreakerPath();
+  const codexDailyGate = options.codexDailyGate ?? {};
   const now = options.now ?? (() => Date.now());
 
   return createWorkerRuntime({
@@ -87,6 +259,9 @@ export function createSpendCircuitBreakerWorker(options: SpendCircuitBreakerWork
     onTick: async (ctx) => {
       ctx.signal?.throwIfAborted();
       await options.onTick?.(ctx);
+      ctx.signal?.throwIfAborted();
+
+      await runCodexDailySpendGateTick(codexDailyGate, options.logger, now());
       ctx.signal?.throwIfAborted();
 
       if (!enabled || Object.keys(tokenBudgetByWorkerKind).length === 0) return;
@@ -141,7 +316,7 @@ export function registerSpendCircuitBreakerWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: SPEND_CIRCUIT_BREAKER_WORKER_KIND,
-    note: 'Off by default. When configured with per-worker token budgets, disables a worker whose attributable Codex-session spend exceeds its budget within a rolling window.',
+    note: 'When configured with per-worker token budgets, disables a worker whose attributable Codex-session spend exceeds its budget within a rolling window. Its codexDailyGate section separately shuts Codex off fleet-wide once one day of Codex tokens across the owner and every remote target exceeds the daily budget; that trip fails every Codex request until `invoker-cli spend-gate reset`.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.spendCircuitBreaker ?? {};
       return createSpendCircuitBreakerWorker({
@@ -152,6 +327,7 @@ export function registerSpendCircuitBreakerWorker(
         tokenBudgetByWorkerKind: config.tokenBudgetByWorkerKind,
         sessionDir: config.sessionDir,
         statePath: config.statePath,
+        codexDailyGate: config.codexDailyGate,
         intervalMs: config.intervalMs,
         tickOnStart: config.tickOnStart,
         now: config.now,


### PR DESCRIPTION
## Summary

The app owner builds its worker dependencies without a `spendCircuitBreaker` entry.

So the spend-circuit-breaker worker resolves an empty config on every one of its wakeups, and its daily Codex gate never evaluates anything.

This passes the resolver's output in, beside the `diskHeadroom` and `claudeOauthRefresh` entries that already reach the same worker set the same way.

## Review Claim

Approve passing the resolved `spendCircuitBreaker` dependencies into the app owner's worker dependency object.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

One added property on an object literal that is already built here, sourced from a resolver that performs no I/O. Every neighbouring entry in that literal follows this exact shape. With `spendCircuitBreaker` absent from `~/.invoker/config.json`, the resolver still yields a daily gate at its 100M default and the per-worker-kind budget stays off, so the only new behaviour is the daily ceiling this stack exists to add.

## Slice Rationale

The app owner and the headless owner build their dependencies at separate sites with separate blast radii, so each gets its own slice. The headless one lands first because it is the production host.

## Non-goals

Does not change the resolver itself.

Does not touch the headless owner's own dependency site.

Does not change any other entry in this dependency object.

## Visual Proof

![Gated Codex task failing in the task inspector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260909-0534f9/codex-spend-gate-task-failed.png)

Caption: the `gated-codex-task` node red and `FAILED` in the DAG, with the task inspector open beside it showing `TASK STATUS failed`, `AI AGENT: Codex`, and the gate's own message in the ERROR panel.

Manually inspected: I opened this PNG. The DAG node reads `E2E Codex Spend Gate Plan / wf-test-1 / FAILED` with a red left edge, the workflow header reads `E2E Codex Spend Gate Plan · failed`, and the right-hand inspector is titled `Codex task blocked by the daily spend…`. Its TASK STATUS row is a red dot with `failed`. The ERROR panel reads in full: `Error: Executor startup failed (worktree): Codex is shut off by the daily spend gate and every Codex request fails until a human reviews the sessions. Tripped 2026-09-04T04:11:00.000Z for day 2026-09-04: 1471.2M tokens exceeds the 100.0M daily budget. Per host: owner=894.9M remote_digital_ocean_3=202.9M. Review the sessions, then clear it with: invoker-cli spend-gate reset (state file: /tmp/invoker-e2e-ezjt9F/codex-spend-gate.json)`, followed by a stack trace through `_TaskRunner.executeTask` and `Exit code: 1`. Below the error the inspector shows `EXECUTOR POOL local-worktree` and `AI AGENT Codex`, confirming the failure came from the Codex path and not a generic startup error. The footer counters read `failed (1)`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` — exit 0
- [x] `pnpm run check:comments` — exit 0
- [x] `pnpm build` — exit 0
- [x] `bash node_modules/.bin/vitest run src/__tests__/config.test.ts` from `packages/app` — pass
- [x] `bash node_modules/.bin/playwright test e2e/codex-spend-gate-blocks-task.spec.ts` from `packages/app` — `1 passed (22.0s)`. Real Electron app, real executor, real Codex agent path: with a tripped gate written into the test dir, the task reaches `failed` and its stored error carries both `every Codex request fails` and `invoker-cli spend-gate reset`
- [ ] UNVERIFIED: live path — the DO1 production host runs the headless owner (slice 3), not this Electron path, and has not been restarted against this build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
