### PR TITLE
[CLI Parity](1) Expose the headless set command family from invoker-cli

### DIFF
--- a/packages/cli/src/__tests__/cli-mutations.test.ts
+++ b/packages/cli/src/__tests__/cli-mutations.test.ts
@@ -91,6 +91,47 @@ describe('invoker-cli mutations', () => {
     output.restore();
   });
 
+  it.each([
+    ['task-pool', 'wf-1/task-1', ['local-only']],
+    ['agent', 'wf-1/task-1', ['claude']],
+    ['task', 'wf-1/task-1', ['config.poolId', 'local-only']],
+  ])('forwards set %s over headless.exec with noTrack', async (subcommand, targetId, rest) => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const execHandler = vi.fn(async (request: unknown) => {
+      expect(request).toEqual({ args: ['set', subcommand, targetId, ...rest], noTrack: true });
+      return { ok: true };
+    });
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.exec', execHandler);
+
+    const code = await main(['set', subcommand, targetId, ...rest], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(execHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toContain(`set ${subcommand} accepted by live owner.`);
+    output.restore();
+  });
+
+  it.each([
+    [['set'], 'Missing set sub-command'],
+    [['set', 'task-pool'], 'Missing id'],
+    [['set', 'task-pool', 'wf-1/task-1'], 'Missing value'],
+  ])('rejects incomplete set invocation %j without contacting the owner', async (argv, expected) => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const execHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.exec', execHandler);
+
+    const code = await main(argv, { createMessageBus: () => bus });
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain(expected);
+    expect(execHandler).not.toHaveBeenCalled();
+    output.restore();
+  });
+
   it('refuses owner-required mutations with actionable guidance when no owner is reachable', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -200,6 +200,7 @@ function usage(): string {
     '  invoker-cli retry <workflowId>',
     '  invoker-cli resume <workflowId>',
     '  invoker-cli retry-tasks --status <status> [--parallel N] [--dry-run]',
+    '  invoker-cli set <sub-command> <id> <value...>',
     '  invoker-cli delete <workflowId>',
     '  invoker-cli delete-all',
     '  invoker-cli owner serve',
@@ -224,6 +225,7 @@ function usage(): string {
     '  retry <workflowId>  Ask a live Invoker owner to retry a workflow.',
     '  resume <workflowId> Ask a live Invoker owner to resume a workflow.',
     '  retry-tasks --status <status>  Retry all tasks matching a status through a live owner.',
+    '  set <sub-command> <id> <value...>  Edit a task or workflow field through a live owner (task-pool, agent, model, prompt, task <fieldPath>, ...).',
     '  delete-all      Ask a live Invoker owner to delete all workflows. Runs unconditionally; the owner snapshots the DB first.',
     '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
@@ -786,6 +788,32 @@ async function runBounded<T>(
   });
   await Promise.all(workers);
   return { accepted, failed };
+}
+
+async function runSetMutation(args: string[], deps: CliDeps): Promise<number> {
+  const [subcommand, targetId] = args;
+  if (!subcommand) {
+    throw new Error('Missing set sub-command. Usage: invoker-cli set <sub-command> <id> <value...>');
+  }
+  if (!targetId) {
+    throw new Error(`Missing id. Usage: invoker-cli set ${subcommand} <id> <value...>`);
+  }
+  if (args.length < 3) {
+    throw new Error(`Missing value. Usage: invoker-cli set ${subcommand} ${targetId} <value...>`);
+  }
+  let bus: MessageBus | undefined;
+  try {
+    bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
+    await requireLiveOwnerForMutation(bus);
+    await sendHeadlessExec(bus, ['set', ...args]);
+    process.stdout.write(`set ${subcommand} accepted by live owner.\n`);
+    return 0;
+  } finally {
+    const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
+    if (disconnect) {
+      disconnect.call(bus);
+    }
+  }
 }
 
 async function runRetryTasks(options: RetryTasksOptions, deps: CliDeps): Promise<number> {
@@ -1403,6 +1431,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         throw new Error(`Unexpected argument: ${argv[1]}`);
       }
       return await runDeleteAllMutation(deps);
+    }
+    if (argv[0] === 'set') {
+      return await runSetMutation(argv.slice(1), deps);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {


### PR DESCRIPTION
## Summary

`invoker-cli` cannot edit a task field that the GUI edits with a click.

The app has had a `set` command family for a long time: `set task-pool`, `set agent`, `set model`, `set prompt`, and a generic `set task <fieldPath> <value>`.

The GUI drives that family through the headless layer. The CLI never learned the verb.

That gap has teeth. A task's `poolId`, `runnerKind` and `executionAgent` are frozen into its config the moment the task is created.

Editing `defaultPoolId` in `config.json` does not move a task that already exists. Re-running an existing task keeps whatever executor it already carries.

So a batch of tasks pinned to an unreachable pool could only be repaired one at a time, by hand, in the UI.

This exposes `set` from the CLI, over the same `headless.exec` channel the other mutation commands already use.

## Before and After

Input `invoker-cli set task-pool wf-1/task-1 local-only`, run by calling the CLI's `main()` with an in-memory stand-in owner that prints whatever reaches it over `headless.exec`, once on base `429af0c6b` and once on this PR's head `4eac80d11`:

```
Before: Unknown command: set
        exit code: 1
After:  owner received: {"args":["set","task-pool","wf-1/task-1","local-only"],"noTrack":true}
        set task-pool accepted by live owner.
        exit code: 0
```

## Review Claim

`invoker-cli set <sub-command> <id> <value...>` reaches the same owner handler the GUI reaches.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

An incomplete `set` invocation never reaches the owner. A missing sub-command, id, or value exits 1 locally, before any request is sent.

Sub-command names are still resolved by the owner, which already refuses unknown ones. The CLI gains no second copy of the registry that could drift from it.

## Slice Rationale

The gate that keeps this class of gap from recurring is the next PR in this stack.

It is separated because its debt baseline counts `set` as exposed, so that baseline only reads correctly once this lands.

## Non-goals

Teaching the CLI the other 28 headless commands it still lacks. This adds one verb; the follow-up records the rest as shrink-only debt.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli-mutations.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm run check:comments`

Six new cases in the shape the neighbouring mutation commands already use. Three assert the exact `headless.exec` payload for `task-pool`, `agent` and `task config.poolId`. Three assert an incomplete invocation never reaches the owner.

Fail-before / pass-after, same command, only `index.ts` reverted between the two runs:

```
without the dispatch case:  Tests  6 failed | 9 passed (15)
with the dispatch case:     Tests  15 passed (15)
```

`pnpm run check:types` and `pnpm run check:comments` both exit 0.

Pre-existing and untouched: `src/__tests__/cli.test.ts` fails 8 of 38 on `origin/master` in a fresh worktree, identical with and without this change (`8 failed | 30 passed` both ways).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4eac80d1`
- Post-revert steps: None
- Data migration? No

The dispatch case is additive. No existing verb changes behavior.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a live-owner mutation path that can change task execution fields (pool, agent, config); validation is local but sub-command semantics stay on the owner.
> 
> **Overview**
> **`invoker-cli` now supports `set <sub-command> <id> <value...>`**, mirroring the GUI’s existing `set` family (`task-pool`, `agent`, `model`, `prompt`, `task <fieldPath>`, etc.) by forwarding to the live owner over **`headless.exec`** with **`noTrack: true`**, same as `retry-task`, `delete`, and similar mutations.
> 
> **`runSetMutation`** validates sub-command, id, and at least one value **locally** (exit 1 with usage errors) before connecting; it then requires a reachable owner and prints `set <subcommand> accepted by live owner.` Help/usage documents the new verb.
> 
> Tests cover three happy-path payloads and three incomplete argv cases that must **not** call `headless.exec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eac80d11e0e26eff327cf5747afdd70a4053dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a CLI `set` command for updating task pools, agents, and tasks with one or more values.
  - Displays an acceptance message after successful updates.
  - Provides usage guidance and clear validation errors for incomplete or invalid commands.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
