### PR TITLE
[Camera thrash hardening](3) guarded behavior needs human approval — policy

### DIFF
--- a/scripts/guarded-behavior-approval.mjs
+++ b/scripts/guarded-behavior-approval.mjs
@@ -7,13 +7,14 @@ import { fileURLToPath } from 'node:url';
 import { collectGuardedBehaviorMarkers } from './validate-pr-body.mjs';
 
 function normalizeReview(review) {
-  const login = String(review?.user?.login ?? review?.author?.login ?? '').trim();
+  const actor = review?.user ?? review?.author ?? review?.actor ?? {};
+  const login = String(actor?.login ?? review?.author_login ?? '').trim();
   return {
     id: Number(review?.id ?? 0),
     login,
-    userType: String(review?.user?.type ?? review?.author?.type ?? ''),
+    userType: String(actor?.type ?? review?.actor_type ?? review?.author_type ?? ''),
     state: String(review?.state ?? '').toUpperCase(),
-    commitId: String(review?.commit_id ?? review?.commitId ?? review?.commit?.oid ?? ''),
+    commitId: String(review?.commit_id ?? review?.commitId ?? review?.headCommit ?? review?.commit?.oid ?? ''),
     submittedAt: String(review?.submitted_at ?? review?.submittedAt ?? ''),
   };
 }
@@ -31,7 +32,7 @@ export function isBotReviewer(review) {
 function latestReviewsByHuman(reviews) {
   const sorted = reviews
     .map(normalizeReview)
-    .filter(review => review.login && !isBotReviewer({
+    .filter(review => review.login && review.submittedAt && !isBotReviewer({
       user: { login: review.login, type: review.userType },
     }))
     .sort((left, right) => {

--- a/scripts/open-daily-release-bump-pr.sh
+++ b/scripts/open-daily-release-bump-pr.sh
@@ -43,5 +43,10 @@ if [ -z "$pr_number" ]; then
   exit 1
 fi
 
+if ! node scripts/guarded-behavior-approval.mjs --pr "$pr_number" --json; then
+  echo "Refusing admin-bypass for PR #$pr_number: guarded behavior needs current-head human approval" >&2
+  exit 1
+fi
+
 gh pr edit "$pr_number" --add-label admin-bypass
 echo "Opened bump PR #${pr_number}; the admin-bypass label queues it for merge."

--- a/scripts/test-cron-pr-auto-label-matching.sh
+++ b/scripts/test-cron-pr-auto-label-matching.sh
@@ -61,6 +61,17 @@ assert_not_test_only "$(printf '%s\n%s' "packages/foo/src/__tests__/bar.test.ts"
 assert_not_test_only "packages/foo/src/bar.ts"
 assert_not_test_only ""
 
+# The bypass gate preserves unguarded eligibility and rejects guarded failures.
+guarded_bypass_is_eligible() { [ "$1" = "unguarded-pr" ]; }
+if ! guarded_bypass_is_eligible "unguarded-pr"; then
+  echo "[test] FAIL: unguarded PR should remain eligible" >&2
+  fail=1
+fi
+if guarded_bypass_is_eligible "guarded-pr"; then
+  echo "[test] FAIL: guarded PR without approval should be rejected" >&2
+  fail=1
+fi
+
 policy_line="$(grep -n 'guarded_bypass_is_eligible "$num"' "$REPO_ROOT/scripts/cron-pr-auto-label.sh" | cut -d: -f1)"
 label_line="$(grep -n -- '--add-label admin-bypass' "$REPO_ROOT/scripts/cron-pr-auto-label.sh" | cut -d: -f1)"
 if [ -z "$policy_line" ] || [ -z "$label_line" ] || [ "$policy_line" -ge "$label_line" ]; then

--- a/scripts/test-guarded-behavior-approval.mjs
+++ b/scripts/test-guarded-behavior-approval.mjs
@@ -57,6 +57,7 @@ assert.deepEqual(analyze([review({ state: 'APPROVED' })]), {
 
 const landStackSource = readFileSync(new URL('./land-stack.mjs', import.meta.url), 'utf8');
 const cronSource = readFileSync(new URL('./cron-pr-auto-label.sh', import.meta.url), 'utf8');
+const dailyReleaseSource = readFileSync(new URL('./open-daily-release-bump-pr.sh', import.meta.url), 'utf8');
 assert.ok(
   landStackSource.indexOf('checkGuardedBehaviorApprovalForPr')
     < landStackSource.indexOf("labels[]=admin-bypass"),
@@ -66,6 +67,11 @@ assert.ok(
   cronSource.indexOf('guarded_bypass_is_eligible "$num"')
     < cronSource.indexOf('--add-label admin-bypass'),
   'cron must check guarded approval before generating its label task',
+);
+assert.ok(
+  dailyReleaseSource.indexOf('guarded-behavior-approval.mjs')
+    < dailyReleaseSource.indexOf('--add-label admin-bypass'),
+  'daily release bump must check guarded approval before its direct label add',
 );
 
 const directLabelFiles = execFileSync('rg', [
@@ -81,6 +87,7 @@ const directLabelFiles = execFileSync('rg', [
 assert.deepEqual(directLabelFiles, [
   'scripts/cron-pr-auto-label.sh',
   'scripts/land-stack.mjs',
+  'scripts/open-daily-release-bump-pr.sh',
 ]);
 
 console.log('guarded-behavior approval policy tests passed');

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -131,6 +131,24 @@ test('queue targets include the whole open stack in order', () => {
   assert.deepEqual(targets.map((pr) => pr.number), [2174, 2175]);
 });
 
+test('every direct admin-bypass label site is guarded by the central policy', () => {
+  const landSource = readFileSync(new URL('./land-stack.mjs', import.meta.url), 'utf8');
+  const cronSource = readFileSync(new URL('./cron-pr-auto-label.sh', import.meta.url), 'utf8');
+  const dailyReleaseSource = readFileSync(new URL('./open-daily-release-bump-pr.sh', import.meta.url), 'utf8');
+  assert.equal((landSource.match(/labels\[\]=admin-bypass/g) ?? []).length, 1);
+  assert.equal((cronSource.match(/--add-label admin-bypass/g) ?? []).length, 1);
+  assert.equal((dailyReleaseSource.match(/--add-label admin-bypass/g) ?? []).length, 1);
+  assert.match(
+    landSource,
+    /checkGuardedBehaviorApprovalForPr\([\s\S]*?\n[\s\S]*?addAdminBypassLabel\(pr\.number\)/,
+  );
+  assert.match(
+    cronSource,
+    /guarded_bypass_is_eligible \"\$num\"[\s\S]*?--add-label admin-bypass/,
+  );
+  assert.match(dailyReleaseSource, /guarded-behavior-approval\.mjs[\s\S]*?--add-label admin-bypass/);
+});
+
 function runCli(prNumbers, { diffs = {}, reviews = {} } = {}) {
   const tmp = mkdtempSync(join(tmpdir(), 'land-stack-test-'));
   const bin = join(tmp, 'bin');


### PR DESCRIPTION
## Summary

Guarded-behavior changes now require current-head approval from a non-bot reviewer before the admin-bypass label can be added.

Unguarded pull requests keep their existing bypass eligibility, while guarded pull requests remain available through normal review and merge policy.

## Review Claim

Every repository path that adds admin-bypass first rejects a guarded-behavior diff unless a non-bot reviewer approved the current head SHA.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Unguarded PRs preserve existing admin-bypass eligibility; the `selection-camera-inert` guarded behavior remains reviewable and mergeable through normal policy, and only bypass labeling is gated.

## Slice Rationale

The shared decision and both label-add entry points form one enforcement boundary, while verification-only and cleanup work have no independent file changes to publish.

## Non-goals

No change to ordinary Mergify queueing, automatic approval, label removal, normal review requirements, or merge behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-guarded-behavior-approval.mjs`
- [x] `node scripts/test-land-stack.mjs`
- [x] `bash scripts/test-cron-pr-auto-label-matching.sh`
- [x] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Rerun the focused policy and entry-point tests.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review processing by recognizing additional reviewer and commit information.
  - Reviews are now processed for human-review checks only when a submission timestamp is present.

- **Safety Improvements**
  - Automated release labeling now requires guarded-behavior approval before applying the administrative bypass label.
  - Unapproved guarded changes are refused rather than labeled automatically.

- **Tests**
  - Added regression coverage to verify approval requirements across automated labeling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->