### PR TITLE
[worker-session-mine-44d7e826f8828fcd](1) Keep recreate-task queue proof deterministic

### DIFF
--- a/scripts/repro/action-graph-query.mjs
+++ b/scripts/repro/action-graph-query.mjs
@@ -55,16 +55,11 @@ switch (command) {
     process.stdout.write(String(intentNode(args[0])?.status ?? ''));
     break;
   }
-  case 'task-event-count-since-intent': {
-    const [taskId, eventType, intentId] = args;
+  case 'task-event-count': {
+    const [taskId, eventType] = args;
     const task = taskNode(taskId);
-    const intent = intentNode(intentId);
-    const since = intent?.createdAt ? Date.parse(intent.createdAt) : NaN;
     const history = Array.isArray(task?.history) ? task.history : [];
-    const count = history.filter((entry) => {
-      const timestamp = entry?.timestamp ? Date.parse(entry.timestamp) : NaN;
-      return entry?.source === eventType && Number.isFinite(timestamp) && Number.isFinite(since) && timestamp >= since;
-    }).length;
+    const count = history.filter((entry) => entry?.source === eventType).length;
     process.stdout.write(String(count));
     break;
   }

--- a/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
@@ -25,6 +25,7 @@ HOME_DIR="$TMP_DIR/home"
 DB_DIR="$HOME_DIR/.invoker-repro"
 PLAN_PATH="$TMP_DIR/repro-plan.yaml"
 CONFIG_PATH="$DB_DIR/config.json"
+export INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH"
 REPO_FIXTURE_DIR="$TMP_DIR/repro-repo"
 IPC_SOCKET_PATH="$TMP_DIR/i.sock"
 OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
@@ -262,6 +263,8 @@ fi
 
 wait_for_intent_status "$BLOCKER_RECREATE_INTENT_ID" "running" 15
 
+TARGET_PENDING_EVENTS_BEFORE="$(query_action_graph_value task-event-count "$TARGET_ID" task.pending)"
+
 HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test node "$HEADLESS_CLIENT_JS" recreate-task "$TARGET_ID" \
   >"$TARGET_RECREATE_STDOUT" 2>"$TARGET_RECREATE_STDERR" &
 TARGET_RECREATE_PID=$!
@@ -285,7 +288,7 @@ sleep 3
 
 BLOCKER_RECREATE_STATUS="$(query_action_graph_value intent-status "$BLOCKER_RECREATE_INTENT_ID")"
 TARGET_RECREATE_STATUS="$(query_action_graph_value intent-status "$TARGET_RECREATE_INTENT_ID")"
-TARGET_PENDING_EVENTS="$(query_action_graph_value task-event-count-since-intent "$TARGET_ID" task.pending "$TARGET_RECREATE_INTENT_ID")"
+TARGET_PENDING_EVENTS_AFTER="$(query_action_graph_value task-event-count "$TARGET_ID" task.pending)"
 TARGET_STATUS_AFTER_SECOND="$(query_action_graph_value task-status "$TARGET_ID")"
 BLOCKER_STATUS_AFTER_SECOND="$(query_action_graph_value task-status "$BLOCKER_ID")"
 
@@ -298,8 +301,8 @@ if [[ "$EXPECTATION" == "bug" ]]; then
     echo "repro: expected target recreate-task intent to be queued behind the running workflow mutation, got $TARGET_RECREATE_STATUS" >&2
     exit 1
   fi
-  if [[ "$TARGET_PENDING_EVENTS" != "0" ]]; then
-    echo "repro: expected no fresh task.pending events for $TARGET_ID after the delayed recreate-task was queued, saw $TARGET_PENDING_EVENTS" >&2
+  if (( TARGET_PENDING_EVENTS_AFTER != TARGET_PENDING_EVENTS_BEFORE )); then
+    echo "repro: expected no fresh task.pending events for $TARGET_ID after the delayed recreate-task was queued, saw $TARGET_PENDING_EVENTS_BEFORE before and $TARGET_PENDING_EVENTS_AFTER after" >&2
     exit 1
   fi
   if [[ "$TARGET_STATUS_AFTER_SECOND" != "completed" ]]; then
@@ -316,8 +319,8 @@ else
     echo "repro: expected target recreate-task intent to take authority immediately, got $TARGET_RECREATE_STATUS" >&2
     exit 1
   fi
-  if [[ "$TARGET_PENDING_EVENTS" == "0" ]]; then
-    echo "repro: expected fresh task.pending events for $TARGET_ID after recreate-task took over, saw 0" >&2
+  if (( TARGET_PENDING_EVENTS_AFTER <= TARGET_PENDING_EVENTS_BEFORE )); then
+    echo "repro: expected a fresh task.pending event for $TARGET_ID after recreate-task took over, saw $TARGET_PENDING_EVENTS_BEFORE before and $TARGET_PENDING_EVENTS_AFTER after" >&2
     exit 1
   fi
   echo "repro: confirmed fix"
@@ -326,7 +329,7 @@ fi
 echo "workflow: $WORKFLOW_ID"
 echo "blocker recreate-task intent: $BLOCKER_RECREATE_INTENT_ID status=$BLOCKER_RECREATE_STATUS"
 echo "target recreate-task intent: $TARGET_RECREATE_INTENT_ID status=$TARGET_RECREATE_STATUS"
-echo "task.pending events after target recreate-task enqueue: $TARGET_PENDING_EVENTS"
+echo "task.pending events around target recreate-task enqueue: before=$TARGET_PENDING_EVENTS_BEFORE after=$TARGET_PENDING_EVENTS_AFTER"
 echo "task status after target recreate-task enqueue: $TARGET_ID=$TARGET_STATUS_AFTER_SECOND"
 echo "task status after target recreate-task enqueue: $BLOCKER_ID=$BLOCKER_STATUS_AFTER_SECOND"
 echo "tmp-dir: $TMP_DIR"


### PR DESCRIPTION
## Summary

Follow-up reflect proof for worker session 01a082c3-ccf9-70c2-bd45-93830520080e.

The recreate-task repro now records the target task.pending count before and after the delayed intent.

That keeps the proof about observable task history rather than intent creation timestamps.

worker-session-mine-44d7e826f8828fcd completed 2 tasks with 0 failed, 0 closed, and 0 skipped.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1788971726947-1/repro-thrash | Prove the thrash detector fires on a fixture copy and stays silent on a clean fixture. | completed |
| wf-1788971726947-1/reflect-and-fix | Reflect via catstack and open a PR to catstack or Invoker by root cause. | completed |

</details>

## Review Claim

The recreate-task repro now proves pending-event behavior by comparing the target task history before and after the delayed intent.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only: the changed files are repro helpers, and the original worker session, production task runner, and merge state are untouched.

## Slice Rationale

This slice carries the durable proof adjustment from the follow-up review without bundling the unrelated reverted token-audit experiment.

## Non-goals

- No production behavior change.
- No merge or queue action.
- No vendoring of skills/reflect/.
- No change to the original worker session artifacts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/check-pr-body-keywords.mjs --body-file /tmp/worker-session-mine-pr.md --declared-unit proof`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file /tmp/worker-session-mine-pr.md --base master`
- [ ] `pnpm run check:comments`
- [ ] `pnpm --filter @invoker/app... build`
- [ ] `REPRO_TIMEOUT_SECONDS=120 xvfb-run --auto-servernum bash scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh --expect-fixed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f42f4afb`
- Post-revert steps: Rerun `node scripts/validate-pr-body-local.mjs --body-file /tmp/worker-session-mine-pr.md --base master`
- Data migration? No

</details>
