### PR TITLE
[Post-fix merge gate runner kind](1) Prove post-fix publication breaks the merge gate config

### DIFF
--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync, execFileSync } from 'node:child_process';
-import type { TaskState } from '@invoker/workflow-core';
+import { applyTaskConfigPatch, type TaskConfigPatch, type TaskState } from '@invoker/workflow-core';
 import { publishAfterFixImpl, type MergeRunnerHost } from '../merge-runner.js';
 
 const REAL_GIT_TIMEOUT_MS = 60_000;
@@ -586,4 +586,97 @@ describe('publishAfterFixImpl integration (real git)', () => {
       rmSync(root, { recursive: true, force: true });
     }
   }, REAL_GIT_TIMEOUT_MS);
+
+  describe('keeps the merge gate config valid under the orchestrator config patch', () => {
+    function mergeGateTask(execution: Record<string, unknown> = {}): TaskState {
+      return {
+        id: '__merge__wf-int',
+        description: 'Merge gate',
+        status: 'running',
+        dependencies: ['t1'],
+        createdAt: new Date(),
+        config: { isMergeNode: true, runnerKind: 'merge', workflowId: 'wf-int' } as any,
+        execution: execution as any,
+      };
+    }
+
+    const taskT1: TaskState = {
+      id: 't1',
+      description: 'Task 1',
+      status: 'completed',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-int' } as any,
+      execution: { branch: 'invoker/t1' } as any,
+    };
+
+    function patchConfigLikeOrchestrator(host: MergeRunnerHost, mergeTask: TaskState): () => unknown {
+      let persistedConfig: unknown = mergeTask.config;
+      host.orchestrator.setTaskReviewReady = vi.fn((_id: string, changes: { config?: TaskConfigPatch }) => {
+        persistedConfig = applyTaskConfigPatch(mergeTask.config, changes.config);
+      }) as any;
+      return () => persistedConfig;
+    }
+
+    it.fails('without review publication', async () => {
+      const sandbox = createSandbox();
+      root = sandbox.root;
+      const mergeTask = mergeGateTask();
+      const host = makeHost(sandbox.hostDir, sandbox.gateDir, [mergeTask, taskT1]);
+      const persistedConfig = patchConfigLikeOrchestrator(host, mergeTask);
+
+      await publishAfterFixImpl(host, mergeTask);
+
+      expect(host.orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
+      expect(persistedConfig()).toMatchObject({ isMergeNode: true, runnerKind: 'merge', summary: '## Summary' });
+    }, REAL_GIT_TIMEOUT_MS);
+
+    it.fails('with review publication', async () => {
+      const sandbox = createSandbox();
+      root = sandbox.root;
+      const fixCommit = git('rev-parse HEAD', sandbox.gateDir);
+      const mergeTask = mergeGateTask({ fixedIntegrationSha: fixCommit });
+      const host = makeHost(sandbox.hostDir, sandbox.gateDir, [mergeTask, taskT1]);
+      (host.persistence as any).loadWorkflow = () => ({
+        id: 'wf-int',
+        onFinish: 'pull_request',
+        mergeMode: 'external_review',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        name: 'Integration Test',
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+      host.publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [{ url: 'https://github.com/example/pr/1', providerId: '1' }],
+        sessionId: 'session-1',
+        agentName: 'claude',
+      });
+      const persistedConfig = patchConfigLikeOrchestrator(host, mergeTask);
+
+      await publishAfterFixImpl(host, mergeTask);
+
+      expect(host.orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
+      expect(persistedConfig()).toMatchObject({ isMergeNode: true, runnerKind: 'merge', summary: '## Summary' });
+    }, REAL_GIT_TIMEOUT_MS);
+
+    it.fails('without a feature branch', async () => {
+      const sandbox = createSandbox();
+      root = sandbox.root;
+      const mergeTask = mergeGateTask();
+      const host = makeHost(sandbox.hostDir, sandbox.gateDir, [mergeTask, taskT1]);
+      (host.persistence as any).loadWorkflow = () => ({
+        id: 'wf-int',
+        onFinish: 'none',
+        mergeMode: 'manual',
+        baseBranch: 'master',
+        name: 'Integration Test',
+      });
+      const persistedConfig = patchConfigLikeOrchestrator(host, mergeTask);
+
+      await publishAfterFixImpl(host, mergeTask);
+
+      expect(host.orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
+      expect(persistedConfig()).toMatchObject({ isMergeNode: true, runnerKind: 'merge', summary: '## Summary' });
+    }, REAL_GIT_TIMEOUT_MS);
+  });
 });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3462,7 +3462,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    it('no featureBranch: early exit with setTaskReviewReady', async () => {
+    it.fails('no featureBranch: early exit with setTaskReviewReady', async () => {
       const { executor, mergeTask, orchestrator, gitCalls } = setupPublishAfterFix({
         featureBranch: undefined,
         gateWorkspacePath: '/tmp/gate-clone',
@@ -3471,7 +3471,7 @@ describe('TaskRunner', () => {
       await executor.publishAfterFix(mergeTask);
 
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
-        config: expect.objectContaining({ runnerKind: 'worktree' }),
+        config: expect.objectContaining({ runnerKind: 'merge' }),
         execution: expect.objectContaining({ workspacePath: '/tmp/gate-clone' }),
       }), expect.objectContaining({ generation: 0 }));
 


### PR DESCRIPTION
## Summary

After an AI fix on a merge gate, publishing the review fails every time with "Task config patch runnerKind="worktree" must pair with isMergeNode=false".

The post-fix publish code marks the gate review-ready with `runnerKind: 'worktree'`. Since #11576, the orchestrator's config patch refuses a merge gate that is not `runnerKind: 'merge'`.

The existing tests missed it because their `setTaskReviewReady` mock never runs the real config patch.

These tests run the real `applyTaskConfigPatch` inside that mock, for all three post-fix exits. They are marked `it.fails` until the fix slice lands.

## Review Claim

Approve that these tests reproduce the post-fix merge gate failure through the real config patch.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test files only. No product file changes, so runtime behavior is identical before and after this slice.

## Slice Rationale

The failure is shown before the fix, so the reviewer sees the bug demonstrated before approving the change that fixes it.

## Non-goals

No product code changes. No change to the orchestrator's config patch check.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- publish-after-fix task-runner-fix-publish-and-ssh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for preserving merge gate configuration when orchestrator settings are patched.
  - Covered workflows with and without review publication, including workflows without a feature branch.
  - Updated the no-feature-branch publish-after-fix test to reflect the expected merge runner behavior.
  - Marked affected scenarios as expected failures while the underlying issues remain unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->