### PR TITLE
[CI regression: cb2de29-playwright-9-of-9](1) Flush status deltas from the app publisher

### DIFF
--- a/packages/app/src/__tests__/task-graph-event-publisher.test.ts
+++ b/packages/app/src/__tests__/task-graph-event-publisher.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+
+function createPublisher() {
+  const send = vi.fn();
+  const publisher = createTaskGraphEventPublisher({
+    getMainWindow: () => ({
+      isDestroyed: () => false,
+      webContents: { send },
+    }) as never,
+    isUiInteractive: () => true,
+    stampDelta: (delta) => delta,
+  });
+  return { publisher, send };
+}
+
+describe('createTaskGraphEventPublisher', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('batches non-status deltas on the normal flush timer', () => {
+    vi.useFakeTimers();
+    const { publisher, send } = createPublisher();
+
+    publisher.publishDelta({
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { execution: { phase: 'executing' } },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    }, []);
+
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(24);
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes status deltas immediately', () => {
+    vi.useFakeTimers();
+    const { publisher, send } = createPublisher();
+
+    publisher.publishDelta({
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { status: 'running' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    }, []);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(
+      'invoker:task-graph-event',
+      expect.objectContaining({
+        type: 'delta',
+        delta: expect.objectContaining({
+          taskId: 'task-1',
+          changes: { status: 'running' },
+        }),
+      }),
+    );
+  });
+});

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -60,13 +60,17 @@ export function createTaskGraphEventPublisher(
     mainWindow.webContents.send('invoker:task-graph-event-batch', batch);
   };
 
-  const publishEvent = (event: TaskGraphEvent): void => {
+  const publishEvent = (event: TaskGraphEvent, publishOptions?: { immediate?: boolean }): void => {
     options.onEvent?.(event);
     const mainWindow = options.getMainWindow();
     if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive()) {
       return;
     }
     pendingEvents.push(event);
+    if (publishOptions?.immediate) {
+      flush();
+      return;
+    }
     if (flushTimer) {
       return;
     }
@@ -76,11 +80,12 @@ export function createTaskGraphEventPublisher(
 
   return {
     publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void {
+      const stampedDelta = options.stampDelta(delta);
       publishEvent({
         type: 'delta',
-        delta: options.stampDelta(delta),
+        delta: stampedDelta,
         workflowRollups: [...workflowRollups],
-      });
+      }, { immediate: stampedDelta.type === 'updated' && stampedDelta.changes.status !== undefined });
     },
     publishSnapshot(
       reason: string,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / 9-of-9 -->

CI job `playwright / 9-of-9` first failed on cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882563

This slice flushes app-published task status deltas immediately while preserving timer batching for non-status updates.

## Review Claim

The app task graph publisher flushes task status deltas immediately so renderer subscribers receive execution state without a timer delay.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only status delta batching changes; non-status deltas keep the existing timer and snapshot behavior is unchanged.

## Slice Rationale

This is the app-side routing slice for the regression; the UI consumer and CI shard wiring are separate stack entries.

## Non-goals

- No UI hook changes.
- No CI workflow changes.
- No snapshot, removal, or non-status delta batching changes.
- No unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- task-graph-event-publisher.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/01-app-publisher.md --changed-files-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/01.changed-files --diff-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/01.diff`
- [x] Workflow task `wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9` completed (passed): `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [x] Workflow task `wf-1789173767579-74/scrub-handoff-artifacts` completed (passed).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dd7164ca`
- Post-revert steps: Re-run the affected Playwright shard if the regression watch is still active.
- Data migration? No

</details>

## Workflow Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / 9-of-9 -->

CI job `playwright / 9-of-9` first failed on cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882563

---
CI regression: cb2de29-playwright-9-of-9 - 3 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1789173767579-74/fix-ci-cb2de29-playwright-9-of-9 | Fix CI job playwright / 9-of-9 first observed failing at cb2de29d1a20853d494345d45d27c2485c03e4ff.<br>Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.<br>Review lane: behavior<br>Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.<br>Effectiveness measurement: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` fails before this change and passes after; that transition is the effectiveness signal.<br>Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.<br>Architectural effect: None expected; no new module boundaries unless the root cause requires it. | completed |
| wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9 | Run the local verification command for CI job playwright / 9-of-9.<br>Review claim: The command passes only when the CI regression is fixed.<br>Review lane: proof<br>Safety invariant: The command is identical before and after the fix.<br>Effectiveness measurement: Exit code of `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` is the effectiveness signal for this proof slice.<br>Slice rationale: One proof slice for the repaired CI job.<br>Architectural effect: None; adds no product behavior. | completed (passed) |
| wf-1789173767579-74/scrub-handoff-artifacts | Check that ephemeral inter-task handoff files are absent before the merge gate.<br>Review claim: The terminal check reports leaked handoff files without changing repository state.<br>Review lane: proof<br>Safety invariant: The check cannot modify files, index state, HEAD, or unrelated untracked content.<br>Effectiveness measurement: The check exits zero only when no handoff path remains.<br>Slice rationale: One terminal proof required on every implementation plan that opens a pull request.<br>Architectural effect: None. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1789173767579-74/fix-ci-cb2de29-playwright-9-of-9

`packages/app/src/task-graph-event-publisher.ts` flushes stamped status deltas without waiting for the batch timer.

`packages/app/src/__tests__/task-graph-event-publisher.test.ts` covers immediate status flushing and normal non-status batching.

### wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9

No repository files changed.

### wf-1789173767579-74/scrub-handoff-artifacts

No repository files changed.

</details>
