### PR TITLE
[Clamp Fleet Accuracy](2) Load operator env in the CI-watch wrapper

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -23,6 +23,7 @@ import {
   resolveE2eAutoFixWorkerConfig,
   DEFAULT_PR_MAINTENANCE_TARGET_REPO,
   DEFAULT_E2E_AUTOFIX_TARGET_REPO,
+  resolveSpendCircuitBreakerWorkerConfig,
 } from '../config.js';
 import { validateInvokerConfig } from '../config-validation.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -1153,5 +1154,24 @@ describe('e2eAutoFix.targetRepos', () => {
     expect(() => validateInvokerConfig({
       e2eAutoFix: { targetRepos: ['owner,other/repo'] },
     })).toThrow(/owner\/repo/);
+  });
+});
+
+describe('resolveSpendCircuitBreakerWorkerConfig', () => {
+  it('names the owner host from config so a fleet member that is also the owner is counted once', () => {
+    const resolved = resolveSpendCircuitBreakerWorkerConfig({
+      remoteTargets: {
+        remote_digital_ocean_1: { host: 'h1', user: 'invoker', sshKeyPath: '/k' },
+        remote_digital_ocean_3: { host: 'h3', user: 'invoker', sshKeyPath: '/k' },
+      },
+      spendCircuitBreaker: { codexDailyGate: { localHostName: 'remote_digital_ocean_1' } },
+    } as never);
+
+    expect(resolved.codexDailyGate?.localHostName).toBe('remote_digital_ocean_1');
+  });
+
+  it('falls back to a neutral owner label when config does not name the host', () => {
+    const resolved = resolveSpendCircuitBreakerWorkerConfig({ remoteTargets: {} } as never);
+    expect(resolved.codexDailyGate?.localHostName).toBe('owner');
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -249,6 +249,7 @@ export interface CodexDailySpendGateConfigEntry {
   enabled?: boolean;
   dailyTokenBudget?: number;
   statePath?: string;
+  localHostName?: string;
 }
 
 export interface SpendCircuitBreakerConfig {
@@ -910,7 +911,7 @@ export function resolveSpendCircuitBreakerWorkerConfig(
       enabled: gate?.enabled ?? true,
       dailyTokenBudget: gate?.dailyTokenBudget ?? DEFAULT_CODEX_DAILY_TOKEN_BUDGET,
       statePath: gate?.statePath,
-      localHostName: 'owner',
+      localHostName: gate?.localHostName ?? 'owner',
       remoteTargets: Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
         name,
         connection: {

--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -158,6 +158,24 @@ describe('runCodexDailySpendGateTick', () => {
     expect(loadCodexSpendGateTrip(config.statePath)?.observedTokens).toBe(900_000_000);
   });
 
+  it('counts a host once when the owner is also a configured remote target', async () => {
+    const config = gateConfig({
+      localHostName: 'remote_digital_ocean_1',
+      tallyLocal: () => 20_406_837,
+      remoteTargets: [
+        { name: 'remote_digital_ocean_1', connection: { host: 'h1', user: 'invoker', sshKeyPath: '/k' } },
+        { name: 'remote_digital_ocean_3', connection: { host: 'h3', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      tallyRemote: async (target: { name: string }) => (target.name === 'remote_digital_ocean_1' ? 20_406_837 : 14_235),
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.tokensByHost.size).toBe(2);
+    expect(result.tokensByHost.get('remote_digital_ocean_1')).toBe(20_406_837);
+    expect(result.totalTokens).toBe(20_421_072);
+  });
+
   it('does nothing when the gate is disabled', async () => {
     const config = gateConfig({ enabled: false, tallyRemote: async () => 500_000_000 });
     const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);

--- a/scripts/cron-e2e-regression-watch.sh
+++ b/scripts/cron-e2e-regression-watch.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+INVOKER_OPERATOR_ENV="${INVOKER_OPERATOR_ENV:-$HOME/.invoker/env.sh}"
+if [ -f "$INVOKER_OPERATOR_ENV" ]; then
+  set +u
+  . "$INVOKER_OPERATOR_ENV"
+  set -u
+fi
+
 # Mirror scripts/e2e-regression-watch.mjs's own CLI > env target-repo
 # precedence just enough to pick a non-colliding lock file: a --target-repo
 # flag on argv wins, otherwise INVOKER_GITHUB_TARGET_REPO, otherwise the


### PR DESCRIPTION
## Summary

Setting the CI-watch cap in `~/.invoker/.slack-owner.env` does nothing, and nothing says so.

The sweep reads `INVOKER_CI_WATCH_CAP` from its environment. It is spawned by the owner, and the owner is launched by the Slack manager with a curated environment — of everything in that file, only `PATH` reaches the owner process. Measured on DO1: 8 of 9 entries arrive as `owner_has=0`.

The wrapper now loads `~/.invoker/env.sh` when present, which is where an operator already keeps this kind of setting.

## Review Claim

Approve the CI-watch wrapper loading `~/.invoker/env.sh` before it runs the sweep, overridable by `INVOKER_OPERATOR_ENV`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Six lines at the top of one wrapper. The load is guarded by `[ -f ]`, so an install without that file is byte-for-byte unchanged. `set +u` is restored to `set -u` immediately around the load so an unset variable inside the operator's own file cannot abort the sweep. The wrapper reads the file and passes nothing new to the sweep beyond what the operator put there; `INVOKER_OPERATOR_ENV` lets a caller point elsewhere or, with a path that does not exist, opt out.

## Slice Rationale

One shell file, kept apart from slice 1's resolver change because it is a different file class and a different failure.

## Non-goals

Does not change how the owner itself is launched or what the Slack manager passes it.

Does not give the sweep a config-file source for the cap.

Does not set a cap value anywhere.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Fail-before / pass-after under a `HOME` whose `.invoker/env.sh` exports `INVOKER_CI_WATCH_CAP=3`, both wrappers sourced under `env -i`:

  ```
  --- master wrapper ---
  cap=UNSET
  --- fixed wrapper ---
  cap=3
  ```

- [x] `bash -n scripts/cron-e2e-regression-watch.sh` — syntax OK
- [x] Live measurement that motivated this, on DO1: every entry of `.slack-owner.env` checked against the owner's `/proc/<pid>/environ` — `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_CHANNEL_ID`, `INVOKER_SLACK_DEFAULT_PRESET`, `INVOKER_SLACK_HI_SMOKE`, `INVOKER_GITHUB_TARGET_REPOS` and `INVOKER_CI_WATCH_CAP` all `owner_has=0`; only `PATH` arrived
- [x] `pnpm run check:comments` — clean
- [ ] UNVERIFIED: not yet exercised through a real sweep on DO1

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; the wrapper stops reading the file and the sweep falls back to whatever env it inherits
- Data migration? No

</details>
