### PR TITLE
[A failed task stores the first error-shaped output, not only the last 50 lines](1) Keep the first error-shaped output

### DIFF
--- a/packages/execution-engine/src/__tests__/failure-error-selection.test.ts
+++ b/packages/execution-engine/src/__tests__/failure-error-selection.test.ts
@@ -1,0 +1,168 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import {
+  BaseExecutor,
+  selectFailedTaskStoredError,
+  type BaseEntry,
+} from '../base-executor.js';
+import { SshExecutor } from '../ssh-executor.js';
+import type { ExecutorHandle, TerminalSpec } from '../executor.js';
+
+let spawnedProcesses: Array<ChildProcess & EventEmitter> = [];
+
+function createMockProcess(): ChildProcess & EventEmitter {
+  const proc = new EventEmitter() as ChildProcess & EventEmitter;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+
+  (proc as any).stdout = stdoutEmitter;
+  (proc as any).stderr = stderrEmitter;
+  (proc as any).stdin = { write: vi.fn(), end: vi.fn() };
+  (proc as any).pid = 12345;
+  (proc as any).killed = false;
+  (proc as any).exitCode = null;
+  proc.kill = vi.fn().mockReturnValue(true);
+
+  return proc;
+}
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const proc = createMockProcess();
+      spawnedProcesses.push(proc);
+      return proc;
+    }),
+  };
+});
+
+function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
+  return {
+    requestId: 'req-1',
+    actionId: 'failed-task',
+    actionType: 'command',
+    inputs: {
+      command: 'pnpm test',
+      description: 'run tests',
+      workspacePath: '/tmp/invoker-failure-error-selection',
+    },
+    callbackUrl: '',
+    timestamps: { createdAt: new Date().toISOString() },
+    ...overrides,
+  };
+}
+
+function currentTailSelection(output: string): string | undefined {
+  const lines = output.split('\n');
+  const tail = lines.slice(-50).join('\n').trim();
+  if (!tail) return undefined;
+  return tail.length > 3000 ? tail.slice(-3000) : tail;
+}
+
+function tracebackThenInstallChatter(): string {
+  return [
+    'Traceback (most recent call last):',
+    '  File "/home/invoker/project/scripts/bootstrap.py", line 7, in <module>',
+    '    import missing_dependency',
+    "ModuleNotFoundError: No module named 'missing_dependency'",
+    ...Array.from({ length: 200 }, (_, index) => `+ package${index.toString().padStart(3, '0')}==1.2.3`),
+  ].join('\n');
+}
+
+class LocalFailureExecutor extends BaseExecutor<BaseEntry> {
+  readonly type = 'local-test';
+
+  async start(_request: WorkRequest): Promise<ExecutorHandle> {
+    throw new Error('Not implemented');
+  }
+
+  async kill(_handle: ExecutorHandle): Promise<void> {}
+  sendInput(_handle: ExecutorHandle, _input: string): void {}
+  getTerminalSpec(_handle: ExecutorHandle): TerminalSpec | null { return null; }
+  getRestoredTerminalSpec(): TerminalSpec { throw new Error('Not implemented'); }
+  async destroyAll(): Promise<void> { this.entries.clear(); }
+
+  protected override async recordTaskResult(): Promise<string | null> {
+    return null;
+  }
+
+  async completeFailedRun(output: string): Promise<WorkResponse> {
+    const request = makeRequest();
+    const handle = this.createHandle(request);
+    const entry: BaseEntry = {
+      request,
+      outputListeners: new Set(),
+      outputBuffer: [output],
+      outputBufferBytes: output.length,
+      evictedChunkCount: 0,
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+    };
+    this.registerEntry(handle, entry);
+    const completed = new Promise<WorkResponse>((resolve) => {
+      this.onComplete(handle, resolve);
+    });
+    await this.handleProcessExit(handle.executionId, request, process.cwd(), 1);
+    return completed;
+  }
+}
+
+async function completeSshFailedRun(output: string): Promise<WorkResponse> {
+  const ssh = new SshExecutor({
+    host: 'localhost',
+    user: 'testuser',
+    sshKeyPath: '/dev/null',
+  });
+  const request = makeRequest();
+  const handle = await ssh.start(request);
+  const completed = new Promise<WorkResponse>((resolve) => {
+    ssh.onComplete(handle, resolve);
+  });
+  const child = spawnedProcesses[spawnedProcesses.length - 1];
+  if (!child) throw new Error('expected SSH process to be spawned');
+
+  child.stdout?.emit('data', Buffer.from(output));
+  child.emit('close', 1, null);
+  return completed;
+}
+
+describe('failed task stored error selection', () => {
+  beforeEach(() => {
+    spawnedProcesses = [];
+  });
+
+  it('keeps a Python traceback that appears before install chatter', () => {
+    const output = tracebackThenInstallChatter();
+
+    const stored = selectFailedTaskStoredError(output);
+
+    expect(stored).toContain('Traceback (most recent call last):');
+    expect(stored).toContain("ModuleNotFoundError: No module named 'missing_dependency'");
+    expect(stored).not.toBe(currentTailSelection(output));
+  });
+
+  it('keeps the existing tail selection byte for byte when no error-shaped content exists', () => {
+    const output = Array.from(
+      { length: 90 },
+      (_, index) => `+ package${index.toString().padStart(3, '0')}==1.2.3`,
+    ).join('\n');
+
+    expect(selectFailedTaskStoredError(output)).toBe(currentTailSelection(output));
+  });
+
+  it('uses the same stored error selection for local and SSH executors', async () => {
+    const output = tracebackThenInstallChatter();
+    const local = new LocalFailureExecutor();
+
+    const localResponse = await local.completeFailedRun(output);
+    const sshResponse = await completeSshFailedRun(output);
+
+    expect(localResponse.outputs.error).toBe(sshResponse.outputs.error);
+    expect(localResponse.outputs.error).toBe(selectFailedTaskStoredError(output));
+  });
+});

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -21,6 +21,53 @@ const DEFAULT_MAX_BUFFER_BYTES = 5 * 1024 * 1024; // 5MB
 const DEFAULT_GIT_NETWORK_TIMEOUT_MS = 15 * 60 * 1000;
 const PROVISION_OUTPUT_TAIL_LINE_LIMIT = 50;
 const PROVISION_OUTPUT_TAIL_CHAR_LIMIT = 32_000;
+const FAILED_TASK_ERROR_TAIL_LINE_LIMIT = 50;
+const FAILED_TASK_ERROR_CHAR_LIMIT = 3000;
+
+const FAILED_TASK_ERROR_LINE_PATTERNS = [
+  /^Traceback \(most recent call last\):$/,
+  /^\s*(?:error|fatal error):\s+\S/i,
+  /^\s*(?:AssertionError|SyntaxError|TypeError|ReferenceError|RangeError|ValueError|RuntimeError|ModuleNotFoundError|ImportError|KeyError|Exception):\s*\S/i,
+  /^\s*(?:FAIL|FAILED)\s+\S/i,
+  /^\s*\S.*\berror\s+TS\d+:/i,
+  /^\s*\S.*:\d+:\d+:\s+(?:error|fatal error):\s+\S/i,
+  /^\s*(?:command failed|error command failed|failed with|exited with).*\b(?:exit code|exit status|code|status)\s*[=:]?\s*[1-9]\d*\b/i,
+  /^\s*(?:exit code|exit status)\s*[=:]?\s*[1-9]\d*\b/i,
+  /\bELIFECYCLE\b.*\bCommand failed with exit code [1-9]\d*\b/i,
+];
+
+function failedTaskErrorTail(output: string): string | undefined {
+  const lines = output.split('\n');
+  const tail = lines.slice(-FAILED_TASK_ERROR_TAIL_LINE_LIMIT).join('\n').trim();
+  if (!tail) return undefined;
+  return tail.length > FAILED_TASK_ERROR_CHAR_LIMIT
+    ? tail.slice(-FAILED_TASK_ERROR_CHAR_LIMIT)
+    : tail;
+}
+
+function findFirstErrorShapedLineStart(output: string): number | undefined {
+  let lineStart = 0;
+  for (const line of output.split('\n')) {
+    const matchLine = line.endsWith('\r') ? line.slice(0, -1) : line;
+    if (FAILED_TASK_ERROR_LINE_PATTERNS.some((pattern) => pattern.test(matchLine))) {
+      return lineStart;
+    }
+    lineStart += line.length + 1;
+  }
+  return undefined;
+}
+
+export function selectFailedTaskStoredError(output: string): string | undefined {
+  const errorStart = findFirstErrorShapedLineStart(output);
+  if (errorStart !== undefined) {
+    const errorSpan = output.slice(errorStart).trim();
+    if (!errorSpan) return undefined;
+    return errorSpan.length > FAILED_TASK_ERROR_CHAR_LIMIT
+      ? errorSpan.slice(0, FAILED_TASK_ERROR_CHAR_LIMIT)
+      : errorSpan;
+  }
+  return failedTaskErrorTail(output);
+}
 
 /**
  * Canonicalizes a repoUrl for `repoProvisionCommands` lookups so
@@ -1317,11 +1364,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     let error: string | undefined;
     if (effectiveExitCode !== 0 && entry) {
       const allOutput = entry.outputBuffer.join('');
-      const lines = allOutput.split('\n');
-      const tail = lines.slice(-50).join('\n').trim();
-      if (tail) {
-        error = tail.length > 3000 ? tail.slice(-3000) : tail;
-      }
+      error = selectFailedTaskStoredError(allOutput);
     }
     if (semanticFailure) {
       error = semanticFailure.message;

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -4,7 +4,7 @@ import { accessSync, constants } from 'node:fs';
 import { normalize } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
-import { BaseExecutor, type BaseEntry } from './base-executor.js';
+import { BaseExecutor, selectFailedTaskStoredError, type BaseEntry } from './base-executor.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import { planManagedWorktree } from './managed-worktree-controller.js';
@@ -1272,11 +1272,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
             if (cleanupFallbackError) {
               mappedError = cleanupFallbackError;
             } else {
-              const lines = allOutput.split('\n');
-              const tail = lines.slice(-50).join('\n').trim();
-              if (tail) {
-                mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
-              }
+              mappedError = selectFailedTaskStoredError(allOutput);
             }
           }
 


### PR DESCRIPTION
## Summary

Failed tasks now retain the earliest error-shaped output when a run continues printing afterward.

Runs without error-shaped content keep the existing last-50-lines selection and 3000-character cap.

## Review Claim

A failed task whose cause appears early and is followed by unrelated chatter stores the cause, not the chatter.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Output with no error-shaped content stores exactly what it stores today: the same tail under the same 3000-character cap. The cap itself does not change.

## Slice Rationale

This is one conceptual unit: which span of failed-run output becomes the stored error. The two executors carry the same selection decision with its focused regression test.

## Non-goals

- No change to the 3000-character cap.
- No change to where errors are stored or to the schema.
- No change to which runs count as failures.
- No new dependency for log parsing.

## Test Plan

<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/failure-error-selection.test.ts`
- Early traceback followed by package-listing chatter retains the traceback.
- Chatter-only output retains the existing tail byte-for-byte.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`.
- Post-revert steps: Rerun the focused execution-engine test.
- Data migration? No.

</details>
