### PR TITLE
[CI regression: cb4133c-playwright-5-of-9](1) Wait for selected task graph

### DIFF
--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -156,6 +156,17 @@ async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promi
   return Date.now() - startedAt;
 }
 
+async function waitForSelectedTaskGraphVisible(page: Page, timeoutMs: number): Promise<void> {
+  await page
+    .getByTestId('selected-workflow-mini-dag')
+    .locator('.react-flow__node:visible')
+    .first()
+    .waitFor({
+      state: 'visible',
+      timeout: timeoutMs,
+    });
+}
+
 async function dragGraphAndAssertViewportMoves(page: Page): Promise<void> {
   const viewport = page.locator('.react-flow__viewport').first();
   const pane = page.locator('.react-flow__pane').first();
@@ -193,6 +204,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       await waitForInvokerBridge(page, 30_000);
       await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10_000 });
       await waitForWorkflowGraphVisible(page, 5000);
+      await waitForSelectedTaskGraphVisible(page, 10_000);
       await dragGraphAndAssertViewportMoves(page);
 
       const result = await page.evaluate(async () => {


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cb4133c66b1bcb2ca5ae4ceae019979b60d7e860; job=playwright / 5-of-9 -->

CI job `playwright / 5-of-9` first failed on default-branch commit cb4133c66b1bcb2ca5ae4ceae019979b60d7e860.

The startup responsiveness spec now waits for the selected task mini graph before it drags the main graph.

That keeps the proof focused on responsiveness after both graph surfaces are ready.

## Review Claim

The Playwright startup responsiveness proof waits for the selected task mini graph before exercising the main graph drag.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The added wait observes an existing readiness signal and does not alter app behavior or weaken the responsiveness assertions.

## Slice Rationale

One proof slice covers the `playwright / 5-of-9` startup readiness timing check without bundling unrelated work.

## Non-goals

No product behavior changes.

No refactor.

No snapshot updates.

No unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:comments`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts e2e/renderer-memory-pressure-recovery.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` (exited 0; Playwright reported 7 passed, 1 flaky)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 25662c4d`
- Post-revert steps: Re-run the `playwright / 5-of-9` command from the Test Plan.
- Data migration? No

</details>
