### PR TITLE
plan doctor: resolve yaml after a packaged install

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -611,6 +611,74 @@ describe('bundled-skills', () => {
     }
   });
 
+  it('records yamlModuleRoot for a packaged install, pointing at a directory that holds node_modules/yaml', () => {
+    const packageRoot = makeTempRoot('invoker-bundled-package-');
+    const resourcesRoot = join(packageRoot, 'vendor', 'Invoker.app', 'Contents', 'Resources');
+    mkdirSync(resourcesRoot, { recursive: true });
+    mkdirSync(join(packageRoot, 'node_modules', 'yaml', 'dist'), { recursive: true });
+    writeFileSync(join(packageRoot, 'node_modules', 'yaml', 'dist', 'index.js'), 'export const parse = () => {};');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBeUndefined();
+      expect(manifest.yamlModuleRoot).toBe(packageRoot);
+      expect(existsSync(join(manifest.yamlModuleRoot, 'node_modules', 'yaml', 'dist', 'index.js'))).toBe(true);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('omits yamlModuleRoot when no reachable node_modules/yaml exists', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.yamlModuleRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
   it('omits sourceRepoRoot for packaged Electron installs, whose resources dir is not a real Invoker checkout', () => {
     const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
     const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -45,6 +45,14 @@ interface BundledSkillsManifest {
    * and can't resolve their own Invoker checkout via git.
    */
   sourceRepoRoot?: string;
+  /**
+   * Directory holding a resolvable `node_modules/yaml`, recorded for packaged
+   * installs whose `sourceRepoRoot` is unset. Read by installed doctor scripts
+   * (skills/plan-to-invoker/scripts/) as the last-resort fallback when they run
+   * from a machine-level skill copy with no checkout and no sibling
+   * node_modules of their own.
+   */
+  yamlModuleRoot?: string;
 }
 
 interface BundledSkillsContext {
@@ -298,6 +306,27 @@ function resolveManagedMcpTargets(isInstalled: IsInstalled = commandExists): Mcp
     },
   ];
   return candidates.map((candidate) => ({ ...candidate, available: isInstalled(candidate.probeCommand) }));
+}
+
+function resolveYamlModuleRoot(context: BundledSkillsContext): string | undefined {
+  const roots: string[] = [];
+  if (context.isPackaged) {
+    const resourceRoot = context.resourcesPath ?? electronResourcesPath();
+    if (resourceRoot) {
+      let dir = resourceRoot;
+      for (let depth = 0; depth < 6; depth += 1) {
+        dir = path.dirname(dir);
+        roots.push(dir);
+      }
+    }
+  } else {
+    roots.push(path.join(context.repoRoot, 'packages', 'app'));
+    roots.push(context.repoRoot);
+  }
+  for (const root of roots) {
+    if (existsSync(path.join(root, 'node_modules', 'yaml', 'dist', 'index.js'))) return root;
+  }
+  return undefined;
 }
 
 function resolveManifestPath(invokerHomeRoot: string): string {
@@ -1049,6 +1078,7 @@ export function installBundledSkills(
     instructionTargets: manifestInstructionTargets,
     instructionHash,
     sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
+    yamlModuleRoot: resolveYamlModuleRoot(context),
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -45,13 +45,6 @@ interface BundledSkillsManifest {
    * and can't resolve their own Invoker checkout via git.
    */
   sourceRepoRoot?: string;
-  /**
-   * Directory holding a resolvable `node_modules/yaml`, recorded for packaged
-   * installs whose `sourceRepoRoot` is unset. Read by installed doctor scripts
-   * (skills/plan-to-invoker/scripts/) as the last-resort fallback when they run
-   * from a machine-level skill copy with no checkout and no sibling
-   * node_modules of their own.
-   */
   yamlModuleRoot?: string;
 }
 

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -281,6 +281,8 @@ STANDALONE_INSTALL_DIR="$(mktemp -d)"
 STANDALONE_INVOKER_HOME="$(mktemp -d)"
 trap 'rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"' EXIT
 cp "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.sh "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.mjs "$STANDALONE_INSTALL_DIR/"
+mkdir -p "$STANDALONE_INSTALL_DIR/vendor"
+cp "$REPO_ROOT"/skills/plan-to-invoker/scripts/vendor/*.mjs "$STANDALONE_INSTALL_DIR/vendor/"
 STANDALONE_DOCTOR="$STANDALONE_INSTALL_DIR/skill-doctor.sh"
 STANDALONE_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
 
@@ -404,6 +406,32 @@ rm -rf "$TOTALLY_BARE_DIR"
 trap - EXIT
 
 echo "OK: a totally bare skills/plan-to-invoker/ copy fails informatively, not with a raw crash"
+
+PACKAGED_INSTALL_DIR="$(mktemp -d)"
+PACKAGED_INVOKER_HOME="$(mktemp -d)"
+trap 'rm -rf "$PACKAGED_INSTALL_DIR" "$PACKAGED_INVOKER_HOME"' EXIT
+cp -R "$SKILL_DIR" "$PACKAGED_INSTALL_DIR/plan-to-invoker"
+cat > "$PACKAGED_INVOKER_HOME/bundled-skills.json" <<'MANIFEST'
+{"bundledHash": "x", "bundledSkillNames": ["plan-to-invoker"], "installedAt": "now", "targets": {}}
+MANIFEST
+mkdir -p "$PACKAGED_INSTALL_DIR/yamlhome/node_modules"
+cp -RL "$REPO_ROOT/packages/app/node_modules/yaml" "$PACKAGED_INSTALL_DIR/yamlhome/node_modules/yaml"
+cat > "$PACKAGED_INVOKER_HOME/bundled-skills.json" <<MANIFEST
+{"bundledHash": "x", "bundledSkillNames": ["plan-to-invoker"], "installedAt": "now", "targets": {}, "yamlModuleRoot": "$PACKAGED_INSTALL_DIR/yamlhome"}
+MANIFEST
+for PACKAGED_SCRIPT in unit-triggers validate-plan lint-review-units check-planning-completeness freshness-check; do
+  PACKAGED_OUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$PACKAGED_INVOKER_HOME" \
+    node "$PACKAGED_INSTALL_DIR/plan-to-invoker/scripts/$PACKAGED_SCRIPT.mjs" /dev/null 2>&1 || true)"
+  case "$PACKAGED_OUT" in
+    *"Unable to resolve yaml runtime"*)
+      fail "Packaged install recording yamlModuleRoot must resolve yaml for $PACKAGED_SCRIPT; got: $PACKAGED_OUT" ;;
+  esac
+done
+
+rm -rf "$PACKAGED_INSTALL_DIR" "$PACKAGED_INVOKER_HOME"
+trap - EXIT
+
+echo "OK: a packaged install resolves yaml through bundled-skills.json yamlModuleRoot"
 
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"

--- a/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
+++ b/skills/plan-to-invoker/scripts/check-planning-completeness.mjs
@@ -11,34 +11,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { homedir } from 'node:os';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-async function importYaml(scriptDir) {
-  try {
-    return await import('yaml');
-  } catch {}
-  const candidates = [
-    process.env.INVOKER_REPO_ROOT,
-    resolve(scriptDir, '../../..'),
-  ].filter(Boolean);
-  try {
-    const manifest = join(homedir(), '.invoker', 'bundled-skills.json');
-    if (existsSync(manifest)) {
-      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
-      if (parsed.sourceRepoRoot) candidates.push(parsed.sourceRepoRoot);
-    }
-  } catch {
-    // ignore
-  }
-  for (const root of candidates) {
-    const repoYamlPath = resolve(root, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(repoYamlPath)) return import(repoYamlPath);
-  }
-  throw new Error('Unable to resolve yaml runtime for check-planning-completeness.');
-}
 
 const { parse: parseYaml } = await importYaml(__dirname);
 

--- a/skills/plan-to-invoker/scripts/freshness-check.mjs
+++ b/skills/plan-to-invoker/scripts/freshness-check.mjs
@@ -4,6 +4,7 @@ import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,19 +30,6 @@ function resolveInvokerRepoRoot(scriptDir) {
     return null;
   }
   return null;
-}
-
-async function importYaml(scriptDir) {
-  try {
-    return await import('yaml');
-  } catch {
-    const repoRoot = resolveInvokerRepoRoot(scriptDir);
-    for (const candidate of ['packages/app/node_modules/yaml/dist/index.js', 'node_modules/yaml/dist/index.js']) {
-      const yamlPath = repoRoot ? resolve(repoRoot, candidate) : null;
-      if (yamlPath && existsSync(yamlPath)) return import(yamlPath);
-    }
-    throw new Error('Unable to resolve yaml runtime. Set INVOKER_REPO_ROOT to an Invoker checkout with installed dependencies.');
-  }
 }
 
 function uniqueSorted(values) {

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -70,28 +71,6 @@ function resolveInvokerRepoRoot(scriptDir) {
  * copied via `installBundledSkills()`, which has no such node_modules
  * anywhere nearby.
  */
-async function importYaml(scriptDir) {
-  try {
-    return await import('yaml');
-  } catch {
-    // Fall through to the checkout-based lookup below.
-  }
-
-  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
-  if (invokerRepoRoot) {
-    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(repoYamlPath)) return import(repoYamlPath);
-  }
-
-  throw new Error(
-    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
-    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
-    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
-    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
-    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
-  );
-}
-
 /**
  * Primary path: a copy vendored directly under this script's own directory
  * (./vendor/review-unit-rules.mjs), re-synced by

--- a/skills/plan-to-invoker/scripts/render-formula.mjs
+++ b/skills/plan-to-invoker/scripts/render-formula.mjs
@@ -11,17 +11,13 @@
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve, join, basename, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, '../../..');
 
-function resolveYamlModulePath(scriptDir) {
-  const localYamlPath = resolve(scriptDir, '../../..', 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
-  return 'yaml';
-}
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const { parse: parseYaml } = await importYaml(__dirname);
 
 function die(msg) {
   console.error(`render-formula: ${msg}`);

--- a/skills/plan-to-invoker/scripts/unit-triggers.mjs
+++ b/skills/plan-to-invoker/scripts/unit-triggers.mjs
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -28,19 +29,6 @@ function resolveInvokerRepoRoot(scriptDir) {
     return null;
   }
   return null;
-}
-
-async function importYaml(scriptDir) {
-  try {
-    return await import('yaml');
-  } catch {
-    const repoRoot = resolveInvokerRepoRoot(scriptDir);
-    for (const candidate of ['packages/app/node_modules/yaml/dist/index.js', 'node_modules/yaml/dist/index.js']) {
-      const yamlPath = repoRoot ? resolve(repoRoot, candidate) : null;
-      if (yamlPath && existsSync(yamlPath)) return import(yamlPath);
-    }
-    throw new Error('Unable to resolve yaml runtime. Set INVOKER_REPO_ROOT to an Invoker checkout with installed dependencies.');
-  }
 }
 
 function resolveReviewUnitRulesModulePath(scriptDir) {

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
+import { importYaml } from './vendor/resolve-yaml.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -152,28 +153,6 @@ function resolveInvokerRepoRoot(scriptDir) {
  * copied via `installBundledSkills()`, which has no such node_modules
  * anywhere nearby.
  */
-async function importYaml(scriptDir) {
-  try {
-    return await import('yaml');
-  } catch {
-    // Fall through to the checkout-based lookup below.
-  }
-
-  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
-  if (invokerRepoRoot) {
-    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(repoYamlPath)) return import(repoYamlPath);
-  }
-
-  throw new Error(
-    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
-    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
-    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
-    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
-    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
-  );
-}
-
 const { parse: parseYaml } = await importYaml(__dirname);
 
 const VALID_ON_FINISH = ['none', 'merge', 'pull_request'];

--- a/skills/plan-to-invoker/scripts/vendor/resolve-yaml.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/resolve-yaml.mjs
@@ -33,7 +33,6 @@ export function resolveInvokerRepoRoot(scriptDir) {
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
     if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // no git checkout around this script
   }
 
   const manifest = readManifest();
@@ -48,7 +47,6 @@ export async function importYaml(scriptDir) {
   try {
     return await import('yaml');
   } catch {
-    // not running inside an install that declares yaml; fall through
   }
 
   const repoRoot = resolveInvokerRepoRoot(scriptDir);

--- a/skills/plan-to-invoker/scripts/vendor/resolve-yaml.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/resolve-yaml.mjs
@@ -1,0 +1,76 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+const YAML_DIST = 'node_modules/yaml/dist/index.js';
+const REPO_YAML_DIST = `packages/app/${YAML_DIST}`;
+
+function readManifest() {
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    return JSON.parse(readFileSync(resolve(invokerHome, 'bundled-skills.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
+  const localRepoRoot = resolve(scriptDir, '../../..');
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
+
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: scriptDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
+  } catch {
+    // no git checkout around this script
+  }
+
+  const manifest = readManifest();
+  if (manifest && typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+    return resolve(manifest.sourceRepoRoot);
+  }
+
+  return null;
+}
+
+export async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // not running inside an install that declares yaml; fall through
+  }
+
+  const repoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (repoRoot) {
+    for (const candidate of [REPO_YAML_DIST, YAML_DIST]) {
+      const yamlPath = resolve(repoRoot, candidate);
+      if (existsSync(yamlPath)) return import(yamlPath);
+    }
+  }
+
+  const manifest = readManifest();
+  if (manifest && typeof manifest.yamlModuleRoot === 'string') {
+    const yamlPath = resolve(manifest.yamlModuleRoot, YAML_DIST);
+    if (existsSync(yamlPath)) return import(yamlPath);
+  }
+
+  throw new Error(
+    'Unable to resolve yaml runtime. Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall so '
+    + 'bundled-skills.json records a yamlModuleRoot. Checked, in order: a plain \'yaml\' import '
+    + '(present inside the invoker-cli npm install, which declares it); '
+    + 'packages/app/node_modules/yaml in a resolvable Invoker checkout via INVOKER_REPO_ROOT, a live '
+    + 'git checkout, or bundled-skills.json sourceRepoRoot; and bundled-skills.json yamlModuleRoot '
+    + 'recorded by a packaged install.',
+  );
+}


### PR DESCRIPTION
## Summary

A packaged install copies the plan-doctor scripts to a machine-level directory. There they have no checkout and no sibling `node_modules`, so none of them can load `yaml`.

The manifest deliberately leaves `sourceRepoRoot` unset for packaged builds, which leaves those scripts with nothing to fall back on. Every one of them dies before doing any work.

The installer now also records where a usable `yaml` lives, and one shared resolver reads it. Resolution is unchanged anywhere it already works today.

## Review Claim

Approve recording `yamlModuleRoot` in the bundled-skills manifest and routing all six plan-doctor scripts through one shared resolver that consults it last.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Resolution order is unchanged wherever it works today: a bare `yaml` import, `INVOKER_REPO_ROOT`, a live checkout, then manifest `sourceRepoRoot`. The new `yamlModuleRoot` is consulted only after all of those fail, and `sourceRepoRoot` keeps its current meaning, so `bundled-skills.test.ts`'s packaged-install expectation still holds.

## Slice Rationale

Three commits, proof first: the regression reproduces the gap, the installer records the location, then the scripts share one resolver and the regression flips to assert the fix.

## Non-goals

- No vendoring of `yaml`; `scripts/vendor-plan-doctor-deps.sh` explains why it stays a real declared dependency.
- No change to the npm-install layout or to `sourceRepoRoot`'s meaning.
- No change to resolution when a checkout, `INVOKER_REPO_ROOT`, or a sibling `node_modules` is present.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` — exit 0, 0 failures, including the new packaged-install case.
- [x] `packages/cli/node_modules/.bin/vitest run src/__tests__/bundled-skills.test.ts` — 21 passed, including two new tests for `yamlModuleRoot`.
- [x] Repro before the fix: `unit-triggers`, `validate-plan`, `lint-review-units`, `check-planning-completeness` exit 1 and `freshness-check` exits 2 with "Unable to resolve yaml runtime"; `render-formula` exits 1 with `ERR_MODULE_NOT_FOUND`.
- [x] Repro after the fix, same shape plus `yamlModuleRoot`: all six resolve `yaml`, and `validate-plan` returns `{"valid":true}` on a fixture with no checkout and no `INVOKER_REPO_ROOT`.
- [x] Pre-existing baseline on untouched `master`: `pnpm --filter @invoker/cli test` fails 5 tests in `src/__tests__/cli.test.ts` (60s live-owner timeouts on this machine). Unchanged by this branch.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>` for each of the three commits, newest first.
- Post-revert steps: None. The manifest field is additive and readers tolerate its absence.
- Data migration? No.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive manifest field and last-resort yaml path resolution; existing checkout and npm install resolution paths are unchanged.
> 
> **Overview**
> **Packaged skill installs** can now load the `yaml` package for plan-doctor scripts: `installBundledSkills` writes optional **`yamlModuleRoot`** on `bundled-skills.json` (discovered by walking up from Electron resources or checking dev `packages/app` / repo roots for `node_modules/yaml/dist/index.js`). Packaged builds still omit `sourceRepoRoot`.
> 
> **Plan-to-invoker doctor scripts** no longer duplicate yaml lookup logic. Six `.mjs` validators import **`./vendor/resolve-yaml.mjs`**, which keeps the same resolution order (bare `yaml` import → Invoker checkout via env/git/manifest `sourceRepoRoot`) and adds a final fallback to manifest **`yamlModuleRoot`**.
> 
> **Tests** cover manifest population/omission in `bundled-skills.test.ts`, vendor copy in standalone install setup, and a packaged-install regression in `test-plan-to-invoker-skill.sh` that asserts scripts do not hit "Unable to resolve yaml runtime".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98112bbe1abc2fb1b4ef551f40af21013b77fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->