### PR TITLE
[Remove optimization skills](2) Verify installer reconciliation

### DIFF
--- a/packages/shell/src/bundled-skills-prune.test.ts
+++ b/packages/shell/src/bundled-skills-prune.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { installBundledSkills } from './bundled-skills.js';
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeSkill(resourcesRoot: string, name: string, category?: string): void {
+  const skillDir = join(resourcesRoot, 'skills', name);
+  const categoryLine = category ? `category: ${category}\n` : '';
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\n${categoryLine}description: test skill\n---\n\n# ${name}\n`,
+  );
+}
+
+function installContext(resourcesRoot: string, invokerHomeRoot: string) {
+  return {
+    isPackaged: true,
+    repoRoot: makeTempRoot('invoker-bundled-repo-'),
+    resourcesPath: resourcesRoot,
+    invokerHomeRoot,
+    isInstalled: () => true,
+  };
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('installBundledSkills pruning', () => {
+  it('removes a dropped bundled skill while preserving kept and non-prefixed folders', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const fakeHome = makeTempRoot('invoker-bundled-fakehome-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    writeSkill(resourcesRoot, 'kept');
+    writeSkill(resourcesRoot, 'dropped');
+
+    try {
+      const context = installContext(resourcesRoot, invokerHomeRoot);
+      installBundledSkills(context);
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        mkdirSync(join(fakeHome, target, 'user-created'), { recursive: true });
+      }
+      rmSync(join(resourcesRoot, 'skills', 'dropped'), { recursive: true, force: true });
+      installBundledSkills(context);
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        const targetRoot = join(fakeHome, target);
+        expect(existsSync(join(targetRoot, 'invoker-kept'))).toBe(true);
+        expect(existsSync(join(targetRoot, 'invoker-dropped'))).toBe(false);
+        expect(existsSync(join(targetRoot, 'user-created'))).toBe(true);
+      }
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  it('keeps a still-bundled optimization skill during a core-filtered reinstall', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const fakeHome = makeTempRoot('invoker-bundled-fakehome-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    writeSkill(resourcesRoot, 'core-skill', 'core');
+    writeSkill(resourcesRoot, 'optimization-skill', 'optimization');
+
+    try {
+      const context = installContext(resourcesRoot, invokerHomeRoot);
+      installBundledSkills(context);
+      installBundledSkills(context, 'install', 'core');
+
+      for (const target of ['.codex/skills', '.claude/skills', '.cursor/skills', '.omp/agent/skills']) {
+        expect(existsSync(join(fakeHome, target, 'invoker-core-skill'))).toBe(true);
+        expect(existsSync(join(fakeHome, target, 'invoker-optimization-skill'))).toBe(true);
+      }
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+});

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -1003,12 +1003,14 @@ export function installBundledSkills(
     throw new Error('Bundled skills are not available in this app build.');
   }
 
+  const previousManifest = readManifest(invokerHomeRoot);
   const bundledSkillNames = listBundledSkillNames(sourceRoot, category);
   for (const skillName of bundledSkillNames) {
     assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
   }
   const bundledHash = hashDirectory(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
+  const currentBundledSkillNames = new Set(prefixedSkillNames(listBundledSkillNames(sourceRoot, 'all')));
   const targets = resolveManagedTargets();
   const commandTargets = resolveManagedCommandTargets();
   const mcpTargets = resolveManagedMcpTargets(isInstalled);
@@ -1018,6 +1020,11 @@ export function installBundledSkills(
 
   for (const target of targets) {
     mkdirSync(target.path, { recursive: true });
+    const previouslyInstalledNames = previousManifest?.targets?.[target.id]?.installedSkillNames ?? [];
+    const droppedSkillNames = previouslyInstalledNames.filter((name) =>
+      name.startsWith(MANAGED_PREFIX) && !currentBundledSkillNames.has(name),
+    );
+    removeManagedSkillDirs(target.path, droppedSkillNames);
     for (const skillName of bundledSkillNames) {
       const sourceDir = path.join(sourceRoot, skillName);
       const targetDir = path.join(target.path, managedSkillName(skillName));
@@ -1032,8 +1039,14 @@ export function installBundledSkills(
 
   const commandSourceRoot = commandSourceDir(sourceRoot);
   const commandFiles = listCommandNames(sourceRoot);
+  const currentCommandNames = new Set(commandFiles.map(commandDisplayName));
   for (const target of commandTargets) {
     mkdirSync(target.path, { recursive: true });
+    const previouslyInstalledNames = previousManifest?.commandTargets?.[target.id]?.installedCommandNames ?? [];
+    const droppedCommandFiles = previouslyInstalledNames
+      .filter((name) => name.startsWith(MANAGED_PREFIX) && !currentCommandNames.has(name))
+      .map((name) => name.endsWith('.md') ? name : `${name}.md`);
+    removeManagedCommandFiles(target.path, droppedCommandFiles);
     for (const fileName of commandFiles) {
       copyFileSync(path.join(commandSourceRoot, fileName), path.join(target.path, fileName));
     }


### PR DESCRIPTION
## Summary

The installer change carries a focused proof that its package test suite passes.

This slice records deterministic verification for the preceding behavior change.

## Review Claim

The package test command passes on the completed installer change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice is proof-only: it adds no product behavior, changes no data, and exercises the completed branch with the repository test command.

## Slice Rationale

Proof is separate so reviewers can distinguish the installer behavior from its execution evidence.

## Non-goals

No product edits, behavior changes, test weakening, or unrelated verification.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/shell && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <proof-commit>`
- Post-revert steps: None
- Data migration? No

</details>
