### PR TITLE
[Session Mine Publisher](1) Let the merge gate alone publish Invoker fixes from reflect tasks

### DIFF
--- a/scripts/worker-session-mine.mjs
+++ b/scripts/worker-session-mine.mjs
@@ -213,20 +213,21 @@ tasks:
 
   - id: reflect-and-fix
     description: |
-      Reflect via catstack and open a PR to catstack or Invoker by root cause.
-      Review claim: Accepted findings land as a non-merged PR in the correct repo for session ${hash}.
+      Reflect via catstack and route each Accepted finding by root cause: catstack gets its own PR; Invoker changes are committed here for the merge gate to publish.
+      Review claim: Accepted findings land exactly once, as a catstack PR or an Invoker commit published by this workflow's merge gate, for session ${hash}.
       Review lane: behavior
       Safety invariant: Never vendor skills/reflect/ into Invoker; never merge; original workflow untouched.
       Acceptance criteria:
-      - Summary says no durable finding or lists PR URL(s).
+      - Summary says no durable finding, lists catstack PR URL(s), or names the Invoker commit(s) left for the merge gate.
       - test ! -e skills/reflect
     maxTurns: 30
     prompt: |
-      Goal: Reflect on thrashy Invoker worker session ${sessionId} (agent=${agentName}) and open a non-merged PR to catstack or Invoker.
+      Goal: Reflect on thrashy Invoker worker session ${sessionId} (agent=${agentName}) and land each Accepted finding exactly once, unmerged.
       Safety invariant: Never vendor skills/reflect/; never merge; do not touch the original repair workflow.
       Implementation details: |
         Clone https://github.com/EdbertChan/catstack.git. Follow engine/skills/reflect/SKILL.md against ${jsonlPath}.
-        Skill/hook/methodology -> catstack PR. Invoker harness/prompt/product -> Invoker PR. Never merge.
+        Skill/hook/methodology -> catstack PR. Invoker harness/prompt/product -> commit in this task's worktree only.
+        For Invoker changes, do not push and do not open a PR: this workflow's merge gate owns Invoker publication (onFinish: pull_request). Never merge.
       Pass condition: Exit 0 when acceptance criteria hold.
     dependencies:
       - repro-thrash

--- a/scripts/worker-session-mine.selftest.mjs
+++ b/scripts/worker-session-mine.selftest.mjs
@@ -144,6 +144,8 @@ try {
     const plan = submitted ? readFileSync(submitted, 'utf8') : '';
     check('plan-omits-pool-by-default', plan.length > 0 && !/poolId:/.test(plan), 'expected no poolId line when none is configured');
     check('plan-keeps-required-header', /^name: /m.test(plan) && /onFinish: pull_request/.test(plan), 'expected the plan header to survive');
+    check('plan-agent-never-opens-invoker-pr', !/open (a |an )?(non-merged )?(Invoker )?PR to (catstack or )?Invoker|open an Invoker PR|-> Invoker PR/i.test(plan), `expected the reflect task not to open its own Invoker PR while onFinish: pull_request also publishes, got:\n${plan}`);
+    check('plan-merge-gate-owns-invoker-publication', /For Invoker changes, do not push and do not open a PR: this workflow's merge gate owns Invoker publication/.test(plan), `expected the reflect task to leave Invoker publication to the merge gate, got:\n${plan}`);
   }
 
   {
@@ -162,7 +164,7 @@ try {
     for (const f of failures) console.error(`FAIL ${f}`);
     process.exit(1);
   }
-  console.log(JSON.stringify({ ok: true, checks: 13 }, null, 2));
+  console.log(JSON.stringify({ ok: true, checks: 15 }, null, 2));
 } finally {
   for (const d of roots) rmSync(d, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

The session miner's reflect task opened its own Invoker PR. The workflow's merge gate then opened a second PR for the same commit.

That produced #12128 and #12132, which carried the identical tree.

Now the reflect task only commits Invoker changes, and the merge gate is the single publisher. catstack fixes still get their own PR.

## Review Claim

The follow-up plan no longer tells the reflect agent to publish Invoker changes, so each Invoker finding yields one PR.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the plan template's task text and its self-test change. Plan shape, onFinish, pool selection, and the miner's filing logic are untouched.

## Slice Rationale

The duplicate comes from one template, so the wording change and the self-test checks that pin it ship together.

## Non-goals

- No change to how sessions are scored or filed.
- No change to merge-gate publication.
- No change to already-filed workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/worker-session-mine.selftest.mjs` fails on the two new checks before the template change and passes with 15 checks after
- [x] Rewording the template to `open an Invoker PR` makes both new checks fail; restoring it makes them pass
- [x] `node scripts/worker-session-mine-thrash.mjs --self-test`
- [x] `node scripts/check-added-comments.mjs`
- [x] Rendered the new `buildFollowUpPlan` output and parsed it with a YAML loader

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwY5e9BQSNBNEUdYsD3LRD
