### PR TITLE
[CI regression: 2096ed4-ssh-shard-31](1) Add merge-clean check helper

### DIFF
--- a/scripts/check-merge-clean.sh
+++ b/scripts/check-merge-clean.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/check-merge-clean.sh [--include-current-diff] <base-ref> <merge-ref> [<merge-ref>...]
+
+Checks whether the refs merge cleanly in a temporary worktree. With
+--include-current-diff, the current worktree diff is applied before merging so
+uncommitted repairs can be verified without mutating the caller's worktree.
+USAGE
+}
+
+include_current_diff=0
+if [[ "${1:-}" == "--include-current-diff" ]]; then
+  include_current_diff=1
+  shift
+fi
+
+if (( ${#@} < 2 )); then
+  usage
+  exit 2
+fi
+
+base_ref="$1"
+shift
+
+repo_root="$(git rev-parse --show-toplevel)"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-merge-check.XXXXXX")"
+worktree_dir="$temp_dir/worktree"
+diff_file="$temp_dir/current.diff"
+
+cleanup() {
+  if git -C "$worktree_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$worktree_dir" merge --abort >/dev/null 2>&1 || true
+  fi
+  git -C "$repo_root" worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+  rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
+git -C "$repo_root" worktree add --detach --quiet "$worktree_dir" "$base_ref"
+
+if [[ "$include_current_diff" == "1" ]]; then
+  git -C "$repo_root" diff --binary HEAD >"$diff_file"
+  git -C "$repo_root" diff --cached --binary HEAD >>"$diff_file"
+  if [[ -s "$diff_file" ]]; then
+    git -C "$worktree_dir" apply --index "$diff_file"
+    git -C "$worktree_dir" \
+      -c user.email=merge-check@example.invalid \
+      -c user.name='Merge Check' \
+      commit --quiet -m 'merge-check current diff'
+  fi
+fi
+
+for merge_ref in "$@"; do
+  git -C "$worktree_dir" merge --no-ff --no-edit "$merge_ref"
+done
+
+if [[ -n "$(git -C "$worktree_dir" status --porcelain)" ]]; then
+  git -C "$worktree_dir" status --short
+  exit 1
+fi
+
+printf 'merge-clean: %s <- %s\n' "$base_ref" "$*"


### PR DESCRIPTION
## Summary

Adds `scripts/check-merge-clean.sh` so review gates can prove selected refs merge in a temporary worktree.

The helper can include the caller diff for repair checks, then tears down the worktree without touching the caller branch.

## Review Claim

The repository has a reusable merge-clean helper for PR publication proof.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The helper creates only a temporary worktree and removes it on exit; it does not alter the caller branch or index.

## Slice Rationale

This tooling helper is separate from the execution-engine behavior so reviewers can inspect the publication proof surface on its own.

## Non-goals

- No execution-engine behavior changes.
- No merge, push, or branch mutation.
- No changes to CI job selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/check-merge-clean.sh origin/master HEAD`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 82012248`
- Post-revert steps: None
- Data migration? No

</details>
