### PR TITLE
[Remove optimization skills](1) Installer removes skills no longer bundled

### DIFF
--- a/packages/shell/src/bundled-skills-prune.test.ts
+++ b/packages/shell/src/bundled-skills-prune.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { installBundledSkills } from './bundled-skills.js';
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeSkill(resourcesRoot: string, name: string, category?: string): void {
+  const skillDir = join(resourcesRoot, 'skills', name);
+  const categoryLine = category ? `category: ${category}\n` : '';
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\n${categoryLine}description: test skill\n---\n\n# ${name}\n`,
+  );
+}
+
+function installContext(resourcesRoot: string, invokerHomeRoot: string) {
+  return {
+    isPackaged: true,
+    repoRoot: makeTempRoot('invoker-bundled-repo-'),
+    resourcesPath: resourcesRoot,
+    invokerHomeRoot,
+    isInstalled: () => true,
+  };
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('installBundledSkills pruning', () => {
+  it('removes a dropped bundled skill while preserving kept and non-prefixed folders', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const fakeHome = makeTempRoot('invoker-bundled-fakehome-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    writeSkill(resourcesRoot, 'kept');
+    writeSkill(resourcesRoot, 'dropped');
+
+    try {
+      const context = installContext(resourcesRoot, invokerHomeRoot);
+      installBundledSkills(context);
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        mkdirSync(join(fakeHome, target, 'user-created'), { recursive: true });
+      }
+      rmSync(join(resourcesRoot, 'skills', 'dropped'), { recursive: true, force: true });
+      installBundledSkills(context);
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        const targetRoot = join(fakeHome, target);
+        expect(existsSync(join(targetRoot, 'invoker-kept'))).toBe(true);
+        expect(existsSync(join(targetRoot, 'invoker-dropped'))).toBe(false);
+        expect(existsSync(join(targetRoot, 'user-created'))).toBe(true);
+      }
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  it('keeps a still-bundled optimization skill during a core-filtered reinstall', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const fakeHome = makeTempRoot('invoker-bundled-fakehome-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    writeSkill(resourcesRoot, 'core-skill', 'core');
+    writeSkill(resourcesRoot, 'optimization-skill', 'optimization');
+
+    try {
+      const context = installContext(resourcesRoot, invokerHomeRoot);
+      installBundledSkills(context);
+      installBundledSkills(context, 'install', 'core');
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        expect(existsSync(join(fakeHome, target, 'invoker-core-skill'))).toBe(true);
+        expect(existsSync(join(fakeHome, target, 'invoker-optimization-skill'))).toBe(true);
+      }
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+});

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -1003,12 +1003,14 @@ export function installBundledSkills(
     throw new Error('Bundled skills are not available in this app build.');
   }
 
+  const previousManifest = readManifest(invokerHomeRoot);
   const bundledSkillNames = listBundledSkillNames(sourceRoot, category);
   for (const skillName of bundledSkillNames) {
     assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
   }
   const bundledHash = hashDirectory(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
+  const currentBundledSkillNames = new Set(prefixedSkillNames(listBundledSkillNames(sourceRoot, 'all')));
   const targets = resolveManagedTargets();
   const commandTargets = resolveManagedCommandTargets();
   const mcpTargets = resolveManagedMcpTargets(isInstalled);
@@ -1018,6 +1020,11 @@ export function installBundledSkills(
 
   for (const target of targets) {
     mkdirSync(target.path, { recursive: true });
+    const previouslyInstalledNames = previousManifest?.targets?.[target.id]?.installedSkillNames ?? [];
+    const droppedSkillNames = previouslyInstalledNames.filter((name) =>
+      name.startsWith(MANAGED_PREFIX) && !currentBundledSkillNames.has(name),
+    );
+    removeManagedSkillDirs(target.path, droppedSkillNames);
     for (const skillName of bundledSkillNames) {
       const sourceDir = path.join(sourceRoot, skillName);
       const targetDir = path.join(target.path, managedSkillName(skillName));
@@ -1032,8 +1039,14 @@ export function installBundledSkills(
 
   const commandSourceRoot = commandSourceDir(sourceRoot);
   const commandFiles = listCommandNames(sourceRoot);
+  const currentCommandNames = new Set(commandFiles.map(commandDisplayName));
   for (const target of commandTargets) {
     mkdirSync(target.path, { recursive: true });
+    const previouslyInstalledNames = previousManifest?.commandTargets?.[target.id]?.installedCommandNames ?? [];
+    const droppedCommandFiles = previouslyInstalledNames
+      .filter((name) => name.startsWith(MANAGED_PREFIX) && !currentCommandNames.has(name))
+      .map((name) => name.endsWith('.md') ? name : `${name}.md`);
+    removeManagedCommandFiles(target.path, droppedCommandFiles);
     for (const fileName of commandFiles) {
       copyFileSync(path.join(commandSourceRoot, fileName), path.join(target.path, fileName));
     }


### PR DESCRIPTION
## Summary

The installer refreshes the skills and slash entries that Invoker manages.

Previously dropped bundled items stayed on a machine after later installs.

Reinstalling now retires recorded managed items that the current bundle no longer ships.

## Review Claim

The installer retires dropped managed skills and slash entries while preserving bundled skills and user-created folders.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Install acts only on recorded `invoker-`-prefixed skill folders and slash files absent from the full bundle; filtered installs preserve still-bundled items and unprefixed folders.

## Slice Rationale

This is the single behavior change; it lands before later slices change the bundle contents.

## Non-goals

No changes to uninstall, status reporting, category selection, MCP targets, instruction targets, or removal of any skill in this slice.

## Architecture

### Before

```mermaid
graph TD
    A["Install copies current bundled items"]
    B["Previously installed dropped items persist"]
    A --> B
```

### After

```mermaid
graph TD
    A["Install reads the previous manifest"]
    B["Install retires managed items absent from the full bundle"]
    C["Install copies current selected items"]
    A --> B --> C
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/shell && pnpm test`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <implementation-commit>`
- Post-revert steps: Rerun `cd packages/shell && pnpm test`
- Data migration? No

</details>
