### PR TITLE
[PR authoring runs the target repo's own body checker for every repo](1) Honor repository checks

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2160,6 +2160,80 @@ describe('TaskRunner', () => {
       }
     });
 
+    function createRepoCheckerWorkspace(checkerSource?: string) {
+      const cwd = createTempWorkspace();
+      if (checkerSource !== undefined) {
+        mkdirSync(join(cwd, 'scripts'), { recursive: true });
+        writeFileSync(join(cwd, 'scripts', 'validate-pr-body-local.mjs'), checkerSource);
+      }
+      return cwd;
+    }
+
+    async function authorNonInvokerBody(body: string, cwd: string) {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      try {
+        const executor = makeStrictGateExecutor(makeBodyEmittingAgent(tempHome, body), cwd);
+        return await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd,
+          repoUrl: 'https://github.com/EdbertChan/catstack',
+        });
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    }
+
+    it('authorPrBodyWithSkill refuses canonical fallback when a non-Invoker repo checker rejects every body', async () => {
+      const cwd = createRepoCheckerWorkspace(
+        "console.error('catstack checker: missing ## Why section'); process.exit(1);\n",
+      );
+
+      const outcome = authorNonInvokerBody(CANONICAL_ONLY_BODY, cwd);
+
+      await expect(outcome).rejects.toThrow(
+        /^\[pr-authoring\] target repo checker rejected every PR body; refusing canonical fallback/,
+      );
+      await expect(outcome).rejects.toThrow(/catstack checker: missing ## Why section/);
+    });
+
+    it('authorPrBodyWithSkill returns the agent body when a non-Invoker repo checker accepts it', async () => {
+      const cwd = createRepoCheckerWorkspace(
+        [
+          "import { readFileSync } from 'node:fs';",
+          "const args = process.argv.slice(2);",
+          "const body = readFileSync(args[args.indexOf('--body-file') + 1], 'utf8');",
+          "process.exit(body.includes('## Summary') && args[args.indexOf('--base') + 1] === 'master' ? 0 : 1);",
+          '',
+        ].join('\n'),
+      );
+
+      const result = await authorNonInvokerBody(CANONICAL_ONLY_BODY, cwd);
+
+      expect(result.agentName).toBe('codex');
+      expect(result.sessionId).not.toBe('canonical-fallback');
+      expect(result.body).toBe(CANONICAL_ONLY_BODY);
+    });
+
+    it('authorPrBodyWithSkill keeps the canonical fallback for a non-Invoker repo without a checker', async () => {
+      const cwd = createRepoCheckerWorkspace();
+
+      const result = await authorNonInvokerBody('## Summary\n\nOnly summary', cwd);
+
+      expect(result.agentName).toBe('canonical');
+      expect(result.sessionId).toBe('canonical-fallback');
+      expect(result.body).toContain('## Test Plan');
+      expect(result.body).toContain('## Revert Plan');
+    });
+
     it('authorPrBodyWithSkill falls back to second agent when first fails', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -259,14 +259,26 @@ export function validateReviewStackPrBodyAgainstLocalDiff(args: {
   baseBranch: string;
 }): string[] {
   const structuralErrors = validateReviewStackPrBody(args.body);
-  const validatorPath = join(args.cwd, 'scripts', 'validate-pr-body-local.mjs');
+  const validatorPath = repoLocalPrBodyCheckerPath(args.cwd);
   if (!existsSync(validatorPath)) {
     return [
       ...structuralErrors,
       `CI-parity PR body validator is missing: ${validatorPath}`,
     ];
   }
+  return [...structuralErrors, ...runRepoLocalPrBodyChecker(args)];
+}
 
+export function repoLocalPrBodyCheckerPath(cwd: string): string {
+  return join(cwd, 'scripts', 'validate-pr-body-local.mjs');
+}
+
+export function runRepoLocalPrBodyChecker(args: {
+  body: string;
+  cwd: string;
+  baseBranch: string;
+}): string[] {
+  const validatorPath = repoLocalPrBodyCheckerPath(args.cwd);
   const tempDir = mkdtempSync(join(tmpdir(), 'invoker-pr-body-'));
   const bodyFile = join(tempDir, 'body.md');
   try {
@@ -276,16 +288,12 @@ export function validateReviewStackPrBodyAgainstLocalDiff(args: {
       [validatorPath, '--body-file', bodyFile, '--base', args.baseBranch],
       { cwd: args.cwd, encoding: 'utf8' },
     );
-    if (result.status === 0) return structuralErrors;
+    if (result.status === 0) return [];
 
     const output = `${String(result.stdout ?? '')}\n${String(result.stderr ?? '')}`.trim();
-    return [
-      ...structuralErrors,
-      `CI-parity PR body validation failed: ${output || 'validator exited without output'}`,
-    ];
+    return [`CI-parity PR body validation failed: ${output || 'validator exited without output'}`];
   } catch (error) {
     return [
-      ...structuralErrors,
       `CI-parity PR body validation could not run: ${error instanceof Error ? error.message : String(error)}`,
     ];
   } finally {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { mkdirSync, readdirSync, copyFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, readdirSync, copyFileSync, rmSync, mkdtempSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
@@ -53,7 +53,9 @@ import {
   buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
   parseMakePrStackPublishResult,
+  repoLocalPrBodyCheckerPath,
   resolveSkillPathViaAgent,
+  runRepoLocalPrBodyChecker,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
   validateReviewStackPrBody,
@@ -1451,6 +1453,7 @@ export class TaskRunner {
     repoUrl?: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }> {
     const strictReviewStack = isInvokerRepoUrl(args.repoUrl);
+    const hasRepoChecker = !strictReviewStack && existsSync(repoLocalPrBodyCheckerPath(args.cwd));
     if (!this.executionAgentRegistry) {
       if (strictReviewStack) {
         throw new Error(
@@ -1508,7 +1511,16 @@ export class TaskRunner {
             cwd: args.cwd,
             baseBranch: args.baseBranch,
           })
-          : validateCanonicalPrBody(result.body);
+          : hasRepoChecker
+            ? [
+              ...validateCanonicalPrBody(result.body),
+              ...runRepoLocalPrBodyChecker({
+                body: result.body,
+                cwd: args.cwd,
+                baseBranch: args.baseBranch,
+              }),
+            ]
+            : validateCanonicalPrBody(result.body);
         if (validationErrors.length > 0) {
           this.logger.warn(
             `[pr-authoring] body validation failed agent=${agent.name} `
@@ -1532,6 +1544,13 @@ export class TaskRunner {
       throw new Error(
         '[pr-authoring] All AI agents failed to author a review-stack PR body for the Invoker repo; '
           + `refusing canonical fallback (it cannot pass scripts/validate-pr-body.mjs). Errors: ${errors.join(' | ')}`,
+      );
+    }
+
+    if (hasRepoChecker) {
+      throw new Error(
+        '[pr-authoring] target repo checker rejected every PR body; refusing canonical fallback. '
+          + `Errors: ${errors.join(' | ')}`,
       );
     }
 


### PR DESCRIPTION
## Summary

Some target repos ship their own local PR description checker script. Invoker now runs that checker for every repo that has it, not only for Invoker itself.

Before, other repos got only a headings check. When every agent's description failed, Invoker published a stock template description anyway.

That is how catstack PR 377 got published even though catstack's own checker said its mix of files could not ship together.

Now, when the repo's checker fails every agent's description, PR authoring stops with the checker's message instead of publishing the stock template.

Repos without that checker file behave exactly as before.

## Review Claim

For a non-Invoker repo that ships its own local PR description checker script, `authorPrBodyWithSkill` runs that checker on each agent's description and throws, instead of returning the canonical fallback, when the checker fails every one.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A repo without `scripts/validate-pr-body-local.mjs` publishes exactly as today: `hasRepoChecker` is false, so it takes the old headings-only path and the old canonical fallback. The Invoker repo keeps its existing strict path unchanged.

## Slice Rationale

One claim in the PR authoring path: `task-runner.ts` gates on the repo's checker, and `pr-authoring.ts` shares the checker spawn it already had for Invoker.

The catstack checker file itself ships as a separate workflow in the catstack repo; each half is inert without the other.

## Non-goals

- No change to the Invoker repo's review-stack schema or its strict path.
- No change for repos that do not ship the checker file.
- No change to the `buildMakePrPrompt` prompt text.
- No hardcoded catstack paths or repo URLs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test --run src/__tests__/task-runner-fix-publish-and-ssh.test.ts` — `Tests  116 passed (116)`.
- [x] Same command with `task-runner.ts` and `pr-authoring.ts` reset to `origin/master` — `Tests  1 failed | 115 passed (116)`; the failing case is `authorPrBodyWithSkill refuses canonical fallback when a non-Invoker repo checker rejects every body`.
- [x] `pnpm run check:comments` — no disallowed comments found.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Non-Invoker repos go back to the headings-only check and canonical fallback.
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
