### PR TITLE
[CI regression: b1615a3-e2e-proof-shard-2](1) Serialize persisted workflow rebuild mutations

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -253,7 +253,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     });
   });
 
-  it.fails('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
+  it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -462,7 +462,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
+  it('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -501,7 +501,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
+  it('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -588,7 +588,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('treats headless rebase-recreate as a recreate fence', async () => {
+  it('treats headless rebase-recreate as a recreate fence', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -633,7 +633,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when retry-workflow fence starts', async () => {
+  it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1097,7 +1097,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
+  it('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1186,7 +1186,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
+  it('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1284,7 +1284,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
+  it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1373,7 +1373,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
+  it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1473,7 +1473,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it.fails('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
+  it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -141,6 +141,7 @@ export class PersistedWorkflowMutationCoordinator {
     this.enqueueStartedAtMs.set(intentId, Date.now());
     this.createTiming(workflowId, channel, intentId, args)
       .mark('PersistedWorkflowMutationCoordinator.enqueue', 'queued', { priority });
+    this.evictQueuedWorkflowIntentsForNewFence(workflowId, intentId);
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
       `enqueue intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
@@ -179,6 +180,7 @@ export class PersistedWorkflowMutationCoordinator {
         priority,
         deferDrain: Boolean(options?.deferDrain),
       });
+    this.evictQueuedWorkflowIntentsForNewFence(workflowId, intentId);
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
       `submit intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} defer=${Boolean(options?.deferDrain)} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
@@ -450,6 +452,14 @@ export class PersistedWorkflowMutationCoordinator {
         `[workflow-mutation-coordinator] evicted ${evictedIds.length} queued intent(s) before fence ${intent.channel}#${intent.id} for ${workflowId}\n`,
       );
     }
+  }
+
+  private evictQueuedWorkflowIntentsForNewFence(workflowId: string, intentId: number): void {
+    const intent = this.persistence.loadWorkflowMutationIntent(intentId);
+    if (!intent || intent.status !== 'queued') {
+      return;
+    }
+    this.evictQueuedWorkflowIntentsForFence(workflowId, intent);
   }
 
   private createRunningIntentInvalidation(intentId: number): InvalidationSignal {


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=b1615a38465727c873db3c176168bb32a414bea0; job=e2e-proof / shard 2 -->

CI job `e2e-proof / shard 2` first failed on default-branch push commit b1615a38465727c873db3c176168bb32a414bea0 in run 34640354643.

It was most recently still red at bd9ddb3c9458feb0fb228d1f88b4056e4bc6bb5a in run 34651771183.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34640354643/job/103398685143

This makes queued workflow mutation fences evict earlier queued intents as soon as the fence is recorded.

The affected coordinator tests now assert the corrected fence ordering directly.

## Review Claim

Queued same-workflow mutation fences now preempt older queued intents before earlier work can run after the fence.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected mutation-fence ordering defect.

## Slice Rationale

One behavior slice contains the failing CI job's root cause and the directly affected coordinator expectations.

The workflow's proof and handoff-scrub tasks did not add reviewable repository changes, so they are represented in the test plan instead of separate empty PRs.

## Non-goals

No refactor, unrelated cleanup, test weakening, or snapshot churn.

No UI behavior, data migration, or public API surface changes.

## Architecture

### Before

```mermaid
graph TD
    A["Older queued intent remains queued"] --> B["Later fence intent runs"]
    B --> C["Older queued intent can run with earlier workflow state"]
```

### After

```mermaid
graph TD
    A["Later fence intent is recorded"] --> B["Coordinator reloads the queued fence intent"]
    B --> C["Older queued same-workflow intents are evicted"]
    C --> D["Only post-fence work remains queued"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='2' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh` (recorded passing by `wf-1789166604923-21/verify-ci-b1615a3-e2e-proof-shard-2`)
- [x] Repository handoff-artifact scrub check (recorded passing by `wf-1789166604923-21/scrub-handoff-artifacts`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-regression-b1615a3-pr-body.md --changed-files-file /tmp/ci-regression-b1615a3-changed-files.txt --diff-file /tmp/ci-regression-b1615a3.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bcf57316`
- Post-revert steps: rerun `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='2' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh`
- Data migration? No

</details>
