### PR TITLE
Bugfix: the CLI silently returns another database's rows with exit 0 when it cannot reach the live owner

### DIFF
--- a/packages/cli/src/__tests__/cli-query.test.ts
+++ b/packages/cli/src/__tests__/cli-query.test.ts
@@ -147,7 +147,7 @@ describe('invoker-cli query', () => {
     const createSpy = vi.spyOn(SQLiteAdapter, 'create');
     const bus = new LocalBus();
 
-    const code = await main(['query', 'workflows', '--output', 'json'], { createMessageBus: () => bus });
+    const code = await main(['query', 'workflows', '--output', 'json', '--standalone'], { createMessageBus: () => bus });
 
     expect(code).toBe(0);
     const parsed = JSON.parse(output.stdout) as Array<{ id: string }>;
@@ -167,7 +167,7 @@ describe('invoker-cli query', () => {
     const bus = new LocalBus();
 
     const code = await main(
-      ['query', 'tasks', '--workflow', 'wf-env', '--status', 'failed', '--output', 'json'],
+      ['query', 'tasks', '--workflow', 'wf-env', '--status', 'failed', '--output', 'json', '--standalone'],
       { createMessageBus: () => bus },
     );
 
@@ -188,11 +188,27 @@ describe('invoker-cli query', () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
 
-    const code = await main(['query', 'workflows', '--output', 'json'], { createMessageBus: () => bus });
+    const code = await main(['query', 'workflows', '--output', 'json', '--standalone'], { createMessageBus: () => bus });
 
     expect(code).toBe(0);
     expect(JSON.parse(output.stdout)).toEqual([]);
     expect(output.stdout).toBe('[]\n');
+    output.restore();
+  });
+
+  it('fails instead of printing standalone rows when no live owner is reachable', async () => {
+    const dbDir = makeTempDir('invoker-cli-query-no-owner-');
+    await seedDb(dbDir);
+    process.env.INVOKER_DB_DIR = dbDir;
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+
+    const code = await main(['query', 'tasks', '--output', 'json'], { createMessageBus: () => bus });
+
+    expect(code).toBe(1);
+    expect(output.stdout).toBe('');
+    expect(output.stderr).toContain('No running Invoker owner is reachable');
+    expect(output.stderr).toContain('--standalone');
     output.restore();
   });
 
@@ -224,7 +240,7 @@ describe('invoker-cli query', () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
 
-    const code = await main(['query', 'capacity'], { createMessageBus: () => bus });
+    const code = await main(['query', 'capacity', '--standalone'], { createMessageBus: () => bus });
 
     expect(code).toBe(1);
     expect(output.stderr).toContain('query capacity requires a live owner');

--- a/packages/cli/src/__tests__/invoker-profile-defaults.test.ts
+++ b/packages/cli/src/__tests__/invoker-profile-defaults.test.ts
@@ -200,7 +200,7 @@ describe('invoker-cli query respects an explicit db-dir location', () => {
     const bus = new LocalBus();
     const output = captureProcessOutput();
 
-    const code = await main(['query', 'workflows', '--output', 'json'], { createMessageBus: () => bus });
+    const code = await main(['query', 'workflows', '--output', 'json', '--standalone'], { createMessageBus: () => bus });
     output.restore();
 
     expect(code).toBe(0);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -165,6 +165,7 @@ type QueryOptions = {
   status?: string;
   filter?: string;
   output: QueryOutput;
+  mode: 'live' | 'standalone';
   forwardedFlags: string[];
 };
 
@@ -222,8 +223,8 @@ function usage(): string {
   return [
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
-    '  invoker-cli query workflows [--status <status>] [--output text|json]',
-    '  invoker-cli query tasks [--workflow <id>] [--status <status>] [--output text|json]',
+    '  invoker-cli query workflows [--status <status>] [--output text|json] [--standalone]',
+    '  invoker-cli query tasks [--workflow <id>] [--status <status>] [--output text|json] [--standalone]',
     '  invoker-cli query capacity [--output text|json]',
     '  invoker-cli wait <workflowId> [--max-wait-ms <ms>] [--poll-interval-ms <ms>]',
     '  invoker-cli retry-task <taskId>',
@@ -248,7 +249,7 @@ function usage(): string {
     '',
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker owner when available, otherwise run standalone.',
-    '  query workflows|tasks  Read workflows or tasks from a live owner, or a read-only database view.',
+    '  query workflows|tasks  Read workflows or tasks from a live owner, or from a read-only database view with --standalone.',
     '  query capacity  Show live pool/member slot usage, queue depth by workflow, and the oldest-waiting task. Requires a live owner.',
     '  wait <workflowId>  Park until a live-owner workflow settles, then print one INVOKER_WAKE line.',
     '  retry-task <taskId>  Ask a live Invoker owner to retry one task.',
@@ -274,7 +275,7 @@ function usage(): string {
     '  --target <path>       MCP config path for planner setup. Defaults to ~/.invoker/mcp.json.',
     '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
     '  --live           Require a running Invoker owner and submit over IPC.',
-    '  --standalone     Skip IPC and run with an isolated CLI database.',
+    '  --standalone     Skip IPC for `run` or `query` and use an isolated/configured CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
     '  --config <path>  Optional config path reserved for CLI runtime configuration.',
     '  --json           Emit only a machine-readable result summary on stdout.',
@@ -343,6 +344,7 @@ function parseQueryArgs(argv: string[]): QueryOptions {
   const options: QueryOptions = {
     resource,
     output: 'text',
+    mode: 'live',
     forwardedFlags: [],
   };
 
@@ -373,8 +375,10 @@ function parseQueryArgs(argv: string[]): QueryOptions {
       }
       options.output = value;
       options.forwardedFlags.push(arg, value);
+    } else if (arg === '--standalone') {
+      options.mode = 'standalone';
     } else if (arg === '--help' || arg === '-h') {
-      throw new Error('Usage: invoker-cli query <workflows|tasks> [--workflow <id>] [--status <status>] [--output text|json]');
+      throw new Error('Usage: invoker-cli query <workflows|tasks> [--workflow <id>] [--status <status>] [--output text|json] [--standalone]');
     } else if (arg.startsWith('--')) {
       throw new Error(`Unknown query option: ${arg}`);
     } else {
@@ -610,6 +614,11 @@ async function queryStandaloneDatabase(options: QueryOptions): Promise<string> {
 }
 
 async function runQuery(options: QueryOptions, deps: CliDeps): Promise<number> {
+  if (options.mode === 'standalone') {
+    process.stdout.write(await queryStandaloneDatabase(options));
+    return 0;
+  }
+
   let bus: MessageBus | undefined;
   try {
     bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
@@ -618,15 +627,13 @@ async function runQuery(options: QueryOptions, deps: CliDeps): Promise<number> {
       process.stdout.write(await queryLiveOwner(options, bus));
       return 0;
     }
+    throw new Error(`${REQUIRED_OWNER_MESSAGE} Use \`--standalone\` to read the configured CLI database directly.`);
   } finally {
     const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
     if (disconnect) {
       disconnect.call(bus);
     }
   }
-
-  process.stdout.write(await queryStandaloneDatabase(options));
-  return 0;
 }
 
 type WaitOptions = {
@@ -719,6 +726,7 @@ function mutationQueryOptions(status: string): QueryOptions {
     resource: 'tasks',
     status,
     output: 'json',
+    mode: 'live',
     forwardedFlags: ['--status', status, '--output', 'json'],
   };
 }


### PR DESCRIPTION
## Summary

Read requests now fail when no running owner answers.

Before this change, the same request could print rows from a different local database and still exit successfully.

Direct database reads remain available, but callers must ask for them explicitly.

## Review Claim

A read request without a reachable running owner fails clearly unless the caller asks for direct database access.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the no-owner read path changes. Direct database reads stay available behind the explicit opt-in flag.

## Slice Rationale

The behavior change and regression test ship together because the defect was silent without an executable assertion on exit code and output.

## Non-goals

No owner discovery changes.

No database schema changes.

No changes to write commands, mutations, or live owner requests after discovery succeeds.

## Architecture

### Before

```mermaid
graph TD
    A["Read request starts"] --> B["Ask for running owner"]
    B --> C["No owner answers"]
    C --> D["Open direct database view"]
    D --> E["Print rows and exit 0"]
```

### After

```mermaid
graph TD
    A["Read request starts"] --> B["Ask for running owner"]
    B --> C["No owner answers"]
    C --> D["Print an explicit failure and exit non-zero"]
    E["Caller uses the opt-in flag"] --> F["Open direct database view"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:comments`
- [x] `cd packages/cli && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ab06041a`
- Post-revert steps: Re-run `cd packages/cli && pnpm test`
- Data migration? No

</details>
