### PR TITLE
Skipped status (1) cascade skipped to never-started dependents on failure

### DIFF
--- a/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
+++ b/packages/workflow-core/src/__tests__/fail-cascade-skip.test.ts
@@ -45,6 +45,12 @@ describe('failed task cascade', () => {
     expect(orchestrator.getTask(b.id)!.execution.blockedBy).toContain('task "a" failed');
     expect(orchestrator.getTask(c.id)!.execution.blockedBy).toContain('task "a" failed');
     expect(orchestrator.getTask(d.id)!.status).not.toBe('skipped');
+    expect(orchestrator.getTask(d.id)!.execution.blockedBy).toBeUndefined();
+    const skippedEventTaskIds = persistence.events
+      .filter((event) => event.eventType === 'task.skipped')
+      .map((event) => event.taskId);
+    expect(skippedEventTaskIds).toEqual(expect.arrayContaining([b.id, c.id]));
+    expect(skippedEventTaskIds).not.toContain(d.id);
     expect([b.id, c.id].map((id) => orchestrator.getTask(id)!.status).filter((status) =>
       status === 'running' || status === 'queued',
     )).toEqual([]);


### PR DESCRIPTION
## Summary

The failure-cascade test now checks that only executable dependent tasks emit `task.skipped` events.

It also verifies reconciliation tasks remain untouched and skipped-task events identify the expected dependent IDs.

## Review Claim

Approve the event-boundary assertions for skipped-task cascades: ordinary dependents emit events, while reconciliation nodes do not.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The test adds assertions only; it uses in-memory persistence and cannot mutate live owner data.

## Slice Rationale

This narrow assertion slice locks event behavior independently from the status-cascade implementation and broader reader updates.

## Non-goals

No production code, scheduler behavior, retry policy, UI, documentation, or database changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/workflow-core test -- --run src/__tests__/fail-cascade-skip.test.ts`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this is test-only.
- Revert command: `git revert <commit>`
- Post-revert steps: Rerun the focused workflow-core test.
- Data migration? No.

</details>
