### PR TITLE
[Discord surface (1) surface discriminator](1) Batch the data-store scale repro inserts in one transaction

### DIFF
--- a/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
+++ b/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
@@ -25,25 +25,27 @@ describe('SQL variables limit (ui-read-scale)', () => {
   it(
     'loadWorkflowTaskSnapshot handles >32k workflows via chunked queries',
     async () => {
-      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-        adapter.saveWorkflow({
-          id: `wf-${i}`,
-          name: `Workflow ${i}`,
-          status: 'pending',
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        });
-        adapter.saveTask(`wf-${i}`, {
-          id: `wf-${i}/t0`,
-          description: `Task ${i}`,
-          status: 'pending',
-          dependencies: [],
-          createdAt: new Date(),
-          config: resolveTaskConfig({ workflowId: `wf-${i}` }),
-          execution: {},
-          taskStateVersion: 1,
-        });
-      }
+      adapter.runInTransaction(() => {
+        for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+          adapter.saveWorkflow({
+            id: `wf-${i}`,
+            name: `Workflow ${i}`,
+            status: 'pending',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+          adapter.saveTask(`wf-${i}`, {
+            id: `wf-${i}/t0`,
+            description: `Task ${i}`,
+            status: 'pending',
+            dependencies: [],
+            createdAt: new Date(),
+            config: resolveTaskConfig({ workflowId: `wf-${i}` }),
+            execution: {},
+            taskStateVersion: 1,
+          });
+        }
+      });
 
       const snapshot = adapter.loadWorkflowTaskSnapshot();
       expect(snapshot.workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
@@ -53,30 +55,34 @@ describe('SQL variables limit (ui-read-scale)', () => {
   );
 
   it('listWorkflows handles >32k workflows via chunked rollup queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
   });
 
   it('loadTasksForWorkflows handles >32k workflow IDs via chunked queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflowIds = Array.from({ length: WORKFLOW_COUNT_ABOVE_LIMIT }, (_, i) => `wf-${i}`);
     const tasks = adapter.loadTasksForWorkflows(workflowIds);

--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -38,9 +38,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('1-arg getEvents overload applies GET_EVENTS_DEFAULT_LIMIT', () => {
     const eventCount = GET_EVENTS_DEFAULT_LIMIT + 5000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1');
     expect(events).toHaveLength(GET_EVENTS_DEFAULT_LIMIT);
@@ -48,9 +50,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('bounded getEvents with explicit limit works correctly', () => {
     const eventCount = 1000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1', 'desc', 100);
     expect(events).toHaveLength(100);

--- a/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
@@ -21,15 +21,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('listWorkflows has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(workflowCount);
@@ -38,15 +40,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('loadWorkflowTaskSnapshot has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const snapshot = adapter.loadWorkflowTaskSnapshot();
     expect(snapshot.workflows).toHaveLength(workflowCount);
@@ -56,16 +60,18 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   it.fails('listWorkflows materializes every row into JS objects', () => {
     const workflowCount = 5_000;
     const descriptionPayload = 'x'.repeat(256);
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i} with a longer name to increase memory footprint`,
-        description: `Description for workflow ${i}: ${descriptionPayload}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i} with a longer name to increase memory footprint`,
+          description: `Description for workflow ${i}: ${descriptionPayload}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     const materializedBytes = Buffer.byteLength(JSON.stringify(workflows));
@@ -100,15 +106,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   });
 
   it('listWorkflowsPaged respects limit at scale without loading all rows', () => {
-    for (let i = 0; i < 5000; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < 5000; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const started = performance.now();
     const result = adapter.listWorkflowsPaged({ limit: 50 });


### PR DESCRIPTION
## Summary

Three data-store scale repro tests seed 5,000 to 37,000 rows one insert at a time, and each insert commits on its own.

Committing every row on its own makes seeding slow, which pushes these tests toward the vitest timeout on a busy host.

This wraps each seeding loop in `adapter.runInTransaction`, so the rows are written in one commit. The row counts and every assertion stay the same.

## Review Claim

The three scale repro tests seed the same rows and check the same assertions, but commit their seed data in one transaction instead of one commit per row.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only files under `packages/data-store/src/__tests__/` change. No product code changes, and every expected count and `it.fails` marker is left exactly as it was.

## Slice Rationale

This lands before the surface column slice so the data-store suite finishes inside the vitest timeout for every later slice in this stack. It is kept apart because it touches no product file.

## Non-goals

- No change to `SQLiteAdapter`, the schema, or any repository.
- No change to row counts, limits, or assertions in these repro files.
- The small 500-row pagination seed is left as it was.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file <this body> --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
