### PR TITLE
[CLI/UI parity for task field edits](1) Keep node: imports intact in the invoker-cli bundle

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   format: ['esm'],
   dts: false,
   clean: true,
+  removeNodeProtocol: false,
   banner: {
     js: '#!/usr/bin/env node',
   },


### PR DESCRIPTION
## Summary

The bundled `invoker-cli` crashes on start on current master. Running `node packages/cli/dist/index.js --help` fails with `Cannot find package 'sea'`.

The bundler strips the `node:` prefix from imports. `node:sea` has no unprefixed alias, so the stripped import cannot resolve.

This slice tells the bundler to keep `node:` prefixes, so the built CLI starts again.

## Before and After

Built the CLI with `cd packages/cli && npx tsup`, then ran `node dist/index.js --help` on master `97f7e86af` (before) and on this slice `68d68a140` (after).

```
Before:
$ node dist/index.js --help; echo "exit $?"
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sea' imported from .../packages/cli/dist/index.js
exit 1

After:
$ node dist/index.js --help; echo "exit $?"
Usage:
  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]
exit 0
```

## Review Claim

Approve keeping `node:` import prefixes in the `invoker-cli` tsup bundle.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the CLI bundle's import specifiers change; every `node:` builtin still resolves, because Node accepts the prefixed form for all builtins.

## Slice Rationale

Later slices in this stack add `invoker-cli set` and prove it with the built CLI. The CLI must start before that proof means anything, so this fix lands first and alone.

## Non-goals

Does not change the standalone SEA build script, which #11945 already patched. Does not change CLI commands or flags.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && npx tsup && node dist/index.js --help` on master `97f7e86af`: exit 1, `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sea'`
- [x] Same command on this slice: exit 0, prints `Usage:`
- [x] `pnpm run check:types` on this slice's commit: exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's merge commit>`
- Post-revert steps: None
- Data migration? No

</details>

