### PR TITLE
Reflect worker session 01a082c3 into recreate-task proof

### DIFF
--- a/scripts/repro/action-graph-query.mjs
+++ b/scripts/repro/action-graph-query.mjs
@@ -55,16 +55,11 @@ switch (command) {
     process.stdout.write(String(intentNode(args[0])?.status ?? ''));
     break;
   }
-  case 'task-event-count-since-intent': {
-    const [taskId, eventType, intentId] = args;
+  case 'task-event-count': {
+    const [taskId, eventType] = args;
     const task = taskNode(taskId);
-    const intent = intentNode(intentId);
-    const since = intent?.createdAt ? Date.parse(intent.createdAt) : NaN;
     const history = Array.isArray(task?.history) ? task.history : [];
-    const count = history.filter((entry) => {
-      const timestamp = entry?.timestamp ? Date.parse(entry.timestamp) : NaN;
-      return entry?.source === eventType && Number.isFinite(timestamp) && Number.isFinite(since) && timestamp >= since;
-    }).length;
+    const count = history.filter((entry) => entry?.source === eventType).length;
     process.stdout.write(String(count));
     break;
   }

--- a/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
@@ -25,6 +25,7 @@ HOME_DIR="$TMP_DIR/home"
 DB_DIR="$HOME_DIR/.invoker-repro"
 PLAN_PATH="$TMP_DIR/repro-plan.yaml"
 CONFIG_PATH="$DB_DIR/config.json"
+export INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH"
 REPO_FIXTURE_DIR="$TMP_DIR/repro-repo"
 IPC_SOCKET_PATH="$TMP_DIR/i.sock"
 OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
@@ -262,6 +263,8 @@ fi
 
 wait_for_intent_status "$BLOCKER_RECREATE_INTENT_ID" "running" 15
 
+TARGET_PENDING_EVENTS_BEFORE="$(query_action_graph_value task-event-count "$TARGET_ID" task.pending)"
+
 HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test node "$HEADLESS_CLIENT_JS" recreate-task "$TARGET_ID" \
   >"$TARGET_RECREATE_STDOUT" 2>"$TARGET_RECREATE_STDERR" &
 TARGET_RECREATE_PID=$!
@@ -285,7 +288,7 @@ sleep 3
 
 BLOCKER_RECREATE_STATUS="$(query_action_graph_value intent-status "$BLOCKER_RECREATE_INTENT_ID")"
 TARGET_RECREATE_STATUS="$(query_action_graph_value intent-status "$TARGET_RECREATE_INTENT_ID")"
-TARGET_PENDING_EVENTS="$(query_action_graph_value task-event-count-since-intent "$TARGET_ID" task.pending "$TARGET_RECREATE_INTENT_ID")"
+TARGET_PENDING_EVENTS_AFTER="$(query_action_graph_value task-event-count "$TARGET_ID" task.pending)"
 TARGET_STATUS_AFTER_SECOND="$(query_action_graph_value task-status "$TARGET_ID")"
 BLOCKER_STATUS_AFTER_SECOND="$(query_action_graph_value task-status "$BLOCKER_ID")"
 
@@ -298,8 +301,8 @@ if [[ "$EXPECTATION" == "bug" ]]; then
     echo "repro: expected target recreate-task intent to be queued behind the running workflow mutation, got $TARGET_RECREATE_STATUS" >&2
     exit 1
   fi
-  if [[ "$TARGET_PENDING_EVENTS" != "0" ]]; then
-    echo "repro: expected no fresh task.pending events for $TARGET_ID after the delayed recreate-task was queued, saw $TARGET_PENDING_EVENTS" >&2
+  if (( TARGET_PENDING_EVENTS_AFTER != TARGET_PENDING_EVENTS_BEFORE )); then
+    echo "repro: expected no fresh task.pending events for $TARGET_ID after the delayed recreate-task was queued, saw $TARGET_PENDING_EVENTS_BEFORE before and $TARGET_PENDING_EVENTS_AFTER after" >&2
     exit 1
   fi
   if [[ "$TARGET_STATUS_AFTER_SECOND" != "completed" ]]; then
@@ -316,8 +319,8 @@ else
     echo "repro: expected target recreate-task intent to take authority immediately, got $TARGET_RECREATE_STATUS" >&2
     exit 1
   fi
-  if [[ "$TARGET_PENDING_EVENTS" == "0" ]]; then
-    echo "repro: expected fresh task.pending events for $TARGET_ID after recreate-task took over, saw 0" >&2
+  if (( TARGET_PENDING_EVENTS_AFTER <= TARGET_PENDING_EVENTS_BEFORE )); then
+    echo "repro: expected a fresh task.pending event for $TARGET_ID after recreate-task took over, saw $TARGET_PENDING_EVENTS_BEFORE before and $TARGET_PENDING_EVENTS_AFTER after" >&2
     exit 1
   fi
   echo "repro: confirmed fix"
@@ -326,7 +329,7 @@ fi
 echo "workflow: $WORKFLOW_ID"
 echo "blocker recreate-task intent: $BLOCKER_RECREATE_INTENT_ID status=$BLOCKER_RECREATE_STATUS"
 echo "target recreate-task intent: $TARGET_RECREATE_INTENT_ID status=$TARGET_RECREATE_STATUS"
-echo "task.pending events after target recreate-task enqueue: $TARGET_PENDING_EVENTS"
+echo "task.pending events around target recreate-task enqueue: before=$TARGET_PENDING_EVENTS_BEFORE after=$TARGET_PENDING_EVENTS_AFTER"
 echo "task status after target recreate-task enqueue: $TARGET_ID=$TARGET_STATUS_AFTER_SECOND"
 echo "task status after target recreate-task enqueue: $BLOCKER_ID=$BLOCKER_STATUS_AFTER_SECOND"
 echo "tmp-dir: $TMP_DIR"


### PR DESCRIPTION
## Summary

This PR lands the accepted Invoker finding from the reflected Codex worker session.

The recreate-task queue proof now selects its disposable repo config and compares pending event counts before and after the queued recreate-task action.

That avoids the timestamp precision trap that made the proof depend on second-rounded event timestamps.

## Review Claim

The `required/23a` recreate-task queue authority proof deterministically catches the reflected failure mode and passes with the corrected harness.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only: this changes repro scripts under `scripts/repro/**` and does not vendor `skills/reflect/`, merge anything, or modify the original repair workflow.

## Slice Rationale

This slice applies the Accepted finding from session `01a082c3-ccf9-70c2-bd45-93830520080e` without bundling catstack skill edits or worker-session tooling backlog.

## Non-goals

No product behavior change.

No catstack skill or hook change.

No worker-session long-polling fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine-thrash.mjs --self-test`
- [x] `bash scripts/test-suites/required/23a-recreate-task-queue-authority.sh`
- [x] `test ! -e skills/reflect`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only repro scripts and query helpers under `scripts/repro/**`; no product runtime behavior.
> 
> **Overview**
> **Proof-only** updates to the recreate-task queue authority repro so assertions stay deterministic.
> 
> The action-graph helper **drops** `task-event-count-since-intent` (intent-bound, timestamp-based filtering) in favor of **`task-event-count`**, which counts all `task.pending` (or other) history entries for a task. The repro script **exports `INVOKER_REPO_CONFIG_PATH`** to the disposable config and **snapshots `task.pending` counts before and after** enqueueing the target recreate-task, then checks that the count is unchanged in the bug case and increases when the fix is in effect—avoiding flaky comparisons tied to second-rounded event timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49fb1bbc60c5886ea3f153c194ce8f209c59432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->