### PR TITLE
[Review-unit checker](1) Print the words behind each review unit

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -182,6 +182,30 @@ export function detectReviewUnits(text) {
   return detected;
 }
 
+function isPathLikeToken(token) {
+  const bareToken = token.replace(/[)\]}>'"`,;:!?.]+$/, '');
+  return bareToken.includes('/') || /\.[a-z0-9]+$/i.test(bareToken);
+}
+
+function blankPathTokens(text) {
+  return String(text).replace(/\S+/g, (token) => (isPathLikeToken(token) ? '_' : token));
+}
+
+export function detectReviewUnitTriggerWords(text) {
+  const haystack = blankPathTokens(String(text).toLowerCase());
+  const wordsByUnit = new Map();
+  for (const [unit, patterns] of UNIT_PATTERNS) {
+    const words = new Set();
+    for (const pattern of patterns) {
+      for (const match of haystack.matchAll(new RegExp(pattern.source, 'g'))) {
+        words.add(match[0].replace(/\s+/g, ' '));
+      }
+    }
+    if (words.size > 0) wordsByUnit.set(unit, words);
+  }
+  return wordsByUnit;
+}
+
 function includedWorkText(text) {
   return String(text)
     .split(/\r?\n/)
@@ -189,25 +213,40 @@ function includedWorkText(text) {
     .join('\n');
 }
 
+function collectIncludedWorkTriggerWords(texts) {
+  const wordsByUnit = new Map();
+  for (const text of texts) {
+    for (const [unit, words] of detectReviewUnitTriggerWords(includedWorkText(text))) {
+      if (!wordsByUnit.has(unit)) wordsByUnit.set(unit, new Set());
+      for (const word of words) wordsByUnit.get(unit).add(word);
+    }
+  }
+  return wordsByUnit;
+}
+
+function formatTriggerWords(wordsByUnit, units) {
+  const unitSet = new Set(units);
+  const perUnit = VALID_REVIEW_UNITS
+    .filter((unit) => unitSet.has(unit))
+    .map((unit) => `${unit}: ${Array.from(wordsByUnit.get(unit) ?? [], (word) => `"${word}"`).join(', ')}`);
+  return `Trigger words: ${perUnit.join('; ')}.`;
+}
+
 export function validateSingleReviewUnitFocus({ texts = [], context }) {
   const errors = [];
 
-  const detected = new Set();
-  for (const text of texts) {
-    for (const unit of detectReviewUnits(includedWorkText(text))) {
-      detected.add(unit);
-    }
-  }
-
-  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  const wordsByUnit = collectIncludedWorkTriggerWords(texts);
+  const detectedProductUnits = Array.from(wordsByUnit.keys()).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
   if (detectedProductUnits.length > 1) {
     errors.push(
-      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task.`,
+      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task. ${formatTriggerWords(wordsByUnit, detectedProductUnits)}`,
     );
   }
 
-  if (detected.has('docs') && detectedProductUnits.length > 0) {
-    errors.push(`${context} mixes docs language with product-unit language; split docs from implementation policy.`);
+  if (wordsByUnit.has('docs') && detectedProductUnits.length > 0) {
+    errors.push(
+      `${context} mixes docs language with product-unit language; split docs from implementation policy. ${formatTriggerWords(wordsByUnit, ['docs', ...detectedProductUnits])}`,
+    );
   }
 
   return errors;
@@ -246,17 +285,11 @@ export function validateReviewUnitFocus({ declaredReviewUnit, texts = [], contex
   const errors = validateSingleReviewUnitFocus({ texts, context });
   if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit)) return errors;
 
-  const detected = new Set();
-  for (const text of texts) {
-    for (const unit of detectReviewUnits(includedWorkText(text))) {
-      detected.add(unit);
-    }
-  }
-
-  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  const wordsByUnit = collectIncludedWorkTriggerWords(texts);
+  const detectedProductUnits = Array.from(wordsByUnit.keys()).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
   if (detectedProductUnits.length === 1 && PRODUCT_REVIEW_UNITS.has(declaredReviewUnit) && detectedProductUnits[0] !== declaredReviewUnit) {
     errors.push(
-      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work.`,
+      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work. ${formatTriggerWords(wordsByUnit, detectedProductUnits)}`,
     );
   }
 

--- a/scripts/test-review-unit-trigger-words.mjs
+++ b/scripts/test-review-unit-trigger-words.mjs
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import {
+  detectReviewUnits,
+  detectReviewUnitTriggerWords,
+  validateChangeTypeItems,
+  validateReviewUnitFocus,
+  validateSingleReviewUnitFocus,
+} from './review-unit-rules.mjs';
+
+const context = 'PR body';
+const pathOnlyBody = 'Routes the chain wrapper through scripts/submit-workflow-chain.sh.';
+
+assert.ok(
+  detectReviewUnits(pathOnlyBody).has('write-path'),
+  'raw keyword matching sees "submit" inside the path, which is what flagged this body before path blanking',
+);
+assert.deepEqual(
+  validateSingleReviewUnitFocus({ texts: [pathOnlyBody], context }),
+  [],
+  'a body naming scripts/submit-workflow-chain.sh with no other write-path keyword must not be flagged for multiple units',
+);
+assert.deepEqual(
+  validateReviewUnitFocus({ declaredReviewUnit: 'routing', texts: [pathOnlyBody], context }),
+  [],
+  'a routing body naming scripts/submit-workflow-chain.sh must not be flagged for write-path',
+);
+assert.deepEqual(
+  validateReviewUnitFocus({
+    declaredReviewUnit: 'routing',
+    texts: ['Routes the chain wrapper through submit-workflow-chain.sh.'],
+    context,
+  }),
+  [],
+  'a bare file name ending in an extension must not count as a unit keyword',
+);
+assert.deepEqual(
+  validateReviewUnitFocus({
+    declaredReviewUnit: 'routing',
+    texts: ['Routes events (see `scripts/enqueue-wakeup.mjs`), then docs/submit notes.'],
+    context,
+  }),
+  [],
+  'path tokens wrapped in backticks, parentheses, or trailing punctuation must still be blanked',
+);
+assert.ok(
+  !detectReviewUnitTriggerWords('Create scripts/x.mjs mutation intents and route them.').has('write-path'),
+  'blanking a path must not join its neighbours into a multi-word keyword',
+);
+
+const proseSubmitErrors = validateSingleReviewUnitFocus({
+  texts: ['Routes the plan and then we submit it.'],
+  context,
+});
+assert.equal(proseSubmitErrors.length, 1, 'prose "submit" alongside routing prose must still be flagged');
+assert.match(proseSubmitErrors[0], /mentions multiple review units \(write-path, routing\)/);
+assert.match(proseSubmitErrors[0], /write-path: "submit"/, 'multiple-units message must name the write-path trigger word');
+assert.match(proseSubmitErrors[0], /routing: "routes"/, 'multiple-units message must name the routing trigger word');
+
+const mixedErrors = validateSingleReviewUnitFocus({
+  texts: ['Submit the plan through scripts/submit-workflow-chain.sh and route it.'],
+  context,
+});
+assert.equal(mixedErrors.length, 1, 'prose "submit" next to a submit path must still be flagged');
+assert.match(mixedErrors[0], /write-path: "submit"; routing: "route"\.$/);
+assert.doesNotMatch(mixedErrors[0], /submit-workflow-chain/, 'path tokens must never be reported as trigger words');
+
+const mismatchErrors = validateReviewUnitFocus({
+  declaredReviewUnit: 'routing',
+  texts: ['Submits the plan.'],
+  context,
+});
+assert.deepEqual(mismatchErrors, [
+  'PR body Review Unit "routing" does not match the described write-path work. Trigger words: write-path: "submits".',
+]);
+
+const docsMixErrors = validateSingleReviewUnitFocus({
+  texts: ['Update the docs and route wakeups.'],
+  context,
+});
+assert.deepEqual(docsMixErrors, [
+  'PR body mixes docs language with product-unit language; split docs from implementation policy. Trigger words: routing: "route", "wakeups"; docs: "docs".',
+]);
+
+assert.deepEqual(
+  validateSingleReviewUnitFocus({
+    texts: ['Routes the plan.', 'Submit it through scripts/separate-queue.sh.'],
+    context,
+  }),
+  [],
+  'a line excluded by an exclusion word inside a path must stay excluded',
+);
+
+assert.equal(
+  validateChangeTypeItems('- scripts/enqueue-wakeup.sh: rewrite', context).length,
+  1,
+  'change types validation must keep matching keywords inside paths',
+);
+
+assert.equal(
+  readFileSync(new URL('../skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs', import.meta.url), 'utf8'),
+  readFileSync(new URL('./review-unit-rules.mjs', import.meta.url), 'utf8'),
+  'vendored review-unit-rules.mjs must be byte-identical to scripts/review-unit-rules.mjs',
+);
+
+console.log('review-unit trigger words: ok');

--- a/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
@@ -182,6 +182,30 @@ export function detectReviewUnits(text) {
   return detected;
 }
 
+function isPathLikeToken(token) {
+  const bareToken = token.replace(/[)\]}>'"`,;:!?.]+$/, '');
+  return bareToken.includes('/') || /\.[a-z0-9]+$/i.test(bareToken);
+}
+
+function blankPathTokens(text) {
+  return String(text).replace(/\S+/g, (token) => (isPathLikeToken(token) ? '_' : token));
+}
+
+export function detectReviewUnitTriggerWords(text) {
+  const haystack = blankPathTokens(String(text).toLowerCase());
+  const wordsByUnit = new Map();
+  for (const [unit, patterns] of UNIT_PATTERNS) {
+    const words = new Set();
+    for (const pattern of patterns) {
+      for (const match of haystack.matchAll(new RegExp(pattern.source, 'g'))) {
+        words.add(match[0].replace(/\s+/g, ' '));
+      }
+    }
+    if (words.size > 0) wordsByUnit.set(unit, words);
+  }
+  return wordsByUnit;
+}
+
 function includedWorkText(text) {
   return String(text)
     .split(/\r?\n/)
@@ -189,25 +213,40 @@ function includedWorkText(text) {
     .join('\n');
 }
 
+function collectIncludedWorkTriggerWords(texts) {
+  const wordsByUnit = new Map();
+  for (const text of texts) {
+    for (const [unit, words] of detectReviewUnitTriggerWords(includedWorkText(text))) {
+      if (!wordsByUnit.has(unit)) wordsByUnit.set(unit, new Set());
+      for (const word of words) wordsByUnit.get(unit).add(word);
+    }
+  }
+  return wordsByUnit;
+}
+
+function formatTriggerWords(wordsByUnit, units) {
+  const unitSet = new Set(units);
+  const perUnit = VALID_REVIEW_UNITS
+    .filter((unit) => unitSet.has(unit))
+    .map((unit) => `${unit}: ${Array.from(wordsByUnit.get(unit) ?? [], (word) => `"${word}"`).join(', ')}`);
+  return `Trigger words: ${perUnit.join('; ')}.`;
+}
+
 export function validateSingleReviewUnitFocus({ texts = [], context }) {
   const errors = [];
 
-  const detected = new Set();
-  for (const text of texts) {
-    for (const unit of detectReviewUnits(includedWorkText(text))) {
-      detected.add(unit);
-    }
-  }
-
-  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  const wordsByUnit = collectIncludedWorkTriggerWords(texts);
+  const detectedProductUnits = Array.from(wordsByUnit.keys()).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
   if (detectedProductUnits.length > 1) {
     errors.push(
-      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task.`,
+      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task. ${formatTriggerWords(wordsByUnit, detectedProductUnits)}`,
     );
   }
 
-  if (detected.has('docs') && detectedProductUnits.length > 0) {
-    errors.push(`${context} mixes docs language with product-unit language; split docs from implementation policy.`);
+  if (wordsByUnit.has('docs') && detectedProductUnits.length > 0) {
+    errors.push(
+      `${context} mixes docs language with product-unit language; split docs from implementation policy. ${formatTriggerWords(wordsByUnit, ['docs', ...detectedProductUnits])}`,
+    );
   }
 
   return errors;
@@ -246,17 +285,11 @@ export function validateReviewUnitFocus({ declaredReviewUnit, texts = [], contex
   const errors = validateSingleReviewUnitFocus({ texts, context });
   if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit)) return errors;
 
-  const detected = new Set();
-  for (const text of texts) {
-    for (const unit of detectReviewUnits(includedWorkText(text))) {
-      detected.add(unit);
-    }
-  }
-
-  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  const wordsByUnit = collectIncludedWorkTriggerWords(texts);
+  const detectedProductUnits = Array.from(wordsByUnit.keys()).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
   if (detectedProductUnits.length === 1 && PRODUCT_REVIEW_UNITS.has(declaredReviewUnit) && detectedProductUnits[0] !== declaredReviewUnit) {
     errors.push(
-      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work.`,
+      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work. ${formatTriggerWords(wordsByUnit, detectedProductUnits)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

The PR-body checker now prints the exact words that made it flag each review unit.

Before, it named the units it found but not the words behind them. Authors had to guess which sentence to reword.

File paths also stop counting as unit keywords. A body that only named a script whose file name holds a keyword was flagged for a unit it did not touch.

The vendored copy of the checker under `skills/plan-to-invoker` stays byte-identical.

## Review Claim

Approve the checker printing its trigger words in every unit message, and ignoring path-like tokens (a slash, or a file extension) when matching unit keywords.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The set of units flagged for prose outside file paths is unchanged. Only path-like tokens stop counting, so no body flagged today for a keyword in its prose passes after this. The keywords themselves are untouched, and the per-file change-kind check still matches keywords inside paths.

## Slice Rationale

One tooling-policy unit: the checker's own messages and its path handling, plus the vendored copy and one focused test file for them.

## Non-goals

No change to any unit keyword.

No new review units.

No change to plan or PR body section rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-review-unit-trigger-words.mjs` — `review-unit trigger words: ok`
- [x] `node scripts/test-review-unit-classification.mjs` — `review-unit classification: all assertions passed`
- [x] Before/after, same two bodies run through `validateSingleReviewUnitFocus` on master and on this branch:

  ```
  --- master ---
  ["PR body mentions multiple review units (write-path, routing); split into one conceptual unit per diff/task."]
  ["PR body mentions multiple review units (write-path, routing); split into one conceptual unit per diff/task."]
  --- branch ---
  []
  ["PR body mentions multiple review units (write-path, routing); split into one conceptual unit per diff/task. Trigger words: write-path: \"submit\"; routing: \"routes\"."]
  ```

  The first body only names a file path, and it now passes. The second body says "submit" in prose, and it is still flagged, now with its words.
- [x] `cmp scripts/review-unit-rules.mjs skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs` — exit 0
- [x] `pnpm run check:comments` — no disallowed comments
- [x] `node scripts/test-pr-body-validator.mjs` — `OK: PR body validator checks passed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
