### PR TITLE
[Skill category](3a) Label every bundled item: docs skills and setup guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,12 @@ bash scripts/setup-agent-skills.sh
 pnpm run build
 ```
 
+Every bundled skill carries a `category:` field in its `SKILL.md` frontmatter. By
+default `setup-agent-skills.sh` installs all of them; set `INVOKER_SKILL_CATEGORY`
+to install only one subset. Use `INVOKER_SKILL_CATEGORY=core` for the skills that
+submit and operate Invoker work, or `INVOKER_SKILL_CATEGORY=optimization` for the
+verification and review skills.
+
 Invoker does not provision machines for you. You are responsible for bringing your own local workstation, VM, container host, or remote machines and making sure the required tools are installed there before running workflows.
 
 If pnpm skips Electron's dependency install hook and you hit `Electron failed to install correctly`, rerun `pnpm install` or any normal launch command after allowing Electron's build script. Recent pnpm versions may require `pnpm approve-builds`.

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: invoker-ops
+category: core
 description: >
   Safely operate existing Invoker workflows and tasks from natural-language requests.
   Trigger when asked to list, inspect, retry, restart, resume, cancel, approve,

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: invoker-setup
+category: core
 description: >
   Get a new machine "good to go" for Invoker and optionally wire up the Slack integration.
   Trigger when asked to set up Invoker, run the setup/tutorial, check the environment,

--- a/skills/loop-generator/SKILL.md
+++ b/skills/loop-generator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: loop-generator
+category: optimization
 description: >
   Generate a reusable loop instruction doc, loop driver script, and Invoker
   workflow from an interview. Trigger: "loop generator", "generate a loop",

--- a/skills/maintain-verify/SKILL.md
+++ b/skills/maintain-verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: maintain-verify
+category: optimization
 description: >
   Keep skills/verify/references/features in sync with sidebar testids, e2e specs,
   and repros. Use when adding UI surfaces, when catalog --check fails, or on a

--- a/skills/reflect-ci/SKILL.md
+++ b/skills/reflect-ci/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: reflect-ci
+category: optimization
 description: >
   Invoker-owned adapter for automated reflect-ci-* / autofix-miss tasks filed by
   the optional CI regression watcher (INVOKER_CI_REGRESSION_REFLECT=1). Use when

--- a/skills/remote-ci-verify/SKILL.md
+++ b/skills/remote-ci-verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: remote-ci-verify
+category: optimization
 description: Push the current branch and verify it against the CI-equivalent test surface on an available SSH remote target, including selecting a target not currently used by Invoker, creating a temporary remote worktree, and running `pnpm run test:all` with CI-style setup. Use when you need pre-merge confidence that mirrors `.github/workflows/ci.yml` more closely than local-only tests.
 ---
 

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: review-compression
+category: optimization
 description: >
   Shape code changes, workflow plans, and PR stacks so each diff is easy to
   review: one local claim, one safety invariant, clear architectural effect,

--- a/skills/route-delegation/SKILL.md
+++ b/skills/route-delegation/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: route-delegation
+category: core
 description: >
   Decide between a subagent swarm and an Invoker submission before fanning
   out. Trigger when about to spawn several subagents, forks, background

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: verify
+category: optimization
 description: >
   Drive and prove Invoker UI/live-path changes via skills/verify/control-invoker.mjs:
   doctor, feature-map prove commands, isolated-Electron drive, visual-proof wrap,

--- a/skills/worker-session-mine/SKILL.md
+++ b/skills/worker-session-mine/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: worker-session-mine
+category: optimization
 description: >
   Invoker-owned adapter for the off-by-default worker-session-mine owner worker.
   Mines terminal fire-and-forget agent sessions (Claude, Codex, OMP) for mechanical


### PR DESCRIPTION
## Summary

Ten bundled skills now say which install group they belong to, core or optimization, in one new `category:` line at the top of each file.

The setup guide gains one paragraph about `INVOKER_SKILL_CATEGORY`, the opt-in variable from step 2, with one example value for each group.

This is step 3a of the skill-category stack. Step 3b labels the remaining seven skills and adds a check that every bundled skill has a label.

## Review Claim

Ten bundled `SKILL.md` files each gain exactly one `category:` frontmatter line with the value shown under Non-goals, and `docs/getting-started.md` gains one paragraph naming `INVOKER_SKILL_CATEGORY` with `core` and `optimization` examples.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Each skill file gains one line inside its existing frontmatter block and no other line changes; the guide gains one paragraph; no source file is touched.

## Slice Rationale

These ten skills fall under the docs review unit. The other seven bundled skills fall under the tooling-policy unit, so they ship in step 3b with the coverage check.

## Non-goals

- No source file changes.
- No skill is moved, renamed, or edited beyond its one new line.
- The seven tooling-policy skills are labeled in step 3b, not here.
- No new skill is added.

Labels in this slice:

- core: invoker-ops, invoker-setup, route-delegation
- optimization: loop-generator, maintain-verify, reflect-ci, remote-ci-verify, review-compression, verify, worker-session-mine

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --stat origin/master HEAD` shows 11 files, 16 insertions, 0 deletions
- [x] `pnpm run check:comments`
- [x] `node scripts/validate-pr-body.mjs --body-file <this body> --changed-files-file <this slice's files>`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that bundled skills are organized into `core` and `optimization` categories.
  - Documented that all bundled skills are installed by default.
  - Added guidance for using `INVOKER_SKILL_CATEGORY` to install only one category.
  - Defined `core` skills as work submission and operation tools, and `optimization` skills as verification and review tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->