### PR TITLE
[Publisher Error Surfacing](1) Report the agent's own error instead of a JSON parse failure

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   buildCanonicalPrBody,
   buildMakePrStackPublishPrompt,
+  extractAgentReportedError,
   parseMakePrStackPublishResult,
   resolvePrBodyValidatorNodeBinary,
   resolveSkillPathViaAgent,
@@ -485,6 +486,29 @@ describe('make-pr stack publish body contract', () => {
 });
 
 // ── resolveSkillPathViaAgent ─────────────────────────────
+
+describe('extractAgentReportedError', () => {
+  it('surfaces the usage-limit message a zero-exit agent reported instead of a body', () => {
+    const stdout = JSON.stringify({
+      type: 'task_complete',
+      last_agent_message: null,
+      error: { message: "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now." },
+    });
+    expect(extractAgentReportedError(stdout)).toBe(
+      "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now.",
+    );
+  });
+
+  it('returns undefined when the agent reported no error', () => {
+    const stdout = JSON.stringify({ type: 'task_complete', last_agent_message: '{"artifacts":[]}' });
+    expect(extractAgentReportedError(stdout)).toBeUndefined();
+  });
+
+  it('skips an error object that carries no message', () => {
+    const stdout = '{"error":{"code":429}} {"error":{"message":"rate limited"}}';
+    expect(extractAgentReportedError(stdout)).toBe('rate limited');
+  });
+});
 
 describe('resolveSkillPathViaAgent', () => {
   it('resolves skill from agent bundledSkillRoot when SKILL.md exists', () => {

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -469,6 +469,23 @@ function extractJsonPayload(raw: string): string {
   return lastValid ?? trimmed;
 }
 
+export function extractAgentReportedError(stdout: string): string | undefined {
+  if (!stdout) return undefined;
+  for (const match of stdout.matchAll(/"error"\s*:\s*\{/g)) {
+    const slice = stdout.slice(match.index);
+    const messageMatch = slice.match(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (!messageMatch) continue;
+    try {
+      const message = JSON.parse(`"${messageMatch[1]}"`) as string;
+      if (message.trim()) return message.trim();
+    } catch {
+      const message = messageMatch[1].trim();
+      if (message) return message;
+    }
+  }
+  return undefined;
+}
+
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
   let parsed: unknown;
   try {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -52,6 +52,7 @@ import {
   isInvokerRepoUrl,
   buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
+  extractAgentReportedError,
   parseMakePrStackPublishResult,
   repoLocalPrBodyCheckerPath,
   resolveSkillPathViaAgent,
@@ -60,6 +61,7 @@ import {
   validateCanonicalPrBody,
   validateReviewStackPrBody,
   validateReviewStackPrBodyAgainstLocalDiff,
+  type MakePrStackArtifactOutput,
   type PrAuthoringContext,
 } from './pr-authoring.js';
 import { ensureRemoteUrl } from './git-config-mutation.js';
@@ -1681,7 +1683,22 @@ export class TaskRunner {
           agentName: agent.name,
           sessionId: result.sessionId,
         });
-        const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+        let parsedArtifacts: MakePrStackArtifactOutput[];
+        try {
+          parsedArtifacts = parseMakePrStackPublishResult(result.body);
+        } catch (parseError) {
+          const reportedError = extractAgentReportedError(result.stdout);
+          logProgress('error', `${agent.name} make-pr agent produced no usable output`, {
+            agentName: agent.name,
+            sessionId: result.sessionId,
+            reportedError: reportedError ?? null,
+            bodyLength: result.body?.length ?? 0,
+          });
+          if (reportedError) {
+            throw new Error(`${agent.name} could not author the PR: ${reportedError}`);
+          }
+          throw parseError;
+        }
 
         // Enforce the make-pr review-stack schema on every published body. Prefer
         // the body actually published on the provider: a lazy agent could report a


### PR DESCRIPTION
## Summary

When the make-pr publisher's agent hits its usage limit, the merge gate now says so instead of blaming JSON.

Codex exits 0 in that case and returns no message, so the publisher parsed an empty body and blamed JSON.

That has happened 24 times across eight days, and the operator never saw the real reason.

The parse site now reports the agent's own error text and logs the raw outcome. Publication stays codex-only, exactly as #11629 decided.

## Review Claim

A publisher failure whose agent reported an error surfaces that error instead of a JSON parse message.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The success path is untouched: parsing, schema validation, and artifact handling run exactly as before. Only the failure branch changes, and when the agent reported no error the original parse error is rethrown unchanged.

## Slice Rationale

One claim in one failure branch, plus its helper and tests. Agent selection is deliberately out of scope.

## Non-goals

- Does not add an agent fallback. #11629 made publication codex-only on purpose, to stop fallback attempts turning a malformed response into a 20-minute gate timeout.
- Does not change the JSON schema, the success path, or PR body validation.
- Does not retry on usage limits.

**Overlapping in-flight work:** #12227 (Typed agent usage limit (3) routing layer) edits the same two files to give the auto-fix breaker a typed `agent-usage-limit` class. That slice classifies the failure; this one reports the agent's message to the operator. Whichever lands second rebases.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `vitest run src/__tests__/pr-authoring.test.ts -t "extractAgentReportedError"` against origin/master's `pr-authoring.ts` — `Tests 3 failed | 33 skipped (36)`, exit 1
- [x] `vitest run src/__tests__/pr-authoring.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts` with the fix — `Test Files 2 passed (2)`, `Tests 153 passed (153)`, exit 0
- [x] `node scripts/check-added-comments.mjs --base origin/master` — `no disallowed comments found`, exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; the gate returns to reporting the parse error
- Data migration? No

</details>
