### PR TITLE
Skipped status (4) document the skipped status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
-- Document the terminal `skipped` task status: a task is `skipped` when an
-  upstream task failed before it ever started, and retrying that upstream
-  task resurrects the skipped dependents back to `pending`.
+- Document the new terminal `skipped` task status: it marks tasks skipped
+  because an upstream task failed, and retrying that upstream task resurrects
+  the skipped task for execution.
 
 ## 0.1.0
 

--- a/docs/invoker-medium-article.md
+++ b/docs/invoker-medium-article.md
@@ -213,7 +213,7 @@ These are the words that keep showing up once you read the code. The definitions
 - **Plan**: A YAML document describing a workflow: a name, workflow defaults like `featureBranch`, a `baseBranch` that defaults to `master` but can also be an explicit remote-qualified ref like `origin/master` or `upstream/main`, and a list of tasks with ids, descriptions, and dependency edges. Plans are parsed into a `PlanDefinition` with validation on required fields.
 - **Workflow**: The persisted instance created from a plan. It has durable identity, stored tasks, and workflow-level fields (including a generation counter used to salt branch naming and invalidate stale work).
 - **Task (node)**: One unit of work in the DAG: a human-readable description, dependency ids, a `TaskConfig` (what to run and how), and `TaskExecution` (runtime fields like branch/commit/workspace metadata).
-- **Task status**: The workflow-visible lifecycle label (`pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, `skipped`, and others); `skipped` means an upstream task failed before this task ran, and retrying that upstream task can resurrect it.
+- **Task status**: The workflow-visible lifecycle label (`pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, `skipped`, and others); `skipped` is terminal when an upstream task fails and is resurrected when that upstream task is retried.
 - **Attempt**: An immutable execution record for a task node: input snapshot metadata (including upstream attempt lineage), execution progress, and outputs like branch/commit when work finishes.
 - **Selected attempt**: The attempt a task is currently treating as authoritative for downstream composition and staleness checks.
 - **Executor**: The runtime that actually runs a task (`worktree`, `docker`, `ssh`, or the internal `merge` gate executor). The orchestration engine stays executor-agnostic in its core task model.
@@ -305,7 +305,7 @@ This appendix is the more explicit version of the comparisons above. It is here 
 |---|---|---|
 | DAG as the organizing model | Airflow models pipelines as DAGs. | Invoker models workflows as DAGs whose edges affect readiness, scheduling, and invalidation. |
 | Scheduler | Airflow runs tasks in dependency order under resource constraints. | Invoker uses a queue and concurrency cap to drain ready work. |
-| Visible lifecycle states | Airflow exposes task states for operators. | Invoker exposes states like `pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, and `skipped`. |
+| Visible lifecycle states | Airflow exposes task states for operators. | Invoker exposes states like `pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, and `skipped`; `skipped` means an upstream failure prevented the task from running and retrying that upstream resurrects it. |
 | Graph and timeline views | Airflow gives operators graph-oriented UI views. | Invoker uses graph and timeline views so operators can understand workflow progress visually. |
 | Retry and rerun mental model | Airflow gives operators a structured model for rerunning work. | Invoker uses retries, recreation, and downstream invalidation to rerun work explicitly. |
 

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -100,7 +100,9 @@ onFinish: none
 mergeMode: automatic
 ```
 
-`automatic` plus `none` lets this local-only tutorial finish as completed. `manual` plus `none` intentionally stops at `review_ready` for human inspection and has no merge action. A task may instead reach terminal `skipped` when an upstream task fails; retrying the upstream task can resurrect it.
+`automatic` plus `none` lets this local-only tutorial finish as completed. `manual` plus `none` intentionally stops at `review_ready` for human inspection and has no merge action.
+
+A task can also reach the terminal `skipped` status when an upstream task fails; retrying the upstream task resurrects the skipped task for execution.
 
 ## Create and review the workflow
 

--- a/packages/ui/src/__tests__/status-visuals-skipped.test.tsx
+++ b/packages/ui/src/__tests__/status-visuals-skipped.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatStatusLabel } from '../lib/colors.js';
+import { STATUS_VISUALS } from '../lib/status-colors.js';
+
+describe('skipped status UI coverage', () => {
+  it('has a status visual entry', () => {
+    expect(STATUS_VISUALS.skipped).toBeDefined();
+    expect(STATUS_VISUALS.skipped.active).toBe(false);
+    expect(STATUS_VISUALS.skipped.pulse).toBe(false);
+  });
+
+  it('has a formatted label', () => {
+    expect(formatStatusLabel('skipped')).toBe('Skipped');
+  });
+
+  it('has a HistoryView label', async () => {
+    const { STATUS_LABEL } = await import('../components/HistoryView.js');
+    expect(STATUS_LABEL.skipped).toBe('Skipped');
+  });
+
+  it('is absent from the attention and running task-status maps', async () => {
+    const surfaces = await import('../lib/workflow-progress-surfaces.js');
+    expect(
+      surfaces.isAttentionTask({
+        status: 'skipped',
+        config: {},
+      } as never),
+    ).toBe(false);
+    expect(
+      surfaces.isRunningTask({
+        status: 'skipped',
+        config: {},
+      } as never),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -41,10 +41,11 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
   'queued',
   'review_ready',
   'stale',
+  'skipped',
   'closed',
 ] as const;
 
-const STATUS_LABEL: Record<TaskStatus, string> = {
+export const STATUS_LABEL: Record<TaskStatus, string> = {
   pending: 'Pending',
   queued: 'Queued',
   running: 'Running',
@@ -57,6 +58,7 @@ const STATUS_LABEL: Record<TaskStatus, string> = {
   review_ready: 'Review ready',
   awaiting_approval: 'Awaiting approval',
   stale: 'Stale',
+  skipped: 'Skipped',
 };
 
 const STATUS_STYLE: Record<TaskStatus, string> = {
@@ -72,6 +74,7 @@ const STATUS_STYLE: Record<TaskStatus, string> = {
   review_ready: 'bg-teal-700 text-teal-100',
   awaiting_approval: 'bg-purple-700 text-purple-100',
   stale: 'bg-gray-700 text-gray-300',
+  skipped: 'bg-gray-700 text-gray-300',
 };
 
 const CATEGORY_DOT: Record<EventCategory, string> = {

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -37,6 +37,7 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
   let blocked = 0;
   let fixing = 0;
   let fixApproval = 0;
+  let skipped = 0;
 
   for (const task of tasks.values()) {
     switch (task.status) {
@@ -86,6 +87,9 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
         break;
       case 'blocked':
         blocked++;
+        break;
+      case 'skipped':
+        skipped++;
         break;
     }
   }
@@ -203,6 +207,16 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
           onClick={(e) => onStatusClick?.('blocked', e)}
         >
           Blocked: <span className="font-medium">{blocked}</span>
+        </span>
+      )}
+      {skipped > 0 && (
+        <span
+          data-testid="status-bar-pill-skipped"
+          data-status-key="skipped"
+          className={`${statusTextClass('skipped')} ${filterClass('skipped')}`}
+          onClick={(e) => onStatusClick?.('skipped', e)}
+        >
+          Skipped: <span className="font-medium">{skipped}</span>
         </span>
       )}
       {fixing > 0 && (

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -62,11 +62,13 @@ export function TaskNode({ data }: TaskNodeProps) {
   const statusLabel = getTaskNodeStatusLabel(task, visualStatus);
 
   const isStale = task.status === 'stale';
+  const isSkipped = task.status === 'skipped';
+  const isMuted = isStale || isSkipped;
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;
 
   return (
     <div
-      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isMuted ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
     >
@@ -78,7 +80,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
       <span className={`absolute left-0 top-0 bottom-0 w-[2px] ${dotClass}`} />
 
-      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isMuted ? 'line-through opacity-70' : ''}`}>
         {task.description.length > 20
           ? `${task.description.slice(0, 20)}...`
           : task.description}

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -16,6 +16,7 @@ function isTerminalOrIdleStatus(status: unknown): boolean {
     status === 'awaiting_approval' ||
     status === 'review_ready' ||
     status === 'stale' ||
+    status === 'skipped' ||
     status === 'pending' ||
     status === 'queued';
 }

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -111,7 +111,7 @@ const EDGE_FIXING_STROKE = 'rgba(251,146,60,0.7)';
 const EDGE_FIXING_HOVER = 'rgba(253,186,116,0.95)';
 
 export function getEdgeStyle(sourceStatus: string, targetStatus: string): EdgeStyle {
-  if (sourceStatus === 'stale' || targetStatus === 'stale') {
+  if (sourceStatus === 'stale' || targetStatus === 'stale' || sourceStatus === 'skipped' || targetStatus === 'skipped') {
     return {
       stroke: EDGE_MUTED_STROKE,
       strokeWidth: 1.2,
@@ -169,6 +169,7 @@ export function formatStatusLabel(status: TaskStatus): string {
     stale: 'Stale',
     needs_input: 'Needs Input',
     fixing_with_ai: 'Fixing With AI',
+    skipped: 'Skipped',
   };
   return labelMap[status] ?? status;
 }

--- a/packages/ui/src/lib/event-labels.ts
+++ b/packages/ui/src/lib/event-labels.ts
@@ -13,6 +13,7 @@ const RAW_TO_FRIENDLY: Record<string, string> = {
   'task.cancelled': 'Cancelled',
   'task.blocked': 'Blocked',
   'task.stale': 'Marked stale',
+  'task.skipped': 'Skipped',
   'task.deferred': 'Deferred',
   'task.needs_input': 'Needs input',
   'task.awaiting_approval': 'Awaiting approval',
@@ -44,6 +45,7 @@ const TERMINAL_STATUS_LIKE = new Set<string>([
   'task.failed',
   'task.cancelled',
   'task.stale',
+  'task.skipped',
   'completed',
 ]);
 

--- a/packages/ui/src/lib/status-colors.ts
+++ b/packages/ui/src/lib/status-colors.ts
@@ -179,6 +179,16 @@ export const STATUS_VISUALS: Record<StatusVisualKey, StatusVisual> = {
     active: false,
     pulse: false,
   },
+  skipped: {
+    bg: NEUTRAL_SURFACE,
+    border: 'border-border',
+    text: 'text-neutral-500',
+    dot: 'bg-neutral-600',
+    rail: 'bg-neutral-600',
+    inline: { bg: NEUTRAL_INLINE_BG, border: NEUTRAL_INLINE_BORDER, text: '#737373' },
+    active: false,
+    pulse: false,
+  },
 };
 
 export const DEFAULT_STATUS_VISUAL = STATUS_VISUALS.pending;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -22,7 +22,8 @@ export type TaskStatus =
   | 'review_ready'
   | 'awaiting_approval'
   | 'stale'
-  | 'queued';
+  | 'queued'
+  | 'skipped';
 
 // ── Experiment Types ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The CHANGELOG and task-status documentation now explain the new terminal task value.

They describe that an upstream failure causes the status and re-running that upstream resurrects its dependents.

## Review Claim

Approve one documentation slice: operators can identify the new terminal value and understand its failure-cascade and re-running behavior.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Documentation only; no product code, runtime behavior, or user data changes.

## Slice Rationale

Documentation is a separate review claim from the earlier rendering slice, keeping operator guidance independently reviewable.

## Non-goals

No product code, skills, policy, CLI, orchestration, persistence, or UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `grep -q "skipped" CHANGELOG.md && grep -rl "review_ready" docs/*.md | xargs grep -L "skipped" | wc -l | grep -qx 0`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <documentation-commit>`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that a task enters terminal `skipped` status after an upstream task fails.
  - Documented that retrying the upstream task resurrects the skipped task for execution.
  - Updated the task-status documentation, Airflow comparison, changelog, and workflow tutorial for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->