### PR TITLE
[CI regression: cb2de29-playwright-planning-chat-restore](1) Restore Playwright shard matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,6 +868,9 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+          - name: codex-spend-gate
+            files: >-
+              e2e/codex-spend-gate-blocks-task.spec.ts
           - name: planning-chat-restore
             files: >-
               e2e/planning-chat-restore-conversational-mode-repro.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / planning-chat-restore -->

CI job `playwright / planning-chat-restore` first failed on default-branch push commit cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

This adds the missing `codex-spend-gate` Playwright shard before `planning-chat-restore` so the matrix keeps those specs separated.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882664

## Review Claim

Add the missing `codex-spend-gate` Playwright matrix shard so `planning-chat-restore` runs only its intended restore spec again.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the CI workflow matrix changes; product code and Playwright spec contents stay unchanged.

## Slice Rationale

One CI-policy slice covers the failing job's root cause and excludes the completed proof-only workflow tasks because they do not change repository state.

## Non-goals

No product behavior change, no Playwright spec edits, no test weakening, and no unrelated CI cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-planning-chat-restore' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-chat-restore-conversational-mode-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [x] `bash scripts/scrub-handoff-artifacts.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-ci-regression-cb2de29-playwright-planning-chat-restore.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6e349038`
- Post-revert steps: Re-run `playwright / planning-chat-restore` to confirm the regression returns if reverting is intentional.
- Data migration? No

</details>
