### PR TITLE
[Spend Gate Self-Count](2) Count the owner once when it is also a remote target

### DIFF
--- a/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-spend-gate.test.ts
@@ -176,7 +176,7 @@ describe('runCodexDailySpendGateTick', () => {
     expect(result.totalTokens).toBe(20_421_072);
   });
 
-  it.fails('counts the owner once when a remote target points at one of its own addresses', async () => {
+  it('counts the owner once when a remote target points at one of its own addresses', async () => {
     const config = gateConfig({
       tallyLocal: () => 18_254,
       localAddresses: new Set(['157.245.231.246']),
@@ -193,7 +193,7 @@ describe('runCodexDailySpendGateTick', () => {
     expect([...result.tokensByHost.keys()]).toEqual(['owner', 'remote_digital_ocean_3']);
   });
 
-  it.fails('skips a remote target on the loopback address without any config', async () => {
+  it('skips a remote target on the loopback address without any config', async () => {
     const tallyRemote = vi.fn(async () => 18_254);
     const config = gateConfig({
       tallyLocal: () => 18_254,

--- a/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
+++ b/packages/execution-engine/src/workers/spend-circuit-breaker-worker.ts
@@ -1,3 +1,5 @@
+import { hostname, networkInterfaces } from 'node:os';
+
 import type { Logger } from '@invoker/contracts';
 
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
@@ -57,6 +59,7 @@ export interface CodexDailySpendGateConfig {
   dailyTokenBudget?: number;
   localHostName?: string;
   localSessionRoot?: string;
+  localAddresses?: ReadonlySet<string>;
   remoteTargets?: ReadonlyArray<CodexSpendGateRemoteTarget>;
   statePath?: string;
   tallyRemote?: (target: CodexSpendGateRemoteTarget, nowMs: number) => Promise<number>;
@@ -106,6 +109,14 @@ export interface CodexDailySpendGateTickResult {
   readonly tokenBudget: number;
   readonly tripped: boolean;
   readonly failedHosts: ReadonlyArray<{ host: string; reason: string }>;
+}
+
+function ownAddresses(): ReadonlySet<string> {
+  const addresses = new Set([hostname().toLowerCase()]);
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) addresses.add(entry.address.toLowerCase());
+  }
+  return addresses;
 }
 
 function defaultTallyRemote(target: CodexSpendGateRemoteTarget, nowMs: number): Promise<number> {
@@ -168,7 +179,9 @@ export async function runCodexDailySpendGateTick(
   }
 
   const tallyRemote = config.tallyRemote ?? defaultTallyRemote;
+  const localAddresses = config.localAddresses ?? ownAddresses();
   for (const target of config.remoteTargets ?? []) {
+    if (localAddresses.has(target.connection.host.toLowerCase())) continue;
     try {
       tokensByHost.set(target.name, await tallyRemote(target, nowMs));
     } catch (error) {


### PR DESCRIPTION
## Summary

The daily Codex clamp now counts the owner machine once, even when config does not name it.

Before, a remote target pointing at the owner's own address was tallied over SSH on top of the local tally.

Now the clamp leaves out any remote target whose host is one of the owner's own addresses or its hostname.

#12045 already let config name the owner. With this change, that config line is no longer required.

## Review Claim

Approve leaving out remote targets whose host matches an address of the owner machine when the clamp adds up the day's tokens.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A remote target on a different machine is still tallied exactly as before. Only a target whose host is one of the owner's own addresses is left out, and the owner's local tally already covers it.

## Slice Rationale

The slice below this one pins the double count. This slice holds only the counting change and flips those two checks to passing.

## Non-goals

No change to the daily budget, the trip file, or how a trip blocks Codex. No change to the per-worker breaker. The `localHostName` setting from #12045 keeps working.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && npx vitest run src/__tests__/codex-spend-gate.test.ts -t "own addresses|loopback"` → `Tests  2 passed | 13 skipped (15)`
- [x] `npx vitest run src/__tests__/codex-spend-gate.test.ts src/__tests__/spend-circuit-breaker-worker.test.ts src/__tests__/spend-circuit-breaker-state.test.ts src/__tests__/codex-spend-gate-live-fleet.integration.test.ts` → `Tests  27 passed (27)`
- [x] `pnpm run check:types` → exit 0
- [x] `pnpm run check:comments` → no disallowed comments

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbWT7AQ3sJY49m13QPcom4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-wide daily spend totals and trip behavior when remote targets overlap the owner host; misclassified addresses could under-count spend and delay trips.
> 
> **Overview**
> The daily Codex spend gate no longer **double-counts** token usage when a configured remote SSH target points at the **owner machine** (same IP or hostname as local).
> 
> `runCodexDailySpendGateTick` now builds a set of **local addresses** (hostname plus all `networkInterfaces()` addresses, overridable via optional `localAddresses` on config) and **skips** remote tallying for any target whose `connection.host` matches that set—local tally already covers that spend. Loopback remotes like `127.0.0.1` are skipped automatically without extra config.
> 
> Two previously failing tests are now **passing** expectations for single owner count and no remote call on loopback self-targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78143599e18c8ce85111c5bc72802d20726375b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->