### PR TITLE
[worker-session-mine-3889e35bdaffabb7](1) Resolve bot review threads after safe push

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -182,6 +182,56 @@ def _safe_push_task_yaml(
     )
 
 
+def _resolve_bot_thread_task_yaml(*, thread_id: str, start_head: str) -> str:
+    query = (
+        "query($id: ID!) { node(id: $id) { ... on PullRequestReviewThread "
+        "{ id isResolved pullRequest { state merged headRefOid } } } }"
+    )
+    mutation = (
+        "mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) "
+        "{ thread { id isResolved } } }"
+    )
+    command = (
+        "set -euo pipefail\n"
+        "python3 - <<'PY'\n"
+        "import json\n"
+        "import subprocess\n"
+        "import sys\n"
+        f"thread_id = {json.dumps(thread_id)}\n"
+        f"start_head = {json.dumps(start_head)}\n"
+        f"query = {json.dumps(query)}\n"
+        f"mutation = {json.dumps(mutation)}\n"
+        "view = subprocess.run(\n"
+        "    ['gh', 'api', 'graphql', '-f', f'id={thread_id}', '-f', f'query={query}'],\n"
+        "    check=True,\n"
+        "    capture_output=True,\n"
+        "    text=True,\n"
+        ")\n"
+        "node = (json.loads(view.stdout).get('data') or {}).get('node')\n"
+        "if not node:\n"
+        "    print(f'review thread not found: {thread_id}', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "pr = node.get('pullRequest') or {}\n"
+        "if node.get('isResolved') or pr.get('state') != 'OPEN' or pr.get('merged'):\n"
+        "    sys.exit(0)\n"
+        "if pr.get('headRefOid') == start_head:\n"
+        "    print('refusing to resolve review thread before a pushed head change', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "subprocess.run(\n"
+        "    ['gh', 'api', 'graphql', '-f', f'threadId={thread_id}', '-f', f'query={mutation}'],\n"
+        "    check=True,\n"
+        ")\n"
+        "PY\n"
+    )
+    return (
+        "  - id: resolve-thread\n"
+        f"    description: {_yaml_str(f'Resolve bot review thread {thread_id} after PR head changes')}\n"
+        "    dependencies: [safe-push]\n"
+        "    command: |\n"
+        f"{_indent_block(command, 6)}\n"
+    )
+
+
 def _shlex(value: str) -> str:
     # Minimal POSIX single-quote wrap; values here are SHAs, branch names, and
     # our own ledger paths/kinds -- none contain single quotes in practice, but
@@ -412,8 +462,9 @@ def build_repair_bot_thread_plan(
 ) -> AsyncRepairPlan:
     name = repair_bot_thread_plan_name(pr.number, start_head)
     prompt = (
-        f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
+        f"Address the unresolved review thread {thread_id}. Address the reviewer's feedback with "
         "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
+        "Do not resolve the GitHub review thread; the downstream resolve-thread task owns that after safe-push. "
         "If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
     )
@@ -431,6 +482,7 @@ def build_repair_bot_thread_plan(
         skip_if_prereq=False,
         foreign=foreign,
     )
+    yaml_text += _resolve_bot_thread_task_yaml(thread_id=thread_id, start_head=start_head)
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
 
 

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -83,7 +83,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         for plan, expected_task_ids, expected_merge_mode, expected_on_finish in (
             (checks_plan, ["repair", "normalize", "safe-push"], "manual", "none"),
             (rebase_plan, ["repair", "safe-push"], "manual", "none"),
-            (bot_thread_plan, ["repair", "safe-push"], "external_review", "pull_request"),
+            (bot_thread_plan, ["repair", "safe-push", "resolve-thread"], "external_review", "pull_request"),
         ):
             with self.subTest(plan=plan.plan_name):
                 doc = yaml.safe_load(plan.yaml_text)
@@ -225,9 +225,15 @@ class AsyncRepairPlanTests(unittest.TestCase):
         plan = async_repair.build_repair_bot_thread_plan(
             pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
+        doc = yaml.safe_load(plan.yaml_text)
+        self.assertEqual([task["id"] for task in doc["tasks"]], ["repair", "safe-push", "resolve-thread"])
+        self.assertEqual(doc["tasks"][2]["dependencies"], ["safe-push"])
         self.assertNotIn("--record-json-ledger", plan.yaml_text)
         self.assertNotIn("--json-kind", plan.yaml_text)
         self.assertIn("Thread: tbot", plan.yaml_text)
+        self.assertIn("Do not resolve the GitHub review thread", doc["tasks"][0]["prompt"])
+        self.assertIn("resolveReviewThread", doc["tasks"][2]["command"])
+        self.assertIn("refusing to resolve review thread before a pushed head change", doc["tasks"][2]["command"])
         self.assertNotIn("executionAgent", plan.yaml_text)
 
     def test_remote_safe_push_never_embeds_macos_owner_ledger_path(self):


### PR DESCRIPTION
## Summary

Bot review-thread repair plans now leave thread resolution to a follow-up task after the safe push has changed the PR head.

This keeps the worker from resolving feedback before GitHub contains the repair commit.

The original repair remains untouched. This PR must not be merged as part of the session-mining workflow.

## Review Claim

Approve the repair-plan policy that resolves a bot review thread only after safe-push has published a changed head.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Never vendor skills/reflect/ into Invoker; never merge; original workflow untouched.

## Slice Rationale

This slice contains only the session-mining follow-up policy change and its local plan-builder coverage.

The proof-only thrash fixture task produced no repository diff, so it is intentionally not published as an empty PR.

## Non-goals

No product runtime behavior changes.

No merge, no branch landing, and no vendored skills/reflect/ content.

No changes to the original worker session or its repair output.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check origin/master..HEAD`
- [x] `pnpm run check:comments`
- [x] `python3 scripts/test_mergify_admin_requeue_async_repair.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 269966ef`
- Post-revert steps: None.
- Data migration? No.

</details>
