### PR TITLE
[Pool Slot Reclaim](1) Free a pool slot when its task can never launch

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-pending-selection-leak.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import { poolMemberHasCapacity, reclaimOrphanedExecutionSlots } from '../task-runner-pool.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+const POOL = {
+  selectionStrategy: 'leastLoaded' as const,
+  maxConcurrentTasksPerMember: 2,
+  members: [{ id: 'local-only', type: 'worktree' as const, maxConcurrentTasks: 2 }],
+};
+
+const MEMBER = POOL.members[0];
+
+function makeRunner(tasks: TaskState[]) {
+  const byId = new Map(tasks.map((task) => [task.id, task]));
+  const runner = new TaskRunner({
+    orchestrator: {
+      getTask: (id: string) => byId.get(id) ?? null,
+      getAllTasks: () => tasks,
+      deferTask: vi.fn(),
+    } as never,
+    persistence: { logEvent: vi.fn(), releaseExecutionResourceLease: vi.fn() } as never,
+    executorRegistry: {
+      getDefault: () => null,
+      get: () => null,
+      getAll: () => [],
+      register: vi.fn(),
+    } as never,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({}),
+    worktreeTargetsProvider: () => ({ 'local-only': { path: '/tmp/local-only' } }),
+    executionPoolsProvider: () => ({ 'local-only': POOL }),
+  } as never);
+  return runner;
+}
+
+function makeTask(id: string, status: string): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'worktree', poolId: 'local-only' },
+    execution: { generation: 0 },
+  } as unknown as TaskState;
+}
+
+function pendingSelections(runner: TaskRunner): Map<string, unknown> {
+  return (runner as unknown as { pendingPoolSelections: Map<string, unknown> }).pendingPoolSelections;
+}
+
+function reserve(runner: TaskRunner, taskId: string): void {
+  pendingSelections(runner).set(taskId, {
+    poolId: 'local-only',
+    member: MEMBER,
+    memberKey: 'worktree:local-only',
+    selectionStrategy: 'leastLoaded',
+  });
+}
+
+function hasCapacity(runner: TaskRunner): boolean {
+  return poolMemberHasCapacity(runner as never, 'local-only', POOL as never, MEMBER as never);
+}
+
+describe('pending pool selections held by unlaunchable tasks', () => {
+  it('counts a reservation against member capacity exactly like a live execution', () => {
+    const runner = makeRunner([makeTask('wf-1/repair', 'failed'), makeTask('wf-2/repair', 'cancelled')]);
+    reserve(runner, 'wf-1/repair');
+    reserve(runner, 'wf-2/repair');
+
+    expect(hasCapacity(runner)).toBe(false);
+  });
+
+  it('frees a member wedged when every holder reached a terminal status', () => {
+    const runner = makeRunner([makeTask('wf-1/repair', 'failed'), makeTask('wf-2/repair', 'cancelled')]);
+    reserve(runner, 'wf-1/repair');
+    reserve(runner, 'wf-2/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(hasCapacity(runner)).toBe(true);
+    expect(pendingSelections(runner).size).toBe(0);
+  });
+
+  it('frees a reservation whose task no longer exists', () => {
+    const runner = makeRunner([makeTask('wf-live/repair', 'queued')]);
+    reserve(runner, 'wf-deleted/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).has('wf-deleted/repair')).toBe(false);
+  });
+
+  it('never frees a reservation held by a task that can still launch', () => {
+    const runner = makeRunner([makeTask('wf-3/repair', 'queued'), makeTask('wf-4/repair', 'running')]);
+    reserve(runner, 'wf-3/repair');
+    reserve(runner, 'wf-4/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).size).toBe(2);
+    expect(hasCapacity(runner)).toBe(false);
+  });
+
+  it('does not wipe reservations when the orchestrator reports no tasks', () => {
+    const runner = makeRunner([]);
+    reserve(runner, 'wf-boot/repair');
+
+    reclaimOrphanedExecutionSlots(runner as never);
+
+    expect(pendingSelections(runner).has('wf-boot/repair')).toBe(true);
+  });
+});

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -565,6 +565,7 @@ export function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRu
     if (allTasks.length === 0 || knownTaskIds.has(entry.taskId)) continue;
     releaseAndKillOrphanedExecution(host, attemptId, entry, 'orphaned');
   }
+  reclaimStalePoolSelections(host, getTask, allTasks, knownTaskIds);
 }
 
 function clearPendingPoolSelection(host: TaskRunnerPoolHost, taskId: string): void {
@@ -573,6 +574,55 @@ function clearPendingPoolSelection(host: TaskRunnerPoolHost, taskId: string): vo
     releasePoolSelectionLease(host, previous);
     host.pendingPoolSelections.delete(taskId);
   }
+}
+
+const UNLAUNCHABLE_TASK_STATUSES = new Set<string>([
+  'completed',
+  'failed',
+  'cancelled',
+  'skipped',
+  'closed',
+  'stale',
+]);
+
+function reclaimStalePoolSelections(
+  host: TaskRunnerPoolHost,
+  getTask: (taskId: string) => TaskState | null | undefined,
+  allTasks: readonly TaskState[],
+  knownTaskIds: ReadonlySet<string>,
+): void {
+  if (!host.pendingPoolSelections) return;
+  for (const [taskId, selection] of [...host.pendingPoolSelections.entries()]) {
+    const task = getTask(taskId);
+    if (task) {
+      if (!UNLAUNCHABLE_TASK_STATUSES.has(task.status)) continue;
+      releaseStalePoolSelection(host, taskId, selection, task.status);
+      continue;
+    }
+    if (allTasks.length === 0 || knownTaskIds.has(taskId)) continue;
+    releaseStalePoolSelection(host, taskId, selection, 'deleted');
+  }
+}
+
+function releaseStalePoolSelection(
+  host: TaskRunnerPoolHost,
+  taskId: string,
+  selection: PoolSelection,
+  reason: string,
+): void {
+  releasePoolSelectionLease(host, selection);
+  host.pendingPoolSelections.delete(taskId);
+  host.logger?.warn?.(
+    `[TaskRunner] reclaimed stale pool selection task=${taskId} member=${selection.memberKey} reason=${reason}; `
+      + 'the holder can never select an executor again',
+    {
+      taskId,
+      member: selection.memberKey,
+      poolId: selection.poolId,
+      reason,
+      module: 'task-runner',
+    },
+  );
 }
 
 function reservePoolMemberSelection(


### PR DESCRIPTION
## Summary

A pool member could report itself full while nothing was running on it.

Picking an executor reserves a slot on a member. A reservation clears only when that same task picks again.

A task that dies before launching never picks again, so its reservation stays counted forever.

On DO1 the single-member `local-only` pool read 2 of 2 in use with zero running tasks and zero leases. Every dispatch deferred for over four hours.

This adds a reclaim step that clears reservations for tasks that ended or no longer exist.

## Review Claim

Approve clearing a member reservation when its task can never launch.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A reservation clears only when its task ended or is absent from the orchestrator. A queued or running task keeps its reservation, and an empty orchestrator view clears nothing.

## Slice Rationale

The reclaim step and its regression test are one claim: an ended task must not count against capacity. Landing them apart would mean shipping a test that asserts the leak is correct.

## Non-goals

No change to selection strategy, member limits, lease persistence, or how reservations are created.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/pool-capacity-pending-selection-leak.test.ts`
- [ ] `pnpm run check:types`
- [ ] `pnpm run check:comments`

Before this change, with the source reverted to master: `Tests  2 failed | 3 passed (5)`.

After: `Tests  5 passed (5)`, `check:types` exit 0, `check:comments` clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 24b5719c19`
- Post-revert steps: None. Reverting restores the previous accounting, so a stuck member needs a restart again.
- Data migration? No

</details>
