### PR TITLE
[Route delegation skill](1) Add the route-delegation skill and decision script

### DIFF
--- a/skills/route-delegation/SKILL.md
+++ b/skills/route-delegation/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: route-delegation
+description: >
+  Decide between a subagent swarm and an Invoker submission before fanning
+  out. Trigger when about to spawn several subagents, forks, background
+  agents, or a multi-agent workflow, and always when any unit would make a
+  commit, a PR, a tag, a merge, or a deploy. Publishing work goes to Invoker
+  when its MCP tools are available; only read-only, report-only work fans out
+  to subagents. Separable and parallel decide nothing on their own.
+---
+
+# route-delegation
+
+Ask one question before fanning out: **what does each unit produce?**
+Being separable or parallel is not a reason to fan out. The output decides.
+
+Handoff mechanics live in `skill://chat-submit/SKILL.md`. YAML construction
+lives in `skill://plan-to-invoker/SKILL.md`. This skill only picks the road.
+
+## Decide
+
+1. **Name every unit's output.** Allowed names:
+   - publishing: `commit`, `pull_request`, `tag`, `merge`, `deploy`, `durable_artifact`
+   - not publishing: `none`, `report`, `research`, `review`, `verification`
+
+   No output named, or a name not on this list: stop and name it. An output
+   nobody declared is unchecked, not clean.
+2. **Some work publishes no matter what it says it produces:** an approved
+   plan, a post-land babysit (wait until `MERGED`, merge-queue watching), and
+   an already-named execution backlog.
+3. **Nothing publishes → subagent fan-out.** Spawn worktree-isolated
+   subagents, collect reports async, and grep each transcript for writes or
+   commits before trusting its summary.
+4. **Something publishes → never a subagent swarm.**
+   - Invoker MCP (`invoker_prepare_plan_review` and `invoker_submit_plan`)
+     missing: stay local — the parent session does it in its own worktree.
+   - One-slice, one-file, or read-only work: stay local in this chat.
+   - Approved plan, or durable/parallel work: submit to Invoker through
+     `skill://chat-submit/SKILL.md`.
+
+Executable form, same table:
+
+```bash
+node skills/route-delegation/scripts/route-delegation.mjs '{"tools":["invoker_prepare_plan_review","invoker_submit_plan"],"work_kind":"durable_parallel","produces":["commit","pull_request"]}'
+```
+
+It prints `{"route": ..., "steps": [...]}` where `route` is one of
+`local`, `delegate_invoker`, or `subagent_fanout`, and exits non-zero on an
+undeclared output or an unknown work kind.
+
+## Why
+
+A swarm that commits works outside Invoker's task graph: no persisted plan,
+no retries, no merge gate, no single reviewed approval, and nothing to
+resume after the chat ends. The failure this skill exists for: eight
+subagents spawned because the work was "separable, default to parallel",
+each producing a PR-worthy commit, with `invoker-cli` installed and the
+routing rule never consulted. Nothing in a fan-out default said no, because
+nothing in it was ever about publishing.
+
+Prior art: least privilege. Saltzer and Schroeder, "Basic Principles of
+Information Protection" (1975),
+https://web.mit.edu/Saltzer/www/publications/protection/Basic.html — base
+access on permission rather than exclusion. A default about saving context
+is not a grant of publishing authority.
+
+## Other harnesses
+
+Personal or harness-agnostic configs that carry their own delegation table
+should defer to this skill when it is installed (as
+`invoker-route-delegation`) and keep their own table only as the fallback.

--- a/skills/route-delegation/scripts/route-delegation.mjs
+++ b/skills/route-delegation/scripts/route-delegation.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const WORK_KINDS = new Set(['readonly', 'small_local', 'approved_plan', 'durable_parallel']);
+export const DURABLE_ALIASES = new Set(['post_land_babysit', 'named_execution_backlog']);
+export const ALWAYS_PUBLISHING_WORK_KINDS = new Set([...DURABLE_ALIASES, 'approved_plan']);
+
+export const PUBLISHING_OUTPUTS = new Set(['commit', 'pull_request', 'tag', 'merge', 'deploy', 'durable_artifact']);
+export const NON_PUBLISHING_OUTPUTS = new Set(['none', 'report', 'research', 'review', 'verification']);
+
+export const INVOKER_REQUIRED_TOOLS = ['invoker_prepare_plan_review', 'invoker_submit_plan'];
+
+export const DELEGATE_HANDOFF_STEPS = [
+  'plan_to_invoker_yaml',
+  'planning_completeness_gate',
+  'invoker_prepare_plan_review',
+  'one_approval_or_auto_submit',
+  'invoker_submit_plan',
+  'invoker_cli_wait_then_end_turn',
+];
+
+export const SUBAGENT_FANOUT_STEPS = [
+  'spawn_worktree_isolated_subagents',
+  'collect_reports_async',
+  'grep_transcripts_for_writes',
+];
+
+export const LOCAL_STEPS = ['stay_local'];
+
+export function invokerMcpAvailable(tools) {
+  const names = new Set(tools);
+  return INVOKER_REQUIRED_TOOLS.every((tool) => names.has(tool));
+}
+
+export function normalizeWorkKind(workKind) {
+  if (DURABLE_ALIASES.has(workKind)) return 'durable_parallel';
+  if (WORK_KINDS.has(workKind)) return workKind;
+  throw new Error(`unknown work_kind: ${JSON.stringify(workKind)}`);
+}
+
+export function routeExecution({ tools, workKind }) {
+  const kind = normalizeWorkKind(workKind);
+  if (!invokerMcpAvailable(tools)) return 'local';
+  if (kind === 'readonly' || kind === 'small_local') return 'local';
+  return 'delegate_invoker';
+}
+
+export function publishes({ workKind, produces }) {
+  if (!Array.isArray(produces)) {
+    throw new Error('produces must be an array of output names');
+  }
+  if (produces.length === 0) {
+    throw new Error("produces must name at least one output; use 'none' for work that publishes nothing");
+  }
+  const unknown = [...new Set(produces)]
+    .filter((output) => !PUBLISHING_OUTPUTS.has(output) && !NON_PUBLISHING_OUTPUTS.has(output))
+    .sort();
+  if (unknown.length > 0) {
+    throw new Error(`unknown produces value(s): ${JSON.stringify(unknown)}`);
+  }
+  if (ALWAYS_PUBLISHING_WORK_KINDS.has(workKind)) return true;
+  return produces.some((output) => PUBLISHING_OUTPUTS.has(output));
+}
+
+export function routeDelegation({ tools, workKind, produces }) {
+  normalizeWorkKind(workKind);
+  if (publishes({ workKind, produces })) return routeExecution({ tools, workKind });
+  return 'subagent_fanout';
+}
+
+export function handoffStepsFor(route) {
+  if (route === 'local') return LOCAL_STEPS;
+  if (route === 'subagent_fanout') return SUBAGENT_FANOUT_STEPS;
+  if (route === 'delegate_invoker') return DELEGATE_HANDOFF_STEPS;
+  throw new Error(`unknown route: ${JSON.stringify(route)}`);
+}
+
+function main(argv) {
+  const payload = argv[0] ? JSON.parse(argv[0]) : {};
+  const tools = payload.tools ?? [];
+  const workKind = payload.work_kind ?? 'small_local';
+  const route = payload.produces === undefined
+    ? routeExecution({ tools, workKind })
+    : routeDelegation({ tools, workKind, produces: payload.produces });
+  process.stdout.write(`${JSON.stringify({ route, steps: handoffStepsFor(route) })}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`route-delegation: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}

--- a/skills/route-delegation/scripts/route-delegation.mjs
+++ b/skills/route-delegation/scripts/route-delegation.mjs
@@ -80,9 +80,7 @@ function main(argv) {
   const payload = argv[0] ? JSON.parse(argv[0]) : {};
   const tools = payload.tools ?? [];
   const workKind = payload.work_kind ?? 'small_local';
-  const route = payload.produces === undefined
-    ? routeExecution({ tools, workKind })
-    : routeDelegation({ tools, workKind, produces: payload.produces });
+  const route = routeDelegation({ tools, workKind, produces: payload.produces });
   process.stdout.write(`${JSON.stringify({ route, steps: handoffStepsFor(route) })}\n`);
 }
 


### PR DESCRIPTION
## Summary

Adds a new delegation skill for Invoker. Before an agent fans out to subagents, it must look at what each unit of work produces.

Units that commit, open a PR, tag, merge, or deploy go to Invoker. Units that only produce a report may fan out.

Today this rule lives only in the personal catstack config, so Invoker users without catstack never see it. This puts the Invoker half in Invoker.

## Review Claim

The new skill doc and its decision script agree: publishing units go to Invoker, report-only units may fan out, and an undeclared output stops the agent.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only a new skill doc and a standalone script are added. Nothing in the product imports or runs the script; agents read the doc only when they choose to.

## Slice Rationale

The skill doc and its script are one idea and read best together. Pointers from other entry points, and the tests, come in later slices.

## Non-goals

- Does not change chat-submit, plan-to-invoker, or any Invoker runtime code.
- Does not change the catstack copy; that is a separate catstack PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node skills/route-delegation/scripts/route-delegation.mjs '{"tools":["invoker_prepare_plan_review","invoker_submit_plan"],"work_kind":"durable_parallel","produces":["commit","pull_request"]}'` prints `delegate_invoker`, exit 0
- [x] same script with `"produces":["maybe_a_pr"]` prints `unknown produces value(s)`, exit 1
- [x] `node scripts/check-added-comments.mjs` — no disallowed comments

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: re-run `bash scripts/setup-agent-skills.sh` so installed agent skills match
- Data migration? No

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142bSVZNrFvBqvbc5oigLNt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation and an opt-in Node script only; no product imports or runtime behavior changes in this slice.
> 
> **Overview**
> Introduces the **`route-delegation`** agent skill so delegation is chosen from **what each unit produces**, not from “parallel/separable” defaults alone.
> 
> The new `SKILL.md` defines allowed publishing vs report-only outputs, treats some work kinds (approved plan, post-land babysit, named backlog) as always publishing, and points publishing work at Invoker (when MCP tools exist) or local execution—never a committing subagent swarm. Report-only work may fan out with transcript checks for hidden writes.
> 
> A companion CLI script **`route-delegation.mjs`** encodes the same rules: it returns `local`, `delegate_invoker`, or `subagent_fanout` plus handoff step names, and **fails** on unknown `work_kind` or undeclared `produces` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de07cdc49b0ac62130e222e34de203ad82407ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for selecting local execution, read-only subagent fan-out, or Invoker-based delegation.
  - Added explicit handling for publishing and other durable work, including required delegation through Invoker when available.
  - Added support for validating expected outputs and displaying the recommended handoff steps.
- **Bug Fixes**
  - Missing output declarations now produce a clear validation error instead of silently using a fallback route.
- **Documentation**
  - Documented routing precedence, supported work types, and decision rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->