### PR TITLE
[Spend Gate Self-Count](1) Prove the clamp counts its own host twice

### DIFF
--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -176,6 +176,39 @@ describe('runCodexDailySpendGateTick', () => {
     expect(result.totalTokens).toBe(20_421_072);
   });
 
+  it.fails('counts the owner once when a remote target points at one of its own addresses', async () => {
+    const config = gateConfig({
+      tallyLocal: () => 18_254,
+      localAddresses: new Set(['157.245.231.246']),
+      remoteTargets: [
+        { name: 'remote_digital_ocean_1', connection: { host: '157.245.231.246', user: 'invoker', sshKeyPath: '/k' } },
+        { name: 'remote_digital_ocean_3', connection: { host: 'h3', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      tallyRemote: async (target: { name: string }) => (target.name === 'remote_digital_ocean_1' ? 18_254 : 0),
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.totalTokens).toBe(18_254);
+    expect([...result.tokensByHost.keys()]).toEqual(['owner', 'remote_digital_ocean_3']);
+  });
+
+  it.fails('skips a remote target on the loopback address without any config', async () => {
+    const tallyRemote = vi.fn(async () => 18_254);
+    const config = gateConfig({
+      tallyLocal: () => 18_254,
+      remoteTargets: [
+        { name: 'self', connection: { host: '127.0.0.1', user: 'invoker', sshKeyPath: '/k' } },
+      ],
+      tallyRemote,
+    });
+
+    const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);
+
+    expect(result.totalTokens).toBe(18_254);
+    expect(tallyRemote).not.toHaveBeenCalled();
+  });
+
   it('does nothing when the gate is disabled', async () => {
     const config = gateConfig({ enabled: false, tallyRemote: async () => 500_000_000 });
     const result = await runCodexDailySpendGateTick(config, makeLogger(), NOW_MS);


### PR DESCRIPTION
## Summary

The daily Codex clamp still counts the owner machine twice when config does not name it.

On DO1 one 18,254-token session showed up as `36508 of 100000000 daily Codex tokens used across 7 host(s)`.

These two tests pin that behavior as a known failure so the fix in the next slice can flip them.

## Review Claim

Approve two tests that show the clamp adds the owner's tokens twice when a remote target is the owner itself.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only a test file changes. Both tests are marked `it.fails`, so the suite stays green and no product code runs differently.

## Slice Rationale

The repro lands before the fix so a reviewer sees the double count before approving the change that removes it.

## Non-goals

No change to how the clamp tallies tokens. No config change. No change to the existing `localHostName` test from #12045.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && npx vitest run src/__tests__/codex-spend-gate.test.ts` → `Tests  15 passed (15)`
- [x] Same two tests as plain `it` before the fix → `expected 36508 to be 18254` (both fail)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbWT7AQ3sJY49m13QPcom4
