### PR TITLE
[Codex Clamp Switch](1) Add the codex-spend-clamp worker toggle

### DIFF
--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -48,6 +48,21 @@ describe('ONBOARDING_WORKER_TOGGLES', () => {
     expect(mine.defaultEnabled).toBeUndefined();
     expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'worker-session-mine')).toBe(false);
   });
+
+  it('exposes codex-spend-clamp as an opt-in desired-state toggle outside onboarding', () => {
+    const clamp = findWorkerToggle('codex-spend-clamp')!;
+    expect(isDesiredStateWorkerToggle(clamp)).toBe(true);
+    expect(clamp.workerKinds).toEqual(['spend-circuit-breaker']);
+    expect(clamp.defaultEnabled).toBeUndefined();
+    expect(ONBOARDING_WORKER_TOGGLES.some((spec) => spec.id === 'codex-spend-clamp')).toBe(false);
+  });
+
+  it('gives every registered builtin worker kind a toggle that can switch it on', () => {
+    const toggled = new Set(
+      WORKER_TOGGLES.flatMap((spec) => (isDesiredStateWorkerToggle(spec) ? [...spec.workerKinds] : [])),
+    );
+    expect(toggled.has('spend-circuit-breaker')).toBe(true);
+  });
 });
 
 describe('policy applyWorkerToggle / readWorkerToggleValue', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -231,7 +231,7 @@ function usage(): string {
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
-    '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, worker-session-mine, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
+    '  worker toggles      Show or set owner worker on/off (pr-status, autofix, PR maintenance, e2e auto-fix, worker-session-mine, codex-spend-clamp, idle-task-cleanup) and policy flags (auto-approve, disk-headroom cleanup).',
     '  spend-gate      Show or clear the Codex daily-spend shutoff. While tripped, every Codex request fails; `reset` reopens it after you review the sessions.',
     '  auto-approve-authors  Show or set GitHub logins in config.json that auto-approve may act on. Does not enable the auto-approve toggle.',
     '',

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -15,6 +15,7 @@ import {
   PR_DUPLICATE_CLOSE_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
+  SPEND_CIRCUIT_BREAKER_WORKER_KIND,
   WORKER_SESSION_MINE_WORKER_KIND,
 } from '@invoker/execution-engine';
 
@@ -109,6 +110,13 @@ export const WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
     label: 'Worker session mine',
     description: 'Mines finished worker agent sessions (Claude, Codex, OMP) for thrash: 40+ turns, 10M+ cache-read or total tokens, or the same shell command 5+ times. Files one Invoker follow-up per session, capped at 1 per tick and 2 per day. Off by default; enable on the DO1 owner only.',
     workerKinds: [WORKER_SESSION_MINE_WORKER_KIND],
+    includeInOnboarding: false,
+  },
+  {
+    id: 'codex-spend-clamp',
+    label: 'Codex daily spend clamp',
+    description: 'Adds up the day\'s Codex tokens on the owner and over SSH on every remote target, and once the fleet total passes the daily budget it writes a trip that makes every Codex request fail until `invoker-cli spend-gate reset`. Off until switched on; enable on the DO1 owner.',
+    workerKinds: [SPEND_CIRCUIT_BREAKER_WORKER_KIND],
     includeInOnboarding: false,
   },
   {


### PR DESCRIPTION
## Summary

The Codex spend clamp shipped without a way to turn it on.

A worker runs only when `worker_desired_states` holds a row for its kind. `autoStarts` is that same value, so there is no default-on path. The only sanctioned writer of that table is a toggle spec, and `spend-circuit-breaker` had none.

The result on DO1: the clamp code was deployed and present in the running build, and the worker never ticked once.

This adds the toggle, off until switched on.

## Review Claim

Approve the `codex-spend-clamp` toggle that writes desired state for `spend-circuit-breaker`, and the check that every desired-state worker kind is reachable from some toggle.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

One entry appended to `WORKER_TOGGLES` and one help line. `includeInOnboarding: false` keeps it out of the setup wizard, and no `defaultEnabled` means it stays off until an operator switches it on, so merging this changes nothing by itself. It writes only `worker_desired_states` for one kind, never a config flag — the invariant `assertWorkerToggleHasSingleSource` already enforces and the suite already covers.

## Slice Rationale

One file plus its test. The clamp's decision logic, config wiring and operator command all landed separately; this is only the missing switch.

## Non-goals

Does not switch the clamp on anywhere.

Does not change the clamp's budget, its tally, or what it does when it trips.

Does not add a default-on path for any worker kind.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Fail-before: with `packages/cli/src/worker-toggles.ts` restored to `origin/master` and the new tests present, `bash node_modules/.bin/vitest run src/__tests__/worker-toggles.test.ts` from `packages/cli` reports `Tests  2 failed | 14 passed (16)`
- [x] Pass-after, same command with the toggle added — `Tests  16 passed (16)`
- [x] `pnpm run check:types` — exit 0
- [x] `pnpm run check:comments` — clean
- [x] Live evidence this was the gap: on DO1, `invoker-cli worker toggles --enable spend-circuit-breaker` answered `Unknown worker toggle id: "spend-circuit-breaker". Known ids: pr-status, autofix, pr-maintenance, e2e-autofix, auto-approve, disk-headroom-cleanup, worker-session-mine, idle-task-cleanup`, and `select ... from worker_desired_states where worker_kind like '%spend%'` returned no row
- [ ] UNVERIFIED: not yet switched on against the DO1 owner

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: if the toggle had been switched on, its `worker_desired_states` row remains and the worker keeps running; disable it first if that is not wanted
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `codex-spend-clamp` worker toggle.
  * The toggle is available through worker-toggle help and can enable the spend circuit breaker.
  * The toggle is opt-in and does not appear during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->