### PR TITLE
[Malformed Workflow Id](1) Stop a spliced id from stalling every cron tick

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -90,7 +90,14 @@ class RepairSubmissionAcknowledgement:
     workflow_id: str | None = None
 
 
-_WORKFLOW_ID_RE = re.compile(r"(?:Workflow ID:|workflow:)\s*(wf-[^\s]+)")
+# A workflow id is one bare token. `[^\s]+` was too permissive: a backslash is
+# not whitespace, so an escaped newline in the submit stdout let the capture run
+# on into the next field (observed: `wf-1788334466115-1\\nrequired-fast`, which
+# matches no workflow and so never settles). Exclude the quoting/escaping
+# characters an id can never contain; stay permissive about the rest, because
+# real ids are not all numeric (`wf-stress-1`, `wf-hitch-fat`) and the app's own
+# predicate is `/^wf-[^/]+$/` (persisted-workflow-mutation-coordinator.ts).
+_WORKFLOW_ID_RE = re.compile(r"(?:Workflow ID:|workflow:)\s*(wf-[^\s\\'\",]+)")
 
 
 def _write_plan_header(

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -4,6 +4,7 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -204,6 +205,20 @@ def workflow_status(workflow_id: str) -> str | None:
     return str(status) if status else None
 
 
+def is_resolvable_workflow_id(value: object) -> bool:
+    """True when `value` could name a real workflow.
+
+    The app's own predicate is `/^wf-[^/]+$/`
+    (persisted-workflow-mutation-coordinator.ts), and ids are not all numeric
+    (`wf-stress-1`, `wf-hitch-fat`), so this stays deliberately loose. It only
+    rejects what a capture bug produces: whitespace, an escape sequence, or a
+    quote spliced in from the surrounding output.
+    """
+    if not isinstance(value, str) or not value.startswith("wf-") or len(value) <= 3:
+        return False
+    return not any(ch in value for ch in " \t\n\r\\\"'/")
+
+
 def settle_workflow_fastpath_rows(ledger, now: int) -> int:
     """Write `<kind>-settled` rows for fast-path submissions whose workflow
     reached a terminal status. Returns how many rows were settled. Rows whose
@@ -223,6 +238,30 @@ def settle_workflow_fastpath_rows(ledger, now: int) -> int:
         key = str(row.get("key") or "")
         existing = ledger.latest(f"{kind}-settled", pr, head, key)
         if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+            continue
+        if not is_resolvable_workflow_id(workflow_id):
+            # Unresolvable is a third outcome, not "still running". Querying it
+            # costs a full headless round trip and can only ever answer "not
+            # found", so the row would be retried on every tick forever and the
+            # tick would keep spending its budget before reaching later repos.
+            print(
+                f"WARN: settle_workflow_fastpath_rows: PR #{pr} {kind} {key!r} stored an "
+                f"unresolvable workflowId {workflow_id!r}; settling it as an infra "
+                f"non-acknowledgement instead of re-querying it.",
+                file=sys.stderr,
+            )
+            ledger.record(
+                f"{kind}-settled", pr, head, key, now,
+                meta={
+                    "workflowId": workflow_id,
+                    "dispatchState": "not-acknowledged",
+                    "failurePhase": "submission",
+                    "outcomeClass": "infra",
+                    "settledBy": "fastpath-observer",
+                    "reason": "unresolvable-workflow-id",
+                },
+            )
+            settled += 1
             continue
         status = workflow_status(str(workflow_id))
         if status in _TERMINAL_WORKFLOW_STATUSES:

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -275,6 +275,37 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertEqual(acknowledgement.workflow_id, "wf-ack")
         self.assertFalse(written_paths[0].exists())
 
+    def test_submit_async_repair_plan_stops_workflow_id_at_an_escaped_newline(self):
+        """An id capture must not run past an escaped newline into the next field.
+
+        Observed on PR #11576: the submit stdout carried the id and the failing
+        job name separated by a literal backslash-n, and `wf-[^\\s]+` swallowed
+        both -- backslash and `n` are not whitespace. The stored id
+        (`wf-1788334466115-1\\nrequired-fast`) then matched no workflow, so the
+        settle loop re-queried it on every cron tick forever.
+        """
+        plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="Workflow ID: wf-1788334466115-1\\nrequired-fast / Guardrails\n",
+            stderr="",
+        )
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", return_value=completed):
+            acknowledgement = async_repair.submit_async_repair_plan(plan)
+        self.assertEqual(acknowledgement.workflow_id, "wf-1788334466115-1")
+
+    def test_submit_async_repair_plan_keeps_non_numeric_workflow_ids(self):
+        """`wf-stress-1` / `wf-hitch-fat` are real ids (stress-fixture.ts,
+        main-process-hitch-fixture.ts), and the app's own predicate is
+        `/^wf-[^/]+$/` -- so the capture must not be narrowed to digits."""
+        plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Workflow ID: wf-stress-1\n", stderr="",
+        )
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", return_value=completed):
+            acknowledgement = async_repair.submit_async_repair_plan(plan)
+        self.assertEqual(acknowledgement.workflow_id, "wf-stress-1")
+
     def test_submit_async_repair_plan_honors_submit_test_seam(self):
         plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -158,6 +158,40 @@ class FastpathSettleObserver(unittest.TestCase):
                 self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
                 status.assert_not_called()
 
+    def test_malformed_workflow_id_is_settled_without_a_status_query(self):
+        """A row whose id can never resolve must not be re-queried every tick.
+
+        Observed on the DO1 owner: 15 rows for merged PR #11576 held
+        `wf-1788334466115-1\\nrequired-fast`. `workflow_status` answered "not
+        found" for ~20s each, the row never reached a terminal status, and the
+        cron tick blew its 240s budget before it ever scanned the second repo.
+        Unresolvable is a third outcome -- it is settled as an infra
+        non-acknowledgement, not retried and not reported clean.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("repair-check", 11576, "head1", "UI Vitest", 100,
+                          meta={"workflowId": "wf-1788334466115-1\\nrequired-fast"})
+            with mock.patch.object(f, "workflow_status") as status:
+                settled = f.settle_workflow_fastpath_rows(ledger, 200)
+                status.assert_not_called()
+            self.assertEqual(settled, 1)
+            row = ledger.latest("repair-check-settled", 11576, "head1", "UI Vitest")
+            self.assertIsNotNone(row)
+            self.assertEqual(row["meta"]["outcomeClass"], "infra")
+            self.assertEqual(row["meta"]["dispatchState"], "not-acknowledged")
+
+    def test_well_formed_id_still_reaches_the_status_query(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("repair-check", 7055, "head2", "pr-body", 100,
+                          meta={"workflowId": "wf-stress-1"})
+            with mock.patch.object(f, "workflow_status", return_value="running") as status:
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+                status.assert_called_once()
+
     def test_unreadable_status_leaves_row_for_ttl_backstop(self):
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

The Mergify admin-bypass cron worker on DO1 had not finished a pass in hours. Every tick hit its 240s timeout and restarted.

It stores the workflow id it parses out of the stdout of the tool that files a repair. The pattern was `wf-[^\s]+`.

A backslash is not whitespace. So an escaped newline in that stdout let the capture run past the id and glue the next field onto it.

PR #11576 stored `wf-1788334466115-1\nrequired-fast` across 15 rows on 2026-09-02. No workflow has that id.

The settle loop therefore never saw a terminal status. It re-asked about all 15 rows on every tick, roughly 20 seconds each.

That is about 300 seconds of lookups inside a 240 second budget, so the tick died early and the second repository never got its turn.

This narrows the capture so it stops at a backslash or a quote. It stays loose about the rest of the id.

It also gives the settle loop a third answer. An id that can never resolve is settled as an infra non-acknowledgement with a warning, rather than being asked about forever.

## Review Claim

A workflow id parsed out of tool output must be one bare token, and a row whose id can never resolve must be settled instead of being asked about on every tick.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Both changes only ever narrow what is accepted or end a retry that could not succeed. The capture still matches every id shape the app itself produces — it is not restricted to numeric ids, because `wf-stress-1` and `wf-hitch-fat` are real and the app's own predicate is `/^wf-[^/]+$/`. A row the new guard settles is one whose lookup could only ever answer "not found", so no reachable repair is cancelled.

## Slice Rationale

Both defects sit on the same failure path and neither one alone ends the stall. Narrowing the capture stops new bad rows but leaves existing ones spinning forever. Settling unresolvable rows drains the existing ones but leaves the generator writing more. Apart, either half ships a fix that does not fix it.

## Non-goals

Does not change the 240s worker tick timeout, `run_headless`'s default timeout, or the per-call retry budget.

Does not make the settle loop batch its lookups; it still issues one query per unresolved row.

Does not change the order in which target repos are scanned, or give any repo its own share of the tick budget.

Does not repair ledger rows already written. Those were settled separately on the DO1 owner, with a backup taken.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_async_repair.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_workflow_fastpath.py`
- [ ] `python3 scripts/test_mergify_admin_requeue.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_plan.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_snapshot.py`
- [ ] `node scripts/check-added-comments.mjs`

Both new tests fail on `origin/master` and pass here.

Before, `test_submit_async_repair_plan_stops_workflow_id_at_an_escaped_newline`:

```
AssertionError: 'wf-1788334466115-1\\nrequired-fast' != 'wf-1788334466115-1'
```

Before, `test_malformed_workflow_id_is_settled_without_a_status_query`:

```
AssertionError: Expected 'workflow_status' to not have been called. Called 1 times.
Calls: [call('wf-1788334466115-1\\nrequired-fast'), call().__hash__()].
```

After:

```
Ran 22 tests in 0.682s
FAILED (errors=2)      <- the same 2 errors origin/master already has; 0 failures

Ran 30 tests in 1.842s
OK
```

Unchanged elsewhere: `plan` 118 OK, `snapshot` 38 OK, `model` 29 OK, main suite 85 OK, `repair_normalize` 15 OK.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e401fd6aa9`
- Post-revert steps: None. Reverting restores the old capture and the forever-retry, so any row written meanwhile with a spliced id would resume stalling ticks.
- Data migration? No. The ledger rows this addressed were settled out of band and are unaffected by a revert.

</details>
