### PR TITLE
[Pool Selection Slot Leak](1) Pin that a terminal holder keeps its pool slot

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import { poolMemberHasCapacity, reclaimOrphanedExecutionSlots } from '../task-runner-pool.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+const POOL = {
+  selectionStrategy: 'leastLoaded' as const,
+  maxConcurrentTasksPerMember: 2,
+  members: [{ id: 'local-only', type: 'worktree' as const, maxConcurrentTasks: 2 }],
+};
+
+const MEMBER = POOL.members[0];
+
+function makeRunner(tasks: TaskState[]) {
+  const byId = new Map(tasks.map((task) => [task.id, task]));
+  const runner = new TaskRunner({
+    orchestrator: {
+      getTask: (id: string) => byId.get(id) ?? null,
+      getAllTasks: () => tasks,
+      deferTask: vi.fn(),
+    } as never,
+    persistence: { logEvent: vi.fn(), releaseExecutionResourceLease: vi.fn() } as never,
+    executorRegistry: {
+      getDefault: () => null,
+      get: () => null,
+      getAll: () => [],
+      register: vi.fn(),
+    } as never,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({}),
+    worktreeTargetsProvider: () => ({ 'local-only': { path: '/tmp/local-only' } }),
+    executionPoolsProvider: () => ({ 'local-only': POOL }),
+  } as never);
+  return runner;
+}
+
+function makeTask(id: string, status: string): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'worktree', poolId: 'local-only' },
+    execution: { generation: 0 },
+  } as unknown as TaskState;
+}
+
+function pendingSelections(runner: TaskRunner): Map<string, unknown> {
+  return (runner as unknown as { pendingPoolSelections: Map<string, unknown> }).pendingPoolSelections;
+}
+
+function reserve(runner: TaskRunner, taskId: string): void {
+  pendingSelections(runner).set(taskId, {
+    poolId: 'local-only',
+    member: MEMBER,
+    memberKey: 'worktree:local-only',
+    selectionStrategy: 'leastLoaded',
+  });
+}
+
+function hasCapacity(runner: TaskRunner): boolean {
+  return poolMemberHasCapacity(runner as never, 'local-only', POOL as never, MEMBER as never);
+}
+
+describe('pending pool selections held by unlaunchable tasks', () => {
+  it('counts a reservation against member capacity exactly like a live execution', () => {
+    const runner = makeRunner([makeTask('wf-1/repair', 'failed'), makeTask('wf-2/repair', 'cancelled')]);
+    reserve(runner, 'wf-1/repair');
+    reserve(runner, 'wf-2/repair');
+
+    expect(hasCapacity(runner)).toBe(false);
+  });
+
+  it('leaves a member wedged when every holder reached a terminal status', () => {
+    const runner = makeRunner([makeTask('wf-1/repair', 'failed'), makeTask('wf-2/repair', 'cancelled')]);
+    reserve(runner, 'wf-1/repair');
+    reserve(runner, 'wf-2/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(hasCapacity(runner)).toBe(false);
+    expect(pendingSelections(runner).size).toBe(2);
+  });
+
+  it('keeps a reservation whose task no longer exists', () => {
+    const runner = makeRunner([makeTask('wf-live/repair', 'queued')]);
+    reserve(runner, 'wf-deleted/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).has('wf-deleted/repair')).toBe(true);
+  });
+
+  it('never frees a reservation held by a task that can still launch', () => {
+    const runner = makeRunner([makeTask('wf-3/repair', 'queued'), makeTask('wf-4/repair', 'running')]);
+    reserve(runner, 'wf-3/repair');
+    reserve(runner, 'wf-4/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).size).toBe(2);
+    expect(hasCapacity(runner)).toBe(false);
+  });
+
+  it('does not wipe reservations when the orchestrator reports no tasks', () => {
+    const runner = makeRunner([]);
+    reserve(runner, 'wf-boot/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).has('wf-boot/repair')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Invoker reserves a pool member for a task just before it launches. The reservation counts against that member's capacity, exactly like a task that is actually running.

The only thing that clears a reservation is the same task launching again.

So when the task instead reaches a terminal status, nothing is left to release it. The member stays occupied by a task that will never run.

These tests write that behavior down as it stands today, before the fix in slice (2) changes it.

They also pin two things any fix must keep. A live holder never loses its reservation. An empty task list never wipes the map.

## Review Claim

The current pool-capacity accounting keeps a member occupied by a reservation whose holder can never launch again, and these tests describe that accurately.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Tests only. No product file changes, so runtime behavior is identical before and after this slice, and the suite stays green on `master`.

## Slice Rationale

The repo orders a stack so the reviewer reads the evidence before the change it justifies. This slice is the evidence; slice (2) changes behavior and flips two assertions.

## Non-goals

Does not change pool accounting, does not free any reservation, and does not touch the spend gate, the dispatcher, or SSH lease accounting.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `npx vitest run src/__tests__/pool-capacity-pending-selection-leak.test.ts` in `packages/execution-engine` → `Tests 5 passed (5)`, exit 0, on `origin/master` with no product change
- [x] `npm run check:types` at repo root → exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ad53a49`
- Post-revert steps: None
- Data migration? No

</details>
