### PR TITLE
[Autofix breaker re-arm](1) Pin the usage-limit pause re-arm loop in breaker integration tests

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker-integration.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker-integration.test.ts
@@ -7,7 +7,9 @@ import type { TaskState } from '@invoker/workflow-core';
 
 import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
 import { createAutoFixRecoveryTick } from '../auto-fix-recovery.js';
-import { loadCircuitBreakerState, isCircuitBreakerPaused, tripCircuitBreaker } from '../auto-fix-circuit-breaker.js';
+import {
+  clearCircuitBreaker, loadCircuitBreakerState, isCircuitBreakerPaused, tripCircuitBreaker,
+} from '../auto-fix-circuit-breaker.js';
 
 const logger = {
   info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn(),
@@ -37,7 +39,7 @@ function makeFailedTask(overrides: Partial<TaskState> = {}): TaskState {
 function makeStore(tasks: TaskState[]) {
   const byId = new Map(tasks.map((t) => [t.id, t]));
   return {
-    listWorkflows: () => [{ id: 'wf-1' }],
+    listWorkflows: () => [{ id: 'wf-1', repoUrl: 'https://github.com/example/repo.git' }],
     loadTasks: () => tasks,
     loadTask: (taskId: string) => byId.get(taskId),
     listWorkflowMutationIntents: () => [],
@@ -120,6 +122,87 @@ describe('auto-fix circuit breaker integration', () => {
     await tick({} as any);
 
     expect(submitted).toContain('wf-1/unrelated');
+  });
+
+  const USAGE_LIMIT_ERROR = "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, "
+    + 'or try again at Sep 16th, 2026 6:14 AM.';
+  const HOUR_MS = 60 * 60 * 1000;
+
+  function runTick(tasks: TaskState[], submitted: string[]) {
+    const submitter = { submit: vi.fn((_wf, _prio, _channel, args: unknown[]) => { submitted.push(args[0] as string); return 1; }) };
+    return createAutoFixRecoveryTick({
+      store: makeStore(tasks), submitter, logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+      circuitBreakerPath,
+      circuitBreakerPauseMs: 6 * HOUR_MS,
+    })({} as any);
+  }
+
+  it.fails('a usage-limit failure that ended before the last trip does not re-arm the expired pause', async () => {
+    const tripAt = new Date(Date.now() - 7 * HOUR_MS);
+    tripCircuitBreaker(circuitBreakerPath, { now: tripAt, reason: 'usage-limit', pauseMs: 6 * HOUR_MS });
+    const staleUsageLimitTask = makeFailedTask({
+      id: 'wf-1/usage-limited',
+      execution: {
+        generation: 2, selectedAttemptId: 'a1', branch: 'x',
+        error: USAGE_LIMIT_ERROR,
+        completedAt: new Date(tripAt.getTime() - 1000),
+      },
+    });
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+
+    await runTick([staleUsageLimitTask, unrelatedTask], submitted);
+
+    const state = loadCircuitBreakerState(circuitBreakerPath);
+    expect(state.triggeredAt).toBe(tripAt.toISOString());
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(false);
+    expect(submitted).not.toContain('wf-1/usage-limited');
+    expect(submitted).toContain('wf-1/unrelated');
+  });
+
+  it.fails('a usage-limit failure that ended before an operator clear does not re-arm the pause', async () => {
+    const failedAt = new Date(Date.now() - 5 * HOUR_MS);
+    tripCircuitBreaker(circuitBreakerPath, { now: new Date(failedAt.getTime() + 1000), reason: 'usage-limit', pauseMs: 6 * HOUR_MS });
+    clearCircuitBreaker(circuitBreakerPath);
+    const staleUsageLimitTask = makeFailedTask({
+      id: 'wf-1/usage-limited',
+      execution: {
+        generation: 2, selectedAttemptId: 'a1', branch: 'x',
+        error: USAGE_LIMIT_ERROR,
+        completedAt: failedAt,
+      },
+    });
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+
+    await runTick([staleUsageLimitTask, unrelatedTask], submitted);
+
+    expect(isCircuitBreakerPaused(loadCircuitBreakerState(circuitBreakerPath), Date.now())).toBe(false);
+    expect(submitted).toContain('wf-1/unrelated');
+  });
+
+  it('a usage-limit failure that ended after the last trip still re-arms the pause', async () => {
+    const tripAt = new Date(Date.now() - 7 * HOUR_MS);
+    tripCircuitBreaker(circuitBreakerPath, { now: tripAt, reason: 'usage-limit', pauseMs: 6 * HOUR_MS });
+    const freshUsageLimitTask = makeFailedTask({
+      id: 'wf-1/usage-limited',
+      execution: {
+        generation: 2, selectedAttemptId: 'a1', branch: 'x',
+        error: USAGE_LIMIT_ERROR,
+        completedAt: new Date(Date.now() - 60 * 1000),
+      },
+    });
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+
+    await runTick([freshUsageLimitTask, unrelatedTask], submitted);
+
+    const state = loadCircuitBreakerState(circuitBreakerPath);
+    expect(state.triggeredAt).not.toBe(tripAt.toISOString());
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(true);
+    expect(submitted).not.toContain('wf-1/unrelated');
   });
 
   it('dispatches normally with no pause file at all', async () => {


### PR DESCRIPTION
## Summary

The auto-fix pause restarts every six hours from the same old usage-limit failure. Auto-fix then never runs again, even after the model quota returns.

This PR only adds tests that show that loop. The fix is the next PR in this stack.

The existing circuit breaker integration tests never reached the breaker. Their fake workflow had no repo URL, so every task stopped at the no-repo check first.

## Review Claim

These tests reproduce the pause re-arm loop and mark its two broken cases as expected failures until the fix lands.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only test code changes. Production code is untouched, so auto-fix behaves exactly as it does today on every host.

## Slice Rationale

The repro lands before the fix so a reviewer sees the loop fail first. The fake workflow repo URL belongs here because without it no breaker test runs at all.

## Non-goals

No production code changes. No change to the pause length or to how usage-limit errors are recognized.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && npx vitest run src/__tests__/auto-fix-circuit-breaker-integration.test.ts` on this commit: all tests green, the two loop cases reported as expected failures
- [x] Same file as it exists on `origin/master` b1615a3846: `Tests 3 failed (3)`, showing the old fake workflow never reached the breaker

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
