### PR TITLE
[Flaky Vitest Workspace](2) Chain babysit investigations instead of firing them in parallel

### DIFF
--- a/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Buffer } from 'node:buffer';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -54,24 +55,23 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('listWorkflows materializes every row into JS objects', () => {
     const workflowCount = 5_000;
+    const descriptionPayload = 'x'.repeat(256);
     for (let i = 0; i < workflowCount; i++) {
       adapter.saveWorkflow({
         id: `wf-${i}`,
         name: `Workflow ${i} with a longer name to increase memory footprint`,
-        description: `Description for workflow ${i} that adds more bytes per row`,
+        description: `Description for workflow ${i}: ${descriptionPayload}`,
         status: 'pending',
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });
     }
 
-    const before = process.memoryUsage().heapUsed;
     const workflows = adapter.listWorkflows();
-    const after = process.memoryUsage().heapUsed;
-    const memoryDelta = after - before;
+    const materializedBytes = Buffer.byteLength(JSON.stringify(workflows));
 
     expect(workflows).toHaveLength(workflowCount);
-    expect(memoryDelta).toBeLessThan(1_000_000);
+    expect(materializedBytes).toBeLessThan(1_000_000);
   });
 
   it('listWorkflowsPaged returns bounded results with pagination metadata', () => {

--- a/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/admin-bypass-e2e-babysit-worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  buildInvestigativePlanYaml,
   DEFAULT_WATCHED_WORKER_KINDS,
   E2E_REGRESSION_NEEDS_HUMAN_INVESTIGATED_KIND_PREFIX,
   E2E_REGRESSION_NEEDS_HUMAN_KIND_PREFIX,
@@ -327,5 +328,20 @@ describe('runAdminBypassE2eBabysitTick', () => {
     expect(planSubmitter.submittedPlans).toHaveLength(1);
     expect(workerLifecycle.startCalls).toHaveLength(2);
     expect(repairFilings.deleteCalls).toHaveLength(2);
+  });
+
+  it('serializes investigative tasks so one stale-filing sweep cannot saturate the owner host', () => {
+    const plan = buildInvestigativePlanYaml([
+      { type: 'worker-start', kind: 'worker-a' },
+      { type: 'worker-start', kind: 'worker-b' },
+      { type: 'worker-start', kind: 'worker-c' },
+    ]);
+
+    expect(plan).toContain('  - id: investigate-finding-1\n');
+    expect(plan).toContain('    dependencies: []\n');
+    expect(plan).toContain('  - id: investigate-finding-2\n');
+    expect(plan).toContain('    dependencies: [investigate-finding-1]\n');
+    expect(plan).toContain('  - id: investigate-finding-3\n');
+    expect(plan).toContain('    dependencies: [investigate-finding-2]\n');
   });
 });

--- a/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
+++ b/packages/execution-engine/src/workers/admin-bypass-e2e-babysit-worker.ts
@@ -157,11 +157,12 @@ function investigativePrompt(action: AdminBypassE2eBabysitAction): string {
 export function buildInvestigativePlanYaml(actions: readonly AdminBypassE2eBabysitAction[]): string {
   const taskLines = actions.flatMap((action, index) => {
     const prompt = investigativePrompt(action);
+    const dependencies = index === 0 ? '[]' : `[investigate-finding-${index}]`;
     return [
       `  - id: investigate-finding-${index + 1}`,
       `    description: ${yamlString(prompt)}`,
       `    prompt: ${yamlString(prompt)}`,
-      '    dependencies: []',
+      `    dependencies: ${dependencies}`,
     ];
   });
   return [

--- a/repro/08-flaky-materialization-proof-heap-instrument.mjs
+++ b/repro/08-flaky-materialization-proof-heap-instrument.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Buffer } from 'node:buffer';
+
+let SQLiteAdapter;
+try {
+  ({ SQLiteAdapter } = await import('../packages/data-store/dist/index.js'));
+} catch (error) {
+  console.error(`cannot load @invoker/data-store dist: ${error.message}`);
+  console.error('run `pnpm --filter @invoker/data-store build` first');
+  process.exit(2);
+}
+
+const WORKFLOW_COUNT = 5_000;
+const THRESHOLD = 1_000_000;
+const ITERATIONS = Number(process.env.REPRO_ITERATIONS ?? 12);
+
+function seed(adapter, withPayload) {
+  const payload = 'x'.repeat(256);
+  for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+    adapter.saveWorkflow({
+      id: `wf-${i}`,
+      name: `Workflow ${i} with a longer name to increase memory footprint`,
+      description: withPayload
+        ? `Description for workflow ${i}: ${payload}`
+        : `Description for workflow ${i} that adds more bytes per row`,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+}
+
+async function sample(withPayload) {
+  const dir = mkdtempSync(join(tmpdir(), 'repro-flaky-'));
+  const adapter = await SQLiteAdapter.create(join(dir, 'invoker.db'), { ownerCapability: true });
+  try {
+    seed(adapter, withPayload);
+    const before = process.memoryUsage().heapUsed;
+    const workflows = adapter.listWorkflows();
+    const after = process.memoryUsage().heapUsed;
+    return { heapDelta: after - before, bytes: Buffer.byteLength(JSON.stringify(workflows)) };
+  } finally {
+    await adapter.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function report(label, values) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const under = values.filter((v) => v < THRESHOLD).length;
+  console.log(
+    `${label.padEnd(22)} min=${min.toLocaleString().padStart(12)}  max=${max.toLocaleString().padStart(12)}  `
+    + `spread=${(max - min).toLocaleString().padStart(12)}  runs_under_${THRESHOLD.toLocaleString()}=${under}/${values.length}`,
+  );
+  return under;
+}
+
+const heapDeltas = [];
+const byteCounts = [];
+for (let i = 0; i < ITERATIONS; i += 1) {
+  const s = await sample(true);
+  heapDeltas.push(s.heapDelta);
+  byteCounts.push(s.bytes);
+}
+
+console.log(`repro: it.fails('listWorkflows materializes every row into JS objects')`);
+console.log(`the block is GREEN only while its assertion THROWS, i.e. while the measured value is >= ${THRESHOLD.toLocaleString()}`);
+console.log(`${ITERATIONS} iterations, ${WORKFLOW_COUNT.toLocaleString()} workflows each\n`);
+
+const heapUnder = report('heapUsed delta (old)', heapDeltas);
+const bytesUnder = report('serialized bytes (new)', byteCounts);
+
+const heapSpread = Math.max(...heapDeltas) - Math.min(...heapDeltas);
+const bytesSpread = Math.max(...byteCounts) - Math.min(...byteCounts);
+
+console.log('');
+let failures = 0;
+if (bytesSpread !== 0) {
+  console.log(`FAIL: serialized-byte instrument varied by ${bytesSpread.toLocaleString()} across runs; it must be constant`);
+  failures += 1;
+} else {
+  console.log(`PASS: serialized-byte instrument is identical on every run (${byteCounts[0].toLocaleString()} bytes)`);
+}
+if (bytesUnder > 0) {
+  console.log(`FAIL: serialized-byte instrument fell under the threshold ${bytesUnder} time(s); the block would go red`);
+  failures += 1;
+} else {
+  console.log(`PASS: serialized-byte instrument never fell under the threshold, so the block cannot flake`);
+}
+if (heapSpread === 0) {
+  console.log(`INCONCLUSIVE: heap instrument did not vary on this host; it is still not a guaranteed-stable measurement`);
+} else {
+  console.log(`OBSERVED: heap instrument varied by ${heapSpread.toLocaleString()} bytes across identical runs (${heapUnder} run(s) under the threshold)`);
+}
+
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

`buildInvestigativePlanYaml` gave every investigation `dependencies: []`, so one wakeup handed the owner all of them at once.

On DO1 that meant single wakeups opening 77, 67 and 63 investigations, each its own agent session. 539 of them fired on 2026-09-04.

Each investigation now depends on the one before it. A wakeup that finds a large backlog walks it instead of launching it.

## Review Claim

Approve chaining the investigative tasks into a dependency sequence so one wakeup cannot saturate the owner host.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Three lines in one builder function, plus its test. Every investigation that was opened before is still opened, with the same id, description and prompt; only the `dependencies` field changes, and the first task keeps `[]` so the chain always has a head. Nothing else in this file is touched — in particular the cooldown #11973 added afterwards is left exactly as it is, which the diff stat of 2 insertions and 1 deletion in the worker shows.

## Slice Rationale

One builder function and its test, separate from the unrelated test-instrument change in slice 1.

## Non-goals

Does not bound how many investigations a wakeup may open. Chaining changes concurrency, not count; a ceiling belongs in the plan parser and is its own change.

Does not change the cooldown, the watched worker set, or the stale-filing TTL.

Does not change which conditions produce an investigation.

## Prior art

This is the three-line change from `f14e835d`, authored 2026-08-31 and never merged: `git merge-base --is-ancestor f14e835d origin/master` reports it is not an ancestor. Only that change is taken here. Restoring the whole file as it stood at `f14e835d` would have reverted the cooldown #11973 landed on 2026-09-04, so the change was re-applied by hand onto current master instead.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Fail-before: with the new test present and the worker reverted to master's builder, `bash node_modules/.bin/vitest run src/__tests__/admin-bypass-e2e-babysit-worker.test.ts` from `packages/execution-engine` fails on `expect(plan).toContain('    dependencies: [investigate-finding-2]\n')` — `Tests  1 failed | 8 passed (9)`
- [x] Pass-after, same command with the builder change applied — `Tests  9 passed (9)`
- [x] Regression check: `grep -c "createInvestigationPlanThrottle\|isThrottled\|throttle.mark"` on the worker returns 6, unchanged from master, confirming the cooldown survived
- [x] `pnpm run check:types` — exit 0
- [x] `pnpm run check:comments` — exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; reverting restores all-parallel dispatch
- Data migration? No

</details>
