### PR TITLE
[Pool Selection Slot Leak](2) Free a pool slot whose holder can never launch

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
@@ -72,24 +72,24 @@ describe('pending pool selections held by unlaunchable tasks', () => {
     expect(hasCapacity(runner)).toBe(false);
   });
 
-  it('leaves a member wedged when every holder reached a terminal status', () => {
+  it('frees a member wedged when every holder reached a terminal status', () => {
     const runner = makeRunner([makeTask('wf-1/repair', 'failed'), makeTask('wf-2/repair', 'cancelled')]);
     reserve(runner, 'wf-1/repair');
     reserve(runner, 'wf-2/repair');
 
     reclaimOrphanedExecutionSlots(runner as never);
 
-    expect(hasCapacity(runner)).toBe(false);
-    expect(pendingSelections(runner).size).toBe(2);
+    expect(hasCapacity(runner)).toBe(true);
+    expect(pendingSelections(runner).size).toBe(0);
   });
 
-  it('keeps a reservation whose task no longer exists', () => {
+  it('frees a reservation whose task no longer exists', () => {
     const runner = makeRunner([makeTask('wf-live/repair', 'queued')]);
     reserve(runner, 'wf-deleted/repair');
 
     reclaimOrphanedExecutionSlots(runner as never);
 
-    expect(pendingSelections(runner).has('wf-deleted/repair')).toBe(true);
+    expect(pendingSelections(runner).has('wf-deleted/repair')).toBe(false);
   });
 
   it('never frees a reservation held by a task that can still launch', () => {

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -565,6 +565,7 @@ export function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRu
     if (allTasks.length === 0 || knownTaskIds.has(entry.taskId)) continue;
     releaseAndKillOrphanedExecution(host, attemptId, entry, 'orphaned');
   }
+  reclaimStalePoolSelections(host, getTask, allTasks, knownTaskIds);
 }
 
 function clearPendingPoolSelection(host: TaskRunnerPoolHost, taskId: string): void {
@@ -573,6 +574,55 @@ function clearPendingPoolSelection(host: TaskRunnerPoolHost, taskId: string): vo
     releasePoolSelectionLease(host, previous);
     host.pendingPoolSelections.delete(taskId);
   }
+}
+
+const UNLAUNCHABLE_TASK_STATUSES = new Set<string>([
+  'completed',
+  'failed',
+  'cancelled',
+  'skipped',
+  'closed',
+  'stale',
+]);
+
+function reclaimStalePoolSelections(
+  host: TaskRunnerPoolHost,
+  getTask: (taskId: string) => TaskState | null | undefined,
+  allTasks: readonly TaskState[],
+  knownTaskIds: ReadonlySet<string>,
+): void {
+  if (!host.pendingPoolSelections) return;
+  for (const [taskId, selection] of [...host.pendingPoolSelections.entries()]) {
+    const task = getTask(taskId);
+    if (task) {
+      if (!UNLAUNCHABLE_TASK_STATUSES.has(task.status)) continue;
+      releaseStalePoolSelection(host, taskId, selection, task.status);
+      continue;
+    }
+    if (allTasks.length === 0 || knownTaskIds.has(taskId)) continue;
+    releaseStalePoolSelection(host, taskId, selection, 'deleted');
+  }
+}
+
+function releaseStalePoolSelection(
+  host: TaskRunnerPoolHost,
+  taskId: string,
+  selection: PoolSelection,
+  reason: string,
+): void {
+  releasePoolSelectionLease(host, selection);
+  host.pendingPoolSelections.delete(taskId);
+  host.logger?.warn?.(
+    `[TaskRunner] reclaimed stale pool selection task=${taskId} member=${selection.memberKey} reason=${reason}; `
+      + 'the holder can never select an executor again',
+    {
+      taskId,
+      member: selection.memberKey,
+      poolId: selection.poolId,
+      reason,
+      module: 'task-runner',
+    },
+  );
 }
 
 function reservePoolMemberSelection(


### PR DESCRIPTION
## Summary

A pool reservation held by a task that can never launch again now gets released, so work routed to that member can start again.

Before this, such a reservation occupied its member forever, because the only code that clears one is the holder's own next launch.

On DO1 that filled the single-member default pool. Every launch was told the member was full, while the database showed nothing running at all.

Every task routed to that pool stopped for about three hours, including the push step that delivers each repair.

The sweep reuses the pass that already reclaims dead executions. It asks the orchestrator which tasks are real, so a launch in progress is never touched.

## Review Claim

Releasing a reservation whose holder is terminal, or absent from the orchestrator, frees the member. A holder that can still launch keeps its reservation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A reservation is released only when the orchestrator reports its holder in a terminal state, or absent while the orchestrator knows about other tasks. Any other holder, including one mid-launch, is left untouched, so this cannot over-subscribe a member. Please confirm this is the invariant you want.

## Slice Rationale

Slice (1) recorded the behavior; this slice changes it and flips the two assertions that described the leak. Keeping them apart lets a reviewer read the change against stated prior behavior.

## Non-goals

Does not change SSH lease accounting, the dispatcher's retry or fencing, the Codex spend gate, or the per-repo worktree limit. Does not change what a deferral does once it happens.

## Architecture

### Before

```mermaid
graph TD
    A["task reserves pool member"] --> B["task reaches terminal status"]
    B --> C["reservation stays in pendingPoolSelections"]
    C --> D["member reads full forever"]
```

### After

```mermaid
graph TD
    A["task reserves pool member"] --> B["task reaches terminal status"]
    B --> C["reclaimOrphanedExecutionSlots sweeps the reservation"]
    C --> D["member capacity is available again"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `npx vitest run src/__tests__/pool-capacity-pending-selection-leak.test.ts` → fails on slice (1) code with `expected false to be true`, passes here: `Tests 5 passed (5)`
- [x] `npx vitest run src/__tests__/pool-capacity-pending-selection-leak.test.ts src/__tests__/pool-capacity-superseded-execution-leak.test.ts src/__tests__/ssh-lease-capacity-authority.proof.test.ts src/__tests__/repo-pool.test.ts src/__tests__/pool-member-pin-across-types.test.ts src/__tests__/pool-member-mismatch-publish-repro.test.ts` → `Tests 59 passed (59)`, exit 0
- [x] `npm run check:types` at repo root → exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8118812`
- Post-revert steps: None. Reverting restores the leak, so the wedge would return after a fresh owner start.
- Data migration? No

</details>
