### PR TITLE
PR-maintenance workers wait for the shared cron lock instead of skipping

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -150,3 +150,48 @@ describe('PR maintenance entrypoints bootstrap', () => {
     ].join('\n'));
   });
 });
+
+describe('cron_lock shared PR-maintenance lock', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'pr-maintenance-lock-wait-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('waits for a lock held by another operation and then takes it', () => {
+    const lockPath = join(workDir, 'pr-crons.lock');
+    const script = [
+      'source scripts/cron-pr-lib.sh',
+      'if command -v flock >/dev/null 2>&1; then',
+      '  flock "$INVOKER_PR_CRON_LOCK" sleep 1 &',
+      '  until ! flock -n "$INVOKER_PR_CRON_LOCK" true; do :; done',
+      'else',
+      '  mkdir "$INVOKER_PR_CRON_LOCK.d"',
+      '  echo "$$" > "$INVOKER_PR_CRON_LOCK.d/pid"',
+      '  ( sleep 1; rm -rf "$INVOKER_PR_CRON_LOCK.d" ) &',
+      'fi',
+      'cron_lock',
+      'echo lock-acquired',
+    ].join('\n');
+
+    const result = spawnSync('bash', ['-c', script], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        INVOKER_PR_CRON_LOCK: lockPath,
+        INVOKER_PR_CRON_LOCK_WAIT_SECS: '10',
+      },
+    });
+
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    expect(output).not.toContain('another PR cron operation in progress');
+    expect(result.stdout).toContain('lock-acquired');
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -389,6 +389,57 @@ describe('PR maintenance workers', () => {
     await worker.stop();
   });
 
+  it('waits for the shared PR-maintenance lock to free up instead of skipping the tick', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    let probes = 0;
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => {
+        probes += 1;
+        return probes <= 2 ? { held: true, reason: 'test-lock-held' } : { held: false };
+      },
+      lockPollMs: 1,
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(probes).toBe(3);
+    expect(spawnHarness.calls).toHaveLength(1);
+  });
+
+  it('skips the tick only after the lock stays held past the wait limit', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    let probes = 0;
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => {
+        probes += 1;
+        return { held: true, reason: 'test-lock-held' };
+      },
+      lockWaitMs: 30,
+      lockPollMs: 5,
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(probes).toBeGreaterThan(1);
+    expect(spawnHarness.calls).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${PR_ADMIN_BYPASS_LAND_WORKER_KIND}] shared PR maintenance lock held; skipping tick`,
+      expect.objectContaining({ worker: PR_ADMIN_BYPASS_LAND_WORKER_KIND, reason: 'test-lock-held' }),
+    );
+  });
+
   it('skips cleanly when the shared PR-maintenance lock is already held', async () => {
     const repoRoot = makeRepoRoot();
     const logger = makeLogger();
@@ -398,6 +449,7 @@ describe('PR maintenance workers', () => {
       repoRoot,
       spawnProcess: spawnHarness.spawnProcess,
       lockProbe: () => ({ held: true, reason: 'test-lock-held' }),
+      lockWaitMs: 0,
       installSignalHandlers: false,
     });
 
@@ -422,6 +474,7 @@ describe('PR maintenance workers', () => {
       repoRoot,
       spawnProcess: spawnHarness.spawnProcess,
       lockProbe: () => ({ held: true, reason: 'test-lock-held' }),
+      lockWaitMs: 0,
       installSignalHandlers: false,
     });
 
@@ -540,6 +593,7 @@ describe('PR maintenance workers', () => {
       repoRoot,
       spawnProcess: makeSpawnHarness().spawnProcess,
       lockProbe: () => ({ held: true, reason: 'lock-held' }),
+      lockWaitMs: 0,
       installSignalHandlers: false,
       store,
     });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { resolve } from 'node:path';
 import type { Readable } from 'node:stream';
 
@@ -38,6 +39,8 @@ export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORK
  * it. Override via INVOKER_PR_MAINTENANCE_TICK_TIMEOUT_MS.
  */
 export const DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS = 4 * 60_000;
+export const DEFAULT_PR_MAINTENANCE_LOCK_WAIT_MS = 4 * 60_000;
+export const DEFAULT_PR_MAINTENANCE_LOCK_POLL_MS = 5_000;
 
 export type PrMaintenanceWorkerKind =
   | typeof PR_ADMIN_BYPASS_LAND_WORKER_KIND
@@ -99,6 +102,8 @@ export interface PrMaintenanceWorkerConfig {
   startDelayMs?: number;
   /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
   lockPath?: string;
+  lockWaitMs?: number;
+  lockPollMs?: number;
   /** Per-tick wall-clock cap for the spawned child. See DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS. */
   tickTimeoutMs?: number;
   /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
@@ -323,6 +328,8 @@ function createPrMaintenanceWorker(
       env: options.env,
       intervalMs: options.intervalMs,
       lockPath: options.lockPath,
+      lockWaitMs: options.lockWaitMs,
+      lockPollMs: options.lockPollMs,
       tickTimeoutMs: options.tickTimeoutMs,
       shell: options.shell,
       spawnProcess: options.spawnProcess,
@@ -345,13 +352,33 @@ async function runPrMaintenanceEntrypoint(
   const lockPath = options.lockPath ?? env.INVOKER_PR_CRON_LOCK ?? defaultPrCronLockPath(env);
   env.INVOKER_PR_CRON_LOCK = lockPath;
   const lockProbe = options.lockProbe ?? probePrMaintenanceLock;
-  const lock = await lockProbe({
+  const probeOptions: PrMaintenanceLockProbeOptions = {
     lockPath,
     env,
     staleLockSeconds: parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_STALE_SECS),
-  });
-
+  };
+  const envLockWaitSecs = parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_WAIT_SECS);
+  const lockWaitMs = options.lockWaitMs
+    ?? (envLockWaitSecs !== undefined ? envLockWaitSecs * 1000 : DEFAULT_PR_MAINTENANCE_LOCK_WAIT_MS);
+  const lockPollMs = options.lockPollMs ?? DEFAULT_PR_MAINTENANCE_LOCK_POLL_MS;
+  const lockWaitDeadline = Date.now() + lockWaitMs;
+  let lock = await lockProbe(probeOptions);
   signal?.throwIfAborted();
+
+  if (lock.held && lockWaitMs > 0) {
+    options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; waiting for it`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      lockPath,
+      reason: lock.reason ?? 'lock-held',
+      lockWaitMs,
+    });
+  }
+  while (lock.held && Date.now() < lockWaitDeadline) {
+    await sleep(Math.min(lockPollMs, Math.max(0, lockWaitDeadline - Date.now())), undefined, { signal });
+    lock = await lockProbe(probeOptions);
+    signal?.throwIfAborted();
+  }
 
   if (lock.held) {
     options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; skipping tick`, {

--- a/scripts/cron-pr-lib.sh
+++ b/scripts/cron-pr-lib.sh
@@ -33,6 +33,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/headless-lib.sh"
 TARGET_REPO="${INVOKER_GITHUB_TARGET_REPO:-Neko-Catpital-Labs/Invoker}"
 PR_AUTHOR="${INVOKER_PR_CRON_AUTHOR:-EdbertChan}"
 CRON_LOCK="${INVOKER_PR_CRON_LOCK:-${TMPDIR:-/tmp}/invoker-pr-crons.lock}"
+CRON_LOCK_WAIT_SECS="${INVOKER_PR_CRON_LOCK_WAIT_SECS:-60}"
 DRY_RUN="${INVOKER_PR_CRON_DRY_RUN:-0}"
 
 # ---------------------------------------------------------------------------
@@ -82,7 +83,7 @@ _cron_lock_reap_stale() {
 cron_lock() {
   if command -v flock >/dev/null 2>&1; then
     exec 9>"$CRON_LOCK"
-    if ! flock -n 9; then
+    if ! flock -w "$CRON_LOCK_WAIT_SECS" 9; then
       log_line "another PR cron operation in progress; exiting"
       exit 0
     fi
@@ -91,11 +92,16 @@ cron_lock() {
 
   # Portable fallback: atomic mkdir lock, reaped only on a dead holder PID.
   local lockdir="${CRON_LOCK}.d"
+  local deadline=$(( $(date +%s) + CRON_LOCK_WAIT_SECS ))
   [ -d "$lockdir" ] && _cron_lock_reap_stale "$lockdir"
-  if ! mkdir "$lockdir" 2>/dev/null; then
-    log_line "another PR cron operation in progress; exiting"
-    exit 0
-  fi
+  until mkdir "$lockdir" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      log_line "another PR cron operation in progress; exiting"
+      exit 0
+    fi
+    sleep 1
+    [ -d "$lockdir" ] && _cron_lock_reap_stale "$lockdir"
+  done
   printf '%s\n' "$$" > "$lockdir/pid"
   CRON_LOCK_DIR="$lockdir"
   # shellcheck disable=SC2064


### PR DESCRIPTION
A worker that found the lock held returned from the tick and retried in
five minutes. Workers that wake in the same second lose to the same
sibling every cycle, so pr-admin-bypass-land skipped 51 consecutive ticks
on the owner host and never queued an admin-bypass PR.

The tick now re-probes the lock until it frees or the wait budget runs
out, and cron_lock waits on flock instead of failing immediately.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RSQnkRXWfVzWrHtPEgvWbx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mutual exclusion timing for production PR cron workers and shell entrypoints; mis-tuned wait limits could delay or still skip maintenance work, but behavior is env-configurable and bounded.
> 
> **Overview**
> PR-maintenance workers and shell cron jobs no longer bail on the first sight of the shared `INVOKER_PR_CRON_LOCK`; they **poll until the lock frees or a wait budget expires**, which should stop sibling workers (e.g. admin-bypass-land) from losing every race and skipping dozens of ticks.
> 
> In **`pr-maintenance-workers.ts`**, each tick re-probes the lock on a **5s default poll interval** for up to **4 minutes** (overridable via `lockWaitMs` / `lockPollMs` or `INVOKER_PR_CRON_LOCK_WAIT_SECS`), logs while waiting, and only then skips. **`cron_lock`** in `cron-pr-lib.sh` mirrors this: **`flock -w`** instead of `-n`, plus a timed retry loop for the mkdir fallback, with **`INVOKER_PR_CRON_LOCK_WAIT_SECS`** defaulting to 60s for scripts.
> 
> Tests cover shell lock acquisition after a short hold and worker behavior for wait-then-run vs wait-then-skip (`lockWaitMs: 0` preserves immediate-skip cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b293eba8f35efe54b6e3d27f007c9e5fc606f159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PR maintenance operations now wait for an existing shared lock instead of immediately skipping.
  - Lock acquisition retries until a configurable timeout, improving reliability when another operation is finishing.
  - Operations still skip safely when the lock remains unavailable beyond the timeout.
  - Stale lock handling continues during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->