### PR TITLE
[PR authoring runs the target repo's own body checker for every repo](1) Honor repository checks

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2160,6 +2160,80 @@ describe('TaskRunner', () => {
       }
     });
 
+    function createRepoCheckerWorkspace(checkerSource?: string) {
+      const cwd = createTempWorkspace();
+      if (checkerSource !== undefined) {
+        mkdirSync(join(cwd, 'scripts'), { recursive: true });
+        writeFileSync(join(cwd, 'scripts', 'validate-pr-body-local.mjs'), checkerSource);
+      }
+      return cwd;
+    }
+
+    async function authorNonInvokerBody(body: string, cwd: string) {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      try {
+        const executor = makeStrictGateExecutor(makeBodyEmittingAgent(tempHome, body), cwd);
+        return await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd,
+          repoUrl: 'https://github.com/EdbertChan/catstack',
+        });
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    }
+
+    it('authorPrBodyWithSkill refuses canonical fallback when a non-Invoker repo checker rejects every body', async () => {
+      const cwd = createRepoCheckerWorkspace(
+        "console.error('catstack checker: missing ## Why section'); process.exit(1);\n",
+      );
+
+      const outcome = authorNonInvokerBody(CANONICAL_ONLY_BODY, cwd);
+
+      await expect(outcome).rejects.toThrow(
+        /^\[pr-authoring\] target repo checker rejected every PR body; refusing canonical fallback/,
+      );
+      await expect(outcome).rejects.toThrow(/catstack checker: missing ## Why section/);
+    });
+
+    it('authorPrBodyWithSkill returns the agent body when a non-Invoker repo checker accepts it', async () => {
+      const cwd = createRepoCheckerWorkspace(
+        [
+          "import { readFileSync } from 'node:fs';",
+          "const args = process.argv.slice(2);",
+          "const body = readFileSync(args[args.indexOf('--body-file') + 1], 'utf8');",
+          "process.exit(body.includes('## Summary') && args[args.indexOf('--base') + 1] === 'master' ? 0 : 1);",
+          '',
+        ].join('\n'),
+      );
+
+      const result = await authorNonInvokerBody(CANONICAL_ONLY_BODY, cwd);
+
+      expect(result.agentName).toBe('codex');
+      expect(result.sessionId).not.toBe('canonical-fallback');
+      expect(result.body).toBe(CANONICAL_ONLY_BODY);
+    });
+
+    it('authorPrBodyWithSkill keeps the canonical fallback for a non-Invoker repo without a checker', async () => {
+      const cwd = createRepoCheckerWorkspace();
+
+      const result = await authorNonInvokerBody('## Summary\n\nOnly summary', cwd);
+
+      expect(result.agentName).toBe('canonical');
+      expect(result.sessionId).toBe('canonical-fallback');
+      expect(result.body).toContain('## Test Plan');
+      expect(result.body).toContain('## Revert Plan');
+    });
+
     it('authorPrBodyWithSkill falls back to second agent when first fails', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -259,14 +259,26 @@ export function validateReviewStackPrBodyAgainstLocalDiff(args: {
   baseBranch: string;
 }): string[] {
   const structuralErrors = validateReviewStackPrBody(args.body);
-  const validatorPath = join(args.cwd, 'scripts', 'validate-pr-body-local.mjs');
+  const validatorPath = repoLocalPrBodyCheckerPath(args.cwd);
   if (!existsSync(validatorPath)) {
     return [
       ...structuralErrors,
       `CI-parity PR body validator is missing: ${validatorPath}`,
     ];
   }
+  return [...structuralErrors, ...runRepoLocalPrBodyChecker(args)];
+}
 
+export function repoLocalPrBodyCheckerPath(cwd: string): string {
+  return join(cwd, 'scripts', 'validate-pr-body-local.mjs');
+}
+
+export function runRepoLocalPrBodyChecker(args: {
+  body: string;
+  cwd: string;
+  baseBranch: string;
+}): string[] {
+  const validatorPath = repoLocalPrBodyCheckerPath(args.cwd);
   const tempDir = mkdtempSync(join(tmpdir(), 'invoker-pr-body-'));
   const bodyFile = join(tempDir, 'body.md');
   try {
@@ -276,16 +288,12 @@ export function validateReviewStackPrBodyAgainstLocalDiff(args: {
       [validatorPath, '--body-file', bodyFile, '--base', args.baseBranch],
       { cwd: args.cwd, encoding: 'utf8' },
     );
-    if (result.status === 0) return structuralErrors;
+    if (result.status === 0) return [];
 
     const output = `${String(result.stdout ?? '')}\n${String(result.stderr ?? '')}`.trim();
-    return [
-      ...structuralErrors,
-      `CI-parity PR body validation failed: ${output || 'validator exited without output'}`,
-    ];
+    return [`CI-parity PR body validation failed: ${output || 'validator exited without output'}`];
   } catch (error) {
     return [
-      ...structuralErrors,
       `CI-parity PR body validation could not run: ${error instanceof Error ? error.message : String(error)}`,
     ];
   } finally {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { mkdirSync, readdirSync, copyFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, readdirSync, copyFileSync, rmSync, mkdtempSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
@@ -53,7 +53,9 @@ import {
   buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
   parseMakePrStackPublishResult,
+  repoLocalPrBodyCheckerPath,
   resolveSkillPathViaAgent,
+  runRepoLocalPrBodyChecker,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
   validateReviewStackPrBody,
@@ -1451,6 +1453,7 @@ export class TaskRunner {
     repoUrl?: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }> {
     const strictReviewStack = isInvokerRepoUrl(args.repoUrl);
+    const hasRepoChecker = !strictReviewStack && existsSync(repoLocalPrBodyCheckerPath(args.cwd));
     if (!this.executionAgentRegistry) {
       if (strictReviewStack) {
         throw new Error(
@@ -1508,7 +1511,16 @@ export class TaskRunner {
             cwd: args.cwd,
             baseBranch: args.baseBranch,
           })
-          : validateCanonicalPrBody(result.body);
+          : hasRepoChecker
+            ? [
+              ...validateCanonicalPrBody(result.body),
+              ...runRepoLocalPrBodyChecker({
+                body: result.body,
+                cwd: args.cwd,
+                baseBranch: args.baseBranch,
+              }),
+            ]
+            : validateCanonicalPrBody(result.body);
         if (validationErrors.length > 0) {
           this.logger.warn(
             `[pr-authoring] body validation failed agent=${agent.name} `
@@ -1532,6 +1544,13 @@ export class TaskRunner {
       throw new Error(
         '[pr-authoring] All AI agents failed to author a review-stack PR body for the Invoker repo; '
           + `refusing canonical fallback (it cannot pass scripts/validate-pr-body.mjs). Errors: ${errors.join(' | ')}`,
+      );
+    }
+
+    if (hasRepoChecker) {
+      throw new Error(
+        '[pr-authoring] target repo checker rejected every PR body; refusing canonical fallback. '
+          + `Errors: ${errors.join(' | ')}`,
       );
     }
 


### PR DESCRIPTION
## Summary

PR authoring now runs the target repository's own checker whenever an agent supplies a candidate body and that repository provides the checker file.

When every candidate fails, authoring stops with the checker output instead of publishing a canonical fallback. Repositories lacking the checker retain their existing behavior.

## Review Claim

The agent authoring path honors a non-Invoker repository's checker for every candidate and refuses canonical fallback after all candidates fail.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A repo without scripts/validate-pr-body-local.mjs publishes exactly as today. Invoker keeps its existing strict review-stack checks.

## Slice Rationale

One authoring-path change with its directly affected regression tests. The shared checker invocation is required by both callers; the target repository's checker implementation belongs to its separate workflow.

Alternative considerations: hardcoding catstack's layout would couple Invoker to one repository. Allowing canonical fallback after checker failure would bypass the repository's publication gate.

Assumptions: the supplied workflow's single behavior claim and safety invariant define this publication slice.

## Non-goals

No changes to repositories without the checker, Invoker's review-stack schema, authoring prompt text, or the existing missing-agent-registry fallback. No checker is added to catstack here.

## Architecture

### Before

Non-Invoker candidate bodies received only canonical structure checks.

### After

They also run scripts/validate-pr-body-local.mjs when present, passing --body-file and --base from the target workspace.

The same checker invocation serves Invoker's strict path. Exhausting agent candidates in an opted-in repository now throws with collected errors instead of returning a canonical body.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test --run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `pnpm run check:comments`
- [x] `bash scripts/scrub-handoff-artifacts.sh`
- [x] `node scripts/check-pr-body-keywords.mjs --body-file /tmp/repo-local-body-checker-pr.md --declared-unit routing`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/repo-local-body-checker-pr.md --base master`

Result: 116 tests passed in one test file. The publication checks above passed locally.

The new cases cover checker failure with diagnostic propagation, successful checker invocation with the base argument, and canonical fallback when no checker exists. No live catstack workflow was run during publication.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; non-Invoker authoring returns to the earlier canonical-only checks.
- Revert command: `git revert <this PR's merge commit>`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request descriptions are now validated against repository-specific checker scripts when available.
  * Agent-authored descriptions are retained when they pass both standard and repository-specific validation.

* **Bug Fixes**
  * Prevented fallback to a standard description when a repository-specific checker rejects all generated descriptions.
  * Repositories without a checker continue using the standard fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->