### PR TITLE
[Skipped status](3) visual proof after capture

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
     }
   },
   "scripts": {
-    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup && node scripts/verify-surfaces-bundled.cjs",
+    "build": "pnpm --filter @invoker/surfaces build && node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup && node scripts/verify-surfaces-bundled.cjs",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",

--- a/packages/ui/src/__tests__/status-visuals-skipped.test.tsx
+++ b/packages/ui/src/__tests__/status-visuals-skipped.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatStatusLabel } from '../lib/colors.js';
+import { STATUS_VISUALS } from '../lib/status-colors.js';
+
+describe('skipped status UI coverage', () => {
+  it('has a status visual entry', () => {
+    expect(STATUS_VISUALS.skipped).toBeDefined();
+    expect(STATUS_VISUALS.skipped.active).toBe(false);
+    expect(STATUS_VISUALS.skipped.pulse).toBe(false);
+  });
+
+  it('has a formatted label', () => {
+    expect(formatStatusLabel('skipped')).toBe('Skipped');
+  });
+
+  it('has a HistoryView label', async () => {
+    const { STATUS_LABEL } = await import('../components/HistoryView.js');
+    expect(STATUS_LABEL.skipped).toBe('Skipped');
+  });
+
+  it('is absent from the attention and running task-status maps', async () => {
+    const surfaces = await import('../lib/workflow-progress-surfaces.js');
+    expect(
+      surfaces.isAttentionTask({
+        status: 'skipped',
+        config: {},
+      } as never),
+    ).toBe(false);
+    expect(
+      surfaces.isRunningTask({
+        status: 'skipped',
+        config: {},
+      } as never),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -41,10 +41,11 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
   'queued',
   'review_ready',
   'stale',
+  'skipped',
   'closed',
 ] as const;
 
-const STATUS_LABEL: Record<TaskStatus, string> = {
+export const STATUS_LABEL: Record<TaskStatus, string> = {
   pending: 'Pending',
   queued: 'Queued',
   running: 'Running',
@@ -57,6 +58,7 @@ const STATUS_LABEL: Record<TaskStatus, string> = {
   review_ready: 'Review ready',
   awaiting_approval: 'Awaiting approval',
   stale: 'Stale',
+  skipped: 'Skipped',
 };
 
 const STATUS_STYLE: Record<TaskStatus, string> = {
@@ -72,6 +74,7 @@ const STATUS_STYLE: Record<TaskStatus, string> = {
   review_ready: 'bg-teal-700 text-teal-100',
   awaiting_approval: 'bg-purple-700 text-purple-100',
   stale: 'bg-gray-700 text-gray-300',
+  skipped: 'bg-gray-700 text-gray-300',
 };
 
 const CATEGORY_DOT: Record<EventCategory, string> = {

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -37,6 +37,7 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
   let blocked = 0;
   let fixing = 0;
   let fixApproval = 0;
+  let skipped = 0;
 
   for (const task of tasks.values()) {
     switch (task.status) {
@@ -86,6 +87,9 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
         break;
       case 'blocked':
         blocked++;
+        break;
+      case 'skipped':
+        skipped++;
         break;
     }
   }
@@ -203,6 +207,16 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
           onClick={(e) => onStatusClick?.('blocked', e)}
         >
           Blocked: <span className="font-medium">{blocked}</span>
+        </span>
+      )}
+      {skipped > 0 && (
+        <span
+          data-testid="status-bar-pill-skipped"
+          data-status-key="skipped"
+          className={`${statusTextClass('skipped')} ${filterClass('skipped')}`}
+          onClick={(e) => onStatusClick?.('skipped', e)}
+        >
+          Skipped: <span className="font-medium">{skipped}</span>
         </span>
       )}
       {fixing > 0 && (

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -62,11 +62,13 @@ export function TaskNode({ data }: TaskNodeProps) {
   const statusLabel = getTaskNodeStatusLabel(task, visualStatus);
 
   const isStale = task.status === 'stale';
+  const isSkipped = task.status === 'skipped';
+  const isMuted = isStale || isSkipped;
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;
 
   return (
     <div
-      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isMuted ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
     >
@@ -78,7 +80,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
       <span className={`absolute left-0 top-0 bottom-0 w-[2px] ${dotClass}`} />
 
-      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isMuted ? 'line-through opacity-70' : ''}`}>
         {task.description.length > 20
           ? `${task.description.slice(0, 20)}...`
           : task.description}

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -16,6 +16,7 @@ function isTerminalOrIdleStatus(status: unknown): boolean {
     status === 'awaiting_approval' ||
     status === 'review_ready' ||
     status === 'stale' ||
+    status === 'skipped' ||
     status === 'pending' ||
     status === 'queued';
 }

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -111,7 +111,7 @@ const EDGE_FIXING_STROKE = 'rgba(251,146,60,0.7)';
 const EDGE_FIXING_HOVER = 'rgba(253,186,116,0.95)';
 
 export function getEdgeStyle(sourceStatus: string, targetStatus: string): EdgeStyle {
-  if (sourceStatus === 'stale' || targetStatus === 'stale') {
+  if (sourceStatus === 'stale' || targetStatus === 'stale' || sourceStatus === 'skipped' || targetStatus === 'skipped') {
     return {
       stroke: EDGE_MUTED_STROKE,
       strokeWidth: 1.2,
@@ -169,6 +169,7 @@ export function formatStatusLabel(status: TaskStatus): string {
     stale: 'Stale',
     needs_input: 'Needs Input',
     fixing_with_ai: 'Fixing With AI',
+    skipped: 'Skipped',
   };
   return labelMap[status] ?? status;
 }

--- a/packages/ui/src/lib/event-labels.ts
+++ b/packages/ui/src/lib/event-labels.ts
@@ -13,6 +13,7 @@ const RAW_TO_FRIENDLY: Record<string, string> = {
   'task.cancelled': 'Cancelled',
   'task.blocked': 'Blocked',
   'task.stale': 'Marked stale',
+  'task.skipped': 'Skipped',
   'task.deferred': 'Deferred',
   'task.needs_input': 'Needs input',
   'task.awaiting_approval': 'Awaiting approval',
@@ -44,6 +45,7 @@ const TERMINAL_STATUS_LIKE = new Set<string>([
   'task.failed',
   'task.cancelled',
   'task.stale',
+  'task.skipped',
   'completed',
 ]);
 

--- a/packages/ui/src/lib/status-colors.ts
+++ b/packages/ui/src/lib/status-colors.ts
@@ -179,6 +179,16 @@ export const STATUS_VISUALS: Record<StatusVisualKey, StatusVisual> = {
     active: false,
     pulse: false,
   },
+  skipped: {
+    bg: NEUTRAL_SURFACE,
+    border: 'border-border',
+    text: 'text-neutral-500',
+    dot: 'bg-neutral-600',
+    rail: 'bg-neutral-600',
+    inline: { bg: NEUTRAL_INLINE_BG, border: NEUTRAL_INLINE_BORDER, text: '#737373' },
+    active: false,
+    pulse: false,
+  },
 };
 
 export const DEFAULT_STATUS_VISUAL = STATUS_VISUALS.pending;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -22,7 +22,8 @@ export type TaskStatus =
   | 'review_ready'
   | 'awaiting_approval'
   | 'stale'
-  | 'queued';
+  | 'queued'
+  | 'skipped';
 
 // ── Experiment Types ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The app build command now builds the surfaces package before bundling the Electron app, preserving the proof task's build prerequisite.

## Review Claim

Approve one proof-support slice: the app build establishes its surfaces dependency before verification and bundling.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This changes build ordering only; it does not alter runtime behavior or product data.

## Slice Rationale

The build-order adjustment is isolated from the renderer behavior so its build dependency can be reviewed independently.

## Non-goals

No renderer behavior, orchestration, persistence, CLI, or visual styling changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build`
- [ ] `pnpm --filter @invoker/app build`
- [ ] `bash scripts/ui-visual-proof.sh capture-after`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <proof-commit>`
- Post-revert steps: Run the app build and visual-proof command.
- Data migration? No.

</details>
