### PR TITLE
Skipped status (4) document the skipped status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Document the terminal `skipped` task status: a task is `skipped` when an
+  upstream task failed before it ever started, and retrying that upstream
+  task resurrects the skipped dependents back to `pending`.
+
 ## 0.1.0
 
 - 0.0.14 through 0.0.19 were version-bumped but never merged into `master`'s

--- a/docs/invoker-medium-article.md
+++ b/docs/invoker-medium-article.md
@@ -213,7 +213,7 @@ These are the words that keep showing up once you read the code. The definitions
 - **Plan**: A YAML document describing a workflow: a name, workflow defaults like `featureBranch`, a `baseBranch` that defaults to `master` but can also be an explicit remote-qualified ref like `origin/master` or `upstream/main`, and a list of tasks with ids, descriptions, and dependency edges. Plans are parsed into a `PlanDefinition` with validation on required fields.
 - **Workflow**: The persisted instance created from a plan. It has durable identity, stored tasks, and workflow-level fields (including a generation counter used to salt branch naming and invalidate stale work).
 - **Task (node)**: One unit of work in the DAG: a human-readable description, dependency ids, a `TaskConfig` (what to run and how), and `TaskExecution` (runtime fields like branch/commit/workspace metadata).
-- **Task status**: The workflow-visible lifecycle label (`pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, and others).
+- **Task status**: The workflow-visible lifecycle label (`pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, `skipped`, and others); `skipped` means an upstream task failed before this task ran, and retrying that upstream task can resurrect it.
 - **Attempt**: An immutable execution record for a task node: input snapshot metadata (including upstream attempt lineage), execution progress, and outputs like branch/commit when work finishes.
 - **Selected attempt**: The attempt a task is currently treating as authoritative for downstream composition and staleness checks.
 - **Executor**: The runtime that actually runs a task (`worktree`, `docker`, `ssh`, or the internal `merge` gate executor). The orchestration engine stays executor-agnostic in its core task model.
@@ -305,7 +305,7 @@ This appendix is the more explicit version of the comparisons above. It is here 
 |---|---|---|
 | DAG as the organizing model | Airflow models pipelines as DAGs. | Invoker models workflows as DAGs whose edges affect readiness, scheduling, and invalidation. |
 | Scheduler | Airflow runs tasks in dependency order under resource constraints. | Invoker uses a queue and concurrency cap to drain ready work. |
-| Visible lifecycle states | Airflow exposes task states for operators. | Invoker exposes states like `pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, and `stale`. |
+| Visible lifecycle states | Airflow exposes task states for operators. | Invoker exposes states like `pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, and `skipped`. |
 | Graph and timeline views | Airflow gives operators graph-oriented UI views. | Invoker uses graph and timeline views so operators can understand workflow progress visually. |
 | Retry and rerun mental model | Airflow gives operators a structured model for rerunning work. | Invoker uses retries, recreation, and downstream invalidation to rerun work explicitly. |
 

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -100,7 +100,7 @@ onFinish: none
 mergeMode: automatic
 ```
 
-`automatic` plus `none` lets this local-only tutorial finish as completed. `manual` plus `none` intentionally stops at `review_ready` for human inspection and has no merge action.
+`automatic` plus `none` lets this local-only tutorial finish as completed. `manual` plus `none` intentionally stops at `review_ready` for human inspection and has no merge action. A task may instead reach terminal `skipped` when an upstream task fails; retrying the upstream task can resurrect it.
 
 ## Create and review the workflow
 


### PR DESCRIPTION
## Summary

Document the new `skipped` task status in the changelog and status reference pages.

Explain that an upstream failure skips dependents, and retrying the upstream resurrects them.

## Review Claim

The changelog and every status reference page describe `skipped` and its retry-resurrection behavior.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Markdown only; no product code, runtime behavior, or user data changes.

## Slice Rationale

Documentation is a separate review claim from the product-code status implementation and its proof.

## Non-goals

No product code, tests, skills, planning policy, or `CLAUDE.md` edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `grep -q "skipped" CHANGELOG.md && grep -rl "review_ready" docs/*.md | xargs grep -L "skipped" | wc -l | grep -qx 0`
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/skipped-status-4-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert f5701a56`.
- Post-revert steps: None.
- Data migration? No.

</details>
