### PR TITLE
[Auto-fix Breaker False Positive](1) Stop a third-party CI check's own throttling from pausing fleet auto-fix

### DIFF
--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -127,4 +127,25 @@ describe('FailureClassifier predicates', () => {
     expect(FailureClassifier.isUsageLimit('AssertionError: expected 1 to be 2')).toBe(false);
     expect(FailureClassifier.isUsageLimit(undefined)).toBe(false);
   });
+
+  it('isUsageLimit ignores a third-party CI check row that reports its own rate limiting', () => {
+    // Live incident 2026-09-12: attempt wf-1788249568173-6/land-verified-pr-acbb90da0
+    // failed on CI, and its execution.error is the merge gate's check table. One row
+    // is CodeRabbit reporting its own review throttling on a PASSING check. That row
+    // tripped the fleet-wide auto-fix breaker for 6h even though no agent quota was hit.
+    const mergeGateCheckTable = [
+      'quality / TypeScript Types\tpass\t42s\thttps://github.com/o/r/actions/runs/33484479428/job/99781265672\t',
+      'CodeRabbit\tpass\t0\t\tReview rate limited',
+      'UI Vitest\tpass\t2m44s\thttps://github.com/o/r/actions/runs/33484479428/job/99781265910\t',
+      '[worktree] Process exited: actionId=wf-1788249568173-6/land-verified-pr exitCode=1',
+    ].join('\n');
+    expect(FailureClassifier.isUsageLimit(mergeGateCheckTable)).toBe(false);
+  });
+
+  it('isUsageLimit still matches a provider HTTP rate-limit refusal', () => {
+    expect(FailureClassifier.isUsageLimit(
+      'API error: 429 {"type":"error","error":{"type":"rate_limit_error",'
+      + '"message":"Number of request tokens has exceeded your per-minute rate limit"}}',
+    )).toBe(true);
+  });
 });

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -24,6 +24,18 @@ export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
   'ssh-disk-full',
 ];
 
+const CI_CHECK_TABLE_ROW = /^[^\t]*\t(?:pass|fail|skipping|pending|cancelled|neutral|timed_out)\t/i;
+
+const AGENT_QUOTA_REFUSAL = new RegExp([
+  'usage limit',
+  'rate[ _-]limit(?:_error|_exceeded)',
+  'rate limit exceeded',
+  'exceeded your (?:[\\w-]+ )?rate limit',
+  'too many requests',
+  'quota exceeded',
+  'exceeded your quota',
+].join('|'), 'i');
+
 export class FailureClassifier {
   /**
    * Map a failed task's `execution.error` to a persisted infra failure class,
@@ -121,6 +133,9 @@ export class FailureClassifier {
    */
   static isUsageLimit(errorText: unknown): boolean {
     if (typeof errorText !== 'string') return false;
-    return /usage limit|rate limit/i.test(errorText);
+    return errorText
+      .split('\n')
+      .filter((line) => !CI_CHECK_TABLE_ROW.test(line))
+      .some((line) => AGENT_QUOTA_REFUSAL.test(line));
   }
 }


### PR DESCRIPTION
## Summary

Invoker's auto-fix worker stopped repairing anything for six hours tonight, and no agent had actually run out of quota.

A merge gate task failed. Its error text is the table of CI checks from the pull request.

One row in that table was CodeRabbit reporting its own review throttling, on a check that passed.

The code deciding "the agent provider is out of quota" matched "rate limit" anywhere in that text. The CodeRabbit row matched.

So the breaker paused every repair fleet-wide.

This change reads the error one line at a time, ignores CI check table rows, and matches provider quota wording instead of a bare "rate limit".

## Review Claim

A third-party CI check reporting its own throttling must not be classified as this fleet's agent provider refusing for quota.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

A genuine agent quota refusal still classifies. Both production error shapes already covered by tests keep passing, and a provider HTTP 429 body joins the covered set. The narrowing only drops matches that came from third-party payload text embedded in the error.

## Slice Rationale

One predicate and its own test file. There is no smaller slice, and the pre-existing failures in the execution-engine auto-fix suites are a separate claim that this branch deliberately leaves alone.

## Non-goals

- Does not change the breaker's six-hour pause duration or where its state file lives.
- Does not change `isTransientGitHubCliError` in `packages/execution-engine/src/git-utils.ts`, which still matches a bare `rate limit`. Its input is one thrown `gh` CLI error message, and its effect is a bounded local retry rather than a fleet-wide pause.
- Does not add a typed quota signal from the executor, which would remove the need to classify free-form process output at all.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/workflow-graph test`
- [ ] `npx tsc --noEmit -p packages/workflow-graph/tsconfig.json`
- [ ] `node scripts/check-added-comments.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d8ab83aa6e`
- Post-revert steps: None. Reverting restores the broad match, which will pause auto-fix again the next time a CI check table contains the words "rate limit".
- Data migration? No

</details>
