### PR TITLE
[CI regression: cb2de29-playwright-2-of-9](1) Add spend gate spec to shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,6 +800,7 @@ jobs:
               e2e/persistence-lifecycle.spec.ts
               e2e/planning-review-scroll.spec.ts
               e2e/planning-submit-to-workflow-graph.spec.ts
+              e2e/codex-spend-gate-blocks-task.spec.ts
           - name: 3-of-9
             files: >-
               e2e/task-death-logs.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb2de29d1a20853d494345d45d27c2485c03e4ff; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` first failed on default-branch push commit cb2de29d1a20853d494345d45d27c2485c03e4ff in run 34419445591.

It was most recently still red at 8ba8a679f3ceced55887c6cab7178eda473d8ef9 in run 34659889255.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/34419445591/job/102691882663

This adds `e2e/codex-spend-gate-blocks-task.spec.ts` to `playwright / 2-of-9` so the repaired coverage runs in that shard.

## Review Claim

The CI workflow shard includes `e2e/codex-spend-gate-blocks-task.spec.ts` in `playwright / 2-of-9`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected shard coverage.

## Slice Rationale

The matrix edit is isolated from the Playwright proof stabilization so the policy change can be reviewed on its own.

## Non-goals

No product code changes, no Playwright spec edits, no test weakening, and no unrelated CI cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-regression-cb2de29-playwright-2-of-9-pr-bodies/01-shard.md --changed-files-file /tmp/ci-regression-cb2de29-playwright-2-of-9-pr-bodies/01-changed-files.txt --diff-file /tmp/ci-regression-cb2de29-playwright-2-of-9-pr-bodies/01.diff`
- [x] `node scripts/check-pr-body-keywords.mjs --body-file /tmp/ci-regression-cb2de29-playwright-2-of-9-pr-bodies/01-shard.md --declared-unit tooling-policy`
- [x] `pnpm run check:comments`
- [x] Workflow task `wf-1789171968899-51/verify-ci-cb2de29-playwright-2-of-9` completed (passed): `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts e2e/planning-review-scroll.spec.ts e2e/planning-submit-to-workflow-graph.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e484b798`
- Post-revert steps: Re-run the affected Playwright shard if the regression watch is still active.
- Data migration? No

</details>
