### PR TITLE
[Typed agent usage limit (2) domain layer](1) Add typed agent quota failure class

### DIFF
--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -91,6 +91,36 @@ describe('FailureClassifier.classifyError', () => {
   });
 });
 
+describe('FailureClassifier.classifyAgentQuotaRefusal', () => {
+  it('classifies both real agent-quota failure shapes seen in production', () => {
+    expect(FailureClassifier.classifyAgentQuotaRefusal(
+      '[Fix with Agent failed] SSH remote script failed (exit=1, phase=remote_agent_fix)\n'
+      + "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to "
+      + 'purchase more credits or try again at Aug 20th, 2026 4:36 AM.',
+    )).toBe('agent-usage-limit');
+    expect(FailureClassifier.classifyAgentQuotaRefusal(
+      'codex fix exited with code 1: [assistant] Model refused: usage limit reached',
+    )).toBe('agent-usage-limit');
+  });
+
+  it('ignores a third-party CI check row that reports its own rate limiting', () => {
+    const mergeGateCheckTable = [
+      'quality / TypeScript Types\tpass\t42s\thttps://github.com/o/r/actions/runs/33484479428/job/99781265672\t',
+      'CodeRabbit\tpass\t0\t\tReview rate limited',
+      'UI Vitest\tpass\t2m44s\thttps://github.com/o/r/actions/runs/33484479428/job/99781265910\t',
+      '[worktree] Process exited: actionId=wf-1788249568173-6/land-verified-pr exitCode=1',
+    ].join('\n');
+    expect(FailureClassifier.classifyAgentQuotaRefusal(mergeGateCheckTable)).toBeUndefined();
+  });
+
+  it('classifies a provider HTTP rate-limit refusal', () => {
+    expect(FailureClassifier.classifyAgentQuotaRefusal(
+      'API error: 429 {"type":"error","error":{"type":"rate_limit_error",'
+      + '"message":"Number of request tokens has exceeded your per-minute rate limit"}}',
+    )).toBe('agent-usage-limit');
+  });
+});
+
 describe('FailureClassifier predicates', () => {
   it('isLiveness only matches liveness_stall', () => {
     expect(FailureClassifier.isLiveness('liveness_stall')).toBe(true);

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -1,4 +1,4 @@
-import type { FailureClass, SshInfraFailureClass } from './types.js';
+import type { AgentFailureClass, FailureClass, SshInfraFailureClass } from './types.js';
 
 /**
  * Single source of truth for categorizing task failures from their error text.
@@ -37,6 +37,16 @@ const AGENT_QUOTA_REFUSAL = new RegExp([
 ].join('|'), 'i');
 
 export class FailureClassifier {
+  static classifyAgentQuotaRefusal(agentOutput: string | undefined): AgentFailureClass | undefined {
+    if (typeof agentOutput !== 'string') return undefined;
+    return agentOutput
+      .split('\n')
+      .filter((line) => !CI_CHECK_TABLE_ROW.test(line))
+      .some((line) => AGENT_QUOTA_REFUSAL.test(line))
+      ? 'agent-usage-limit'
+      : undefined;
+  }
+
   /**
    * Map a failed task's `execution.error` to a persisted infra failure class,
    * or `undefined` when the text does not match a known machine-owned bucket.

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -278,7 +278,9 @@ export type SshInfraFailureClass =
 
 export type TransientFailureClass = 'ssh-transport-transient';
 
-export type FailureClass = 'liveness_stall' | SshInfraFailureClass | TransientFailureClass;
+export type AgentFailureClass = 'agent-usage-limit';
+
+export type FailureClass = 'liveness_stall' | SshInfraFailureClass | TransientFailureClass | AgentFailureClass;
 
 export function isLivenessFailureClass(failureClass: FailureClass | undefined): boolean {
   return failureClass === 'liveness_stall';


### PR DESCRIPTION
## Summary

Add a typed `agent-usage-limit` failure class and a named matcher for provider quota refusals.

The class is dormant in this slice, so existing classifier results and worker behavior stay unchanged.

## Review Claim

`FailureClassifier` can name an agent provider quota refusal as `agent-usage-limit` without changing existing classifier results.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Nothing reads the new class in this slice. Existing `classifyError` inputs and `isUsageLimit` results remain unchanged.

## Slice Rationale

Vocabulary and its boundary matcher are the domain foundation. Producers and consumers belong in later slices.

## Non-goals

No producer or consumer uses the class. No routing, pause duration, breaker state, UI, or documentation changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-graph && pnpm test`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file /tmp/typed-agent-usage-limit-2-domain.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
