### PR TITLE
[Clamp Fleet Accuracy](1) Let config name the owner's own host

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -23,6 +23,7 @@ import {
   resolveE2eAutoFixWorkerConfig,
   DEFAULT_PR_MAINTENANCE_TARGET_REPO,
   DEFAULT_E2E_AUTOFIX_TARGET_REPO,
+  resolveSpendCircuitBreakerWorkerConfig,
 } from '../config.js';
 import { validateInvokerConfig } from '../config-validation.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -1153,5 +1154,24 @@ describe('e2eAutoFix.targetRepos', () => {
     expect(() => validateInvokerConfig({
       e2eAutoFix: { targetRepos: ['owner,other/repo'] },
     })).toThrow(/owner\/repo/);
+  });
+});
+
+describe('resolveSpendCircuitBreakerWorkerConfig', () => {
+  it('names the owner host from config so a fleet member that is also the owner is counted once', () => {
+    const resolved = resolveSpendCircuitBreakerWorkerConfig({
+      remoteTargets: {
+        remote_digital_ocean_1: { host: 'h1', user: 'invoker', sshKeyPath: '/k' },
+        remote_digital_ocean_3: { host: 'h3', user: 'invoker', sshKeyPath: '/k' },
+      },
+      spendCircuitBreaker: { codexDailyGate: { localHostName: 'remote_digital_ocean_1' } },
+    } as never);
+
+    expect(resolved.codexDailyGate?.localHostName).toBe('remote_digital_ocean_1');
+  });
+
+  it('falls back to a neutral owner label when config does not name the host', () => {
+    const resolved = resolveSpendCircuitBreakerWorkerConfig({ remoteTargets: {} } as never);
+    expect(resolved.codexDailyGate?.localHostName).toBe('owner');
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -249,6 +249,7 @@ export interface CodexDailySpendGateConfigEntry {
   enabled?: boolean;
   dailyTokenBudget?: number;
   statePath?: string;
+  localHostName?: string;
 }
 
 export interface SpendCircuitBreakerConfig {
@@ -910,7 +911,7 @@ export function resolveSpendCircuitBreakerWorkerConfig(
       enabled: gate?.enabled ?? true,
       dailyTokenBudget: gate?.dailyTokenBudget ?? DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
       statePath: gate?.statePath,
-      localHostName: 'owner',
+      localHostName: gate?.localHostName ?? 'owner',
       remoteTargets: Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
         name,
         connection: {

--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -158,6 +158,24 @@ describe('runCodexDailySpendGateTick', () => {
     expect(loadCodexSpendGateTrip(config.statePath)?.observedTokens).toBe(900_000_000);
   });
 
+  it('counts a host once when the owner is also a configured remote target', async () => {
+    const config = gateConfig({
+      localHostName: 'remote_digital_ocean_1',
+      tallyLocal: () => 20_406_837,
+      remoteTargets: [
+        { name: 'remote_digital_ocean_1', connection: { host: 'h1', user: 'invoker', sshKeyPath: '/k' } },
+        { name: 'remote_digital_ocean_3', connection: { host: 'h3', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      tallyRemote: async (target: { name: string }) => (target.name === 'remote_digital_ocean_1' ? 20_406_837 : 14_235),
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.tokensByHost.size).toBe(2);
+    expect(result.tokensByHost.get('remote_digital_ocean_1')).toBe(20_406_837);
+    expect(result.totalTokens).toBe(20_421_072);
+  });
+
   it('does nothing when the gate is disabled', async () => {
     const config = gateConfig({ enabled: false, tallyRemote: async () => 500_000_000 });
     const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);


### PR DESCRIPTION
## Summary

The clamp counted DO1 twice.

`resolveSpendCircuitBreakerWorkerConfig` hardcoded the owner's tally key as `owner`. On a box that is also a configured remote target, the same machine lands under two keys and its tokens are added twice.

Measured live on DO1 for 2026-09-09: `owner=20,406,837` and `remote_digital_ocean_1=20,406,837`, a reported total of `41,222,237` against a real `20,815,400`.

`tokensByHost` is already keyed by name, so matching names collapse on their own. The only thing missing was a way to say the owner *is* `remote_digital_ocean_1`.

## Review Claim

Approve reading the owner's tally key from `spendCircuitBreaker.codexDailyGate.localHostName`, defaulting to `owner` when config does not name it.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

One field on the resolver's output changes, from a constant to a config lookup with that same constant as its fallback, so an install that does not name the host behaves exactly as before. Naming a host can only merge two tally keys into one, never invent or drop a host: the reported total moves down toward the truth and the clamp trips later, never earlier. No SSH, no tally arithmetic, and no trip logic is touched.

## Slice Rationale

The resolver and its test only. The wrapper's separate env problem is slice 2 because it is a different file class and a different failure.

## Non-goals

Does not detect automatically that the owner is a fleet member; an operator names it.

Does not change the daily budget, the tally, or what happens on a trip.

Does not touch the worker's own decision logic, which already collapses same-named hosts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Fail-before: the new resolver test against master's hardcoded value — `AssertionError: expected 'owner' to be 'remote_digital_ocean_1'`, `Tests  1 failed | 1 passed`
- [x] Pass-after: `bash node_modules/.bin/vitest run src/__tests__/config.test.ts -t "resolveSpendCircuitBreakerWorkerConfig"` from `packages/app` — `Tests  2 passed`
- [x] Invariant test added in `packages/execution-engine`: with the owner named as a fleet member, `tokensByHost.size` is 2 not 3 and the total is `20,421,072` — 13 tests pass
- [x] Live measurement that motivated this, run on DO1 against real rollout logs:

  ```
  PROOF DAY 2026-09-09 budget=40,000,000
    owner                          20,406,837
    remote_digital_ocean_1         20,406,837
    remote_digital_ocean_6            148,341
    remote_digital_ocean_7            131,841
    remote_digital_ocean_5            114,146
    remote_digital_ocean_3             14,235
    remote_digital_ocean_4                  0
    TOTAL                          41,222,237
  ```

- [x] `pnpm run check:types` — exit 0
- [x] `pnpm run check:comments` — clean
- [ ] UNVERIFIED: `localHostName` is not yet set in DO1's config; the double count stands there until an operator sets it

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; the key returns to the constant `owner`
- Data migration? No

</details>
