### PR TITLE
[Discord surface (1) surface discriminator](2) Tag every chat-thread row with the surface that wrote it

### DIFF
--- a/packages/data-store/src/__tests__/slack-session-repository.test.ts
+++ b/packages/data-store/src/__tests__/slack-session-repository.test.ts
@@ -28,6 +28,7 @@ describe('SlackSessionRepository', () => {
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
       confirmationMode: 'require' as const,
+      surface: 'slack',
     };
 
     repo.saveLaunchContext(context);
@@ -48,6 +49,7 @@ describe('SlackSessionRepository', () => {
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
       confirmationMode: 'require' as const,
+      surface: 'slack',
     };
     try {
       const writer = await SQLiteAdapter.create(databasePath, { ownerCapability: true });

--- a/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
+++ b/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
@@ -25,25 +25,27 @@ describe('SQL variables limit (ui-read-scale)', () => {
   it(
     'loadWorkflowTaskSnapshot handles >32k workflows via chunked queries',
     async () => {
-      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-        adapter.saveWorkflow({
-          id: `wf-${i}`,
-          name: `Workflow ${i}`,
-          status: 'pending',
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        });
-        adapter.saveTask(`wf-${i}`, {
-          id: `wf-${i}/t0`,
-          description: `Task ${i}`,
-          status: 'pending',
-          dependencies: [],
-          createdAt: new Date(),
-          config: resolveTaskConfig({ workflowId: `wf-${i}` }),
-          execution: {},
-          taskStateVersion: 1,
-        });
-      }
+      adapter.runInTransaction(() => {
+        for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+          adapter.saveWorkflow({
+            id: `wf-${i}`,
+            name: `Workflow ${i}`,
+            status: 'pending',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+          adapter.saveTask(`wf-${i}`, {
+            id: `wf-${i}/t0`,
+            description: `Task ${i}`,
+            status: 'pending',
+            dependencies: [],
+            createdAt: new Date(),
+            config: resolveTaskConfig({ workflowId: `wf-${i}` }),
+            execution: {},
+            taskStateVersion: 1,
+          });
+        }
+      });
 
       const snapshot = adapter.loadWorkflowTaskSnapshot();
       expect(snapshot.workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
@@ -53,30 +55,34 @@ describe('SQL variables limit (ui-read-scale)', () => {
   );
 
   it('listWorkflows handles >32k workflows via chunked rollup queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
   });
 
   it('loadTasksForWorkflows handles >32k workflow IDs via chunked queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflowIds = Array.from({ length: WORKFLOW_COUNT_ABOVE_LIMIT }, (_, i) => `wf-${i}`);
     const tasks = adapter.loadTasksForWorkflows(workflowIds);

--- a/packages/data-store/src/__tests__/surface-discriminator.test.ts
+++ b/packages/data-store/src/__tests__/surface-discriminator.test.ts
@@ -1,0 +1,317 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConversationRepository } from '../conversation-repository.js';
+import { SlackPlanDraftRepository, type CreateSlackPlanDraft } from '../slack-plan-draft-repository.js';
+import { SlackSessionRepository } from '../slack-session-repository.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const SURFACE_TABLES = [
+  'conversations',
+  'slack_launch_contexts',
+  'slack_plan_drafts',
+  'slack_pending_confirmations',
+] as const;
+
+const PRE_SURFACE_DDL = `
+  CREATE TABLE conversations (
+    thread_ts TEXT PRIMARY KEY,
+    channel_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    mode TEXT DEFAULT 'plan',
+    extracted_plan TEXT,
+    plan_submitted INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE TABLE slack_launch_contexts (
+    thread_ts TEXT PRIMARY KEY,
+    repo_url TEXT NOT NULL,
+    harness_preset TEXT NOT NULL,
+    working_dir TEXT NOT NULL,
+    requested_by TEXT NOT NULL,
+    lobby_channel_id TEXT NOT NULL,
+    confirmation_mode TEXT NOT NULL DEFAULT 'require',
+    harness_session_id TEXT
+  );
+  CREATE TABLE slack_plan_drafts (
+    draft_id TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    planning_draft_id TEXT,
+    channel_id TEXT NOT NULL,
+    thread_ts TEXT NOT NULL,
+    message_ts TEXT,
+    slack_file_id TEXT,
+    plan_text TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    summary_json TEXT NOT NULL,
+    status TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    harness_preset TEXT NOT NULL,
+    working_dir TEXT NOT NULL,
+    requested_by TEXT NOT NULL,
+    confirmation_mode TEXT NOT NULL DEFAULT 'require',
+    created_at TEXT NOT NULL,
+    decided_at TEXT,
+    decided_by TEXT,
+    execution_key TEXT,
+    workflow_ids_json TEXT,
+    PRIMARY KEY (draft_id, version)
+  );
+  CREATE TABLE slack_pending_confirmations (
+    confirm_key TEXT PRIMARY KEY,
+    thread_ts TEXT NOT NULL,
+    channel_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+  );
+  INSERT INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at)
+    VALUES ('legacy-thread', 'C1', 'U1', 'plan', NULL, 0, '2026-09-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z');
+  INSERT INTO slack_launch_contexts (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode)
+    VALUES ('legacy-thread', 'https://github.com/acme/repo.git', 'claude', '/tmp/repo', 'U1', 'C1', 'require');
+  INSERT INTO slack_plan_drafts (draft_id, version, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash,
+      summary_json, status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at)
+    VALUES ('legacy-draft', 1, 'C1', 'legacy-thread', '1.2', 'F1', 'name: legacy', 'hash', '{}', 'ready',
+      'https://github.com/acme/repo.git', 'claude', '/tmp/repo', 'U1', 'require', '2026-09-01T00:00:00.000Z');
+  INSERT INTO slack_pending_confirmations (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at)
+    VALUES ('legacy-confirm', 'legacy-thread', 'C1', 'U1', 'plan_submission', '{"ok":true}', '2026-09-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z');
+`;
+
+function draftInput(threadTs: string, surface?: string): CreateSlackPlanDraft {
+  return {
+    channelId: 'C1',
+    threadTs,
+    planText: `name: ${surface ?? 'default'}\ntasks:\n  - id: task\n    description: Test`,
+    summaryJson: '{}',
+    repoUrl: 'https://github.com/acme/repo.git',
+    harnessPreset: 'codex',
+    workingDir: '/tmp/repo',
+    requestedBy: 'U1',
+    confirmationMode: 'require',
+    ...(surface ? { surface } : {}),
+  };
+}
+
+function launchContext(threadTs: string, surface?: string) {
+  return {
+    threadTs,
+    repoUrl: 'https://github.com/acme/repo.git',
+    harnessPreset: 'claude',
+    workingDir: '/tmp/repo',
+    requestedBy: 'U1',
+    lobbyChannelId: 'C1',
+    confirmationMode: 'require' as const,
+    ...(surface ? { surface } : {}),
+  };
+}
+
+describe('surface discriminator: upgrade of a pre-surface database', () => {
+  let directory: string;
+  let databasePath: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'surface-discriminator-'));
+    databasePath = join(directory, 'legacy.db');
+    const legacy = new DatabaseSync(databasePath);
+    try {
+      legacy.exec(PRE_SURFACE_DDL);
+    } finally {
+      legacy.close();
+    }
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  function snapshotLegacyColumns(): Map<string, { columns: string[]; rows: unknown[] }> {
+    const reader = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      return new Map(SURFACE_TABLES.map((table) => {
+        const columns = reader.prepare(`PRAGMA table_info(${table})`).all().map((column) => String(column.name));
+        return [table, { columns, rows: reader.prepare(`SELECT * FROM ${table}`).all() }];
+      }));
+    } finally {
+      reader.close();
+    }
+  }
+
+  it('reads pre-existing rows with no surface value back as slack through every repository', async () => {
+    const adapter = await SQLiteAdapter.create(databasePath, { ownerCapability: true });
+    try {
+      expect(new ConversationRepository(adapter).loadConversation('legacy-thread')?.surface).toBe('slack');
+      const sessions = new SlackSessionRepository(adapter);
+      expect(sessions.getLaunchContext('legacy-thread')?.surface).toBe('slack');
+      expect(sessions.getPendingConfirmation('legacy-confirm')?.surface).toBe('slack');
+      expect(sessions.getLatestPendingConfirmationForThread('legacy-thread', 'slack')?.confirmKey).toBe('legacy-confirm');
+      const drafts = new SlackPlanDraftRepository(adapter);
+      expect(drafts.get('legacy-draft', 1)?.surface).toBe('slack');
+      expect(drafts.getReady('C1', 'legacy-thread', 'slack')?.draftId).toBe('legacy-draft');
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('adds only the surface column and its index, leaving every legacy value untouched across restarts', async () => {
+    const before = snapshotLegacyColumns();
+
+    for (let startup = 0; startup < 2; startup++) {
+      const adapter = await SQLiteAdapter.create(databasePath, { ownerCapability: true });
+      adapter.close();
+
+      const reader = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        for (const table of SURFACE_TABLES) {
+          const legacy = before.get(table)!;
+          const columns = reader.prepare(`PRAGMA table_info(${table})`).all();
+          expect(columns.map((column) => column.name)).toEqual([...legacy.columns, 'surface']);
+          expect(columns.find((column) => column.name === 'surface')).toMatchObject({
+            type: 'TEXT',
+            notnull: 1,
+            dflt_value: "'slack'",
+          });
+          expect(reader.prepare(`SELECT ${legacy.columns.join(', ')} FROM ${table}`).all()).toEqual(legacy.rows);
+          expect(reader.prepare(`SELECT surface FROM ${table}`).all()).toEqual([{ surface: 'slack' }]);
+          expect(
+            reader.prepare(`PRAGMA index_info(idx_${table}_surface_thread)`).all().map((column) => column.name),
+          ).toEqual(['surface', 'thread_ts']);
+        }
+      } finally {
+        reader.close();
+      }
+    }
+  });
+});
+
+describe('surface discriminator: two surfaces sharing one thread id', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => adapter.close());
+
+  it('defaults every write to slack when no surface is passed', () => {
+    new ConversationRepository(adapter).saveConversation('T1', [{ role: 'user', content: 'hi' }], null, false, 'C1', 'U1');
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.saveLaunchContext(launchContext('T1'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {},
+    });
+    const draft = new SlackPlanDraftRepository(adapter).create(draftInput('T1'));
+
+    expect(adapter.loadConversation('T1')?.surface).toBe('slack');
+    expect(adapter.loadSlackLaunchContext('T1')?.surface).toBe('slack');
+    expect(adapter.loadSlackPendingConfirmation('K1')?.surface).toBe('slack');
+    expect(adapter.loadSlackPlanDraft(draft.draftId, draft.version)?.surface).toBe('slack');
+  });
+
+  it('keeps plan drafts for the same channel and thread separate per surface', () => {
+    const repository = new SlackPlanDraftRepository(adapter);
+    const makeReady = (surface: string) => {
+      const draft = repository.create(draftInput('shared-thread', surface));
+      repository.bindMessage(draft, `${surface}.msg`);
+      repository.bindAttachment(draft, `${surface}-file`);
+      repository.markReady(draft);
+      return draft;
+    };
+
+    const slackDraft = makeReady('slack');
+    const discordDraft = makeReady('discord');
+
+    expect(repository.getReady('C1', 'shared-thread', 'slack')).toMatchObject({
+      draftId: slackDraft.draftId,
+      surface: 'slack',
+      status: 'ready',
+      version: 1,
+    });
+    expect(repository.getReady('C1', 'shared-thread', 'discord')).toMatchObject({
+      draftId: discordDraft.draftId,
+      surface: 'discord',
+      status: 'ready',
+      version: 1,
+    });
+  });
+
+  it('keeps pending confirmations for the same thread separate per surface', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'slack-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'slack' },
+    }, new Date('2026-09-01T00:00:00.000Z'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'discord-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'discord' }, surface: 'discord',
+    }, new Date('2026-09-02T00:00:00.000Z'));
+
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread', 'slack')).toMatchObject({
+      confirmKey: 'slack-key', surface: 'slack', payload: { from: 'slack' },
+    });
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread', 'discord')).toMatchObject({
+      confirmKey: 'discord-key', surface: 'discord', payload: { from: 'discord' },
+    });
+    expect(sessions.getPendingConfirmation('slack-key', 'discord')).toBeNull();
+    expect(sessions.getPendingConfirmation('discord-key', 'slack')).toBeNull();
+  });
+
+  it('refuses to overwrite a slack conversation from another surface and leaves the slack row intact', () => {
+    const repository = new ConversationRepository(adapter);
+    repository.saveConversation('shared-thread', [{ role: 'user', content: 'from slack' }], null, false, 'C1', 'U1');
+
+    expect(() => repository.saveConversation(
+      'shared-thread', [{ role: 'user', content: 'from discord' }], null, false, 'D1', 'U2', 'plan', 'discord',
+    )).toThrow(/belongs to surface 'slack'/);
+
+    expect(repository.loadConversation('shared-thread', 'discord')).toBeNull();
+    expect(repository.loadConversation('shared-thread', 'slack')).toMatchObject({
+      channelId: 'C1',
+      userId: 'U1',
+      surface: 'slack',
+      messages: [{ role: 'user', content: 'from slack' }],
+    });
+  });
+
+  it('refuses to overwrite a slack launch context from another surface and leaves the slack row intact', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.saveLaunchContext(launchContext('shared-thread'));
+
+    expect(() => sessions.saveLaunchContext({ ...launchContext('shared-thread', 'discord'), workingDir: '/tmp/discord' }))
+      .toThrow(/belongs to surface 'slack'/);
+
+    expect(sessions.getLaunchContext('shared-thread', 'discord')).toBeNull();
+    expect(sessions.getLaunchContext('shared-thread', 'slack')).toMatchObject({ workingDir: '/tmp/repo', surface: 'slack' });
+
+    sessions.deleteLaunchContext('shared-thread', 'discord');
+    expect(sessions.getLaunchContext('shared-thread', 'slack')).not.toBeNull();
+  });
+
+  it('refuses to reuse a slack confirmation key from another surface', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'slack' },
+    });
+
+    expect(() => sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'discord' }, surface: 'discord',
+    })).toThrow(/belongs to surface 'slack'/);
+    expect(sessions.getPendingConfirmation('K1')).toMatchObject({ surface: 'slack', payload: { from: 'slack' } });
+  });
+
+  it('returns every surface when a read omits the surface filter', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'slack-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {},
+    }, new Date('2026-09-01T00:00:00.000Z'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'discord-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {}, surface: 'discord',
+    }, new Date('2026-09-02T00:00:00.000Z'));
+
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread')?.confirmKey).toBe('discord-key');
+    expect(sessions.getPendingConfirmation('slack-key')?.surface).toBe('slack');
+    expect(sessions.getPendingConfirmation('discord-key')?.surface).toBe('discord');
+  });
+});

--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -38,9 +38,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('1-arg getEvents overload applies GET_EVENTS_DEFAULT_LIMIT', () => {
     const eventCount = GET_EVENTS_DEFAULT_LIMIT + 5000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1');
     expect(events).toHaveLength(GET_EVENTS_DEFAULT_LIMIT);
@@ -48,9 +50,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('bounded getEvents with explicit limit works correctly', () => {
     const eventCount = 1000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1', 'desc', 100);
     expect(events).toHaveLength(100);

--- a/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
@@ -21,15 +21,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('listWorkflows has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(workflowCount);
@@ -38,15 +40,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('loadWorkflowTaskSnapshot has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const snapshot = adapter.loadWorkflowTaskSnapshot();
     expect(snapshot.workflows).toHaveLength(workflowCount);
@@ -56,16 +60,18 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   it.fails('listWorkflows materializes every row into JS objects', () => {
     const workflowCount = 5_000;
     const descriptionPayload = 'x'.repeat(256);
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i} with a longer name to increase memory footprint`,
-        description: `Description for workflow ${i}: ${descriptionPayload}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i} with a longer name to increase memory footprint`,
+          description: `Description for workflow ${i}: ${descriptionPayload}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     const materializedBytes = Buffer.byteLength(JSON.stringify(workflows));
@@ -100,15 +106,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   });
 
   it('listWorkflowsPaged respects limit at scale without loading all rows', () => {
-    for (let i = 0; i < 5000; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < 5000; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const started = performance.now();
     const result = adapter.listWorkflowsPaged({ limit: 50 });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -11,6 +11,8 @@ import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
 export type ConversationMode = 'agent' | 'plan';
+export type ChatSurface = string;
+export const DEFAULT_CHAT_SURFACE: ChatSurface = 'slack';
 // ── Conversation Types ─────────────────────────────────────
 
 export interface Conversation {
@@ -22,6 +24,7 @@ export interface Conversation {
   planSubmitted: boolean;
   createdAt: string;
   updatedAt: string;
+  surface?: ChatSurface;
 }
 
 export interface ConversationMessage {
@@ -56,6 +59,7 @@ export interface SlackLaunchContext {
   lobbyChannelId: string;
   confirmationMode: PlanningConfirmationMode;
   harnessSessionId?: string;
+  surface?: ChatSurface;
 }
 
 export type SlackPlanDraftStatus =
@@ -89,6 +93,7 @@ export interface SlackPlanDraft {
   decidedBy?: string;
   executionKey?: string;
   workflowIdsJson?: string;
+  surface?: ChatSurface;
 }
 
 export interface SlackPendingConfirmation {
@@ -100,6 +105,7 @@ export interface SlackPendingConfirmation {
   payloadJson: string;
   createdAt: string;
   expiresAt: string;
+  surface?: ChatSurface;
 }
 
 // ── Workflow Channel Types (Slack workflow↔channel mapping) ─
@@ -469,13 +475,13 @@ export interface PersistenceAdapter {
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;
-  loadConversation(threadTs: string): Conversation | undefined;
+  loadConversation(threadTs: string, surface?: ChatSurface): Conversation | undefined;
   updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'mode' | 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void;
   deleteConversation(threadTs: string): void;
 
   // Conversation queries
-  listActiveConversations(): Conversation[];
-  listActivePlanConversations(channelId: string, userId: string): Conversation[];
+  listActiveConversations(surface?: ChatSurface): Conversation[];
+  listActivePlanConversations(channelId: string, userId: string, surface?: ChatSurface): Conversation[];
   deleteConversationsOlderThan(cutoffIso: string): number;
 
   // Conversation messages
@@ -493,17 +499,17 @@ export interface PersistenceAdapter {
 
   // Slack plan submission session state
   saveSlackLaunchContext(context: SlackLaunchContext): void;
-  loadSlackLaunchContext(threadTs: string): SlackLaunchContext | undefined;
-  deleteSlackLaunchContext(threadTs: string): void;
+  loadSlackLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | undefined;
+  deleteSlackLaunchContext(threadTs: string, surface?: ChatSurface): void;
   saveSlackPlanDraft(draft: SlackPlanDraft): void;
   loadSlackPlanDraft(draftId: string, version: number): SlackPlanDraft | undefined;
-  loadReadySlackPlanDraft(channelId: string, threadTs: string): SlackPlanDraft | undefined;
+  loadReadySlackPlanDraft(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined;
   updateSlackPlanDraft(draftId: string, version: number, changes: Partial<Pick<SlackPlanDraft, 'messageTs' | 'slackFileId' | 'status' | 'decidedAt' | 'decidedBy' | 'executionKey' | 'workflowIdsJson'>>): void;
   claimSlackPlanDraft(draftId: string, version: number, executionKey: string): boolean;
-  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string): void;
+  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string, surface?: ChatSurface): void;
   saveSlackPendingConfirmation(confirmation: SlackPendingConfirmation): void;
-  loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined;
-  loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined;
+  loadSlackPendingConfirmation(confirmKey: string, surface?: ChatSurface): SlackPendingConfirmation | undefined;
+  loadLatestSlackPendingConfirmationByThread(threadTs: string, surface?: ChatSurface): SlackPendingConfirmation | undefined;
   deleteSlackPendingConfirmation(confirmKey: string): void;
 
   // Repair filings (cross-system CI/PR repair dedup ledger)

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -7,7 +7,8 @@
  */
 
 import type { PlanDefinition } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
+import type { PersistenceAdapter, ChatSurface, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 // ── Public Types ─────────────────────────────────────────────
@@ -22,6 +23,7 @@ export interface ConversationEntry {
   planSubmitted: boolean;
   createdAt: string;
   updatedAt: string;
+  surface: ChatSurface;
 }
 
 export interface ConversationMessageEntry {
@@ -68,10 +70,11 @@ export class ConversationRepository {
     channelId?: string,
     userId?: string,
     mode?: ConversationMode,
+    surface: ChatSurface = DEFAULT_CHAT_SURFACE,
   ): void {
     const now = new Date().toISOString();
 
-    const existing = this.adapter.loadConversation(threadTs);
+    const existing = this.adapter.loadConversation(threadTs, surface);
 
     const planJson = extractedPlan ? JSON.stringify(extractedPlan) : null;
 
@@ -92,6 +95,7 @@ export class ConversationRepository {
         planSubmitted: planSubmitted ?? false,
         createdAt: now,
         updatedAt: now,
+        surface,
       });
     }
 
@@ -124,8 +128,8 @@ export class ConversationRepository {
    * Load a conversation with all its messages, deserializing JSON fields.
    * Returns null if the conversation does not exist.
    */
-  loadConversation(threadTs: string): ConversationEntry | null {
-    const conv = this.adapter.loadConversation(threadTs);
+  loadConversation(threadTs: string, surface?: ChatSurface): ConversationEntry | null {
+    const conv = this.adapter.loadConversation(threadTs, surface);
     if (!conv) return null;
 
     const rawMessages = this.adapter.loadMessages(threadTs);
@@ -143,6 +147,7 @@ export class ConversationRepository {
       planSubmitted: conv.planSubmitted,
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
+      surface: conv.surface ?? DEFAULT_CHAT_SURFACE,
     };
   }
 
@@ -158,8 +163,8 @@ export class ConversationRepository {
    * List all active (non-submitted) conversations.
    * Returns conversation metadata without messages for efficiency.
    */
-  listActiveConversations(): Array<Omit<ConversationEntry, 'messages'>> {
-    const conversations = this.adapter.listActiveConversations();
+  listActiveConversations(surface?: ChatSurface): Array<Omit<ConversationEntry, 'messages'>> {
+    const conversations = this.adapter.listActiveConversations(surface);
     return conversations.map((conv) => ({
       threadTs: conv.threadTs,
       channelId: conv.channelId,
@@ -169,6 +174,7 @@ export class ConversationRepository {
       planSubmitted: conv.planSubmitted,
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
+      surface: conv.surface ?? DEFAULT_CHAT_SURFACE,
     }));
   }
 

--- a/packages/data-store/src/slack-plan-draft-repository.ts
+++ b/packages/data-store/src/slack-plan-draft-repository.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
-import type { PersistenceAdapter, SlackPlanDraft } from './adapter.js';
+import type { ChatSurface, PersistenceAdapter, SlackPlanDraft } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 export interface CreateSlackPlanDraft {
@@ -13,6 +14,7 @@ export interface CreateSlackPlanDraft {
   workingDir: string;
   requestedBy: string;
   confirmationMode: SlackPlanDraft['confirmationMode'];
+  surface?: ChatSurface;
 }
 
 export class SlackPlanDraftRepository {
@@ -35,9 +37,10 @@ export class SlackPlanDraftRepository {
         throw new Error('Slack review must reference the exact current doctor-approved planning draft.');
       }
     }
-    const previous = this.adapter.loadReadySlackPlanDraft(input.channelId, input.threadTs);
+    const surface = input.surface ?? DEFAULT_CHAT_SURFACE;
+    const previous = this.adapter.loadReadySlackPlanDraft(input.channelId, input.threadTs, surface);
     const version = (previous?.version ?? 0) + 1;
-    this.adapter.supersedeReadySlackPlanDrafts(input.channelId, input.threadTs, now);
+    this.adapter.supersedeReadySlackPlanDrafts(input.channelId, input.threadTs, now, surface);
     const draft: SlackPlanDraft = {
       draftId: randomUUID(),
       version,
@@ -54,6 +57,7 @@ export class SlackPlanDraftRepository {
       requestedBy: input.requestedBy,
       confirmationMode: input.confirmationMode,
       createdAt: now,
+      surface,
     };
     this.adapter.saveSlackPlanDraft(draft);
     return draft;
@@ -63,8 +67,8 @@ export class SlackPlanDraftRepository {
     return this.adapter.loadSlackPlanDraft(draftId, version);
   }
 
-  getReady(channelId: string, threadTs: string): SlackPlanDraft | undefined {
-    return this.adapter.loadReadySlackPlanDraft(channelId, threadTs);
+  getReady(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined {
+    return this.adapter.loadReadySlackPlanDraft(channelId, threadTs, surface);
   }
 
   bindMessage(draft: SlackPlanDraft, messageTs: string): void {

--- a/packages/data-store/src/slack-session-repository.ts
+++ b/packages/data-store/src/slack-session-repository.ts
@@ -1,9 +1,11 @@
 import type {
+  ChatSurface,
   Conversation,
   PersistenceAdapter,
   SlackLaunchContext,
   SlackPendingConfirmation,
 } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 
 export interface CreateSlackPendingConfirmation {
   confirmKey: string;
@@ -12,6 +14,7 @@ export interface CreateSlackPendingConfirmation {
   userId: string;
   kind: string;
   payload: unknown;
+  surface?: ChatSurface;
 }
 
 export interface PendingSlackConfirmation extends Omit<SlackPendingConfirmation, 'payloadJson'> {
@@ -25,12 +28,12 @@ export class SlackSessionRepository {
     this.adapter.saveSlackLaunchContext(context);
   }
 
-  getLaunchContext(threadTs: string): SlackLaunchContext | null {
-    return this.adapter.loadSlackLaunchContext(threadTs) ?? null;
+  getLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | null {
+    return this.adapter.loadSlackLaunchContext(threadTs, surface) ?? null;
   }
 
-  deleteLaunchContext(threadTs: string): void {
-    this.adapter.deleteSlackLaunchContext(threadTs);
+  deleteLaunchContext(threadTs: string, surface?: ChatSurface): void {
+    this.adapter.deleteSlackLaunchContext(threadTs, surface);
   }
 
   createPendingConfirmation(
@@ -40,6 +43,7 @@ export class SlackSessionRepository {
     const createdAtIso = createdAt.toISOString();
     const pending: PendingSlackConfirmation = {
       ...confirmation,
+      surface: confirmation.surface ?? DEFAULT_CHAT_SURFACE,
       createdAt: createdAtIso,
       // Confirmations never expire: a staged plan stays submittable until it
       // is explicitly consumed or cancelled. The column is kept populated only
@@ -53,14 +57,14 @@ export class SlackSessionRepository {
     return pending;
   }
 
-  getPendingConfirmation(confirmKey: string): PendingSlackConfirmation | null {
-    const confirmation = this.adapter.loadSlackPendingConfirmation(confirmKey);
+  getPendingConfirmation(confirmKey: string, surface?: ChatSurface): PendingSlackConfirmation | null {
+    const confirmation = this.adapter.loadSlackPendingConfirmation(confirmKey, surface);
     return confirmation ? this.toPending(confirmation) : null;
   }
 
   /** The most recently staged confirmation for a thread, regardless of key. */
-  getLatestPendingConfirmationForThread(threadTs: string): PendingSlackConfirmation | null {
-    const confirmation = this.adapter.loadLatestSlackPendingConfirmationByThread(threadTs);
+  getLatestPendingConfirmationForThread(threadTs: string, surface?: ChatSurface): PendingSlackConfirmation | null {
+    const confirmation = this.adapter.loadLatestSlackPendingConfirmationByThread(threadTs, surface);
     return confirmation ? this.toPending(confirmation) : null;
   }
 
@@ -68,8 +72,8 @@ export class SlackSessionRepository {
     this.adapter.deleteSlackPendingConfirmation(confirmKey);
   }
 
-  listActivePlanThreads(channelId: string, userId: string): Conversation[] {
-    return this.adapter.listActivePlanConversations(channelId, userId);
+  listActivePlanThreads(channelId: string, userId: string, surface?: ChatSurface): Conversation[] {
+    return this.adapter.listActivePlanConversations(channelId, userId, surface);
   }
 
   private toPending(confirmation: SlackPendingConfirmation): PendingSlackConfirmation {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -54,6 +54,7 @@ import type {
   TaskEvent,
   TaskEventListFilters,
   ActivityLogEntry,
+  ChatSurface,
   Conversation,
   ConversationMessage,
   PlanningDraft,
@@ -70,6 +71,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
 import {
@@ -706,6 +708,10 @@ function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatL
 }
 function isPlanningConfirmationMode(value: unknown): value is PlanningConfirmationMode {
   return value === 'require' || value === 'auto_submit';
+}
+
+function surfaceFilter(surface: ChatSurface | undefined): { sql: string; params: ChatSurface[] } {
+  return surface === undefined ? { sql: '', params: [] } : { sql: ' AND surface = ?', params: [surface] };
 }
 
 function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
@@ -2386,23 +2392,38 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Conversations ───────────────────────────────────────
 
   saveConversation(conversation: Conversation): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      conversation.threadTs,
-      conversation.channelId,
-      conversation.userId,
-      conversation.mode ?? 'plan',
-      conversation.extractedPlan,
-      conversation.planSubmitted ? 1 : 0,
-      conversation.createdAt,
-      conversation.updatedAt,
-    ]);
+    const surface = conversation.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('conversations', 'thread_ts', conversation.threadTs, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        conversation.threadTs,
+        conversation.channelId,
+        conversation.userId,
+        conversation.mode ?? 'plan',
+        conversation.extractedPlan,
+        conversation.planSubmitted ? 1 : 0,
+        conversation.createdAt,
+        conversation.updatedAt,
+        surface,
+      ]);
+    });
   }
 
-  loadConversation(threadTs: string): Conversation | undefined {
-    const row = this.queryOne('SELECT * FROM conversations WHERE thread_ts = ?', [threadTs]);
+  private assertRowOwnedBySurface(table: string, keyColumn: string, key: string, surface: ChatSurface): void {
+    const existing = this.queryOne(`SELECT surface FROM ${table} WHERE ${keyColumn} = ?`, [key]);
+    if (existing && existing.surface !== surface) {
+      throw new Error(
+        `${table} row ${key} belongs to surface '${String(existing.surface)}'; refusing to overwrite it from surface '${surface}'.`,
+      );
+    }
+  }
+
+  loadConversation(threadTs: string, surface?: ChatSurface): Conversation | undefined {
+    const filter = surfaceFilter(surface);
+    const row = this.queryOne(`SELECT * FROM conversations WHERE thread_ts = ?${filter.sql}`, [threadTs, ...filter.params]);
     if (!row) return undefined;
     return {
       threadTs: row.thread_ts as string,
@@ -2413,6 +2434,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     };
   }
 
@@ -2452,9 +2474,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  listActiveConversations(): Conversation[] {
+  listActiveConversations(surface?: ChatSurface): Conversation[] {
+    const filter = surfaceFilter(surface);
     const rows = this.queryAll(
-      'SELECT * FROM conversations WHERE plan_submitted = 0 ORDER BY updated_at DESC',
+      `SELECT * FROM conversations WHERE plan_submitted = 0${filter.sql} ORDER BY updated_at DESC`,
+      filter.params,
     );
     return rows.map((row: any) => ({
       threadTs: row.thread_ts as string,
@@ -2465,15 +2489,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     }));
   }
 
-  listActivePlanConversations(channelId: string, userId: string): Conversation[] {
+  listActivePlanConversations(channelId: string, userId: string, surface?: ChatSurface): Conversation[] {
+    const filter = surfaceFilter(surface);
     const rows = this.queryAll(`
       SELECT * FROM conversations
-      WHERE channel_id = ? AND user_id = ? AND mode = 'plan' AND plan_submitted = 0
+      WHERE channel_id = ? AND user_id = ? AND mode = 'plan' AND plan_submitted = 0${filter.sql}
       ORDER BY updated_at DESC
-    `, [channelId, userId]);
+    `, [channelId, userId, ...filter.params]);
     return rows.map((row: any) => ({
       threadTs: row.thread_ts as string,
       channelId: row.channel_id as string,
@@ -2483,6 +2509,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     }));
   }
 
@@ -2646,26 +2673,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Slack Plan Submission Session State ─────────────────
 
   saveSlackLaunchContext(context: SlackLaunchContext): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO slack_launch_contexts
-        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      context.threadTs,
-      context.repoUrl,
-      context.harnessPreset,
-      context.workingDir,
-      context.requestedBy,
-      context.lobbyChannelId,
-      context.confirmationMode ?? 'require',
-      context.harnessSessionId ?? null,
-    ]);
+    const surface = context.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('slack_launch_contexts', 'thread_ts', context.threadTs, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO slack_launch_contexts
+          (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        context.threadTs,
+        context.repoUrl,
+        context.harnessPreset,
+        context.workingDir,
+        context.requestedBy,
+        context.lobbyChannelId,
+        context.confirmationMode ?? 'require',
+        context.harnessSessionId ?? null,
+        surface,
+      ]);
+    });
   }
 
-  loadSlackLaunchContext(threadTs: string): SlackLaunchContext | undefined {
+  loadSlackLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_launch_contexts WHERE thread_ts = ?',
-      [threadTs],
+      `SELECT * FROM slack_launch_contexts WHERE thread_ts = ?${filter.sql}`,
+      [threadTs, ...filter.params],
     ) as Record<string, unknown> | undefined;
     if (!row) return undefined;
     return {
@@ -2677,19 +2710,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
       lobbyChannelId: row.lobby_channel_id as string,
       confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       harnessSessionId: typeof row.harness_session_id === 'string' ? row.harness_session_id : undefined,
+      surface: row.surface as ChatSurface,
     };
   }
 
-  deleteSlackLaunchContext(threadTs: string): void {
-    this.execRun('DELETE FROM slack_launch_contexts WHERE thread_ts = ?', [threadTs]);
+  deleteSlackLaunchContext(threadTs: string, surface?: ChatSurface): void {
+    const filter = surfaceFilter(surface);
+    this.execRun(`DELETE FROM slack_launch_contexts WHERE thread_ts = ?${filter.sql}`, [threadTs, ...filter.params]);
   }
 
   saveSlackPlanDraft(draft: SlackPlanDraft): void {
     this.execRun(`
       INSERT OR REPLACE INTO slack_plan_drafts
         (draft_id, version, planning_draft_id, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
-         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json, surface)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       draft.draftId,
       draft.version,
@@ -2712,6 +2747,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       draft.decidedBy ?? null,
       draft.executionKey ?? null,
       draft.workflowIdsJson ?? null,
+      draft.surface ?? DEFAULT_CHAT_SURFACE,
     ]);
   }
 
@@ -2723,13 +2759,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return row ? this.toSlackPlanDraft(row) : undefined;
   }
 
-  loadReadySlackPlanDraft(channelId: string, threadTs: string): SlackPlanDraft | undefined {
+  loadReadySlackPlanDraft(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(`
       SELECT * FROM slack_plan_drafts
-      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'
+      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'${filter.sql}
       ORDER BY version DESC
       LIMIT 1
-    `, [channelId, threadTs]) as Record<string, unknown> | undefined;
+    `, [channelId, threadTs, ...filter.params]) as Record<string, unknown> | undefined;
     return row ? this.toSlackPlanDraft(row) : undefined;
   }
 
@@ -2790,12 +2827,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string): void {
+  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string, surface?: ChatSurface): void {
+    const filter = surfaceFilter(surface);
     this.execRun(`
       UPDATE slack_plan_drafts
       SET status = 'superseded', decided_at = ?
-      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'
-    `, [decidedAt, channelId, threadTs]);
+      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'${filter.sql}
+    `, [decidedAt, channelId, threadTs, ...filter.params]);
   }
 
   private toSlackPlanDraft(row: Record<string, unknown>): SlackPlanDraft {
@@ -2821,38 +2859,46 @@ export class SQLiteAdapter implements PersistenceAdapter {
       decidedBy: typeof row.decided_by === 'string' ? row.decided_by : undefined,
       executionKey: typeof row.execution_key === 'string' ? row.execution_key : undefined,
       workflowIdsJson: typeof row.workflow_ids_json === 'string' ? row.workflow_ids_json : undefined,
+      surface: row.surface as ChatSurface,
     };
   }
 
   saveSlackPendingConfirmation(confirmation: SlackPendingConfirmation): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO slack_pending_confirmations
-        (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      confirmation.confirmKey,
-      confirmation.threadTs,
-      confirmation.channelId,
-      confirmation.userId,
-      confirmation.kind,
-      confirmation.payloadJson,
-      confirmation.createdAt,
-      confirmation.expiresAt,
-    ]);
+    const surface = confirmation.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('slack_pending_confirmations', 'confirm_key', confirmation.confirmKey, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO slack_pending_confirmations
+          (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        confirmation.confirmKey,
+        confirmation.threadTs,
+        confirmation.channelId,
+        confirmation.userId,
+        confirmation.kind,
+        confirmation.payloadJson,
+        confirmation.createdAt,
+        confirmation.expiresAt,
+        surface,
+      ]);
+    });
   }
 
-  loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined {
+  loadSlackPendingConfirmation(confirmKey: string, surface?: ChatSurface): SlackPendingConfirmation | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_pending_confirmations WHERE confirm_key = ?',
-      [confirmKey],
+      `SELECT * FROM slack_pending_confirmations WHERE confirm_key = ?${filter.sql}`,
+      [confirmKey, ...filter.params],
     ) as Record<string, unknown> | undefined;
     return row ? this.mapSlackPendingConfirmation(row) : undefined;
   }
 
-  loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined {
+  loadLatestSlackPendingConfirmationByThread(threadTs: string, surface?: ChatSurface): SlackPendingConfirmation | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_pending_confirmations WHERE thread_ts = ? ORDER BY created_at DESC, rowid DESC LIMIT 1',
-      [threadTs],
+      `SELECT * FROM slack_pending_confirmations WHERE thread_ts = ?${filter.sql} ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+      [threadTs, ...filter.params],
     ) as Record<string, unknown> | undefined;
     return row ? this.mapSlackPendingConfirmation(row) : undefined;
   }
@@ -2867,6 +2913,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       payloadJson: row.payload_json as string,
       createdAt: row.created_at as string,
       expiresAt: row.expires_at as string,
+      surface: row.surface as ChatSurface,
     };
   }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -171,7 +171,8 @@ export const SCHEMA_DDL = `
         extracted_plan TEXT,
         plan_submitted INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE TABLE IF NOT EXISTS planning_drafts (
@@ -215,7 +216,8 @@ export const SCHEMA_DDL = `
         requested_by TEXT NOT NULL,
         lobby_channel_id TEXT NOT NULL,
         confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
-        harness_session_id TEXT
+        harness_session_id TEXT,
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE TABLE IF NOT EXISTS slack_plan_drafts (
@@ -240,6 +242,7 @@ export const SCHEMA_DDL = `
         decided_by TEXT,
         execution_key TEXT,
         workflow_ids_json TEXT,
+        surface TEXT NOT NULL DEFAULT 'slack',
         PRIMARY KEY (draft_id, version)
       );
 
@@ -254,7 +257,8 @@ export const SCHEMA_DDL = `
         kind TEXT NOT NULL,
         payload_json TEXT NOT NULL,
         created_at TEXT NOT NULL,
-        expires_at TEXT NOT NULL
+        expires_at TEXT NOT NULL,
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE INDEX IF NOT EXISTS idx_slack_pending_confirmations_expiry
@@ -677,6 +681,10 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_id TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_hash TEXT',
   'ALTER TABLE workflows ADD COLUMN staged INTEGER NOT NULL DEFAULT 0 CHECK (staged IN (0, 1))',
+  "ALTER TABLE conversations ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_launch_contexts ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_plan_drafts ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_pending_confirmations ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
 ];
 
 /**
@@ -760,6 +768,10 @@ export const POST_MIGRATION_STATEMENTS = [
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha ON repair_filings(kind, subject, state_sha)',
+  'CREATE INDEX IF NOT EXISTS idx_conversations_surface_thread ON conversations(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_launch_contexts_surface_thread ON slack_launch_contexts(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_plan_drafts_surface_thread ON slack_plan_drafts(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_pending_confirmations_surface_thread ON slack_pending_confirmations(surface, thread_ts)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */


### PR DESCRIPTION
## Summary

A second chat surface (Discord) is coming. Today the Slack chat tables have no way to say which surface wrote a row.

This adds a `surface` column to `conversations`, `slack_launch_contexts`, `slack_plan_drafts` and `slack_pending_confirmations`. It defaults to `'slack'`, so every existing row reads back as Slack.

Older databases get the column through guarded `ALTER TABLE` migrations, plus one `(surface, thread_ts)` index per table.

Repository reads take an optional surface. Leaving it out returns the same rows as today.

A save now refuses to overwrite a row that another surface already owns for the same key. That turns a silent overwrite into a loud error.

## Before and After

Input: save a Slack launch context for thread `T1` (working dir `/tmp/slack`), then save one for the same thread from surface `'discord'` (working dir `/tmp/discord`), using a throwaway probe test run with `pnpm exec vitest run src/__tests__/zz-probe.test.ts` in `packages/data-store` on base `59dc97199` and head `d8b629032`.

```text
Before: PROBE discord save -> saved
Before: PROBE thread T1 now -> workingDir=/tmp/discord surface=undefined
After:  PROBE discord save -> error: slack_launch_contexts row T1 belongs to surface 'slack'; refusing to overwrite it from surface 'discord'.
After:  PROBE thread T1 now -> workingDir=/tmp/slack surface=slack
```

## Review Claim

Every row in the four Slack chat tables carries an explicit surface, existing rows read back as `'slack'`, and a save cannot silently replace a row owned by another surface.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The migration is additive only. No column is dropped, no stored value is rewritten, and a read that omits a surface returns exactly what it returns today. Every write that omits a surface is stored as `'slack'`.

## Slice Rationale

Persistence is the lowest layer, and every later Discord slice depends on the surface existing in the schema. The column and its default ship together, because a column without its default would mislabel existing rows.

## Non-goals

- No Discord code and no change to the Surface interface.
- No renaming of the `slack_*` tables.
- No caller moved off the `'slack'` default; every current caller behaves as before.
- `workflow_channels` and `workflow-channel-repository.ts` are not touched.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file <this body> --base <slice 1 stack branch>`

New coverage in `packages/data-store/src/__tests__/surface-discriminator.test.ts`: an upgraded pre-surface database reads back as `'slack'` through every repository and keeps legacy values across restarts; plan drafts and pending confirmations for the same thread stay separate per surface; a save from another surface over a Slack conversation, launch context, or confirmation key is refused and the Slack row is left intact.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No. A database that already ran the migration keeps an unused `surface` column and its indexes after a revert; old code ignores them.

</details>

