### PR TITLE
[Plan drafts](1) Plan drafts (1): the planner never gets told to save a draft where it cannot

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -403,6 +403,74 @@ describe('plan draft file - activation side', () => {
     expect(existsSync(path)).toBe(false);
     expect(conversation.lastTurnDraftPlanText).toBeNull();
     expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('asks for inline YAML when the working folder is read-only', async () => {
+    chmodSync(workingDir, 0o555);
+    try {
+      const conversation = new PlanConversation({ workingDir, threadTs: 'read-only-123', plannerRetryLimit: 0 });
+
+      mockSpawn.mockReturnValueOnce(fakePlannerChild(INLINE_PLAN_RESPONSE));
+      await conversation.sendMessage('Create the plan');
+
+      const turnPrompt = String(mockSpawn.mock.calls[0]?.[1]);
+      expect(turnPrompt).toContain('inside a ```yaml code block');
+      expect(turnPrompt).not.toContain('write the COMPLETE YAML to');
+      expect(conversation.planDraftFilePath()).toBeNull();
+    } finally {
+      chmodSync(workingDir, 0o755);
+    }
+  });
+
+  it('uses an inline YAML reply as the draft when the working folder is read-only', async () => {
+    chmodSync(workingDir, 0o555);
+    try {
+      const conversation = new PlanConversation({ workingDir, threadTs: 'read-only-456', plannerRetryLimit: 0 });
+
+      mockSpawn.mockReturnValueOnce(fakePlannerChild(INLINE_PLAN_RESPONSE));
+      await conversation.sendMessage('Create the plan');
+
+      expect(conversation.lastTurnDraftPlanText).not.toBeNull();
+      const parsedDraft = parseYaml(conversation.lastTurnDraftPlanText!) as Record<string, unknown>;
+      expect(parsedDraft.name).toBe('Draft Activation');
+      expect(conversation.lastTurnDraftFromSidecarFile).toBe(false);
+    } finally {
+      chmodSync(workingDir, 0o755);
+    }
+  });
+
+  it('writes and picks up the draft under plannerScratchRoot when one is given', async () => {
+    const plannerScratchRoot = mkdtempSync(join(tmpdir(), 'plan-draft-scratch-'));
+    try {
+      const conversation = new PlanConversation({
+        workingDir,
+        plannerScratchRoot,
+        threadTs: 'scratch-123',
+        plannerRetryLimit: 0,
+      });
+      const expectedPath = join(plannerScratchRoot, 'plan-drafts', 'scratch-123.yaml');
+      expect(conversation.planDraftFilePath()).toBe(expectedPath);
+
+      mockSpawn.mockReturnValueOnce(fakePlannerChild(
+        'Drafted the plan.',
+        () => writeFileSync(expectedPath, VALID_PLAN_YAML, 'utf8'),
+      ));
+      await conversation.sendMessage('Create the plan');
+
+      expect(String(mockSpawn.mock.calls[0]?.[1])).toContain(`write the COMPLETE YAML to \`${expectedPath}\``);
+      expect(conversation.lastTurnDraftPlanText).toBe(VALID_PLAN_YAML.trim());
+      expect(conversation.lastTurnDraftFromSidecarFile).toBe(true);
+      expect(existsSync(join(workingDir, '.invoker'))).toBe(false);
+    } finally {
+      rmSync(plannerScratchRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('puts the plan-intent file under plannerScratchRoot when one is given', () => {
+    const plannerScratchRoot = join(tmpdir(), 'plan-intent-scratch');
+    const conversation = new PlanConversation({ workingDir, plannerScratchRoot, threadTs: 'intent-123' });
+
+    expect(conversation.planIntentSignalFilePath()).toBe(join(plannerScratchRoot, 'plan-intent', 'intent-123.json'));
   });
 
   it('keeps one default doctor budget across every production PlanConversation host', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -125,6 +125,7 @@ export interface PlanConversationConfig {
   planningCommandBuilder?: PlanningCommandBuilder;
   /** Root directory for codebase exploration. */
   workingDir?: string;
+  plannerScratchRoot?: string;
   /** Subprocess timeout in milliseconds. Default: 300000 (5 minutes). */
   timeoutMs?: number;
   /** Slack thread timestamp. Required for persistence. */
@@ -525,6 +526,8 @@ export class PlanConversation {
   private _submittedPlanText: string | null = null;
   private _planSubmitted = false;
   readonly workingDir?: string;
+  private plannerScratchRoot?: string;
+  private planDraftDirUnavailable = false;
   private timeoutMs: number;
   private threadTs?: string;
   private channelId?: string;
@@ -570,6 +573,7 @@ export class PlanConversation {
     this.mode = config.mode ?? 'plan';
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.workingDir = config.workingDir;
+    this.plannerScratchRoot = config.plannerScratchRoot;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.threadTs = config.threadTs;
     this.channelId = config.channelId;
@@ -972,9 +976,16 @@ export class PlanConversation {
   // its output limit. Gated on workingDir + threadTs; without both, planning
   // falls back to inline extraction unchanged. `.invoker/` is gitignored.
   planDraftFilePath(): string | null {
-    if (!this.workingDir || !this.threadTs) return null;
+    if (this.planDraftDirUnavailable) return null;
+    return this.plannerScratchFilePath('plan-drafts', 'yaml');
+  }
+
+  private plannerScratchFilePath(folder: string, extension: string): string | null {
+    if (!this.threadTs) return null;
+    const root = this.plannerScratchRoot ?? (this.workingDir ? join(this.workingDir, '.invoker') : undefined);
+    if (!root) return null;
     const safeId = this.threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
-    return join(this.workingDir, '.invoker', 'plan-drafts', `${safeId}.yaml`);
+    return join(root, folder, `${safeId}.${extension}`);
   }
 
   private readPlanDraftFile(): string | null {
@@ -994,6 +1005,7 @@ export class PlanConversation {
   // write is required each turn (getDraftedPlan must never return a stale plan)
   // and the planner's write into it succeeds.
   private resetPlanDraftFile(): void {
+    this.planDraftDirUnavailable = false;
     const path = this.planDraftFilePath();
     if (!path) return;
     try {
@@ -1001,6 +1013,7 @@ export class PlanConversation {
       mkdirSync(dirname(path), { recursive: true });
     } catch (err) {
       this.log('plan-conversation', 'error', `Failed to reset plan draft file ${path}: ${err}`);
+      this.planDraftDirUnavailable = true;
     }
   }
 
@@ -1010,9 +1023,7 @@ export class PlanConversation {
   // every turn so a stale signal from turn N can't leak into turn N+1.
   // `.invoker/` is gitignored.
   planIntentSignalFilePath(): string | null {
-    if (!this.workingDir || !this.threadTs) return null;
-    const safeId = this.threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
-    return join(this.workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+    return this.plannerScratchFilePath('plan-intent', 'json');
   }
 
   private readPlanIntentSignalFile(): PlanIntentSignal | null {


### PR DESCRIPTION
## Summary

When the draft folder cannot be made, the planner is now told to paste YAML in chat so the draft can still be picked up.

Callers can also choose a writable scratch folder for draft and intent files. Existing callers keep their current paths by default.

This is part 1 of 2. The desktop app will choose a folder under Invoker home in part 2.

## Review Claim

When the plan conversation cannot make its draft folder, its turn prompt requests inline YAML; callers may choose the scratch folder used for draft and intent files.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

When no scratch folder is passed and the working folder is writable, draft and intent file paths, prompts, and draft pickup remain byte-for-byte unchanged.

## Slice Rationale

The plan conversation owns its scratch files. Its optional folder and inline fallback form one behavior slice with directly affected tests; desktop folder selection belongs in part 2.

Alternative considerations: changing the whole app's repoRoot exceeds this scope. Logging alone cannot provide a draft. Reading chat text cannot help while the prompt forbids inline YAML.

Assumptions: the supplied plan defines the scope and safety invariant. Verification-only tasks introduced no additional file changes and therefore need no separate PR.

## Non-goals

No changes to the desktop app, side panel, in-app planner sidecar, repoRoot, or Slack's folder choice.

## Architecture

### Before

Draft and intent files use workingDir/.invoker. A draft-folder setup error is logged, but the prompt still names the unavailable draft path.

### After

An optional plannerScratchRoot supplies the root for both files. A draft reset error makes planDraftFilePath return null for that turn, selecting the existing inline YAML prompts and pickup.

The unavailable-folder flag clears at the next reset so file mode can resume when folder setup succeeds.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test src/__tests__/plan-draft-file-activation.test.ts` — 1 test file passed; 22 tests passed.
- [x] Read-only folder cases check the inline prompt, absence of the file-write instruction, and draft pickup from an inline YAML reply.
- [x] Scratch-folder cases check the named draft path, file pickup, and intent path. Existing default-path cases also pass.
- [x] `pnpm run check:comments` — passed.
- [x] `bash scripts/scrub-handoff-artifacts.sh` — scrub-handoff-artifacts-ok.
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/plan-drafts-1-pr.md --base master` — passed against the actual diff.

These tests use a fake planner process and real temporary folders. The installed AppImage and desktop UI were not exercised. Node 22.22.1 ran the tests; the repository requests Node 26.x.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before part 2 adopts plannerScratchRoot. If part 2 has landed, revert that caller change first.
- Revert command: `git revert d4396adff97348a876715c6bb5d9f57b17980fc4` (or the corresponding landed commit).
- Post-revert steps: rerun the focused plan draft tests. The previous unavailable-folder behavior returns.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable scratch storage for planner drafts and intent signals.
  - Planner drafts now fall back to inline YAML when the working folder isn’t writable.
  - Planner draft files are stored in the configured scratch location when available.

- **Bug Fixes**
  - Prevented repeated filesystem attempts after draft storage becomes unavailable.
  - Improved handling of planner draft and intent-signal paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->