### PR TITLE
[Plan linter](1) plan linter recognises hook paths

### DIFF
--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -38,6 +38,7 @@ Positive fixtures demonstrate valid plan patterns:
 - **06-invoker-dogfood-mergify-stack.yaml** - Invoker-on-Invoker PR publication example with focused skill verification
 - **07-prompt-edit-layered-split-with-dormant.yaml** - Dependency-first layer split for prompt-edit bridge work, including a dormant activation slice
 - **11-entity-research-aggregate-fan-in.yaml** - Multi-extDep fan-in on shared trunk (carve-out from stacked_basebranch_default)
+- **12-hook-plan-with-readme.yaml** - Behavior slice in a non-Invoker repo whose README sits beside the hook's `detect.py` (lint treats it as part of the hook)
 - Implementation fixtures use focused verification by default. Full-suite gates are optional and risk-based, not a validator requirement.
 
 All positive fixtures are extracted from `references/examples.md` sections 1-4.
@@ -60,6 +61,7 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 - **anti-pattern-k-missing-review-compression.yaml** - Implementation task omits review-compression metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-n-broad-autofix-policy-review-unit.yaml** - #1574-shaped auto-fix policy task combines scan, validation, duplicate suppression, and submit work (**fails `skill-doctor` review-unit lint**)
 - **anti-pattern-o-all-in-one-autofix-review-unit.yaml** - Original all-in-one auto-fix task combines ownership, policy, wakeups, and CLI activation (**fails `skill-doctor` review-unit lint**)
+- **anti-pattern-q-behavior-plus-unrelated-docs.yaml** - Hook behavior slice that also edits a README outside the hook's `detect.py` directory (**fails `skill-doctor` lint, not YAML schema**)
 
 ### Edge Cases (specific validation errors)
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-q-behavior-plus-unrelated-docs.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-q-behavior-plus-unrelated-docs.yaml
@@ -1,0 +1,95 @@
+name: "Invalid behavior lane mixed with an unrelated README"
+description: "Hook behavior slice that also edits a README outside the hook's own directory."
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/hooks-repo.git
+tasks:
+  - id: implement-stale-lock-hook
+    description: |
+      Review claim:
+      - The stale-lock hook flags lock files older than one hour.
+      Review lane:
+      - behavior
+      Safety invariant:
+      - Lock files younger than one hour are never flagged.
+      Effectiveness measurement:
+      - `python3 -m pytest engine/hooks/stale-lock` exits 0.
+      Slice rationale:
+      - This should be one hook slice, so the shared hooks index must not ride along.
+      Architectural effect:
+      - Adds one detector under engine/hooks/stale-lock.
+      Goal:
+      - Detect stale lock files.
+      Motivation:
+      - Stale locks block later runs without any visible error.
+      Alternative considerations:
+      - Option A (chosen): a dedicated hook with its own README.
+      - Option B: fold the check into an existing hook.
+      Implementation details:
+      - Add detect.py and the README beside it, and also edit the shared hooks index.
+      Non-goals:
+      - No change to other hooks.
+      Layer: domain
+      Feature state: active
+      Files:
+      - engine/hooks/stale-lock/detect.py
+      - engine/hooks/stale-lock/README.md
+      - engine/hooks/README.md
+      Change types:
+      - engine/hooks/stale-lock/detect.py: create
+      - engine/hooks/stale-lock/README.md: create
+      - engine/hooks/README.md: modify
+      Acceptance criteria:
+      - Pass condition: `python3 -m pytest engine/hooks/stale-lock` exits 0.
+    prompt: |
+      Review claim:
+      - The stale-lock hook flags lock files older than one hour.
+      Review lane:
+      - behavior
+      Safety invariant:
+      - Lock files younger than one hour are never flagged.
+      Slice rationale:
+      - One hook slice.
+      Architectural effect:
+      - Adds one detector under engine/hooks/stale-lock.
+      Goal:
+      - Detect stale lock files.
+      Motivation:
+      - Stale locks block later runs without any visible error.
+      Alternative considerations:
+      - Option A (chosen): a dedicated hook with its own README.
+      - Option B: fold the check into an existing hook.
+      Implementation details:
+      - Create engine/hooks/stale-lock/detect.py and its README, and list the hook in engine/hooks/README.md.
+      Non-goals:
+      - No change to other hooks.
+      Assume no prior context. The detector must flag lock files older than one hour and ignore younger ones. Pass condition: `python3 -m pytest engine/hooks/stale-lock` exits 0.
+    dependencies: []
+  - id: scrub-handoff-artifacts
+    description: |
+      Review claim:
+      - No ephemeral handoff files are left behind before the PR merge gate.
+      Review lane:
+      - proof
+      Safety invariant:
+      - This read-only check changes no files.
+      Effectiveness measurement:
+      - `bash scripts/scrub-handoff-artifacts.sh` exits 0.
+      Slice rationale:
+      - The scrub check runs last and stays separate from implementation.
+      Architectural effect:
+      - No architecture change.
+      Goal:
+      - Confirm no handoff artifacts remain.
+      Motivation:
+      - Uncommitted handoff files do not flow across worktrees.
+      Alternative considerations:
+      - Option A (chosen): a read-only absence check.
+      Implementation details:
+      - Run the handoff scrub script without --apply.
+      Non-goals:
+      - Do not modify source files.
+      Layer: e2e_regression
+      Feature state: active
+    command: 'bash scripts/scrub-handoff-artifacts.sh'
+    dependencies: [implement-stale-lock-hook]

--- a/skills/plan-to-invoker/fixtures/positive/12-hook-plan-with-readme.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/12-hook-plan-with-readme.yaml
@@ -1,0 +1,95 @@
+name: "Hook plan with its README"
+description: "Behavior slice for a hook in a repository without packages/ or scripts/ folders, shipping the README that sits beside the hook's detect.py."
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/hooks-repo.git
+tasks:
+  - id: implement-stale-lock-hook
+    description: |
+      Review claim:
+      - The stale-lock hook flags lock files older than one hour.
+      Review lane:
+      - behavior
+      Safety invariant:
+      - Lock files younger than one hour are never flagged.
+      Effectiveness measurement:
+      - `python3 -m pytest engine/hooks/stale-lock` exits 0.
+      Slice rationale:
+      - One hook: its detector, its test, and the file beside them that describes the hook.
+      Architectural effect:
+      - Adds one detector under engine/hooks/stale-lock.
+      Goal:
+      - Detect stale lock files.
+      Motivation:
+      - Stale locks block later runs without any visible error.
+      Alternative considerations:
+      - Option A (chosen): a dedicated hook.
+      - Option B: fold the check into an existing hook.
+      Implementation details:
+      - Add detect.py, its test, and the hook description beside them.
+      Non-goals:
+      - No change to other hooks.
+      Layer: domain
+      Feature state: active
+      Files:
+      - engine/hooks/stale-lock/detect.py
+      - engine/hooks/stale-lock/test_detect.py
+      - engine/hooks/stale-lock/README.md
+      Change types:
+      - engine/hooks/stale-lock/detect.py: create
+      - engine/hooks/stale-lock/test_detect.py: create
+      - engine/hooks/stale-lock/README.md: create
+      Acceptance criteria:
+      - Pass condition: `python3 -m pytest engine/hooks/stale-lock` exits 0.
+    prompt: |
+      Review claim:
+      - The stale-lock hook flags lock files older than one hour.
+      Review lane:
+      - behavior
+      Safety invariant:
+      - Lock files younger than one hour are never flagged.
+      Slice rationale:
+      - One hook: its detector, its test, and the file beside them that describes the hook.
+      Architectural effect:
+      - Adds one detector under engine/hooks/stale-lock.
+      Goal:
+      - Detect stale lock files.
+      Motivation:
+      - Stale locks block later runs without any visible error.
+      Alternative considerations:
+      - Option A (chosen): a dedicated hook.
+      - Option B: fold the check into an existing hook.
+      Implementation details:
+      - Create engine/hooks/stale-lock/detect.py and engine/hooks/stale-lock/test_detect.py, and the hook description beside them.
+      Non-goals:
+      - No change to other hooks.
+      Assume no prior context. The detector must flag lock files older than one hour and ignore younger ones. Pass condition: `python3 -m pytest engine/hooks/stale-lock` exits 0.
+    dependencies: []
+  - id: scrub-handoff-artifacts
+    description: |
+      Review claim:
+      - No ephemeral handoff files are left behind before the PR merge gate.
+      Review lane:
+      - proof
+      Safety invariant:
+      - This read-only check changes no files.
+      Effectiveness measurement:
+      - `bash scripts/scrub-handoff-artifacts.sh` exits 0.
+      Slice rationale:
+      - The scrub check runs last and stays separate from implementation.
+      Architectural effect:
+      - No architecture change.
+      Goal:
+      - Confirm no handoff artifacts remain.
+      Motivation:
+      - Uncommitted handoff files do not flow across worktrees.
+      Alternative considerations:
+      - Option A (chosen): a read-only absence check.
+      Implementation details:
+      - Run the handoff scrub script without --apply.
+      Non-goals:
+      - Do not modify source files.
+      Layer: e2e_regression
+      Feature state: active
+    command: 'bash scripts/scrub-handoff-artifacts.sh'
+    dependencies: [implement-stale-lock-hook]

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -127,12 +127,26 @@ function reset_file_buckets() {
   file_has_policy = 0
   file_has_docs = 0
 }
+function collect_hook_dirs(s,    after) {
+  while (match(s, /[a-z0-9_.\/-]+\/detect\.py/)) {
+    after = substr(s, RSTART + RLENGTH, 1)
+    if (after !~ /[a-z0-9_]/) {
+      hook_dirs[substr(s, RSTART, RLENGTH - length("/detect.py"))] = 1
+    }
+    s = substr(s, RSTART + RLENGTH)
+  }
+}
+function is_hook_readme(path) {
+  if (path !~ /\/readme\.md$/) return 0
+  return ((substr(path, 1, length(path) - length("/readme.md"))) in hook_dirs)
+}
 function classify_file_path(path) {
   if (path == "") return
   if (path ~ /^scripts\/repro\//) {
     file_has_proof = 1
     return
   }
+  if (is_hook_readme(path)) return
   if (path ~ /^skills\// || path ~ /^docs\// || path ~ /\.md$/) {
     file_has_docs = 1
     return
@@ -279,7 +293,7 @@ function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
     if (length(prompt_text) < 120) {
       errors[++errn] = "Task \"" id "\" prompt too short (<120 chars); include file paths + explicit acceptance criteria"
     }
-    if (prompt_text !~ /(packages\/|scripts\/|docs\/|skills\/|\.ts|\.tsx|\.js|\.jsx|\.json|\.md|\.sh|\.yaml|\.yml)/) {
+    if (prompt_text !~ /(packages\/|scripts\/|docs\/|skills\/|\.ts|\.tsx|\.js|\.jsx|\.json|\.md|\.sh|\.yaml|\.yml|[A-Za-z0-9_-]\/[A-Za-z0-9_.\/-]*[A-Za-z0-9_-]\.[A-Za-z])/) {
       errors[++errn] = "Task \"" id "\" prompt missing concrete file paths or file extensions"
     }
     if (tolower(prompt_text) !~ /(acceptance criteria|must|ensure|verify|expected|should)/) {
@@ -485,6 +499,11 @@ BEGIN {
   on_finish = "pull_request"
   enforce_layering = 1
   is_scratch = 0
+}
+
+FNR == NR {
+  collect_hook_dirs(tolower($0))
+  next
 }
 
 {
@@ -766,4 +785,4 @@ END {
   }
   print "Atomicity lint passed: " ARGV[1]
 }
-' "$file"
+' "$file" "$file"

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -27,6 +27,7 @@ DOCTOR_NEGATIVE_FIXTURES=(
   "anti-pattern-n-broad-autofix-policy-review-unit.yaml"
   "anti-pattern-o-all-in-one-autofix-review-unit.yaml"
   "anti-pattern-p-inter-task-ephemeral-carry.yaml"
+  "anti-pattern-q-behavior-plus-unrelated-docs.yaml"
 )
 
 is_doctor_negative_fixture() {
@@ -1532,6 +1533,39 @@ test_lint_rejects_behavior_plus_proof_files() {
   fi
 }
 
+test_lint_accepts_hook_readme_beside_detect_py() {
+  local fixture="$POSITIVE_DIR/12-hook-plan-with-readme.yaml"
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" --strict-delegation "$fixture" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected lint to accept a hook README beside its detect.py and non-Invoker file paths, got: $output" >&2
+    return 1
+  fi
+}
+
+test_lint_rejects_behavior_plus_unrelated_docs() {
+  local fixture="$NEGATIVE_DIR/anti-pattern-q-behavior-plus-unrelated-docs.yaml"
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" --strict-delegation "$fixture" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected lint to reject a behavior lane that edits a README outside the hook directory" >&2
+    return 1
+  fi
+
+  if ! grep -q 'mixes Review lane "behavior" with policy/docs/proof files' <<<"$output"; then
+    echo "Expected behavior-plus-docs lint error, got: $output" >&2
+    return 1
+  fi
+}
+
 test_lint_rejects_refactor_plus_fields() {
   local fixture="$NEGATIVE_DIR/anti-pattern-m-refactor-plus-fields.yaml"
   local output
@@ -1698,6 +1732,8 @@ run_test "Lint: reject missing design sections for prompt tasks" test_lint_requi
 run_test "Lint: reject missing review-compression sections" test_lint_requires_review_compression_sections
 run_test "Lint: reject missing review lane" test_lint_requires_review_lane
 run_test "Lint: reject behavior lane mixed with proof files" test_lint_rejects_behavior_plus_proof_files
+run_test "Lint: accept hook README beside detect.py" test_lint_accepts_hook_readme_beside_detect_py
+run_test "Lint: reject behavior lane mixed with unrelated docs" test_lint_rejects_behavior_plus_unrelated_docs
 run_test "Lint: reject refactor lane mixed with field additions" test_lint_rejects_refactor_plus_fields
 run_test "Lint: reject inter-task ephemeral carry without commit" test_lint_rejects_inter_task_ephemeral_carry_without_commit
 run_test "Lint: accept prompt tasks with design sections" test_lint_accepts_design_sections_for_prompt_tasks


### PR DESCRIPTION
## Summary

The plan linter now accepts file paths from any repository, and lets a hook's README ship in the same slice as the hook it documents.

Before, the linter only knew Invoker folders like `packages/` and `skills/`. A plan for a Python hook under `engine/` was rejected as having no concrete file paths.

Before, every `.md` file counted as documentation. A hook's own `README.md` made its behavior plan fail, even though the detector playbook requires that README to ship with the hook.

Now any path with a slash and a file extension counts.

A `README.md` counts as part of the hook only when the same plan names a `detect.py` in that folder.

## Review Claim

The plan linter treats any slash-and-extension path as concrete, and treats a `README.md` beside a `detect.py` named in the same plan as part of that hook.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every plan the linter accepts today is still accepted, and every plan it flags for mixing a docs-only change into a behavior slice is still flagged; only the two false cases change.

## Slice Rationale

One tooling-policy unit: the linter's path recognition in `skills/plan-to-invoker/scripts/lint-task-atomicity.sh`, plus the positive and negative fixtures that pin both edges.

## Non-goals

- No change to lane rules.
- No change to which docs-only changes are flagged: a README outside the hook's `detect.py` folder is still flagged in a behavior slice.
- No change to the other plan checks (schema, completeness, review units).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` exits 0, including `Lint: accept hook README beside detect.py` and `Lint: reject behavior lane mixed with unrelated docs`.
- [x] `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh --strict-delegation skills/plan-to-invoker/fixtures/positive/12-hook-plan-with-readme.yaml` exits 0 on this branch and exits 1 with the master copy of the linter.
- [x] `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh --strict-delegation skills/plan-to-invoker/fixtures/negative/anti-pattern-q-behavior-plus-unrelated-docs.yaml` exits 1 with the behavior-plus-docs error.
- [x] `pnpm run check:comments` exits 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
