### PR TITLE
[Say when the known-model list is a built-in fallback, not the agent's own answer](1) Clarify fallback provenance in rejection hint

### DIFF
--- a/packages/execution-engine/src/__tests__/model-rejection-provenance.test.ts
+++ b/packages/execution-engine/src/__tests__/model-rejection-provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { assertExecutionModelSupported, type ExecutionAgent } from '../agent.js';
+
+const supportedModels = [{ id: 'gpt-5', label: 'GPT-5' }];
+const currentWording =
+  'Execution model "claude" is not supported for execution agent "codex". Known models: [gpt-5].';
+
+function rejectionMessage(agent: Pick<ExecutionAgent, 'name' | 'supportedModels' | 'supportsModel' | 'supportedModelsProvenance'>): string {
+  try {
+    assertExecutionModelSupported(agent, 'claude');
+    throw new Error('expected model rejection');
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+describe('model rejection provenance', () => {
+  it('keeps today\'s wording when the agent answered', () => {
+    const agent = {
+      name: 'codex',
+      supportedModels,
+      supportedModelsProvenance: 'agent' as const,
+    };
+
+    expect(rejectionMessage(agent)).toBe(currentWording);
+  });
+
+  it('marks built-in model lists as a fallback', () => {
+    const agent = {
+      name: 'codex',
+      supportedModels,
+      supportedModelsProvenance: 'built-in' as const,
+    };
+
+    expect(rejectionMessage(agent)).toContain('built-in fallback');
+    expect(rejectionMessage(agent)).toContain('live discovery was unavailable');
+    expect(rejectionMessage(agent)).not.toBe(currentWording);
+  });
+
+  it('keeps today\'s wording when provenance is absent', () => {
+    const agent = { name: 'codex', supportedModels };
+
+    expect(rejectionMessage(agent)).toBe(currentWording);
+  });
+});

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -14,6 +14,7 @@ export interface ExecutionModelOption {
   label: string;
 }
 
+export type SupportedModelsProvenance = 'agent' | 'built-in';
 
 export const DEFAULT_EXECUTION_AGENT = 'codex';
 
@@ -24,6 +25,7 @@ export interface ExecutionAgent {
   readonly bundledSkillRoot?: string;
   readonly bundledSkills?: readonly string[];
   readonly supportedModels?: readonly ExecutionModelOption[];
+  readonly supportedModelsProvenance?: SupportedModelsProvenance;
   supportsModel?(executionModel: string): boolean;
   buildCommand(fullPrompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
@@ -35,7 +37,7 @@ export interface ExecutionAgent {
 }
 
 export function assertExecutionModelSupported(
-  agent: Pick<ExecutionAgent, 'name' | 'supportedModels' | 'supportsModel'>,
+  agent: Pick<ExecutionAgent, 'name' | 'supportedModels' | 'supportedModelsProvenance' | 'supportsModel'>,
   executionModel: string | null | undefined,
 ): void {
   const normalizedModel = executionModel?.trim();
@@ -43,7 +45,11 @@ export function assertExecutionModelSupported(
   if (agent.supportedModels?.some((candidate) => candidate.id === normalizedModel)) return;
   if (agent.supportsModel?.(normalizedModel)) return;
   const supported = agent.supportedModels?.map((candidate) => candidate.id) ?? [];
-  const hint = supported.length > 0 ? ` Known models: [${supported.join(', ')}].` : '';
+  const hint = supported.length > 0
+    ? agent.supportedModelsProvenance === 'built-in'
+      ? ` Known models: [${supported.join(', ')}] (built-in fallback; live discovery was unavailable).`
+      : ` Known models: [${supported.join(', ')}].`
+    : '';
   throw new Error(`Execution model "${normalizedModel}" is not supported for execution agent "${agent.name}".${hint}`);
 }
 

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -2,7 +2,13 @@ import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+import type {
+  ExecutionAgent,
+  AgentCommandSpec,
+  AgentCommandBuildOptions,
+  ExecutionModelOption,
+  SupportedModelsProvenance,
+} from '../agent.js';
 import { createCodexSpendGateReader, type CodexSpendGateReader } from '../codex-spend-gate.js';
 
 export interface CodexExecutionAgentConfig {
@@ -75,7 +81,11 @@ export class CodexExecutionAgent implements ExecutionAgent {
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
   private readonly spendGate: CodexSpendGateReader;
-  private supportedModelCache?: { expiresAt: number; models: readonly ExecutionModelOption[] };
+  private supportedModelCache?: {
+    expiresAt: number;
+    models: readonly ExecutionModelOption[];
+    provenance: SupportedModelsProvenance;
+  };
 
   constructor(config: CodexExecutionAgentConfig = {}) {
     this.command = config.command ?? 'codex';
@@ -86,6 +96,10 @@ export class CodexExecutionAgent implements ExecutionAgent {
   }
   get supportedModels(): readonly ExecutionModelOption[] {
     return this.getSupportedModels();
+  }
+  get supportedModelsProvenance(): SupportedModelsProvenance {
+    this.getSupportedModels();
+    return this.supportedModelCache!.provenance;
   }
 
 
@@ -131,6 +145,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.supportedModelCache = {
       expiresAt: now + CODEX_MODEL_CACHE_MS,
       models,
+      provenance: discovered.kind === 'success' ? 'agent' : 'built-in',
     };
     return models;
   }


### PR DESCRIPTION
## Summary

`packages/execution-engine/src/agent.ts:46` builds the unsupported-model hint from whatever `agent.supportedModels` holds:

  const hint = supported.length > 0 ? ` Known models: [${supported.join(', ')}].` : '';

It has no way to know whether those models came from asking the agent or from a hardcoded constant, so it words both the same way.

An operator reading `Known models: [gpt-5.5, gpt-5.5-pro, gpt-5.4, ...]` reasonably takes it as what Codex accepts. It was not. That sent the operator looking for a nonexistent package upgrade.

The upstream slice gave the Codex agent a discriminated probe outcome. This slice carries that provenance to the sentence a human reads.

## Review Claim

The operator sentence says where its known models came from, so it never presents a hardcoded constant as the agent's own answer.

## Review Lane

- behavior

## Review Unit

- routing

## Safety Invariant

When the list came from asking the agent, the sentence is byte-for-byte what it is today; only the built-in-constant wording differs. Agents that expose no provenance keep today's wording.

## Slice Rationale

One conceptual unit: the wording of one operator-facing sentence and the provenance it needs to word it.

## Non-goals

- No change to which models are accepted or rejected.
- No change to the discovery contract introduced upstream.
- No edits to the Claude or OMP agents beyond whatever the shared shape requires.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/model-rejection-provenance.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
