### PR TITLE
[CI regression: cb2de29-playwright-9-of-9](2) Flush status deltas in the UI task hook

### DIFF
--- a/packages/app/src/__tests__/task-graph-event-publisher.test.ts
+++ b/packages/app/src/__tests__/task-graph-event-publisher.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+
+function createPublisher() {
+  const send = vi.fn();
+  const publisher = createTaskGraphEventPublisher({
+    getMainWindow: () => ({
+      isDestroyed: () => false,
+      webContents: { send },
+    }) as never,
+    isUiInteractive: () => true,
+    stampDelta: (delta) => delta,
+  });
+  return { publisher, send };
+}
+
+describe('createTaskGraphEventPublisher', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('batches non-status deltas on the normal flush timer', () => {
+    vi.useFakeTimers();
+    const { publisher, send } = createPublisher();
+
+    publisher.publishDelta({
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { execution: { phase: 'executing' } },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    }, []);
+
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(24);
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes status deltas immediately', () => {
+    vi.useFakeTimers();
+    const { publisher, send } = createPublisher();
+
+    publisher.publishDelta({
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { status: 'running' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    }, []);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(
+      'invoker:task-graph-event',
+      expect.objectContaining({
+        type: 'delta',
+        delta: expect.objectContaining({
+          taskId: 'task-1',
+          changes: { status: 'running' },
+        }),
+      }),
+    );
+  });
+});

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -60,13 +60,17 @@ export function createTaskGraphEventPublisher(
     mainWindow.webContents.send('invoker:task-graph-event-batch', batch);
   };
 
-  const publishEvent = (event: TaskGraphEvent): void => {
+  const publishEvent = (event: TaskGraphEvent, publishOptions?: { immediate?: boolean }): void => {
     options.onEvent?.(event);
     const mainWindow = options.getMainWindow();
     if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive()) {
       return;
     }
     pendingEvents.push(event);
+    if (publishOptions?.immediate) {
+      flush();
+      return;
+    }
     if (flushTimer) {
       return;
     }
@@ -76,11 +80,12 @@ export function createTaskGraphEventPublisher(
 
   return {
     publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void {
+      const stampedDelta = options.stampDelta(delta);
       publishEvent({
         type: 'delta',
-        delta: options.stampDelta(delta),
+        delta: stampedDelta,
         workflowRollups: [...workflowRollups],
-      });
+      }, { immediate: stampedDelta.type === 'updated' && stampedDelta.changes.status !== undefined });
     },
     publishSnapshot(
       reason: string,

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -113,6 +113,36 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
   });
 
+  it('flushes status deltas before the batch timer', async () => {
+    const t1 = makeUITask({ id: 't1', status: 'pending' });
+
+    const { getTasksMock, onTaskGraphEventMock, fireDelta } = installInvoker({
+      bootstrap: { tasks: [t1], streamSequence: 0 },
+      responses: [{ tasks: [t1], workflows: [], streamSequence: 0 }],
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getTasksMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireDelta({
+        type: 'updated',
+        taskId: 't1',
+        changes: { status: 'running' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+        streamSequence: 1,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.tasks.get('t1')?.status).toBe('running');
+  });
+
   it('detects a 1,2,4 gap and triggers exactly one re-sync via refreshTaskGraph', async () => {
     const initial = [
       makeUITask({ id: 't1', status: 'pending' }),

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -559,9 +559,9 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       }
 
       graphEventPipelineRef.current?.push(event);
-      if (delta.type === 'removed') {
-        // Removals are rare, user-initiated, and destructive: flush the batch
-        // window so the graph reflects them immediately instead of ~100ms later.
+      if (delta.type === 'removed' || (delta.type === 'updated' && delta.changes.status !== undefined)) {
+        // Status changes drive the visible execution counters; flush them like
+        // removals so the task map and queue chips move in the same paint turn.
         graphEventPipelineRef.current?.flushNow();
       }
     };


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / 9-of-9 -->

CI job `playwright / 9-of-9` first failed on cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882563

This slice flushes UI-applied task status deltas immediately so the task map updates before the batch timer.

## Review Claim

The UI task hook flushes incoming status deltas immediately so task state and execution counters update in the same paint turn.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the hook delta flush trigger widens from removals to removals plus status updates; resync and replay guards stay unchanged.

## Slice Rationale

This is the UI activation-surface slice for the regression; app event publication and CI shard wiring stay in their own stack entries.

## Non-goals

- No app event publisher changes.
- No CI workflow changes.
- No task graph resync policy changes.
- No unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- use-tasks-stream-gap-detect.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/02-ui-hook.md --changed-files-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/02.changed-files --diff-file /tmp/invoker-ci-regression-cb2de29-playwright-9-of-9-bodies/02.diff`
- [x] Workflow task `wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9` completed (passed): `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [x] Workflow task `wf-1789173767579-74/scrub-handoff-artifacts` completed (passed).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f022c914`
- Post-revert steps: Re-run the affected Playwright shard if the regression watch is still active.
- Data migration? No

</details>

## Workflow Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / 9-of-9 -->

CI job `playwright / 9-of-9` first failed on cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882563

---
CI regression: cb2de29-playwright-9-of-9 - 3 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1789173767579-74/fix-ci-cb2de29-playwright-9-of-9 | Fix CI job playwright / 9-of-9 first observed failing at cb2de29d1a20853d494345d45d27c2485c03e4ff.<br>Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.<br>Review lane: behavior<br>Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.<br>Effectiveness measurement: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` fails before this change and passes after; that transition is the effectiveness signal.<br>Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.<br>Architectural effect: None expected; no new module boundaries unless the root cause requires it. | completed |
| wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9 | Run the local verification command for CI job playwright / 9-of-9.<br>Review claim: The command passes only when the CI regression is fixed.<br>Review lane: proof<br>Safety invariant: The command is identical before and after the fix.<br>Effectiveness measurement: Exit code of `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts e2e/rebase-recreate-ui-drift-repro.spec.ts e2e/rebase-recreate-ui-never-recovers.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` is the effectiveness signal for this proof slice.<br>Slice rationale: One proof slice for the repaired CI job.<br>Architectural effect: None; adds no product behavior. | completed (passed) |
| wf-1789173767579-74/scrub-handoff-artifacts | Check that ephemeral inter-task handoff files are absent before the merge gate.<br>Review claim: The terminal check reports leaked handoff files without changing repository state.<br>Review lane: proof<br>Safety invariant: The check cannot modify files, index state, HEAD, or unrelated untracked content.<br>Effectiveness measurement: The check exits zero only when no handoff path remains.<br>Slice rationale: One terminal proof required on every implementation plan that opens a pull request.<br>Architectural effect: None. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1789173767579-74/fix-ci-cb2de29-playwright-9-of-9

`packages/ui/src/hooks/useTasks.ts` flushes status delta batches the same way it already flushes removals.

`packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx` proves a status delta updates hook state before the timer.

### wf-1789173767579-74/verify-ci-cb2de29-playwright-9-of-9

No repository files changed.

### wf-1789173767579-74/scrub-handoff-artifacts

No repository files changed.

</details>
