### PR TITLE
[CLI/UI parity for task field edits](8) Pass the configured default agent to the GUI mutation orchestrator

### DIFF
--- a/packages/app/src/__tests__/merge-node-default-agent.test.ts
+++ b/packages/app/src/__tests__/merge-node-default-agent.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
+import { loadDefaultExecutionAgent } from '../config.js';
+import { applyConfiguredPlanDefaults } from '../plan-parser.js';
+
+const PLAN: PlanDefinition = {
+  name: 'merge-node-default-agent',
+  baseBranch: 'master',
+  featureBranch: 'feature/merge-node-default-agent',
+  tasks: [
+    { id: 'implement', description: 'Implement', prompt: 'Do the thing' },
+    { id: 'verify', description: 'Verify', command: 'echo verify', dependencies: ['implement'] },
+  ],
+};
+
+const COMMAND_ONLY_PLAN: PlanDefinition = {
+  name: 'merge-node-default-agent-commands',
+  baseBranch: 'master',
+  featureBranch: 'feature/merge-node-default-agent-commands',
+  tasks: [{ id: 'verify', description: 'Verify', command: 'echo verify' }],
+};
+
+describe('submitted merge node execution agent', () => {
+  let configDir: string;
+  let adapter: SQLiteAdapter | undefined;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), 'invoker-merge-node-agent-'));
+    process.env.INVOKER_REPO_CONFIG_PATH = join(configDir, 'config.json');
+  });
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    delete process.env.INVOKER_REPO_CONFIG_PATH;
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(value: Record<string, unknown>): void {
+    writeFileSync(process.env.INVOKER_REPO_CONFIG_PATH!, JSON.stringify(value));
+  }
+
+  async function submitAndReadMergeAgent(plan: PlanDefinition): Promise<string | null | undefined> {
+    adapter = await SQLiteAdapter.create(':memory:');
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 1,
+      defaultExecutionAgentProvider: loadDefaultExecutionAgent,
+    });
+    orchestrator.loadPlan(applyConfiguredPlanDefaults(plan));
+    const mergeNode = orchestrator.getAllTasks().find((task) => task.config.isMergeNode);
+    expect(mergeNode).toBeDefined();
+    expect(mergeNode?.config.executionAgent).toBe(adapter.getExecutionAgent(mergeNode!.id));
+    return adapter.getExecutionAgent(mergeNode!.id);
+  }
+
+  it('persists the configured default agent on the merge node', async () => {
+    writeConfig({ defaultExecutionAgent: 'claude' });
+
+    expect(await submitAndReadMergeAgent(PLAN)).toBe('claude');
+  });
+
+  it('persists the configured default agent on a merge node whose tasks declare none', async () => {
+    writeConfig({ defaultExecutionAgent: 'claude' });
+
+    expect(await submitAndReadMergeAgent(COMMAND_ONLY_PLAN)).toBe('claude');
+  });
+
+  it('falls back to the built-in default agent when config sets nothing', async () => {
+    writeConfig({});
+
+    expect(await submitAndReadMergeAgent(COMMAND_ONLY_PLAN)).toBe('codex');
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -741,6 +741,9 @@ export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = (config.defaultExecutionHarness ?? config.defaultExecutionAgent)?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
 }
+export function loadDefaultExecutionAgent(): string {
+  return resolveDefaultExecutionAgent(loadConfig());
+}
 
 /**
  * Resolve the configured execution-agent allowlist.

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -5,41 +5,14 @@ export interface HeadlessCommandDefinition {
   readonly kind: HeadlessCommandKind;
 }
 
-export type HeadlessSetSubcommandScope = 'task' | 'workflow';
-
-export interface HeadlessSetSubcommandDefinition {
-  readonly name: string;
-  readonly scope: HeadlessSetSubcommandScope;
-}
-
-export const HEADLESS_SET_SUBCOMMANDS = [
-  { name: 'command', scope: 'task' },
-  { name: 'prompt', scope: 'task' },
-  { name: 'pool', scope: 'task' },
-  { name: 'executor', scope: 'task' },
-  { name: 'agent', scope: 'task' },
-  { name: 'model', scope: 'task' },
-  { name: 'task-pool', scope: 'task' },
-  { name: 'merge-mode', scope: 'workflow' },
-  { name: 'fix-prompt', scope: 'task' },
-  { name: 'fix-context', scope: 'task' },
-  { name: 'gate-policy', scope: 'task' },
-  { name: 'workflow', scope: 'workflow' },
-  { name: 'task', scope: 'task' },
-] as const satisfies readonly HeadlessSetSubcommandDefinition[];
-
-export type HeadlessSetSubcommand = (typeof HEADLESS_SET_SUBCOMMANDS)[number]['name'];
-
-export function formatHeadlessSetSubcommands(separator: string): string {
-  return HEADLESS_SET_SUBCOMMANDS.map((definition) => definition.name).join(separator);
-}
-
-export function findHeadlessSetSubcommandScope(
-  subcommand: string | undefined,
-): HeadlessSetSubcommandScope | undefined {
-  if (!subcommand) return undefined;
-  return HEADLESS_SET_SUBCOMMANDS.find((definition) => definition.name === subcommand)?.scope;
-}
+export {
+  HEADLESS_SET_SUBCOMMANDS,
+  findHeadlessSetSubcommandScope,
+  formatHeadlessSetSubcommands,
+  type HeadlessSetSubcommand,
+  type HeadlessSetSubcommandDefinition,
+  type HeadlessSetSubcommandScope,
+} from '@invoker/contracts';
 
 export const HEADLESS_COMMANDS = [
   { name: 'owner-serve', kind: 'special' },

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -45,6 +45,7 @@ import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   filterExecutionHarnesses,
   loadConfig,
+  loadDefaultExecutionAgent,
   resolveAutoFixExecutionModel,
   resolveDefaultTaskExecutionSettings,
   type InvokerConfig,
@@ -1621,6 +1622,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
       defaultPoolId: invokerConfig.defaultPoolId,
       availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
+      defaultExecutionAgentProvider: loadDefaultExecutionAgent,
       deferRunningUntilLaunch: true,
       onRecreateTasksReset: (taskIds) => {
         resetAutoFixBudgetForTasks(persistence, taskIds);

--- a/packages/cli/src/__tests__/cli-mutations.test.ts
+++ b/packages/cli/src/__tests__/cli-mutations.test.ts
@@ -1,10 +1,12 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { HEADLESS_SET_SUBCOMMANDS } from '@invoker/contracts';
 import { LocalBus } from '@invoker/transport';
+import { ALREADY_TERMINAL_TASK_STATUSES } from '@invoker/workflow-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { main } from '../index.js';
+import { CLI_SET_FIELDS, main } from '../index.js';
 
 const tempDirs: string[] = [];
 
@@ -185,5 +187,248 @@ describe('invoker-cli mutations', () => {
     expect(code).toBe(0);
     expect(output.stdout).toContain('No tasks matched status "failed".');
     output.restore();
+  });
+});
+
+type OwnerTask = {
+  id: string;
+  status: string;
+  config: Record<string, unknown>;
+};
+
+const TASK_ID = 'wf-1/task-a';
+
+function ownerTask(overrides: Partial<OwnerTask> = {}): OwnerTask {
+  return {
+    id: TASK_ID,
+    status: 'pending',
+    config: { workflowId: 'wf-1', runnerKind: 'worktree', poolId: 'local-worktree' },
+    ...overrides,
+  };
+}
+
+function mergeNodeTask(): OwnerTask {
+  return ownerTask({
+    id: '__merge__wf-1',
+    config: { workflowId: 'wf-1', runnerKind: 'merge', isMergeNode: true },
+  });
+}
+
+function dockerTask(): OwnerTask {
+  return ownerTask({ config: { workflowId: 'wf-1', runnerKind: 'docker' } });
+}
+
+function liveOwnerWithTask(task: OwnerTask) {
+  const bus = new LocalBus();
+  const queryHandler = vi.fn(async () => ({ output: JSON.stringify(task) }));
+  const execHandler = vi.fn(async () => ({ ok: true }));
+  bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+  bus.onRequest('headless.query', queryHandler);
+  bus.onRequest('headless.exec', execHandler);
+  return { bus, queryHandler, execHandler };
+}
+
+async function runSet(argv: string[], task: OwnerTask) {
+  const output = captureProcessOutput();
+  const owner = liveOwnerWithTask(task);
+  const code = await main(['set', ...argv], { createMessageBus: () => owner.bus });
+  output.restore();
+  return { code, stdout: output.stdout, stderr: output.stderr, ...owner };
+}
+
+const POSITIVE_SET_CASES: Record<string, { task: OwnerTask; values: string[] }> = {
+  command: { task: ownerTask(), values: ['pnpm', 'test'] },
+  prompt: { task: ownerTask(), values: ['Fix the flaky assertion'] },
+  pool: { task: ownerTask(), values: ['ssh', 'remote-1'] },
+  executor: { task: ownerTask(), values: ['docker'] },
+  agent: { task: ownerTask(), values: ['claude'] },
+  model: { task: ownerTask(), values: ['claude-opus-5'] },
+  'task-pool': { task: ownerTask(), values: ['gpu-pool'] },
+  'fix-prompt': { task: ownerTask({ status: 'failed' }), values: ['Retry with verbose logging'] },
+  'fix-context': { task: ownerTask({ status: 'failed' }), values: ['Build log excerpt'] },
+  'gate-policy': { task: ownerTask(), values: ['wf-upstream', 'review_ready'] },
+  task: { task: ownerTask(), values: ['config.poolId', 'gpu-pool'] },
+};
+
+describe('invoker-cli set', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts exactly the task-scoped set sub-commands in the headless registry', () => {
+    const registryTaskFields = HEADLESS_SET_SUBCOMMANDS
+      .filter((definition) => definition.scope === 'task')
+      .map((definition) => definition.name);
+
+    expect([...CLI_SET_FIELDS].sort()).toEqual([...registryTaskFields].sort());
+  });
+
+  it('has a positive case for every accepted field', () => {
+    expect(Object.keys(POSITIVE_SET_CASES).sort()).toEqual([...CLI_SET_FIELDS].sort());
+  });
+
+  it('lists set as its own subcommand in --help with every accepted field', async () => {
+    const output = captureProcessOutput();
+    const code = await main(['--help']);
+    output.restore();
+
+    const usageBlock = output.stdout.split('\n\n')[0].split('\n').slice(1);
+    const subcommands = usageBlock.map((line) => line.trim().split(/\s+/)[1]);
+    expect(code).toBe(0);
+    expect(subcommands).toContain('set');
+    expect(output.stdout).toContain(`Fields: ${CLI_SET_FIELDS.join(', ')}.`);
+  });
+
+  it.each(Object.entries(POSITIVE_SET_CASES))('sends set %s to the live owner over headless.exec', async (field, { task, values }) => {
+    const result = await runSet([field, TASK_ID, ...values], task);
+
+    expect(result.stderr).toBe('');
+    expect(result.code).toBe(0);
+    expect(result.queryHandler).toHaveBeenCalledWith({
+      kind: 'cli-query',
+      args: ['query', 'task', TASK_ID, '--output', 'json'],
+    });
+    expect(result.execHandler).toHaveBeenCalledTimes(1);
+    expect(result.execHandler).toHaveBeenCalledWith({ args: ['set', field, TASK_ID, ...values], noTrack: true });
+    expect(result.stdout).toContain(`set ${field} accepted by live owner.`);
+  });
+
+  it('allows an agent change on a merge node', async () => {
+    const result = await runSet(['agent', '__merge__wf-1', 'codex'], mergeNodeTask());
+
+    expect(result.code).toBe(0);
+    expect(result.execHandler).toHaveBeenCalledWith({ args: ['set', 'agent', '__merge__wf-1', 'codex'], noTrack: true });
+  });
+
+  it('passes values after -- through verbatim', async () => {
+    const result = await runSet(['command', TASK_ID, '--', 'git', 'push', '--force-with-lease'], ownerTask());
+
+    expect(result.code).toBe(0);
+    expect(result.execHandler).toHaveBeenCalledWith({
+      args: ['set', 'command', TASK_ID, 'git', 'push', '--force-with-lease'],
+      noTrack: true,
+    });
+  });
+
+  it.each(['running', 'fixing_with_ai'])('edits a %s task when --force is given', async (status) => {
+    const result = await runSet(['agent', TASK_ID, 'claude', '--force'], ownerTask({ status }));
+
+    expect(result.code).toBe(0);
+    expect(result.execHandler).toHaveBeenCalledWith({ args: ['set', 'agent', TASK_ID, 'claude'], noTrack: true });
+  });
+
+  it.each(ALREADY_TERMINAL_TASK_STATUSES)('refuses a %s task as terminal', async (status) => {
+    const result = await runSet(['agent', TASK_ID, 'claude', '--force'], ownerTask({ status }));
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(`Cannot set agent on task "${TASK_ID}": it is ${status}, a terminal state.`);
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it.each(['running', 'fixing_with_ai'])('refuses a %s task without --force', async (status) => {
+    const result = await runSet(['agent', TASK_ID, 'claude'], ownerTask({ status }));
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(`it is ${status} and its launched attempt has already resolved its configuration`);
+    expect(result.stderr).toContain('re-run with --force');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['task-pool', ['gpu-pool']],
+    ['pool', ['ssh', 'remote-1']],
+    ['executor', ['worktree']],
+    ['task', ['config.poolId', 'gpu-pool']],
+  ])('refuses set %s on a merge node', async (field, values) => {
+    const result = await runSet([field, '__merge__wf-1', ...values], mergeNodeTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(`Cannot set ${field} on task "__merge__wf-1": merge nodes run on the merge executor and cannot take a pool, pool member, or executor change.`);
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it('refuses to move a task onto the merge executor', async () => {
+    const result = await runSet(['executor', TASK_ID, 'merge'], ownerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('the merge executor is reserved for merge nodes.');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it.each(['docker', 'scratch'])('refuses a pool member for the %s executor', async (runnerKind) => {
+    const result = await runSet(['pool', TASK_ID, runnerKind, 'remote-1'], ownerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(`${runnerKind} tasks cannot take a pool member.`);
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it('refuses a task-pool change on a docker task', async () => {
+    const result = await runSet(['task-pool', TASK_ID, 'gpu-pool'], dockerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('docker tasks cannot take a pool.');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it('refuses a config.poolId write on a docker task', async () => {
+    const result = await runSet(['task', TASK_ID, 'config.poolId', 'gpu-pool'], dockerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('docker tasks cannot have a pool or pool member; use `invoker-cli set executor`');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it('refuses a config.runnerKind write that would leave a docker task holding a pool', async () => {
+    const result = await runSet(['task', TASK_ID, 'config.runnerKind', 'docker'], ownerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('docker tasks cannot have a pool or pool member');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it('refuses clearing the pool of a worktree task', async () => {
+    const result = await runSet(['task', TASK_ID, 'config.poolId', 'null'], ownerTask());
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('worktree tasks require a non-empty pool');
+    expect(result.execHandler).not.toHaveBeenCalled();
+  });
+
+  it.each(
+    HEADLESS_SET_SUBCOMMANDS.filter((definition) => definition.scope === 'workflow').map((definition) => definition.name),
+  )('refuses the workflow-scoped %s sub-command without contacting the owner', async (field) => {
+    const createMessageBus = vi.fn(() => new LocalBus());
+    const output = captureProcessOutput();
+    const code = await main(['set', field, 'wf-1', 'automatic'], { createMessageBus });
+    output.restore();
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain(`Unknown set field: "${field}". Task fields: ${CLI_SET_FIELDS.join(', ')}`);
+    expect(createMessageBus).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [['agent'], 'Missing taskId.'],
+    [['agent', TASK_ID], 'Missing value.'],
+    [['agent', TASK_ID, '--froce', 'claude'], 'Unknown set option: --froce.'],
+  ])('refuses incomplete or malformed set %j without contacting the owner', async (argv, message) => {
+    const createMessageBus = vi.fn(() => new LocalBus());
+    const output = captureProcessOutput();
+    const code = await main(['set', ...argv], { createMessageBus });
+    output.restore();
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain(message);
+    expect(createMessageBus).not.toHaveBeenCalled();
+  });
+
+  it('refuses set when no owner is reachable', async () => {
+    const output = captureProcessOutput();
+    const code = await main(['set', 'agent', TASK_ID, 'claude'], { createMessageBus: () => new LocalBus() });
+    output.restore();
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('No running Invoker owner is reachable');
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import {
   DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
+  listHeadlessSetSubcommandsForScope,
   readInvokerConfigFile,
   resolveHeadlessOwnerLaunchSpec,
   resolveInvokerHomeRoot,
@@ -36,11 +37,13 @@ import {
 } from '@invoker/execution-engine';
 import { type MessageBus } from '@invoker/transport';
 import {
+  ALREADY_TERMINAL_TASK_STATUSES,
   Orchestrator,
   parsePlanFile,
   type OrchestratorMessageBus,
   type PlanDefinition,
   type TaskState,
+  type TaskStatus,
 } from '@invoker/workflow-core';
 import { logCaughtException } from './logging.js';
 import {
@@ -176,6 +179,33 @@ type RetryTaskRow = {
   status?: string;
 };
 
+type SetOptions = {
+  field: string;
+  taskId: string;
+  values: string[];
+  force: boolean;
+};
+
+type ExecutorRouting = {
+  runnerKind?: string;
+  poolId?: string;
+  poolMemberId?: string;
+};
+
+type SetTargetTask = {
+  id: string;
+  status: string;
+  isMergeNode: boolean;
+  routing: ExecutorRouting;
+};
+
+export const CLI_SET_FIELDS: readonly string[] = listHeadlessSetSubcommandsForScope('task');
+
+const LAUNCHED_TASK_STATUSES = new Set<string>(['running', 'fixing_with_ai']);
+const RUNNER_KINDS_REQUIRING_POOL = new Set<string>(['worktree', 'ssh']);
+const RUNNER_KINDS_FORBIDDING_POOL = new Set<string>(['docker', 'merge', 'scratch']);
+const ROUTING_CONFIG_FIELD_PATH = /^(?:raw\.)?config\.(runnerKind|poolId|poolMemberId)$/;
+
 const silentLogger: Logger = {
   debug() {},
   info() {},
@@ -200,6 +230,7 @@ function usage(): string {
     '  invoker-cli retry <workflowId>',
     '  invoker-cli resume <workflowId>',
     '  invoker-cli retry-tasks --status <status> [--parallel N] [--dry-run]',
+    '  invoker-cli set <field> <taskId> <value...> [--force] [-- <value...>]',
     '  invoker-cli delete <workflowId>',
     '  invoker-cli delete-all',
     '  invoker-cli owner serve',
@@ -224,6 +255,7 @@ function usage(): string {
     '  retry <workflowId>  Ask a live Invoker owner to retry a workflow.',
     '  resume <workflowId> Ask a live Invoker owner to resume a workflow.',
     '  retry-tasks --status <status>  Retry all tasks matching a status through a live owner.',
+    `  set <field> <taskId> <value...>  Edit one task field through a live owner. Fields: ${CLI_SET_FIELDS.join(', ')}. Refuses terminal tasks, running tasks without --force, and pool or executor changes the task's runner kind cannot take.`,
     '  delete-all      Ask a live Invoker owner to delete all workflows. Runs unconditionally; the owner snapshots the DB first.',
     '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
@@ -252,6 +284,8 @@ function usage(): string {
     '  --poll-interval-ms <ms>  Query interval for `wait`. Defaults to 5000.',
     '  --parallel N    Maximum concurrent mutation requests for `retry-tasks`. Defaults to 8.',
     '  --dry-run       Print matching task IDs for `retry-tasks` without mutating.',
+    '  --force         Let `set` edit a running task; the owner cancels the launched attempt first.',
+    '  --              End `set` options; later arguments are passed as values even if they start with --.',
     '  --output <fmt>   Query output format. Supported values: text, json. Defaults to text.',
     '  --from-env       Run Slack setup from SLACK_* environment values without prompts.',
     '  --fix            Best-effort install of missing doctor tools.',
@@ -755,6 +789,172 @@ async function runDeleteAllMutation(deps: CliDeps): Promise<number> {
     await requireLiveOwnerForMutation(bus);
     await sendHeadlessExec(bus, ['delete-all']);
     process.stdout.write('delete-all accepted by live owner.\n');
+    return 0;
+  } finally {
+    const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
+    if (disconnect) {
+      disconnect.call(bus);
+    }
+  }
+}
+
+function setUsage(field = `<${CLI_SET_FIELDS.join('|')}>`, taskId = '<taskId>'): string {
+  return `Usage: invoker-cli set ${field} ${taskId} <value...> [--force]`;
+}
+
+function parseSetArgs(argv: string[]): SetOptions {
+  const positional: string[] = [];
+  let force = false;
+  let optionsEnded = false;
+  for (const arg of argv) {
+    if (optionsEnded) {
+      positional.push(arg);
+    } else if (arg === '--') {
+      optionsEnded = true;
+    } else if (arg === '--force') {
+      force = true;
+    } else if (arg === '--help') {
+      throw new Error(setUsage());
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown set option: ${arg}. Put -- before values that start with --.`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const [field, taskId, ...values] = positional;
+  if (!field) {
+    throw new Error(`Missing set field. ${setUsage()}`);
+  }
+  if (!CLI_SET_FIELDS.includes(field)) {
+    throw new Error(`Unknown set field: "${field}". Task fields: ${CLI_SET_FIELDS.join(', ')}`);
+  }
+  if (!taskId) {
+    throw new Error(`Missing taskId. ${setUsage(field)}`);
+  }
+  if (values.length === 0) {
+    throw new Error(`Missing value. ${setUsage(field, taskId)}`);
+  }
+  return { field, taskId, values, force };
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function parseMetadataArg(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function parseSetTargetTask(output: string, taskId: string): SetTargetTask {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch (err) {
+    throw new Error(`Could not parse task query JSON for "${taskId}": ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const record = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+  if (typeof record.id !== 'string' || typeof record.status !== 'string') {
+    throw new Error(`Live owner returned an invalid task for "${taskId}": missing id or status`);
+  }
+  const config = (record.config && typeof record.config === 'object' ? record.config : {}) as Record<string, unknown>;
+  return {
+    id: record.id,
+    status: record.status,
+    isMergeNode: config.isMergeNode === true || config.runnerKind === 'merge',
+    routing: {
+      runnerKind: optionalString(config.runnerKind),
+      poolId: optionalString(config.poolId),
+      poolMemberId: optionalString(config.poolMemberId),
+    },
+  };
+}
+
+async function querySetTargetTask(bus: MessageBus, taskId: string): Promise<SetTargetTask> {
+  const raw = await withTimeout(
+    bus.request('headless.query', {
+      kind: 'cli-query',
+      args: ['query', 'task', taskId, '--output', 'json'],
+    }),
+    15_000,
+  );
+  return parseSetTargetTask(validateLiveQueryResponse(raw), taskId);
+}
+
+function describeExecutorRoutingViolation(routing: ExecutorRouting): string | undefined {
+  const { runnerKind } = routing;
+  if (!runnerKind) return undefined;
+  if (RUNNER_KINDS_REQUIRING_POOL.has(runnerKind) && !routing.poolId) {
+    return `${runnerKind} tasks require a non-empty pool`;
+  }
+  if (RUNNER_KINDS_FORBIDDING_POOL.has(runnerKind) && (routing.poolId || routing.poolMemberId)) {
+    return `${runnerKind} tasks cannot have a pool or pool member`;
+  }
+  return undefined;
+}
+
+function findExecutorRoutingRefusal(options: SetOptions, task: SetTargetTask): string | undefined {
+  const { field, values } = options;
+  const routingKey = field === 'task' ? values[0]?.match(ROUTING_CONFIG_FIELD_PATH)?.[1] : undefined;
+  const changesRouting = field === 'pool' || field === 'executor' || field === 'task-pool' || routingKey !== undefined;
+  if (!changesRouting) {
+    return undefined;
+  }
+  if (task.isMergeNode) {
+    return 'merge nodes run on the merge executor and cannot take a pool, pool member, or executor change';
+  }
+  if (field === 'pool' || field === 'executor') {
+    const [runnerKind, poolMemberId] = values;
+    if (runnerKind === 'merge') {
+      return 'the merge executor is reserved for merge nodes';
+    }
+    if (RUNNER_KINDS_FORBIDDING_POOL.has(runnerKind) && poolMemberId) {
+      return `${runnerKind} tasks cannot take a pool member`;
+    }
+    return undefined;
+  }
+  if (field === 'task-pool') {
+    const { runnerKind } = task.routing;
+    return runnerKind && RUNNER_KINDS_FORBIDDING_POOL.has(runnerKind)
+      ? `${runnerKind} tasks cannot take a pool`
+      : undefined;
+  }
+  if (!routingKey) {
+    return undefined;
+  }
+  const requested = optionalString(parseMetadataArg(values.slice(1).join(' ')));
+  const violation = describeExecutorRoutingViolation({ ...task.routing, [routingKey]: requested });
+  return violation
+    ? `${violation}; use \`invoker-cli set executor\` or \`invoker-cli set task-pool\` to change routing`
+    : undefined;
+}
+
+function findSetRefusal(options: SetOptions, task: SetTargetTask): string | undefined {
+  if (ALREADY_TERMINAL_TASK_STATUSES.includes(task.status as TaskStatus)) {
+    return `it is ${task.status}, a terminal state`;
+  }
+  if (LAUNCHED_TASK_STATUSES.has(task.status) && !options.force) {
+    return `it is ${task.status} and its launched attempt has already resolved its configuration; re-run with --force to cancel that attempt and apply the change`;
+  }
+  return findExecutorRoutingRefusal(options, task);
+}
+
+async function runSetMutation(options: SetOptions, deps: CliDeps): Promise<number> {
+  let bus: MessageBus | undefined;
+  try {
+    bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
+    await requireLiveOwnerForMutation(bus);
+    const task = await querySetTargetTask(bus, options.taskId);
+    const refusal = findSetRefusal(options, task);
+    if (refusal) {
+      throw new Error(`Cannot set ${options.field} on task "${task.id}": ${refusal}.`);
+    }
+    await sendHeadlessExec(bus, ['set', options.field, options.taskId, ...options.values]);
+    process.stdout.write(`set ${options.field} accepted by live owner.\n`);
     return 0;
   } finally {
     const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
@@ -1403,6 +1603,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         throw new Error(`Unexpected argument: ${argv[1]}`);
       }
       return await runDeleteAllMutation(deps);
+    }
+    if (argv[0] === 'set') {
+      return await runSetMutation(parseSetArgs(argv.slice(1)), deps);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   format: ['esm'],
   dts: false,
   clean: true,
+  removeNodeProtocol: false,
   banner: {
     js: '#!/usr/bin/env node',
   },

--- a/packages/contracts/src/headless-set-subcommands.ts
+++ b/packages/contracts/src/headless-set-subcommands.ts
@@ -1,0 +1,41 @@
+export type HeadlessSetSubcommandScope = 'task' | 'workflow';
+
+export interface HeadlessSetSubcommandDefinition {
+  readonly name: string;
+  readonly scope: HeadlessSetSubcommandScope;
+}
+
+export const HEADLESS_SET_SUBCOMMANDS = [
+  { name: 'command', scope: 'task' },
+  { name: 'prompt', scope: 'task' },
+  { name: 'pool', scope: 'task' },
+  { name: 'executor', scope: 'task' },
+  { name: 'agent', scope: 'task' },
+  { name: 'model', scope: 'task' },
+  { name: 'task-pool', scope: 'task' },
+  { name: 'merge-mode', scope: 'workflow' },
+  { name: 'fix-prompt', scope: 'task' },
+  { name: 'fix-context', scope: 'task' },
+  { name: 'gate-policy', scope: 'task' },
+  { name: 'workflow', scope: 'workflow' },
+  { name: 'task', scope: 'task' },
+] as const satisfies readonly HeadlessSetSubcommandDefinition[];
+
+export type HeadlessSetSubcommand = (typeof HEADLESS_SET_SUBCOMMANDS)[number]['name'];
+
+export function formatHeadlessSetSubcommands(separator: string): string {
+  return HEADLESS_SET_SUBCOMMANDS.map((definition) => definition.name).join(separator);
+}
+
+export function findHeadlessSetSubcommandScope(
+  subcommand: string | undefined,
+): HeadlessSetSubcommandScope | undefined {
+  if (!subcommand) return undefined;
+  return HEADLESS_SET_SUBCOMMANDS.find((definition) => definition.name === subcommand)?.scope;
+}
+
+export function listHeadlessSetSubcommandsForScope(scope: HeadlessSetSubcommandScope): string[] {
+  return HEADLESS_SET_SUBCOMMANDS
+    .filter((definition) => definition.scope === scope)
+    .map((definition) => definition.name);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,4 +20,5 @@ export * from './headless-owner-launch.ts';
 export * from './planning-surface.ts';
 export * from './verification-contract.ts';
 export * from './task-filter.ts';
+export * from './headless-set-subcommands.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/workflow-core/src/__tests__/merge-node-default-agent.test.ts
+++ b/packages/workflow-core/src/__tests__/merge-node-default-agent.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator, type OrchestratorConfig } from '../orchestrator.js';
+import type { PlanDefinition } from '../plan-parser.js';
+import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+function makeOrchestrator(overrides: Partial<OrchestratorConfig> = {}): Orchestrator {
+  return new Orchestrator({
+    persistence: new InMemoryPersistence(),
+    messageBus: new InMemoryBus(),
+    maxConcurrency: 2,
+    ...overrides,
+  });
+}
+
+function commandPlan(name: string): PlanDefinition {
+  return {
+    name,
+    baseBranch: 'master',
+    featureBranch: `feature/${name}`,
+    tasks: [
+      { id: 'build', description: 'Build', command: 'echo build' },
+      { id: 'verify', description: 'Verify', command: 'echo verify', dependencies: ['build'] },
+    ],
+  };
+}
+
+function mergeNodeOf(orchestrator: Orchestrator, workflowId: string) {
+  return orchestrator
+    .getAllTasks()
+    .find((task) => task.config.isMergeNode && task.config.workflowId === workflowId);
+}
+
+function submit(orchestrator: Orchestrator, plan: PlanDefinition): string {
+  orchestrator.loadPlan(plan);
+  const workflowId = orchestrator.getAllTasks().find((task) => task.config.isMergeNode)?.config.workflowId;
+  if (!workflowId) throw new Error('merge node not created');
+  return workflowId;
+}
+
+describe('merge node execution agent', () => {
+  it('carries the configured default agent on a submitted plan', () => {
+    const orchestrator = makeOrchestrator({ defaultExecutionAgentProvider: () => 'claude' });
+
+    const workflowId = submit(orchestrator, commandPlan('configured-default'));
+
+    expect(mergeNodeOf(orchestrator, workflowId)?.config.executionAgent).toBe('claude');
+  });
+
+  it('leaves the agent unset when config names no default, so the built-in fallback applies', () => {
+    const withoutProvider = makeOrchestrator();
+    const blankProvider = makeOrchestrator({ defaultExecutionAgentProvider: () => '   ' });
+    const emptyProvider = makeOrchestrator({ defaultExecutionAgentProvider: () => undefined });
+
+    for (const orchestrator of [withoutProvider, blankProvider, emptyProvider]) {
+      const workflowId = submit(orchestrator, commandPlan('no-default'));
+      const mergeNode = mergeNodeOf(orchestrator, workflowId);
+      expect(mergeNode?.config.executionAgent).toBeUndefined();
+      expect(mergeNode?.config).not.toHaveProperty('executionAgent');
+    }
+  });
+
+  it('prefers an agent the plan tasks declare over the configured default', () => {
+    const orchestrator = makeOrchestrator({ defaultExecutionAgentProvider: () => 'claude' });
+    const plan = commandPlan('declared-agent');
+    plan.tasks[0] = { ...plan.tasks[0], command: undefined, prompt: 'Build it', executionAgent: 'omp' };
+
+    const workflowId = submit(orchestrator, plan);
+
+    expect(mergeNodeOf(orchestrator, workflowId)?.config.executionAgent).toBe('omp');
+  });
+
+  it('carries the configured default on a forked workflow merge node', () => {
+    let configured: string | undefined;
+    const orchestrator = makeOrchestrator({ defaultExecutionAgentProvider: () => configured });
+    const sourceWorkflowId = submit(orchestrator, commandPlan('fork-default'));
+    expect(mergeNodeOf(orchestrator, sourceWorkflowId)?.config.executionAgent).toBeUndefined();
+
+    configured = 'claude';
+    const { forkedWorkflowId } = orchestrator.forkWorkflow(sourceWorkflowId, { autoStart: false });
+
+    expect(mergeNodeOf(orchestrator, forkedWorkflowId)?.config.executionAgent).toBe('claude');
+  });
+
+  it('keeps the source merge node agent on a forked workflow', () => {
+    const orchestrator = makeOrchestrator({ defaultExecutionAgentProvider: () => 'claude' });
+    const sourceWorkflowId = submit(orchestrator, commandPlan('fork-source-agent'));
+    orchestrator.editTaskAgent(mergeNodeOf(orchestrator, sourceWorkflowId)!.id, 'omp');
+
+    const { forkedWorkflowId } = orchestrator.forkWorkflow(sourceWorkflowId, { autoStart: false });
+
+    expect(mergeNodeOf(orchestrator, forkedWorkflowId)?.config.executionAgent).toBe('omp');
+  });
+
+  it('leaves a forked merge node unset when neither source nor config names an agent', () => {
+    const orchestrator = makeOrchestrator();
+    const sourceWorkflowId = submit(orchestrator, commandPlan('fork-no-default'));
+
+    const { forkedWorkflowId } = orchestrator.forkWorkflow(sourceWorkflowId, { autoStart: false });
+
+    expect(mergeNodeOf(orchestrator, forkedWorkflowId)?.config.executionAgent).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './state-machine.js';
 export * from './response-handler.js';
 export * from './scheduler.js';
 export * from './orchestrator.js';
+export { ALREADY_TERMINAL_TASK_STATUSES } from './orchestrator/cancellation.js';
 export * from './task-id-scope.js';
 export * from './merge-conflict-error.js';
 export * from './review-gate-artifacts.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -751,6 +751,7 @@ export interface OrchestratorConfig {
   deferRunningUntilLaunch?: boolean;
   /** Resolve the repo default branch. Must throw when no safe branch is known. */
   resolveRepoDefaultBranch?: (repoUrl: string) => string;
+  defaultExecutionAgentProvider?: () => string | undefined;
   /** Invoked after recreate-class mutations reset the supplied task IDs. */
   onRecreateTasksReset?: (taskIds: readonly string[]) => void;
   /**
@@ -796,6 +797,7 @@ export class Orchestrator {
   private readonly deferRunningUntilLaunch: boolean;
   private readonly launchDeferralBackoffMs?: number;
   private readonly resolveRepoDefaultBranch: (repoUrl: string) => string;
+  private readonly defaultExecutionAgentProvider?: () => string | undefined;
   private readonly onRecreateTasksReset?: (taskIds: readonly string[]) => void;
 
   private activeWorkflowIds = new Set<string>();
@@ -858,6 +860,7 @@ export class Orchestrator {
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
     this.launchDeferralBackoffMs = config.launchDeferralBackoffMs;
     this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
+    this.defaultExecutionAgentProvider = config.defaultExecutionAgentProvider;
     this.onRecreateTasksReset = config.onRecreateTasksReset;
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
@@ -896,6 +899,14 @@ export class Orchestrator {
     for (const task of tasks) {
       this.stateMachine.restoreTask(task);
     }
+  }
+
+  private mergeNodeExecutionAgentConfig(workflowTasks: readonly TaskState[]): { executionAgent?: string } {
+    const declared = workflowTasks
+      .map((task) => task.config.executionAgent?.trim())
+      .find((agent): agent is string => Boolean(agent));
+    const executionAgent = declared || this.defaultExecutionAgentProvider?.()?.trim();
+    return executionAgent ? { executionAgent } : {};
   }
 
   /**
@@ -1599,7 +1610,12 @@ export class Orchestrator {
       mergeNodeId,
       descriptionForMergeNode(plan),
       leafIds,
-      { workflowId, isMergeNode: true, runnerKind: 'merge' },
+      {
+        workflowId,
+        isMergeNode: true,
+        runnerKind: 'merge',
+        ...this.mergeNodeExecutionAgentConfig(validatedTasks),
+      },
     );
 
     // ── Pass 2: all validation passed — persist everything ──
@@ -2759,7 +2775,12 @@ export class Orchestrator {
       newMergeId,
       mergeDescription,
       leafIds,
-      { workflowId: newWfId, isMergeNode: true, runnerKind: 'merge' },
+      {
+        workflowId: newWfId,
+        isMergeNode: true,
+        runnerKind: 'merge',
+        ...this.mergeNodeExecutionAgentConfig(sourceMergeNode ? [sourceMergeNode, ...createdNew] : createdNew),
+      },
     );
     this.createAndSync(newMerge);
     this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'created', task: newMerge });

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -28,6 +28,8 @@ import { buildTaskResetChanges, type TaskResetKind } from '../task-reset-policy.
 
 const TASK_DELTA_CHANNEL = 'task.delta';
 
+export const ALREADY_TERMINAL_TASK_STATUSES: readonly TaskStatus[] = ['completed', 'closed', 'stale'];
+
 function isActiveForInvalidation(status: TaskStatus): boolean {
   return (
     status === 'running' ||
@@ -209,8 +211,7 @@ export function cancelTaskImpl(
   const task = host.stateGetTask(taskId);
   if (!task) throw new OrchestratorError('TASK_NOT_FOUND', `Task "${taskId}" not found`);
 
-  const terminal: Partial<Record<TaskStatus, true>> = { completed: true, closed: true, stale: true };
-  if (terminal[task.status]) {
+  if (ALREADY_TERMINAL_TASK_STATUSES.includes(task.status)) {
     throw new OrchestratorError('TASK_ALREADY_TERMINAL', `Task "${taskId}" is already ${task.status}`);
   }
 


### PR DESCRIPTION
## Summary

The orchestrator that desktop edit handlers build now gets `loadDefaultExecutionAgent`. Merge nodes it creates carry the user's configured default agent.

## Before and After

Same input on both refs: a small test script in `packages/app` that sets `defaultExecutionAgent` to `claude` in config, fires the desktop `invoker:clear` edit handler (which rebuilds the orchestrator), loads a one-task command-only plan, and prints the agent saved on its merge node; run with `pnpm exec vitest run` on base `3cf2c4ba2` and head `cedf008c5`.

```text
Before: RESULT merge node executionAgent: null
After:  RESULT merge node executionAgent: "claude"
```

## Review Claim

Approve passing `defaultExecutionAgentProvider: loadDefaultExecutionAgent` to the GUI mutation handlers' orchestrator.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This adds one optional config field; the orchestrator already tolerates it being absent, and its value comes from the same config the app already reads.

## Slice Rationale

The review units differ: this file and the owner's `main.ts` belong to different units. So each wiring change is its own slice.

## Non-goals

Does not change the owner orchestrators in `main.ts`. Does not change which agent non-merge tasks use.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/merge-node-default-agent.test.ts`: passed
- [x] `cd packages/app && pnpm test` failures are not from this stack: re-running the 20 failing files gives the same 19 failed files and 55 failed tests on master `97f7e86af` and on this stack's tree
- [x] `pnpm run check:types` on this slice's commit: exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's merge commit>`
- Post-revert steps: None
- Data migration? No

</details>

