### PR TITLE
Resolve bot review threads after safe push

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -182,6 +182,56 @@ def _safe_push_task_yaml(
     )
 
 
+def _resolve_bot_thread_task_yaml(*, thread_id: str, start_head: str) -> str:
+    query = (
+        "query($id: ID!) { node(id: $id) { ... on PullRequestReviewThread "
+        "{ id isResolved pullRequest { state merged headRefOid } } } }"
+    )
+    mutation = (
+        "mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) "
+        "{ thread { id isResolved } } }"
+    )
+    command = (
+        "set -euo pipefail\n"
+        "python3 - <<'PY'\n"
+        "import json\n"
+        "import subprocess\n"
+        "import sys\n"
+        f"thread_id = {json.dumps(thread_id)}\n"
+        f"start_head = {json.dumps(start_head)}\n"
+        f"query = {json.dumps(query)}\n"
+        f"mutation = {json.dumps(mutation)}\n"
+        "view = subprocess.run(\n"
+        "    ['gh', 'api', 'graphql', '-f', f'id={thread_id}', '-f', f'query={query}'],\n"
+        "    check=True,\n"
+        "    capture_output=True,\n"
+        "    text=True,\n"
+        ")\n"
+        "node = (json.loads(view.stdout).get('data') or {}).get('node')\n"
+        "if not node:\n"
+        "    print(f'review thread not found: {thread_id}', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "pr = node.get('pullRequest') or {}\n"
+        "if node.get('isResolved') or pr.get('state') != 'OPEN' or pr.get('merged'):\n"
+        "    sys.exit(0)\n"
+        "if pr.get('headRefOid') == start_head:\n"
+        "    print('refusing to resolve review thread before a pushed head change', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "subprocess.run(\n"
+        "    ['gh', 'api', 'graphql', '-f', f'threadId={thread_id}', '-f', f'query={mutation}'],\n"
+        "    check=True,\n"
+        ")\n"
+        "PY\n"
+    )
+    return (
+        "  - id: resolve-thread\n"
+        f"    description: {_yaml_str(f'Resolve bot review thread {thread_id} after PR head changes')}\n"
+        "    dependencies: [safe-push]\n"
+        "    command: |\n"
+        f"{_indent_block(command, 6)}\n"
+    )
+
+
 def _shlex(value: str) -> str:
     # Minimal POSIX single-quote wrap; values here are SHAs, branch names, and
     # our own ledger paths/kinds -- none contain single quotes in practice, but
@@ -412,8 +462,9 @@ def build_repair_bot_thread_plan(
 ) -> AsyncRepairPlan:
     name = repair_bot_thread_plan_name(pr.number, start_head)
     prompt = (
-        f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
+        f"Address the unresolved review thread {thread_id}. Address the reviewer's feedback with "
         "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
+        "Do not resolve the GitHub review thread; the downstream resolve-thread task owns that after safe-push. "
         "If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
     )
@@ -431,6 +482,7 @@ def build_repair_bot_thread_plan(
         skip_if_prereq=False,
         foreign=foreign,
     )
+    yaml_text += _resolve_bot_thread_task_yaml(thread_id=thread_id, start_head=start_head)
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -83,7 +83,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         for plan, expected_task_ids, expected_merge_mode, expected_on_finish in (
             (checks_plan, ["repair", "normalize", "safe-push"], "manual", "none"),
             (rebase_plan, ["repair", "safe-push"], "manual", "none"),
-            (bot_thread_plan, ["repair", "safe-push"], "external_review", "pull_request"),
+            (bot_thread_plan, ["repair", "safe-push", "resolve-thread"], "external_review", "pull_request"),
         ):
             with self.subTest(plan=plan.plan_name):
                 doc = yaml.safe_load(plan.yaml_text)
@@ -225,9 +225,15 @@ class AsyncRepairPlanTests(unittest.TestCase):
         plan = async_repair.build_repair_bot_thread_plan(
             pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
+        doc = yaml.safe_load(plan.yaml_text)
+        self.assertEqual([task["id"] for task in doc["tasks"]], ["repair", "safe-push", "resolve-thread"])
+        self.assertEqual(doc["tasks"][2]["dependencies"], ["safe-push"])
         self.assertNotIn("--record-json-ledger", plan.yaml_text)
         self.assertNotIn("--json-kind", plan.yaml_text)
         self.assertIn("Thread: tbot", plan.yaml_text)
+        self.assertIn("Do not resolve the GitHub review thread", doc["tasks"][0]["prompt"])
+        self.assertIn("resolveReviewThread", doc["tasks"][2]["command"])
+        self.assertIn("refusing to resolve review thread before a pushed head change", doc["tasks"][2]["command"])
         self.assertNotIn("executionAgent", plan.yaml_text)
 
     def test_remote_safe_push_never_embeds_macos_owner_ledger_path(self):


### PR DESCRIPTION
## Summary

Bot-thread repair plans now resolve GitHub review threads only after the guarded push finishes.

The repair worker fixes code and commits locally. A downstream task checks that the PR head changed before resolving the thread.

## Review Claim

Bot-thread repair plans order review-thread resolution after `safe-push`, and the repair prompt tells the coding worker not to resolve the thread itself.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Never vendors `skills/reflect/`, never merges, and does not touch the original repair workflow. The change only rewrites generated follow-up plans for future bot-thread repairs.

## Slice Rationale

The proof slice already established the worker session was mined. This slice changes only the generated repair workflow that caused the premature thread resolution.

## Non-goals

- No merge behavior changes.
- No worker-session detector threshold changes.
- No catstack skill or hook edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 scripts/test_mergify_admin_requeue_async_repair.py`
- [x] `git diff --check`
- [x] `pnpm run check:comments`
- [x] `test ! -e skills/reflect`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d3d7de39`
- Post-revert steps: None
- Data migration? No

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated GitHub GraphQL thread resolution with head-SHA guards; wrong behavior could resolve threads prematurely or leave them open, but scope is limited to generated bot-thread repair plans.
> 
> **Overview**
> Bot-thread async repair workflows now **defer GitHub review-thread resolution** until after the guarded push.
> 
> `build_repair_bot_thread_plan` adds a third task, **`resolve-thread`**, chained after **`safe-push`**. That task runs embedded Python via `gh api graphql` to no-op when the thread is already resolved or the PR is closed/merged, **refuse** if the PR head is still the repair `start_head`, and only then call **`resolveReviewThread`**.
> 
> The repair worker prompt is updated to **address** feedback locally without resolving the thread; tests assert the new task order, dependencies, and safety strings in the generated YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d7de39a730e55ec54563163d6a32e7024ea7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->