### PR TITLE
[Invoker optimizations: push-not-poll skill](1) Add push-not-poll optimization skill

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,12 @@ bash scripts/setup-agent-skills.sh
 pnpm run build
 ```
 
+Every bundled skill carries a `category:` field in its `SKILL.md` frontmatter. By
+default `setup-agent-skills.sh` installs all of them; set `INVOKER_SKILL_CATEGORY`
+to install only one subset. Use `INVOKER_SKILL_CATEGORY=core` for the skills that
+submit and operate Invoker work, or `INVOKER_SKILL_CATEGORY=optimization` for the
+verification and review skills.
+
 Invoker does not provision machines for you. You are responsible for bringing your own local workstation, VM, container host, or remote machines and making sure the required tools are installed there before running workflows.
 
 If pnpm skips Electron's dependency install hook and you hit `Electron failed to install correctly`, rerun `pnpm install` or any normal launch command after allowing Electron's build script. Recent pnpm versions may require `pnpm approve-builds`.

--- a/scripts/test-bundled-skill-categories.mjs
+++ b/scripts/test-bundled-skill-categories.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_ROOT = path.join(REPO_ROOT, 'skills');
+const SELECTABLE_CATEGORIES = ['core', 'optimization'];
+
+function listBundledSkillNames() {
+  return readdirSync(SOURCE_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(path.join(SOURCE_ROOT, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function readBundledSkillCategory(name) {
+  const lines = readFileSync(path.join(SOURCE_ROOT, name, 'SKILL.md'), 'utf8').split('\n');
+  if (lines[0]?.trim() !== '---') return null;
+  for (const line of lines.slice(1)) {
+    const trimmed = line.trim();
+    if (trimmed === '---') return null;
+    const match = /^category:\s*(.*)$/.exec(trimmed);
+    if (!match) continue;
+    const value = match[1].trim().replace(/^['"]|['"]$/g, '').trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+const names = listBundledSkillNames();
+if (names.length === 0) {
+  console.error(`FAIL: no bundled skills found under ${SOURCE_ROOT}; the check could not run`);
+  process.exit(1);
+}
+
+const missing = [];
+const unknown = [];
+const byCategory = new Map(SELECTABLE_CATEGORIES.map((category) => [category, []]));
+
+for (const name of names) {
+  const category = readBundledSkillCategory(name);
+  if (category === null) {
+    missing.push(name);
+    continue;
+  }
+  if (!byCategory.has(category)) {
+    unknown.push(`${name} (category: ${category})`);
+    continue;
+  }
+  byCategory.get(category).push(name);
+}
+
+const covered = SELECTABLE_CATEGORIES.reduce((total, category) => total + byCategory.get(category).length, 0);
+
+for (const name of missing) {
+  console.error(`FAIL: skills/${name}/SKILL.md has no category: field, so INVOKER_SKILL_CATEGORY installs silently omit it`);
+}
+for (const entry of unknown) {
+  console.error(`FAIL: skills/${entry} is not one of ${SELECTABLE_CATEGORIES.join(', ')}`);
+}
+
+if (missing.length > 0 || unknown.length > 0 || covered !== names.length) {
+  console.error(`FAIL: ${covered}/${names.length} bundled skills are reachable by a filtered install`);
+  process.exit(1);
+}
+
+for (const category of SELECTABLE_CATEGORIES) {
+  console.log(`PASS: ${category} -> ${byCategory.get(category).length} skills`);
+}
+console.log(`PASS: all ${names.length} bundled skills carry a selectable category`);

--- a/scripts/test-suites/required/11-bundled-skill-categories.sh
+++ b/scripts/test-suites/required/11-bundled-skill-categories.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+node scripts/test-bundled-skill-categories.mjs

--- a/skills/chat-submit/SKILL.md
+++ b/skills/chat-submit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: chat-submit
+category: core
 description: >
   Automatically route approved plans and durable/parallel execution work from
   normal chat into Invoker. Trigger when the user has a plan ready to run,

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: invoker-ops
+category: core
 description: >
   Safely operate existing Invoker workflows and tasks from natural-language requests.
   Trigger when asked to list, inspect, retry, restart, resume, cancel, approve,

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: invoker-setup
+category: core
 description: >
   Get a new machine "good to go" for Invoker and optionally wire up the Slack integration.
   Trigger when asked to set up Invoker, run the setup/tutorial, check the environment,

--- a/skills/land-stack/SKILL.md
+++ b/skills/land-stack/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: land-stack
+category: core
 description: >
   Land (queue/merge) a Mergify-managed PR stack safely. Trigger when asked to
   land, merge, ship, or queue a PR or PR stack with Mergify. Enforces that you

--- a/skills/loop-generator/SKILL.md
+++ b/skills/loop-generator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: loop-generator
+category: optimization
 description: >
   Generate a reusable loop instruction doc, loop driver script, and Invoker
   workflow from an interview. Trigger: "loop generator", "generate a loop",

--- a/skills/maintain-verify/SKILL.md
+++ b/skills/maintain-verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: maintain-verify
+category: optimization
 description: >
   Keep skills/verify/references/features in sync with sidebar testids, e2e specs,
   and repros. Use when adding UI surfaces, when catalog --check fails, or on a

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: make-pr
+category: core
 description: >
   Create or update a pull request in this repo using the preferred PR schema,
   upstream-first branch workflow, and repo-specific publication rules. Trigger

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: plan-to-invoker
+category: core
 description: >
   Convert a plan into an Invoker YAML plan file. After `install-skills`, this
   routing is always on via Cursor `~/.cursor/rules/invoker-execution-precedence.mdc`,

--- a/skills/prove-it/SKILL.md
+++ b/skills/prove-it/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prove-it
+category: optimization
 description: >
   Shared evidence rule for investigating, diagnosing, debugging, proving, or explaining what happened or why for any problem or situation:
   do not assert something is fixed, working, passing, merged, or running

--- a/skills/push-not-poll/SKILL.md
+++ b/skills/push-not-poll/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: push-not-poll
+category: optimization
+description: >
+  Prefer a push/wait mechanism over a short-interval poll loop for any
+  long-running wait inside a turn-based agent harness. Use when designing or
+  reviewing a workflow step that waits on a background process, CI job, or
+  other long-running task, since each poll turn resends the whole growing
+  conversation and token cost compounds with turn count, not wall-clock time.
+---
+
+# push-not-poll
+
+## Principle
+
+In a turn-based agent harness, every turn resends the whole conversation so
+far. A short-interval poll loop ("check every 10s") turns a single wait into
+many turns, and each of those turns pays for the full, ever-growing
+transcript again. Token cost compounds with turn count, not wall-clock time.
+
+Prefer a mechanism that does not cost a conversational turn per check:
+
+- A single blocking call with a generous timeout.
+- A host-level callback or notification (push, not poll).
+- If polling is unavoidable, a turn-based check with an interval sized to
+  the real expected duration, plus a hard turn cap.
+
+## Worked example: fix-ci auto-repair
+
+The fix-ci auto-repair flow waits on a backgrounded CI verify command. Two
+poll policies were measured against the same 45-minute wait with
+`node scripts/fix-ci-token-bench.mjs --gate [--candidate baseline]`:
+
+- 10s poll interval, no turn cap: 74,147,000 tokens.
+- 180s poll interval, 15-turn cap: 966,000 tokens.
+
+That is a 98.7% reduction for the same real wait. The 180s/15-turn policy
+has been part of this repo's default check suite since PRs #11887-#11891
+(merged 2026-09-03).
+
+## See also
+
+`corpus/skills/principle-push-not-poll` in `EdbertChan/catstack` is the
+sibling, cross-project origin of this same principle.

--- a/skills/reflect-ci/SKILL.md
+++ b/skills/reflect-ci/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: reflect-ci
+category: optimization
 description: >
   Invoker-owned adapter for automated reflect-ci-* / autofix-miss tasks filed by
   the optional CI regression watcher (INVOKER_CI_REGRESSION_REFLECT=1). Use when

--- a/skills/remote-ci-verify/SKILL.md
+++ b/skills/remote-ci-verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: remote-ci-verify
+category: optimization
 description: Push the current branch and verify it against the CI-equivalent test surface on an available SSH remote target, including selecting a target not currently used by Invoker, creating a temporary remote worktree, and running `pnpm run test:all` with CI-style setup. Use when you need pre-merge confidence that mirrors `.github/workflows/ci.yml` more closely than local-only tests.
 ---
 

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: review-compression
+category: optimization
 description: >
   Shape code changes, workflow plans, and PR stacks so each diff is easy to
   review: one local claim, one safety invariant, clear architectural effect,

--- a/skills/route-delegation/SKILL.md
+++ b/skills/route-delegation/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: route-delegation
+category: core
 description: >
   Decide between a subagent swarm and an Invoker submission before fanning
   out. Trigger when about to spawn several subagents, forks, background

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: verify
+category: optimization
 description: >
   Drive and prove Invoker UI/live-path changes via skills/verify/control-invoker.mjs:
   doctor, feature-map prove commands, isolated-Electron drive, visual-proof wrap,

--- a/skills/visual-proof/SKILL.md
+++ b/skills/visual-proof/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: visual-proof
+category: optimization
 description: >
   Capture before/after UI screenshots and video for Invoker plans that modify
   the UI.

--- a/skills/worker-session-mine/SKILL.md
+++ b/skills/worker-session-mine/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: worker-session-mine
+category: optimization
 description: >
   Invoker-owned adapter for the off-by-default worker-session-mine owner worker.
   Mines terminal fire-and-forget agent sessions (Claude, Codex, OMP) for mechanical

--- a/skills/workflow-chain-submit/SKILL.md
+++ b/skills/workflow-chain-submit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: workflow-chain-submit
+category: core
 description: >
   Submit a workflow chain headlessly, where each workflow is gated on the
   previous workflow's merge gate.


### PR DESCRIPTION
## Summary

Adds a new skill file, `skills/push-not-poll/SKILL.md`, tagged `category: optimization`.

It tells agents to wait on long jobs with one blocking call or a notification, not a fast check loop.

Each check in a turn-based agent resends the whole conversation, so cost grows with the number of checks, not with minutes waited.

The fix-ci repair flow is the worked example: a 10s check with no cap cost 74,147,000 tokens; a 180s check with a 15-turn cap cost 966,000.

This sits on top of the skill category stack, whose `category:` filter lets optimization skills install apart from core ones.

## Review Claim

`skills/push-not-poll/SKILL.md` is one new, self-contained skill with `category: optimization` frontmatter that states the push-over-poll principle and the measured fix-ci numbers exactly.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice only creates one new file, `skills/push-not-poll/SKILL.md`. It does not modify `packages/shell/src/bundled-skills.ts`, any other skill, or any file owned by the skill category stack below it.

## Slice Rationale

The skill text is kept apart from the category mechanism it depends on (the skill category stack below) and from any change to the fix-ci prompt itself, which is separate, independent work.

## Non-goals

- No change to `packages/shell/src/bundled-skills.ts` or the `install-skills` entry point.
- No change to any other skill file.
- No change to the fix-ci prompt (`buildRepairPrompt` in `packages/app/src/review-gate-ci-repair-workflow.ts`).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-bundled-skill-categories.mjs`
- [x] `pnpm run check:comments`
- [x] `grep -c -e '74,147,000' -e '966,000' skills/push-not-poll/SKILL.md`
- [x] `grep -n '^category: optimization$' skills/push-not-poll/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
