### PR TITLE
[Discord surface (2) surface-neutral channel repo resolver](2) Add a surface-neutral channel-to-repo resolver with logged precedence

### DIFF
--- a/packages/data-store/src/__tests__/slack-session-repository.test.ts
+++ b/packages/data-store/src/__tests__/slack-session-repository.test.ts
@@ -28,6 +28,7 @@ describe('SlackSessionRepository', () => {
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
       confirmationMode: 'require' as const,
+      surface: 'slack',
     };
 
     repo.saveLaunchContext(context);
@@ -48,6 +49,7 @@ describe('SlackSessionRepository', () => {
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
       confirmationMode: 'require' as const,
+      surface: 'slack',
     };
     try {
       const writer = await SQLiteAdapter.create(databasePath, { ownerCapability: true });

--- a/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
+++ b/packages/data-store/src/__tests__/sql-variables-limit.repro.test.ts
@@ -25,25 +25,27 @@ describe('SQL variables limit (ui-read-scale)', () => {
   it(
     'loadWorkflowTaskSnapshot handles >32k workflows via chunked queries',
     async () => {
-      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-        adapter.saveWorkflow({
-          id: `wf-${i}`,
-          name: `Workflow ${i}`,
-          status: 'pending',
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        });
-        adapter.saveTask(`wf-${i}`, {
-          id: `wf-${i}/t0`,
-          description: `Task ${i}`,
-          status: 'pending',
-          dependencies: [],
-          createdAt: new Date(),
-          config: resolveTaskConfig({ workflowId: `wf-${i}` }),
-          execution: {},
-          taskStateVersion: 1,
-        });
-      }
+      adapter.runInTransaction(() => {
+        for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+          adapter.saveWorkflow({
+            id: `wf-${i}`,
+            name: `Workflow ${i}`,
+            status: 'pending',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+          adapter.saveTask(`wf-${i}`, {
+            id: `wf-${i}/t0`,
+            description: `Task ${i}`,
+            status: 'pending',
+            dependencies: [],
+            createdAt: new Date(),
+            config: resolveTaskConfig({ workflowId: `wf-${i}` }),
+            execution: {},
+            taskStateVersion: 1,
+          });
+        }
+      });
 
       const snapshot = adapter.loadWorkflowTaskSnapshot();
       expect(snapshot.workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
@@ -53,30 +55,34 @@ describe('SQL variables limit (ui-read-scale)', () => {
   );
 
   it('listWorkflows handles >32k workflows via chunked rollup queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(WORKFLOW_COUNT_ABOVE_LIMIT);
   });
 
   it('loadTasksForWorkflows handles >32k workflow IDs via chunked queries', async () => {
-    for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < WORKFLOW_COUNT_ABOVE_LIMIT; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflowIds = Array.from({ length: WORKFLOW_COUNT_ABOVE_LIMIT }, (_, i) => `wf-${i}`);
     const tasks = adapter.loadTasksForWorkflows(workflowIds);

--- a/packages/data-store/src/__tests__/surface-discriminator.test.ts
+++ b/packages/data-store/src/__tests__/surface-discriminator.test.ts
@@ -1,0 +1,317 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConversationRepository } from '../conversation-repository.js';
+import { SlackPlanDraftRepository, type CreateSlackPlanDraft } from '../slack-plan-draft-repository.js';
+import { SlackSessionRepository } from '../slack-session-repository.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const SURFACE_TABLES = [
+  'conversations',
+  'slack_launch_contexts',
+  'slack_plan_drafts',
+  'slack_pending_confirmations',
+] as const;
+
+const PRE_SURFACE_DDL = `
+  CREATE TABLE conversations (
+    thread_ts TEXT PRIMARY KEY,
+    channel_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    mode TEXT DEFAULT 'plan',
+    extracted_plan TEXT,
+    plan_submitted INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE TABLE slack_launch_contexts (
+    thread_ts TEXT PRIMARY KEY,
+    repo_url TEXT NOT NULL,
+    harness_preset TEXT NOT NULL,
+    working_dir TEXT NOT NULL,
+    requested_by TEXT NOT NULL,
+    lobby_channel_id TEXT NOT NULL,
+    confirmation_mode TEXT NOT NULL DEFAULT 'require',
+    harness_session_id TEXT
+  );
+  CREATE TABLE slack_plan_drafts (
+    draft_id TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    planning_draft_id TEXT,
+    channel_id TEXT NOT NULL,
+    thread_ts TEXT NOT NULL,
+    message_ts TEXT,
+    slack_file_id TEXT,
+    plan_text TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    summary_json TEXT NOT NULL,
+    status TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    harness_preset TEXT NOT NULL,
+    working_dir TEXT NOT NULL,
+    requested_by TEXT NOT NULL,
+    confirmation_mode TEXT NOT NULL DEFAULT 'require',
+    created_at TEXT NOT NULL,
+    decided_at TEXT,
+    decided_by TEXT,
+    execution_key TEXT,
+    workflow_ids_json TEXT,
+    PRIMARY KEY (draft_id, version)
+  );
+  CREATE TABLE slack_pending_confirmations (
+    confirm_key TEXT PRIMARY KEY,
+    thread_ts TEXT NOT NULL,
+    channel_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+  );
+  INSERT INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at)
+    VALUES ('legacy-thread', 'C1', 'U1', 'plan', NULL, 0, '2026-09-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z');
+  INSERT INTO slack_launch_contexts (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode)
+    VALUES ('legacy-thread', 'https://github.com/acme/repo.git', 'claude', '/tmp/repo', 'U1', 'C1', 'require');
+  INSERT INTO slack_plan_drafts (draft_id, version, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash,
+      summary_json, status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at)
+    VALUES ('legacy-draft', 1, 'C1', 'legacy-thread', '1.2', 'F1', 'name: legacy', 'hash', '{}', 'ready',
+      'https://github.com/acme/repo.git', 'claude', '/tmp/repo', 'U1', 'require', '2026-09-01T00:00:00.000Z');
+  INSERT INTO slack_pending_confirmations (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at)
+    VALUES ('legacy-confirm', 'legacy-thread', 'C1', 'U1', 'plan_submission', '{"ok":true}', '2026-09-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z');
+`;
+
+function draftInput(threadTs: string, surface?: string): CreateSlackPlanDraft {
+  return {
+    channelId: 'C1',
+    threadTs,
+    planText: `name: ${surface ?? 'default'}\ntasks:\n  - id: task\n    description: Test`,
+    summaryJson: '{}',
+    repoUrl: 'https://github.com/acme/repo.git',
+    harnessPreset: 'codex',
+    workingDir: '/tmp/repo',
+    requestedBy: 'U1',
+    confirmationMode: 'require',
+    ...(surface ? { surface } : {}),
+  };
+}
+
+function launchContext(threadTs: string, surface?: string) {
+  return {
+    threadTs,
+    repoUrl: 'https://github.com/acme/repo.git',
+    harnessPreset: 'claude',
+    workingDir: '/tmp/repo',
+    requestedBy: 'U1',
+    lobbyChannelId: 'C1',
+    confirmationMode: 'require' as const,
+    ...(surface ? { surface } : {}),
+  };
+}
+
+describe('surface discriminator: upgrade of a pre-surface database', () => {
+  let directory: string;
+  let databasePath: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'surface-discriminator-'));
+    databasePath = join(directory, 'legacy.db');
+    const legacy = new DatabaseSync(databasePath);
+    try {
+      legacy.exec(PRE_SURFACE_DDL);
+    } finally {
+      legacy.close();
+    }
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  function snapshotLegacyColumns(): Map<string, { columns: string[]; rows: unknown[] }> {
+    const reader = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      return new Map(SURFACE_TABLES.map((table) => {
+        const columns = reader.prepare(`PRAGMA table_info(${table})`).all().map((column) => String(column.name));
+        return [table, { columns, rows: reader.prepare(`SELECT * FROM ${table}`).all() }];
+      }));
+    } finally {
+      reader.close();
+    }
+  }
+
+  it('reads pre-existing rows with no surface value back as slack through every repository', async () => {
+    const adapter = await SQLiteAdapter.create(databasePath, { ownerCapability: true });
+    try {
+      expect(new ConversationRepository(adapter).loadConversation('legacy-thread')?.surface).toBe('slack');
+      const sessions = new SlackSessionRepository(adapter);
+      expect(sessions.getLaunchContext('legacy-thread')?.surface).toBe('slack');
+      expect(sessions.getPendingConfirmation('legacy-confirm')?.surface).toBe('slack');
+      expect(sessions.getLatestPendingConfirmationForThread('legacy-thread', 'slack')?.confirmKey).toBe('legacy-confirm');
+      const drafts = new SlackPlanDraftRepository(adapter);
+      expect(drafts.get('legacy-draft', 1)?.surface).toBe('slack');
+      expect(drafts.getReady('C1', 'legacy-thread', 'slack')?.draftId).toBe('legacy-draft');
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('adds only the surface column and its index, leaving every legacy value untouched across restarts', async () => {
+    const before = snapshotLegacyColumns();
+
+    for (let startup = 0; startup < 2; startup++) {
+      const adapter = await SQLiteAdapter.create(databasePath, { ownerCapability: true });
+      adapter.close();
+
+      const reader = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        for (const table of SURFACE_TABLES) {
+          const legacy = before.get(table)!;
+          const columns = reader.prepare(`PRAGMA table_info(${table})`).all();
+          expect(columns.map((column) => column.name)).toEqual([...legacy.columns, 'surface']);
+          expect(columns.find((column) => column.name === 'surface')).toMatchObject({
+            type: 'TEXT',
+            notnull: 1,
+            dflt_value: "'slack'",
+          });
+          expect(reader.prepare(`SELECT ${legacy.columns.join(', ')} FROM ${table}`).all()).toEqual(legacy.rows);
+          expect(reader.prepare(`SELECT surface FROM ${table}`).all()).toEqual([{ surface: 'slack' }]);
+          expect(
+            reader.prepare(`PRAGMA index_info(idx_${table}_surface_thread)`).all().map((column) => column.name),
+          ).toEqual(['surface', 'thread_ts']);
+        }
+      } finally {
+        reader.close();
+      }
+    }
+  });
+});
+
+describe('surface discriminator: two surfaces sharing one thread id', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => adapter.close());
+
+  it('defaults every write to slack when no surface is passed', () => {
+    new ConversationRepository(adapter).saveConversation('T1', [{ role: 'user', content: 'hi' }], null, false, 'C1', 'U1');
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.saveLaunchContext(launchContext('T1'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {},
+    });
+    const draft = new SlackPlanDraftRepository(adapter).create(draftInput('T1'));
+
+    expect(adapter.loadConversation('T1')?.surface).toBe('slack');
+    expect(adapter.loadSlackLaunchContext('T1')?.surface).toBe('slack');
+    expect(adapter.loadSlackPendingConfirmation('K1')?.surface).toBe('slack');
+    expect(adapter.loadSlackPlanDraft(draft.draftId, draft.version)?.surface).toBe('slack');
+  });
+
+  it('keeps plan drafts for the same channel and thread separate per surface', () => {
+    const repository = new SlackPlanDraftRepository(adapter);
+    const makeReady = (surface: string) => {
+      const draft = repository.create(draftInput('shared-thread', surface));
+      repository.bindMessage(draft, `${surface}.msg`);
+      repository.bindAttachment(draft, `${surface}-file`);
+      repository.markReady(draft);
+      return draft;
+    };
+
+    const slackDraft = makeReady('slack');
+    const discordDraft = makeReady('discord');
+
+    expect(repository.getReady('C1', 'shared-thread', 'slack')).toMatchObject({
+      draftId: slackDraft.draftId,
+      surface: 'slack',
+      status: 'ready',
+      version: 1,
+    });
+    expect(repository.getReady('C1', 'shared-thread', 'discord')).toMatchObject({
+      draftId: discordDraft.draftId,
+      surface: 'discord',
+      status: 'ready',
+      version: 1,
+    });
+  });
+
+  it('keeps pending confirmations for the same thread separate per surface', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'slack-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'slack' },
+    }, new Date('2026-09-01T00:00:00.000Z'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'discord-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'discord' }, surface: 'discord',
+    }, new Date('2026-09-02T00:00:00.000Z'));
+
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread', 'slack')).toMatchObject({
+      confirmKey: 'slack-key', surface: 'slack', payload: { from: 'slack' },
+    });
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread', 'discord')).toMatchObject({
+      confirmKey: 'discord-key', surface: 'discord', payload: { from: 'discord' },
+    });
+    expect(sessions.getPendingConfirmation('slack-key', 'discord')).toBeNull();
+    expect(sessions.getPendingConfirmation('discord-key', 'slack')).toBeNull();
+  });
+
+  it('refuses to overwrite a slack conversation from another surface and leaves the slack row intact', () => {
+    const repository = new ConversationRepository(adapter);
+    repository.saveConversation('shared-thread', [{ role: 'user', content: 'from slack' }], null, false, 'C1', 'U1');
+
+    expect(() => repository.saveConversation(
+      'shared-thread', [{ role: 'user', content: 'from discord' }], null, false, 'D1', 'U2', 'plan', 'discord',
+    )).toThrow(/belongs to surface 'slack'/);
+
+    expect(repository.loadConversation('shared-thread', 'discord')).toBeNull();
+    expect(repository.loadConversation('shared-thread', 'slack')).toMatchObject({
+      channelId: 'C1',
+      userId: 'U1',
+      surface: 'slack',
+      messages: [{ role: 'user', content: 'from slack' }],
+    });
+  });
+
+  it('refuses to overwrite a slack launch context from another surface and leaves the slack row intact', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.saveLaunchContext(launchContext('shared-thread'));
+
+    expect(() => sessions.saveLaunchContext({ ...launchContext('shared-thread', 'discord'), workingDir: '/tmp/discord' }))
+      .toThrow(/belongs to surface 'slack'/);
+
+    expect(sessions.getLaunchContext('shared-thread', 'discord')).toBeNull();
+    expect(sessions.getLaunchContext('shared-thread', 'slack')).toMatchObject({ workingDir: '/tmp/repo', surface: 'slack' });
+
+    sessions.deleteLaunchContext('shared-thread', 'discord');
+    expect(sessions.getLaunchContext('shared-thread', 'slack')).not.toBeNull();
+  });
+
+  it('refuses to reuse a slack confirmation key from another surface', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'slack' },
+    });
+
+    expect(() => sessions.createPendingConfirmation({
+      confirmKey: 'K1', threadTs: 'T1', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: { from: 'discord' }, surface: 'discord',
+    })).toThrow(/belongs to surface 'slack'/);
+    expect(sessions.getPendingConfirmation('K1')).toMatchObject({ surface: 'slack', payload: { from: 'slack' } });
+  });
+
+  it('returns every surface when a read omits the surface filter', () => {
+    const sessions = new SlackSessionRepository(adapter);
+    sessions.createPendingConfirmation({
+      confirmKey: 'slack-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {},
+    }, new Date('2026-09-01T00:00:00.000Z'));
+    sessions.createPendingConfirmation({
+      confirmKey: 'discord-key', threadTs: 'shared-thread', channelId: 'C1', userId: 'U1', kind: 'plan_submission', payload: {}, surface: 'discord',
+    }, new Date('2026-09-02T00:00:00.000Z'));
+
+    expect(sessions.getLatestPendingConfirmationForThread('shared-thread')?.confirmKey).toBe('discord-key');
+    expect(sessions.getPendingConfirmation('slack-key')?.surface).toBe('slack');
+    expect(sessions.getPendingConfirmation('discord-key')?.surface).toBe('discord');
+  });
+});

--- a/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-get-events.repro.test.ts
@@ -38,9 +38,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('1-arg getEvents overload applies GET_EVENTS_DEFAULT_LIMIT', () => {
     const eventCount = GET_EVENTS_DEFAULT_LIMIT + 5000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1');
     expect(events).toHaveLength(GET_EVENTS_DEFAULT_LIMIT);
@@ -48,9 +50,11 @@ describe('getEvents default limit (ui-read-scale)', () => {
 
   it('bounded getEvents with explicit limit works correctly', () => {
     const eventCount = 1000;
-    for (let i = 0; i < eventCount; i++) {
-      adapter.logEvent('wf-1/t1', 'task.progress', { i });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < eventCount; i++) {
+        adapter.logEvent('wf-1/t1', 'task.progress', { i });
+      }
+    });
 
     const events = adapter.getEvents('wf-1/t1', 'desc', 100);
     expect(events).toHaveLength(100);

--- a/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
+++ b/packages/data-store/src/__tests__/unbounded-workflow-select.repro.test.ts
@@ -21,15 +21,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('listWorkflows has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     expect(workflows).toHaveLength(workflowCount);
@@ -38,15 +40,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
 
   it.fails('loadWorkflowTaskSnapshot has no LIMIT and returns all workflows regardless of count', () => {
     const workflowCount = 10_000;
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const snapshot = adapter.loadWorkflowTaskSnapshot();
     expect(snapshot.workflows).toHaveLength(workflowCount);
@@ -56,16 +60,18 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   it.fails('listWorkflows materializes every row into JS objects', () => {
     const workflowCount = 5_000;
     const descriptionPayload = 'x'.repeat(256);
-    for (let i = 0; i < workflowCount; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i} with a longer name to increase memory footprint`,
-        description: `Description for workflow ${i}: ${descriptionPayload}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < workflowCount; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i} with a longer name to increase memory footprint`,
+          description: `Description for workflow ${i}: ${descriptionPayload}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const workflows = adapter.listWorkflows();
     const materializedBytes = Buffer.byteLength(JSON.stringify(workflows));
@@ -100,15 +106,17 @@ describe('unbounded workflow SELECT (ui-read-scale proof)', () => {
   });
 
   it('listWorkflowsPaged respects limit at scale without loading all rows', () => {
-    for (let i = 0; i < 5000; i++) {
-      adapter.saveWorkflow({
-        id: `wf-${i}`,
-        name: `Workflow ${i}`,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    }
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < 5000; i++) {
+        adapter.saveWorkflow({
+          id: `wf-${i}`,
+          name: `Workflow ${i}`,
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    });
 
     const started = performance.now();
     const result = adapter.listWorkflowsPaged({ limit: 50 });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -11,6 +11,8 @@ import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
 export type ConversationMode = 'agent' | 'plan';
+export type ChatSurface = string;
+export const DEFAULT_CHAT_SURFACE: ChatSurface = 'slack';
 // ── Conversation Types ─────────────────────────────────────
 
 export interface Conversation {
@@ -22,6 +24,7 @@ export interface Conversation {
   planSubmitted: boolean;
   createdAt: string;
   updatedAt: string;
+  surface?: ChatSurface;
 }
 
 export interface ConversationMessage {
@@ -56,6 +59,7 @@ export interface SlackLaunchContext {
   lobbyChannelId: string;
   confirmationMode: PlanningConfirmationMode;
   harnessSessionId?: string;
+  surface?: ChatSurface;
 }
 
 export type SlackPlanDraftStatus =
@@ -89,6 +93,7 @@ export interface SlackPlanDraft {
   decidedBy?: string;
   executionKey?: string;
   workflowIdsJson?: string;
+  surface?: ChatSurface;
 }
 
 export interface SlackPendingConfirmation {
@@ -100,6 +105,7 @@ export interface SlackPendingConfirmation {
   payloadJson: string;
   createdAt: string;
   expiresAt: string;
+  surface?: ChatSurface;
 }
 
 // ── Workflow Channel Types (Slack workflow↔channel mapping) ─
@@ -469,13 +475,13 @@ export interface PersistenceAdapter {
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;
-  loadConversation(threadTs: string): Conversation | undefined;
+  loadConversation(threadTs: string, surface?: ChatSurface): Conversation | undefined;
   updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'mode' | 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void;
   deleteConversation(threadTs: string): void;
 
   // Conversation queries
-  listActiveConversations(): Conversation[];
-  listActivePlanConversations(channelId: string, userId: string): Conversation[];
+  listActiveConversations(surface?: ChatSurface): Conversation[];
+  listActivePlanConversations(channelId: string, userId: string, surface?: ChatSurface): Conversation[];
   deleteConversationsOlderThan(cutoffIso: string): number;
 
   // Conversation messages
@@ -493,17 +499,17 @@ export interface PersistenceAdapter {
 
   // Slack plan submission session state
   saveSlackLaunchContext(context: SlackLaunchContext): void;
-  loadSlackLaunchContext(threadTs: string): SlackLaunchContext | undefined;
-  deleteSlackLaunchContext(threadTs: string): void;
+  loadSlackLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | undefined;
+  deleteSlackLaunchContext(threadTs: string, surface?: ChatSurface): void;
   saveSlackPlanDraft(draft: SlackPlanDraft): void;
   loadSlackPlanDraft(draftId: string, version: number): SlackPlanDraft | undefined;
-  loadReadySlackPlanDraft(channelId: string, threadTs: string): SlackPlanDraft | undefined;
+  loadReadySlackPlanDraft(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined;
   updateSlackPlanDraft(draftId: string, version: number, changes: Partial<Pick<SlackPlanDraft, 'messageTs' | 'slackFileId' | 'status' | 'decidedAt' | 'decidedBy' | 'executionKey' | 'workflowIdsJson'>>): void;
   claimSlackPlanDraft(draftId: string, version: number, executionKey: string): boolean;
-  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string): void;
+  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string, surface?: ChatSurface): void;
   saveSlackPendingConfirmation(confirmation: SlackPendingConfirmation): void;
-  loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined;
-  loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined;
+  loadSlackPendingConfirmation(confirmKey: string, surface?: ChatSurface): SlackPendingConfirmation | undefined;
+  loadLatestSlackPendingConfirmationByThread(threadTs: string, surface?: ChatSurface): SlackPendingConfirmation | undefined;
   deleteSlackPendingConfirmation(confirmKey: string): void;
 
   // Repair filings (cross-system CI/PR repair dedup ledger)

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -7,7 +7,8 @@
  */
 
 import type { PlanDefinition } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
+import type { PersistenceAdapter, ChatSurface, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 // ── Public Types ─────────────────────────────────────────────
@@ -22,6 +23,7 @@ export interface ConversationEntry {
   planSubmitted: boolean;
   createdAt: string;
   updatedAt: string;
+  surface: ChatSurface;
 }
 
 export interface ConversationMessageEntry {
@@ -68,10 +70,11 @@ export class ConversationRepository {
     channelId?: string,
     userId?: string,
     mode?: ConversationMode,
+    surface: ChatSurface = DEFAULT_CHAT_SURFACE,
   ): void {
     const now = new Date().toISOString();
 
-    const existing = this.adapter.loadConversation(threadTs);
+    const existing = this.adapter.loadConversation(threadTs, surface);
 
     const planJson = extractedPlan ? JSON.stringify(extractedPlan) : null;
 
@@ -92,6 +95,7 @@ export class ConversationRepository {
         planSubmitted: planSubmitted ?? false,
         createdAt: now,
         updatedAt: now,
+        surface,
       });
     }
 
@@ -124,8 +128,8 @@ export class ConversationRepository {
    * Load a conversation with all its messages, deserializing JSON fields.
    * Returns null if the conversation does not exist.
    */
-  loadConversation(threadTs: string): ConversationEntry | null {
-    const conv = this.adapter.loadConversation(threadTs);
+  loadConversation(threadTs: string, surface?: ChatSurface): ConversationEntry | null {
+    const conv = this.adapter.loadConversation(threadTs, surface);
     if (!conv) return null;
 
     const rawMessages = this.adapter.loadMessages(threadTs);
@@ -143,6 +147,7 @@ export class ConversationRepository {
       planSubmitted: conv.planSubmitted,
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
+      surface: conv.surface ?? DEFAULT_CHAT_SURFACE,
     };
   }
 
@@ -158,8 +163,8 @@ export class ConversationRepository {
    * List all active (non-submitted) conversations.
    * Returns conversation metadata without messages for efficiency.
    */
-  listActiveConversations(): Array<Omit<ConversationEntry, 'messages'>> {
-    const conversations = this.adapter.listActiveConversations();
+  listActiveConversations(surface?: ChatSurface): Array<Omit<ConversationEntry, 'messages'>> {
+    const conversations = this.adapter.listActiveConversations(surface);
     return conversations.map((conv) => ({
       threadTs: conv.threadTs,
       channelId: conv.channelId,
@@ -169,6 +174,7 @@ export class ConversationRepository {
       planSubmitted: conv.planSubmitted,
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
+      surface: conv.surface ?? DEFAULT_CHAT_SURFACE,
     }));
   }
 

--- a/packages/data-store/src/slack-plan-draft-repository.ts
+++ b/packages/data-store/src/slack-plan-draft-repository.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
-import type { PersistenceAdapter, SlackPlanDraft } from './adapter.js';
+import type { ChatSurface, PersistenceAdapter, SlackPlanDraft } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import { PlanningDraftRepository } from './planning-draft-repository.js';
 
 export interface CreateSlackPlanDraft {
@@ -13,6 +14,7 @@ export interface CreateSlackPlanDraft {
   workingDir: string;
   requestedBy: string;
   confirmationMode: SlackPlanDraft['confirmationMode'];
+  surface?: ChatSurface;
 }
 
 export class SlackPlanDraftRepository {
@@ -35,9 +37,10 @@ export class SlackPlanDraftRepository {
         throw new Error('Slack review must reference the exact current doctor-approved planning draft.');
       }
     }
-    const previous = this.adapter.loadReadySlackPlanDraft(input.channelId, input.threadTs);
+    const surface = input.surface ?? DEFAULT_CHAT_SURFACE;
+    const previous = this.adapter.loadReadySlackPlanDraft(input.channelId, input.threadTs, surface);
     const version = (previous?.version ?? 0) + 1;
-    this.adapter.supersedeReadySlackPlanDrafts(input.channelId, input.threadTs, now);
+    this.adapter.supersedeReadySlackPlanDrafts(input.channelId, input.threadTs, now, surface);
     const draft: SlackPlanDraft = {
       draftId: randomUUID(),
       version,
@@ -54,6 +57,7 @@ export class SlackPlanDraftRepository {
       requestedBy: input.requestedBy,
       confirmationMode: input.confirmationMode,
       createdAt: now,
+      surface,
     };
     this.adapter.saveSlackPlanDraft(draft);
     return draft;
@@ -63,8 +67,8 @@ export class SlackPlanDraftRepository {
     return this.adapter.loadSlackPlanDraft(draftId, version);
   }
 
-  getReady(channelId: string, threadTs: string): SlackPlanDraft | undefined {
-    return this.adapter.loadReadySlackPlanDraft(channelId, threadTs);
+  getReady(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined {
+    return this.adapter.loadReadySlackPlanDraft(channelId, threadTs, surface);
   }
 
   bindMessage(draft: SlackPlanDraft, messageTs: string): void {

--- a/packages/data-store/src/slack-session-repository.ts
+++ b/packages/data-store/src/slack-session-repository.ts
@@ -1,9 +1,11 @@
 import type {
+  ChatSurface,
   Conversation,
   PersistenceAdapter,
   SlackLaunchContext,
   SlackPendingConfirmation,
 } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 
 export interface CreateSlackPendingConfirmation {
   confirmKey: string;
@@ -12,6 +14,7 @@ export interface CreateSlackPendingConfirmation {
   userId: string;
   kind: string;
   payload: unknown;
+  surface?: ChatSurface;
 }
 
 export interface PendingSlackConfirmation extends Omit<SlackPendingConfirmation, 'payloadJson'> {
@@ -25,12 +28,12 @@ export class SlackSessionRepository {
     this.adapter.saveSlackLaunchContext(context);
   }
 
-  getLaunchContext(threadTs: string): SlackLaunchContext | null {
-    return this.adapter.loadSlackLaunchContext(threadTs) ?? null;
+  getLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | null {
+    return this.adapter.loadSlackLaunchContext(threadTs, surface) ?? null;
   }
 
-  deleteLaunchContext(threadTs: string): void {
-    this.adapter.deleteSlackLaunchContext(threadTs);
+  deleteLaunchContext(threadTs: string, surface?: ChatSurface): void {
+    this.adapter.deleteSlackLaunchContext(threadTs, surface);
   }
 
   createPendingConfirmation(
@@ -40,6 +43,7 @@ export class SlackSessionRepository {
     const createdAtIso = createdAt.toISOString();
     const pending: PendingSlackConfirmation = {
       ...confirmation,
+      surface: confirmation.surface ?? DEFAULT_CHAT_SURFACE,
       createdAt: createdAtIso,
       // Confirmations never expire: a staged plan stays submittable until it
       // is explicitly consumed or cancelled. The column is kept populated only
@@ -53,14 +57,14 @@ export class SlackSessionRepository {
     return pending;
   }
 
-  getPendingConfirmation(confirmKey: string): PendingSlackConfirmation | null {
-    const confirmation = this.adapter.loadSlackPendingConfirmation(confirmKey);
+  getPendingConfirmation(confirmKey: string, surface?: ChatSurface): PendingSlackConfirmation | null {
+    const confirmation = this.adapter.loadSlackPendingConfirmation(confirmKey, surface);
     return confirmation ? this.toPending(confirmation) : null;
   }
 
   /** The most recently staged confirmation for a thread, regardless of key. */
-  getLatestPendingConfirmationForThread(threadTs: string): PendingSlackConfirmation | null {
-    const confirmation = this.adapter.loadLatestSlackPendingConfirmationByThread(threadTs);
+  getLatestPendingConfirmationForThread(threadTs: string, surface?: ChatSurface): PendingSlackConfirmation | null {
+    const confirmation = this.adapter.loadLatestSlackPendingConfirmationByThread(threadTs, surface);
     return confirmation ? this.toPending(confirmation) : null;
   }
 
@@ -68,8 +72,8 @@ export class SlackSessionRepository {
     this.adapter.deleteSlackPendingConfirmation(confirmKey);
   }
 
-  listActivePlanThreads(channelId: string, userId: string): Conversation[] {
-    return this.adapter.listActivePlanConversations(channelId, userId);
+  listActivePlanThreads(channelId: string, userId: string, surface?: ChatSurface): Conversation[] {
+    return this.adapter.listActivePlanConversations(channelId, userId, surface);
   }
 
   private toPending(confirmation: SlackPendingConfirmation): PendingSlackConfirmation {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -54,6 +54,7 @@ import type {
   TaskEvent,
   TaskEventListFilters,
   ActivityLogEntry,
+  ChatSurface,
   Conversation,
   ConversationMessage,
   PlanningDraft,
@@ -70,6 +71,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from './adapter.js';
+import { DEFAULT_CHAT_SURFACE } from './adapter.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
 import {
@@ -706,6 +708,10 @@ function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatL
 }
 function isPlanningConfirmationMode(value: unknown): value is PlanningConfirmationMode {
   return value === 'require' || value === 'auto_submit';
+}
+
+function surfaceFilter(surface: ChatSurface | undefined): { sql: string; params: ChatSurface[] } {
+  return surface === undefined ? { sql: '', params: [] } : { sql: ' AND surface = ?', params: [surface] };
 }
 
 function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
@@ -2386,23 +2392,38 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Conversations ───────────────────────────────────────
 
   saveConversation(conversation: Conversation): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      conversation.threadTs,
-      conversation.channelId,
-      conversation.userId,
-      conversation.mode ?? 'plan',
-      conversation.extractedPlan,
-      conversation.planSubmitted ? 1 : 0,
-      conversation.createdAt,
-      conversation.updatedAt,
-    ]);
+    const surface = conversation.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('conversations', 'thread_ts', conversation.threadTs, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        conversation.threadTs,
+        conversation.channelId,
+        conversation.userId,
+        conversation.mode ?? 'plan',
+        conversation.extractedPlan,
+        conversation.planSubmitted ? 1 : 0,
+        conversation.createdAt,
+        conversation.updatedAt,
+        surface,
+      ]);
+    });
   }
 
-  loadConversation(threadTs: string): Conversation | undefined {
-    const row = this.queryOne('SELECT * FROM conversations WHERE thread_ts = ?', [threadTs]);
+  private assertRowOwnedBySurface(table: string, keyColumn: string, key: string, surface: ChatSurface): void {
+    const existing = this.queryOne(`SELECT surface FROM ${table} WHERE ${keyColumn} = ?`, [key]);
+    if (existing && existing.surface !== surface) {
+      throw new Error(
+        `${table} row ${key} belongs to surface '${String(existing.surface)}'; refusing to overwrite it from surface '${surface}'.`,
+      );
+    }
+  }
+
+  loadConversation(threadTs: string, surface?: ChatSurface): Conversation | undefined {
+    const filter = surfaceFilter(surface);
+    const row = this.queryOne(`SELECT * FROM conversations WHERE thread_ts = ?${filter.sql}`, [threadTs, ...filter.params]);
     if (!row) return undefined;
     return {
       threadTs: row.thread_ts as string,
@@ -2413,6 +2434,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     };
   }
 
@@ -2452,9 +2474,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  listActiveConversations(): Conversation[] {
+  listActiveConversations(surface?: ChatSurface): Conversation[] {
+    const filter = surfaceFilter(surface);
     const rows = this.queryAll(
-      'SELECT * FROM conversations WHERE plan_submitted = 0 ORDER BY updated_at DESC',
+      `SELECT * FROM conversations WHERE plan_submitted = 0${filter.sql} ORDER BY updated_at DESC`,
+      filter.params,
     );
     return rows.map((row: any) => ({
       threadTs: row.thread_ts as string,
@@ -2465,15 +2489,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     }));
   }
 
-  listActivePlanConversations(channelId: string, userId: string): Conversation[] {
+  listActivePlanConversations(channelId: string, userId: string, surface?: ChatSurface): Conversation[] {
+    const filter = surfaceFilter(surface);
     const rows = this.queryAll(`
       SELECT * FROM conversations
-      WHERE channel_id = ? AND user_id = ? AND mode = 'plan' AND plan_submitted = 0
+      WHERE channel_id = ? AND user_id = ? AND mode = 'plan' AND plan_submitted = 0${filter.sql}
       ORDER BY updated_at DESC
-    `, [channelId, userId]);
+    `, [channelId, userId, ...filter.params]);
     return rows.map((row: any) => ({
       threadTs: row.thread_ts as string,
       channelId: row.channel_id as string,
@@ -2483,6 +2509,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
+      surface: row.surface as ChatSurface,
     }));
   }
 
@@ -2646,26 +2673,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Slack Plan Submission Session State ─────────────────
 
   saveSlackLaunchContext(context: SlackLaunchContext): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO slack_launch_contexts
-        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      context.threadTs,
-      context.repoUrl,
-      context.harnessPreset,
-      context.workingDir,
-      context.requestedBy,
-      context.lobbyChannelId,
-      context.confirmationMode ?? 'require',
-      context.harnessSessionId ?? null,
-    ]);
+    const surface = context.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('slack_launch_contexts', 'thread_ts', context.threadTs, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO slack_launch_contexts
+          (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        context.threadTs,
+        context.repoUrl,
+        context.harnessPreset,
+        context.workingDir,
+        context.requestedBy,
+        context.lobbyChannelId,
+        context.confirmationMode ?? 'require',
+        context.harnessSessionId ?? null,
+        surface,
+      ]);
+    });
   }
 
-  loadSlackLaunchContext(threadTs: string): SlackLaunchContext | undefined {
+  loadSlackLaunchContext(threadTs: string, surface?: ChatSurface): SlackLaunchContext | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_launch_contexts WHERE thread_ts = ?',
-      [threadTs],
+      `SELECT * FROM slack_launch_contexts WHERE thread_ts = ?${filter.sql}`,
+      [threadTs, ...filter.params],
     ) as Record<string, unknown> | undefined;
     if (!row) return undefined;
     return {
@@ -2677,19 +2710,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
       lobbyChannelId: row.lobby_channel_id as string,
       confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       harnessSessionId: typeof row.harness_session_id === 'string' ? row.harness_session_id : undefined,
+      surface: row.surface as ChatSurface,
     };
   }
 
-  deleteSlackLaunchContext(threadTs: string): void {
-    this.execRun('DELETE FROM slack_launch_contexts WHERE thread_ts = ?', [threadTs]);
+  deleteSlackLaunchContext(threadTs: string, surface?: ChatSurface): void {
+    const filter = surfaceFilter(surface);
+    this.execRun(`DELETE FROM slack_launch_contexts WHERE thread_ts = ?${filter.sql}`, [threadTs, ...filter.params]);
   }
 
   saveSlackPlanDraft(draft: SlackPlanDraft): void {
     this.execRun(`
       INSERT OR REPLACE INTO slack_plan_drafts
         (draft_id, version, planning_draft_id, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
-         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json, surface)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       draft.draftId,
       draft.version,
@@ -2712,6 +2747,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       draft.decidedBy ?? null,
       draft.executionKey ?? null,
       draft.workflowIdsJson ?? null,
+      draft.surface ?? DEFAULT_CHAT_SURFACE,
     ]);
   }
 
@@ -2723,13 +2759,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return row ? this.toSlackPlanDraft(row) : undefined;
   }
 
-  loadReadySlackPlanDraft(channelId: string, threadTs: string): SlackPlanDraft | undefined {
+  loadReadySlackPlanDraft(channelId: string, threadTs: string, surface?: ChatSurface): SlackPlanDraft | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(`
       SELECT * FROM slack_plan_drafts
-      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'
+      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'${filter.sql}
       ORDER BY version DESC
       LIMIT 1
-    `, [channelId, threadTs]) as Record<string, unknown> | undefined;
+    `, [channelId, threadTs, ...filter.params]) as Record<string, unknown> | undefined;
     return row ? this.toSlackPlanDraft(row) : undefined;
   }
 
@@ -2790,12 +2827,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string): void {
+  supersedeReadySlackPlanDrafts(channelId: string, threadTs: string, decidedAt: string, surface?: ChatSurface): void {
+    const filter = surfaceFilter(surface);
     this.execRun(`
       UPDATE slack_plan_drafts
       SET status = 'superseded', decided_at = ?
-      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'
-    `, [decidedAt, channelId, threadTs]);
+      WHERE channel_id = ? AND thread_ts = ? AND status = 'ready'${filter.sql}
+    `, [decidedAt, channelId, threadTs, ...filter.params]);
   }
 
   private toSlackPlanDraft(row: Record<string, unknown>): SlackPlanDraft {
@@ -2821,38 +2859,46 @@ export class SQLiteAdapter implements PersistenceAdapter {
       decidedBy: typeof row.decided_by === 'string' ? row.decided_by : undefined,
       executionKey: typeof row.execution_key === 'string' ? row.execution_key : undefined,
       workflowIdsJson: typeof row.workflow_ids_json === 'string' ? row.workflow_ids_json : undefined,
+      surface: row.surface as ChatSurface,
     };
   }
 
   saveSlackPendingConfirmation(confirmation: SlackPendingConfirmation): void {
-    this.execRun(`
-      INSERT OR REPLACE INTO slack_pending_confirmations
-        (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      confirmation.confirmKey,
-      confirmation.threadTs,
-      confirmation.channelId,
-      confirmation.userId,
-      confirmation.kind,
-      confirmation.payloadJson,
-      confirmation.createdAt,
-      confirmation.expiresAt,
-    ]);
+    const surface = confirmation.surface ?? DEFAULT_CHAT_SURFACE;
+    this.runTransaction(() => {
+      this.assertRowOwnedBySurface('slack_pending_confirmations', 'confirm_key', confirmation.confirmKey, surface);
+      this.execRun(`
+        INSERT OR REPLACE INTO slack_pending_confirmations
+          (confirm_key, thread_ts, channel_id, user_id, kind, payload_json, created_at, expires_at, surface)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        confirmation.confirmKey,
+        confirmation.threadTs,
+        confirmation.channelId,
+        confirmation.userId,
+        confirmation.kind,
+        confirmation.payloadJson,
+        confirmation.createdAt,
+        confirmation.expiresAt,
+        surface,
+      ]);
+    });
   }
 
-  loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined {
+  loadSlackPendingConfirmation(confirmKey: string, surface?: ChatSurface): SlackPendingConfirmation | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_pending_confirmations WHERE confirm_key = ?',
-      [confirmKey],
+      `SELECT * FROM slack_pending_confirmations WHERE confirm_key = ?${filter.sql}`,
+      [confirmKey, ...filter.params],
     ) as Record<string, unknown> | undefined;
     return row ? this.mapSlackPendingConfirmation(row) : undefined;
   }
 
-  loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined {
+  loadLatestSlackPendingConfirmationByThread(threadTs: string, surface?: ChatSurface): SlackPendingConfirmation | undefined {
+    const filter = surfaceFilter(surface);
     const row = this.queryOne(
-      'SELECT * FROM slack_pending_confirmations WHERE thread_ts = ? ORDER BY created_at DESC, rowid DESC LIMIT 1',
-      [threadTs],
+      `SELECT * FROM slack_pending_confirmations WHERE thread_ts = ?${filter.sql} ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+      [threadTs, ...filter.params],
     ) as Record<string, unknown> | undefined;
     return row ? this.mapSlackPendingConfirmation(row) : undefined;
   }
@@ -2867,6 +2913,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       payloadJson: row.payload_json as string,
       createdAt: row.created_at as string,
       expiresAt: row.expires_at as string,
+      surface: row.surface as ChatSurface,
     };
   }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -171,7 +171,8 @@ export const SCHEMA_DDL = `
         extracted_plan TEXT,
         plan_submitted INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE TABLE IF NOT EXISTS planning_drafts (
@@ -215,7 +216,8 @@ export const SCHEMA_DDL = `
         requested_by TEXT NOT NULL,
         lobby_channel_id TEXT NOT NULL,
         confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
-        harness_session_id TEXT
+        harness_session_id TEXT,
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE TABLE IF NOT EXISTS slack_plan_drafts (
@@ -240,6 +242,7 @@ export const SCHEMA_DDL = `
         decided_by TEXT,
         execution_key TEXT,
         workflow_ids_json TEXT,
+        surface TEXT NOT NULL DEFAULT 'slack',
         PRIMARY KEY (draft_id, version)
       );
 
@@ -254,7 +257,8 @@ export const SCHEMA_DDL = `
         kind TEXT NOT NULL,
         payload_json TEXT NOT NULL,
         created_at TEXT NOT NULL,
-        expires_at TEXT NOT NULL
+        expires_at TEXT NOT NULL,
+        surface TEXT NOT NULL DEFAULT 'slack'
       );
 
       CREATE INDEX IF NOT EXISTS idx_slack_pending_confirmations_expiry
@@ -677,6 +681,10 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_id TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_hash TEXT',
   'ALTER TABLE workflows ADD COLUMN staged INTEGER NOT NULL DEFAULT 0 CHECK (staged IN (0, 1))',
+  "ALTER TABLE conversations ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_launch_contexts ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_plan_drafts ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
+  "ALTER TABLE slack_pending_confirmations ADD COLUMN surface TEXT NOT NULL DEFAULT 'slack'",
 ];
 
 /**
@@ -760,6 +768,10 @@ export const POST_MIGRATION_STATEMENTS = [
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha ON repair_filings(kind, subject, state_sha)',
+  'CREATE INDEX IF NOT EXISTS idx_conversations_surface_thread ON conversations(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_launch_contexts_surface_thread ON slack_launch_contexts(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_plan_drafts_surface_thread ON slack_plan_drafts(surface, thread_ts)',
+  'CREATE INDEX IF NOT EXISTS idx_slack_pending_confirmations_surface_thread ON slack_pending_confirmations(surface, thread_ts)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */

--- a/packages/slack-bug-scan/package.json
+++ b/packages/slack-bug-scan/package.json
@@ -9,6 +9,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "require": "./src/index.ts"
+    },
+    "./repo-url": {
+      "types": "./src/repo-url.ts",
+      "import": "./src/repo-url.ts",
+      "require": "./src/repo-url.ts"
     }
   },
   "scripts": {

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -20,6 +20,7 @@
     "@invoker/data-store": "workspace:*",
     "@invoker/execution-engine": "workspace:*",
     "@invoker/planning-core": "workspace:*",
+    "@invoker/slack-bug-scan": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "@slack/bolt": "^4.6.0",

--- a/packages/surfaces/src/__tests__/channel-repo-resolver.test.ts
+++ b/packages/surfaces/src/__tests__/channel-repo-resolver.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+import {
+  CHANNEL_REPO_SOURCE_PRECEDENCE,
+  resolveChannelRepo,
+  type ChannelRepoLookups,
+} from '../channel-repo-resolver.js';
+
+const CONFIG_REPO = 'https://github.com/acme/config-repo.git';
+const BINDING_REPO = 'https://github.com/acme/binding-repo.git';
+const TOPIC_REPO = 'https://github.com/acme/topic-repo.git';
+const PURPOSE_REPO = 'https://github.com/acme/purpose-repo.git';
+
+// ── Mock @slack/bolt so SlackSurface can be constructed without a network ──
+
+const conversationsInfo = vi.fn();
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    command = vi.fn();
+    action = vi.fn();
+    event = vi.fn();
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: { postMessage: vi.fn().mockResolvedValue({ ts: '1.1' }), update: vi.fn().mockResolvedValue({}) },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }) },
+      conversations: { info: (...args: unknown[]) => conversationsInfo(...args) },
+    };
+  }
+  return { App: MockApp };
+});
+
+const { SlackSurface } = await import('../slack/slack-surface.js');
+
+/**
+ * The channel-default resolution that shipped before this resolver existed:
+ * static config binding first, then the persisted channel binding, then nothing.
+ */
+function legacyResolveChannelDefaultRepoUrl(
+  channelId: string | undefined,
+  configBindings: Record<string, string>,
+  persisted: Record<string, string>,
+): string | undefined {
+  if (!channelId) return undefined;
+  const configured = configBindings[channelId];
+  if (configured) return normalize(configured);
+  const mapped = persisted[channelId];
+  if (mapped) return normalize(mapped);
+  return undefined;
+}
+
+function normalize(repoUrl: string): string {
+  return repoUrl.trim().replace(/^<([^|>]+)(?:\|[^>]+)?>$/, '$1').replace(/\/+$/, '');
+}
+
+function lookupsFor(sources: {
+  config?: string;
+  binding?: string;
+  topic?: string;
+  purpose?: string;
+  log?: ChannelRepoLookups['log'];
+}): ChannelRepoLookups {
+  return {
+    configBinding: () => sources.config,
+    persistedBinding: () => sources.binding,
+    channelTopic: () => sources.topic,
+    channelPurpose: () => sources.purpose,
+    normalizeRepoUrl: normalize,
+    log: sources.log,
+  };
+}
+
+describe('resolveChannelRepo', () => {
+  it('documents config > binding > topic > purpose as its precedence', () => {
+    expect([...CHANNEL_REPO_SOURCE_PRECEDENCE]).toEqual(['config', 'binding', 'topic', 'purpose']);
+  });
+
+  it('returns nothing when the channel id is missing', async () => {
+    const resolution = await resolveChannelRepo({ surface: 'slack' }, lookupsFor({ config: CONFIG_REPO }));
+    expect(resolution).toEqual({ candidates: [], conflict: false });
+  });
+
+  it('returns nothing when no source answers', async () => {
+    const resolution = await resolveChannelRepo({ surface: 'slack', channelId: 'C1' }, lookupsFor({}));
+    expect(resolution.repoUrl).toBeUndefined();
+    expect(resolution.conflict).toBe(false);
+  });
+
+  it('prefers the config binding over the persisted binding', async () => {
+    const resolution = await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C1' },
+      lookupsFor({ config: CONFIG_REPO, binding: BINDING_REPO }),
+    );
+    expect(resolution.repoUrl).toBe(CONFIG_REPO);
+    expect(resolution.source).toBe('config');
+  });
+
+  it('falls back to the channel topic when no binding exists', async () => {
+    const resolution = await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C1' },
+      lookupsFor({ topic: `bugs go here ${TOPIC_REPO}` }),
+    );
+    expect(resolution.repoUrl).toBe(TOPIC_REPO);
+    expect(resolution.source).toBe('topic');
+    expect(resolution.conflict).toBe(false);
+  });
+
+  it('falls back to the channel purpose when the topic carries no url', async () => {
+    const resolution = await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C1' },
+      lookupsFor({ topic: 'no url here', purpose: `repo: ${PURPOSE_REPO}` }),
+    );
+    expect(resolution.repoUrl).toBe(PURPOSE_REPO);
+    expect(resolution.source).toBe('purpose');
+  });
+
+  it('picks the config binding and logs both values when a topic url conflicts', async () => {
+    const log = vi.fn();
+    const resolution = await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C_CONFLICT' },
+      lookupsFor({ config: CONFIG_REPO, topic: `see ${TOPIC_REPO}`, log }),
+    );
+
+    expect(resolution.repoUrl).toBe(CONFIG_REPO);
+    expect(resolution.source).toBe('config');
+    expect(resolution.conflict).toBe(true);
+    expect(resolution.candidates).toEqual([
+      { source: 'config', repoUrl: CONFIG_REPO },
+      { source: 'topic', repoUrl: TOPIC_REPO },
+    ]);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const [source, level, message] = log.mock.calls[0];
+    expect(source).toBe('slack');
+    expect(level).toBe('warn');
+    expect(message).toContain('CHANNEL_REPO_CONFLICT');
+    expect(message).toContain('C_CONFLICT');
+    expect(message).toContain(CONFIG_REPO);
+    expect(message).toContain(TOPIC_REPO);
+    expect(message).toContain('config > binding > topic > purpose');
+  });
+
+  it('names every disagreeing source in the conflict log', async () => {
+    const log = vi.fn();
+    await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C_ALL' },
+      lookupsFor({ config: CONFIG_REPO, binding: BINDING_REPO, topic: TOPIC_REPO, purpose: PURPOSE_REPO, log }),
+    );
+    const message = log.mock.calls[0][2];
+    for (const repoUrl of [CONFIG_REPO, BINDING_REPO, TOPIC_REPO, PURPOSE_REPO]) {
+      expect(message).toContain(repoUrl);
+    }
+  });
+
+  it('does not log a conflict when every source agrees', async () => {
+    const log = vi.fn();
+    const resolution = await resolveChannelRepo(
+      { surface: 'slack', channelId: 'C1' },
+      lookupsFor({ config: CONFIG_REPO, binding: `${CONFIG_REPO}/`, topic: `docs ${CONFIG_REPO}`, log }),
+    );
+    expect(resolution.conflict).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('keys lookups by surface and channel id', async () => {
+    const seen: Array<{ surface: string; channelId: string }> = [];
+    await resolveChannelRepo({ surface: 'discord', channelId: 'C_KEY' }, {
+      configBinding: (key) => { seen.push({ ...key }); return undefined; },
+      persistedBinding: (key) => { seen.push({ ...key }); return CONFIG_REPO; },
+    });
+    expect(seen).toEqual([
+      { surface: 'discord', channelId: 'C_KEY' },
+      { surface: 'discord', channelId: 'C_KEY' },
+    ]);
+  });
+
+  it('treats a throwing lookup as no answer so a binding still resolves', async () => {
+    const resolution = await resolveChannelRepo({ surface: 'slack', channelId: 'C1' }, {
+      configBinding: () => CONFIG_REPO,
+      channelTopic: () => { throw new Error('conversations.info unavailable'); },
+      normalizeRepoUrl: normalize,
+    });
+    expect(resolution.repoUrl).toBe(CONFIG_REPO);
+    expect(resolution.conflict).toBe(false);
+  });
+});
+
+// ── Parity with the pre-resolver Slack behaviour ─────────────
+
+const BINDING_WORKFLOW_PREFIX = '__slack_channel_repo__:';
+
+interface BindingFixture {
+  name: string;
+  channelId: string | undefined;
+  config: Record<string, string>;
+  persisted: Record<string, string>;
+}
+
+const BINDING_FIXTURES: BindingFixture[] = [
+  { name: 'no channel id', channelId: undefined, config: {}, persisted: {} },
+  { name: 'config binding only', channelId: 'C_CFG', config: { C_CFG: CONFIG_REPO }, persisted: {} },
+  { name: 'persisted binding only', channelId: 'C_DB', config: {}, persisted: { C_DB: BINDING_REPO } },
+  {
+    name: 'config binding wins over persisted binding',
+    channelId: 'C_BOTH',
+    config: { C_BOTH: CONFIG_REPO },
+    persisted: { C_BOTH: BINDING_REPO },
+  },
+  {
+    name: 'slack-escaped config url is unwrapped',
+    channelId: 'C_ESC',
+    config: { C_ESC: `<${CONFIG_REPO}|acme/config-repo>` },
+    persisted: {},
+  },
+  { name: 'trailing slash is trimmed', channelId: 'C_SLASH', config: { C_SLASH: `${CONFIG_REPO}/` }, persisted: {} },
+  { name: 'unbound channel', channelId: 'C_NONE', config: {}, persisted: {} },
+];
+
+async function buildSurface(config: Record<string, string>, persisted: Record<string, string>) {
+  const adapter = await SQLiteAdapter.create(':memory:');
+  const workflowChannelRepo = new WorkflowChannelRepository(adapter);
+  for (const [channelId, repoUrl] of Object.entries(persisted)) {
+    workflowChannelRepo.save({
+      workflowId: `${BINDING_WORKFLOW_PREFIX}${channelId}`,
+      channelId,
+      repoUrl,
+      createdAt: new Date().toISOString(),
+    });
+  }
+  const surface = new SlackSurface({
+    defaultRepoUrl: 'https://github.com/example/default-repo.git',
+    botToken: 'xoxb-test',
+    appToken: 'xapp-test',
+    signingSecret: 'secret',
+    channelRepoBindings: config,
+    workflowChannelRepo,
+    log: vi.fn(),
+  });
+  return { surface, adapter };
+}
+
+describe('SlackSurface.resolveChannelDefaultRepoUrl parity', () => {
+  beforeEach(() => {
+    conversationsInfo.mockReset();
+    conversationsInfo.mockResolvedValue({ channel: {} });
+  });
+
+  for (const fixture of BINDING_FIXTURES) {
+    it(`resolves the same repo as before for: ${fixture.name}`, async () => {
+      const { surface, adapter } = await buildSurface(fixture.config, fixture.persisted);
+      try {
+        const resolved = await (surface as unknown as {
+          resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+        }).resolveChannelDefaultRepoUrl(fixture.channelId);
+        expect(resolved).toBe(legacyResolveChannelDefaultRepoUrl(fixture.channelId, fixture.config, fixture.persisted));
+      } finally {
+        adapter.close();
+      }
+    });
+  }
+
+  it('ignores a workflow channel mapping that is not a repo binding', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const workflowChannelRepo = new WorkflowChannelRepository(adapter);
+    workflowChannelRepo.save({
+      workflowId: 'wf-not-a-binding',
+      channelId: 'C_WF',
+      repoUrl: BINDING_REPO,
+      createdAt: new Date().toISOString(),
+    });
+    const surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/default-repo.git',
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      workflowChannelRepo,
+      log: vi.fn(),
+    });
+    try {
+      const resolved = await (surface as unknown as {
+        resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+      }).resolveChannelDefaultRepoUrl('C_WF');
+      expect(resolved).toBeUndefined();
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('logs the conflict and keeps the config binding when the channel topic disagrees', async () => {
+    const log = vi.fn();
+    const adapter = await SQLiteAdapter.create(':memory:');
+    conversationsInfo.mockResolvedValue({ channel: { topic: { value: `bugs -> ${TOPIC_REPO}` } } });
+    const surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/default-repo.git',
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      channelRepoBindings: { C_CONFLICT: CONFIG_REPO },
+      log,
+    });
+    try {
+      const resolved = await (surface as unknown as {
+        resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+      }).resolveChannelDefaultRepoUrl('C_CONFLICT');
+      expect(resolved).toBe(CONFIG_REPO);
+      const conflictLog = log.mock.calls.find((call) => String(call[2]).includes('CHANNEL_REPO_CONFLICT'));
+      expect(conflictLog).toBeDefined();
+      expect(conflictLog?.[1]).toBe('warn');
+      expect(conflictLog?.[2]).toContain(CONFIG_REPO);
+      expect(conflictLog?.[2]).toContain(TOPIC_REPO);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('adopts the channel topic repo when no binding exists', async () => {
+    conversationsInfo.mockResolvedValue({ channel: { purpose: { value: `repo ${PURPOSE_REPO}` } } });
+    const surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/default-repo.git',
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      log: vi.fn(),
+    });
+    const resolved = await (surface as unknown as {
+      resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+    }).resolveChannelDefaultRepoUrl('C_TOPIC');
+    expect(resolved).toBe(PURPOSE_REPO);
+  });
+
+  it('reads channel metadata once per channel within the cache window', async () => {
+    conversationsInfo.mockResolvedValue({ channel: { topic: { value: `repo ${TOPIC_REPO}` } } });
+    const surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/default-repo.git',
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      log: vi.fn(),
+    });
+    const resolve = (surface as unknown as {
+      resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+    }).resolveChannelDefaultRepoUrl.bind(surface);
+
+    expect(await resolve('C_CACHE')).toBe(TOPIC_REPO);
+    expect(await resolve('C_CACHE')).toBe(TOPIC_REPO);
+    expect(conversationsInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to no channel default when channel metadata cannot be read', async () => {
+    conversationsInfo.mockRejectedValue(new Error('missing_scope'));
+    const surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/default-repo.git',
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      log: vi.fn(),
+    });
+    const resolved = await (surface as unknown as {
+      resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined>;
+    }).resolveChannelDefaultRepoUrl('C_NOINFO');
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-plan-intent-confirm-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-confirm-repros.e2e.test.ts
@@ -4,6 +4,7 @@ import * as childProcess from 'node:child_process';
 import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
 import { SlackSurface } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 
 interface MockHandler {
   pattern: string | RegExp;
@@ -130,6 +131,7 @@ describe('Slack plan-intent confirmation repro', () => {
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (command) => { commands.push(command); });
   });
@@ -239,6 +241,7 @@ describe('Slack plan-intent confirmation repro', () => {
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,
+      planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     });
     await surface.start(async (command) => { commands.push(command); });
 

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@invoker/data-store';
 import { SlackSurface } from '../slack/slack-surface.js';
 import type { SurfaceCommand } from '../surface.js';
+import { fakeCodexPlanningCommandBuilder } from './test-support/fake-codex-planning-command-builder.js';
 import { SessionIdentifier } from '../slack/thread-session-manager.js';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 
@@ -143,6 +144,7 @@ function config(repo: ConversationRepository, extra: Partial<ConstructorParamete
     enableImmediateAck: false,
     planningHeartbeatIntervalSeconds: 0,
     log: silentLog,
+    planningCommandBuilder: fakeCodexPlanningCommandBuilder,
     ...extra,
   };
 }

--- a/packages/surfaces/src/channel-repo-resolver.ts
+++ b/packages/surfaces/src/channel-repo-resolver.ts
@@ -1,0 +1,101 @@
+import { extractRepoUrlFromText } from '@invoker/slack-bug-scan/repo-url';
+import type { LogFn } from './surface.js';
+
+export const CHANNEL_REPO_SOURCE_PRECEDENCE = ['config', 'binding', 'topic', 'purpose'] as const;
+
+export type ChannelRepoSource = (typeof CHANNEL_REPO_SOURCE_PRECEDENCE)[number];
+
+export interface ChannelRepoKey {
+  surface: string;
+  channelId: string;
+}
+
+type LookupResult = string | undefined;
+
+export type ChannelRepoLookup = (key: ChannelRepoKey) => LookupResult | Promise<LookupResult>;
+
+export interface ChannelRepoLookups {
+  configBinding?: ChannelRepoLookup;
+  persistedBinding?: ChannelRepoLookup;
+  channelTopic?: ChannelRepoLookup;
+  channelPurpose?: ChannelRepoLookup;
+  normalizeRepoUrl?: (raw: string) => string;
+  sameRepoUrl?: (a: string, b: string) => boolean;
+  log?: LogFn;
+}
+
+export interface ChannelRepoCandidate {
+  source: ChannelRepoSource;
+  repoUrl: string;
+}
+
+export interface ChannelRepoResolution {
+  repoUrl?: string;
+  source?: ChannelRepoSource;
+  candidates: ChannelRepoCandidate[];
+  conflict: boolean;
+}
+
+const URL_BEARING_TEXT_SOURCES: ReadonlySet<ChannelRepoSource> = new Set<ChannelRepoSource>(['topic', 'purpose']);
+
+function defaultNormalizeRepoUrl(raw: string): string {
+  return raw.trim().replace(/\/+$/, '');
+}
+
+function defaultSameRepoUrl(a: string, b: string): boolean {
+  return a === b;
+}
+
+function lookupFor(lookups: ChannelRepoLookups, source: ChannelRepoSource): ChannelRepoLookup | undefined {
+  switch (source) {
+    case 'config': return lookups.configBinding;
+    case 'binding': return lookups.persistedBinding;
+    case 'topic': return lookups.channelTopic;
+    case 'purpose': return lookups.channelPurpose;
+  }
+}
+
+function describeCandidates(candidates: ChannelRepoCandidate[]): string {
+  return candidates.map((candidate) => `${candidate.source}=${candidate.repoUrl}`).join(', ');
+}
+
+function formatConflict(key: ChannelRepoKey, winner: ChannelRepoCandidate, candidates: ChannelRepoCandidate[]): string {
+  return `[CHANNEL_REPO_CONFLICT] channel=${key.channelId} sources disagree; `
+    + `using ${winner.source}=${winner.repoUrl} `
+    + `(precedence ${CHANNEL_REPO_SOURCE_PRECEDENCE.join(' > ')}); `
+    + `all sources: ${describeCandidates(candidates)}`;
+}
+
+export async function resolveChannelRepo(
+  key: { surface: string; channelId?: string },
+  lookups: ChannelRepoLookups,
+): Promise<ChannelRepoResolution> {
+  if (!key.channelId) return { candidates: [], conflict: false };
+
+  const resolvedKey: ChannelRepoKey = { surface: key.surface, channelId: key.channelId };
+  const normalizeRepoUrl = lookups.normalizeRepoUrl ?? defaultNormalizeRepoUrl;
+  const sameRepoUrl = lookups.sameRepoUrl ?? defaultSameRepoUrl;
+  const candidates: ChannelRepoCandidate[] = [];
+
+  for (const source of CHANNEL_REPO_SOURCE_PRECEDENCE) {
+    const lookup = lookupFor(lookups, source);
+    if (!lookup) continue;
+    let raw: LookupResult;
+    try {
+      raw = await lookup(resolvedKey);
+    } catch {
+      raw = undefined;
+    }
+    const value = URL_BEARING_TEXT_SOURCES.has(source) ? extractRepoUrlFromText(raw) : raw?.trim() || undefined;
+    if (!value) continue;
+    candidates.push({ source, repoUrl: normalizeRepoUrl(value) });
+  }
+
+  const winner = candidates[0];
+  if (!winner) return { candidates, conflict: false };
+
+  const conflict = candidates.some((candidate) => !sameRepoUrl(candidate.repoUrl, winner.repoUrl));
+  if (conflict) lookups.log?.(key.surface, 'warn', formatConflict(resolvedKey, winner, candidates));
+
+  return { repoUrl: winner.repoUrl, source: winner.source, candidates, conflict };
+}

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -1,2 +1,3 @@
 export * from './surface.js';
+export * from './channel-repo-resolver.js';
 export * from './slack/index.js';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -21,6 +21,7 @@ import {
   type PlanningConfirmationMode,
 } from '@invoker/planning-core';
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress } from '../surface.js';
+import { resolveChannelRepo } from '../channel-repo-resolver.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus, clampMrkdwnText } from './slack-formatter.js';
@@ -265,6 +266,7 @@ const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!']);
 const GITHUB_REPO_ROOT_PATH_RE = /^\/[^/]+\/[^/]+(?:\.git)?\/?$/;
 const INVALID_LITERAL_REPO_URL_GUIDANCE = 'Use a GitHub repo URL or a clone URL ending in .git.';
 const CHANNEL_REPO_BINDING_WORKFLOW_PREFIX = '__slack_channel_repo__:';
+const CHANNEL_METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
 const CHANNEL_REPO_SETUP_INTENT_RE = /\b(?:set\s*up|setup|configure|map|bind)\b/i;
 const CHANNEL_REPO_PAIR_RE = /#([A-Za-z0-9][A-Za-z0-9_-]{0,79})\s*(?:(?:=>|->|=|:|\bto\b|\bfor\b|\brepo(?:sitory)?\b)\s*)?(<((?:https?|ssh):\/\/[^|>\s]+|git@[\w.-]+:[^|>\s]+)(?:\|[^>]+)?>|\b(?:https?:\/\/[^\s<>()\[\]{}"'|]+|ssh:\/\/[^\s<>()\[\]{}"'|]+|git@[\w.-]+:[^\s<>()\[\]{}"'|]+))/gi;
 
@@ -647,6 +649,7 @@ export class SlackSurface implements Surface {
   private defaultRepoUrl?: string;
   private channelRepoBindings: Record<string, string>;
   private workflowChannelRepo?: WorkflowChannelRepository;
+  private channelMetadataCache = new Map<string, { fetchedAt: number; topic?: string; purpose?: string }>();
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
   private onRestartInvoker?: () => Promise<void>;
@@ -1206,7 +1209,7 @@ export class SlackSurface implements Surface {
       ? this.findMentionedRepoAlias(parsed.text)
       : undefined;
     const mentionedRepoResolution = mentionedRepoAlias ? this.resolveRepoUrl(mentionedRepoAlias) : {};
-    const channelDefaultRepoUrl = this.resolveChannelDefaultRepoUrl(channel);
+    const channelDefaultRepoUrl = await this.resolveChannelDefaultRepoUrl(channel);
     const routeRepoUrl = explicitRepoResolution.url
       ?? detectedRepoResolution.url
       ?? mentionedRepoResolution.url
@@ -2421,15 +2424,34 @@ ${text}`;
     );
   }
 
-  private resolveChannelDefaultRepoUrl(channelId: string | undefined): string | undefined {
-    if (!channelId) return undefined;
-    const configured = this.channelRepoBindings[channelId];
-    if (configured) return this.normalizeRepositoryUrl(configured);
-    const mapping = this.workflowChannelRepo?.getByChannelId(channelId);
-    if (isChannelRepoBinding(mapping) && mapping?.repoUrl) {
-      return this.normalizeRepositoryUrl(mapping.repoUrl);
+  private async resolveChannelDefaultRepoUrl(channelId: string | undefined): Promise<string | undefined> {
+    const resolution = await resolveChannelRepo({ surface: this.type, channelId }, {
+      configBinding: (key) => this.channelRepoBindings[key.channelId],
+      persistedBinding: (key) => {
+        const mapping = this.workflowChannelRepo?.getByChannelId(key.channelId);
+        return isChannelRepoBinding(mapping) ? mapping?.repoUrl : undefined;
+      },
+      channelTopic: async (key) => (await this.fetchChannelMetadata(key.channelId)).topic,
+      channelPurpose: async (key) => (await this.fetchChannelMetadata(key.channelId)).purpose,
+      normalizeRepoUrl: (raw) => this.normalizeRepositoryUrl(raw),
+      sameRepoUrl,
+      log: this.log,
+    });
+    return resolution.repoUrl;
+  }
+
+  private async fetchChannelMetadata(channelId: string): Promise<{ topic?: string; purpose?: string }> {
+    const cached = this.channelMetadataCache.get(channelId);
+    if (cached && Date.now() - cached.fetchedAt < CHANNEL_METADATA_CACHE_TTL_MS) return cached;
+    let metadata: { topic?: string; purpose?: string } = {};
+    try {
+      const info = await this.app.client.conversations.info({ channel: channelId });
+      metadata = { topic: info.channel?.topic?.value, purpose: info.channel?.purpose?.value };
+    } catch {
+      metadata = {};
     }
-    return undefined;
+    this.channelMetadataCache.set(channelId, { ...metadata, fetchedAt: Date.now() });
+    return metadata;
   }
 
   private async handleChannelRepoSetup(

--- a/packages/surfaces/tsup.config.ts
+++ b/packages/surfaces/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     '@invoker/data-store',
     '@invoker/execution-engine',
     '@invoker/planning-core',
+    '@invoker/slack-bug-scan',
     '@invoker/transport',
     'yaml',
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       '@invoker/planning-core':
         specifier: workspace:*
         version: link:../planning-core
+      '@invoker/slack-bug-scan':
+        specifier: workspace:*
+        version: link:../slack-bug-scan
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport


### PR DESCRIPTION
## Summary

Slack now asks one shared resolver which repo a channel means. The resolver takes a surface name and a channel id, so a later Discord surface can use it too.

Before this, the answer lived in a private SlackSurface method. The bug-scan worker used a second rule: a git URL in the channel topic or purpose. Slack never looked there.

The resolver checks four places in a fixed order: config, the saved channel binding, the topic, then the purpose. The first answer wins.

When those places disagree, it logs a `[CHANNEL_REPO_CONFLICT]` warning naming every place and value. It never picks one quietly.

Channels with a config or saved binding get the same repo as before. Channels with neither can now pick up a repo URL from their topic or purpose.

Topic and purpose come from one Slack `conversations.info` call, cached for five minutes per channel. A failed call counts as no answer.

## Review Claim

One surface-neutral resolver answers which repo a channel means, with a fixed, logged order over config, saved binding, topic, and purpose.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

For every channel with a config or saved binding, the resolver returns the same repo as the old private method, because those two places still come first. When places disagree, the higher one wins and a warning names every value; it never picks quietly.

## Slice Rationale

Which repo a channel means is shared domain logic, not Slack transport. Later Discord slices need it before a second surface can find a repo at all.

The topic and purpose rule is folded in here on purpose. Landing the shared resolver without it would keep two different answers to the same question.

## Non-goals

- No Discord code.
- No change to the five-step repo order in `handleAppMention`; only its channel-default step now asks the resolver.
- No change to the bug-scan worker.
- `slackChannelRepos` config stays.

## Architecture

### Before

```mermaid
graph TD
    A["handleAppMention"] --> B["private SlackSurface.resolveChannelDefaultRepoUrl"]
    B --> C["slackChannelRepos config"]
    B --> D["saved channel binding in DB"]
    E["slack-bug-scan worker"] --> F["repo URL in channel topic or purpose"]
```

### After

```mermaid
graph TD
    A["handleAppMention"] --> B["SlackSurface.resolveChannelDefaultRepoUrl"]
    B --> R["resolveChannelRepo(surface, channelId)"]
    R --> C["1. slackChannelRepos config"]
    R --> D["2. saved channel binding in DB"]
    R --> T["3. channel topic via conversations.info, 5 min cache"]
    R --> P["4. channel purpose"]
    R --> W["warn CHANNEL_REPO_CONFLICT when places disagree"]
    E["slack-bug-scan worker"] --> F["repo URL in channel topic or purpose"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test`: `Tests 630 passed (630)`, exit 0. Includes the new `src/__tests__/channel-repo-resolver.test.ts`.
- [x] `pnpm --filter @invoker/surfaces build`: CJS and DTS build success, exit 0.
- [x] `pnpm run check:comments`: no disallowed comments found.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; Slack falls back to config and saved binding only.
- Data migration? No

</details>
